### PR TITLE
397 fix forward references in expressionbuilder 4

### DIFF
--- a/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
@@ -176,7 +176,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                     bool b => b ? "true" : "false",
                     decimal d => FormattableString.Invariant($"{d}m"),
                     int i => FormattableString.Invariant($"{i}"),
-                    var v when v.IsObjectNullOrDefault() => $"default({typeToCSharpConverter.ToCSharp(type)})",
+                    var v when v.IsObjectNullOrDefault() => DefaultExpressionForType(),
                     _ => FormattableString.Invariant($"{value}"),
                 };
             }
@@ -185,16 +185,26 @@ namespace Hl7.Cql.CodeGeneration.NET
                 // Reference Types
                 text = value switch
                 {
-                    null when type == typeof(object)    => "null",
-                    null => $"default({typeToCSharpConverter.ToCSharp(type)})",
-                    Type t   => $"typeof({typeToCSharpConverter.ToCSharp(t)})",
-                    Uri u    => $"new Uri(\"{u}\")",
-                    string s => SymbolDisplay.FormatLiteral(s, true),
-                    _        => FormattableString.Invariant($"{value}")
+                    null when type == typeof(object) => "null",
+                    null                             => DefaultExpressionForType(),
+                    Type t                           => $"typeof({typeToCSharpConverter.ToCSharp(t)})",
+                    Uri u                            => $"new Uri(\"{u}\")",
+                    string s                         => SymbolDisplay.FormatLiteral(s, true),
+                    _                                => FormattableString.Invariant($"{value}")
                 };
             }
 
             return $"{indentString}{text}";
+
+            string DefaultExpressionForType()
+            {
+                // NOTE: Be careful changing this to include the type name,
+                // there are cases in this file where an exact match on "null"
+                // or "default" is expected, and this will break it.
+                //
+                // return $"default({typeToCSharpConverter.ToCSharp(type)})";
+                return "default";
+            }
         }
 
         private static string ConvertParameterExpression(string leadingIndentString, ParameterExpression pe)

--- a/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
+++ b/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
+[CqlLibrary("CqlBooleanTest", "1.0.000")]
+public class CqlBooleanTest_1_0_000
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<bool?> __SomethingTrueEqualsTrue;
+
+    #endregion
+    public CqlBooleanTest_1_0_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+
+        __SomethingTrueEqualsTrue = new Lazy<bool?>(this.SomethingTrueEqualsTrue_Value);
+    }
+	private bool? SomethingTrueEqualsTrue_Value()
+	{
+		bool? a_ = context.Operators.Equal(1, 1);
+		bool? b_ = context.Operators.Equal(a_, true);
+
+		return b_;
+	}
+
+    [CqlDeclaration("SomethingTrueEqualsTrue")]
+	public bool? SomethingTrueEqualsTrue() => 
+		__SomethingTrueEqualsTrue.Value;
+
+}

--- a/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIRConversionTest", "2023.0.0")]
 public class FHIRConversionTest_2023_0_0
 {

--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIRHelpers", "4.0.1")]
 public class FHIRHelpers_4_0_1
 {

--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -114,28 +114,28 @@ public class FHIRHelpers_4_0_1
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default, w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default, y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default, true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default, false, true);
 
 						return ad_;
 					}
@@ -251,11 +251,11 @@ public class FHIRHelpers_4_0_1
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -317,11 +317,11 @@ public class FHIRHelpers_4_0_1
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -365,7 +365,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((ratio is null))
 			{
-				return default(CqlRatio);
+				return default;
 			}
 			else
 			{
@@ -388,7 +388,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((coding is null))
 			{
-				return default(CqlCode);
+				return default;
 			}
 			else
 			{
@@ -415,7 +415,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((concept is null))
 			{
-				return default(CqlConcept);
+				return default;
 			}
 			else
 			{

--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -114,28 +114,28 @@ public class FHIRHelpers_4_0_1
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(null, w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(null, y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, null, true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, null, false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
 
 						return ad_;
 					}
@@ -251,11 +251,11 @@ public class FHIRHelpers_4_0_1
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -317,11 +317,11 @@ public class FHIRHelpers_4_0_1
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -365,7 +365,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((ratio is null))
 			{
-				return null;
+				return default(CqlRatio);
 			}
 			else
 			{
@@ -388,7 +388,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((coding is null))
 			{
-				return null;
+				return default(CqlCode);
 			}
 			else
 			{
@@ -415,7 +415,7 @@ public class FHIRHelpers_4_0_1
 		{
 			if ((concept is null))
 			{
-				return null;
+				return default(CqlConcept);
 			}
 			else
 			{

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -68,7 +68,7 @@ public class TestRetrieve_1_0_1
     #endregion
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -76,7 +76,7 @@ public class TestRetrieve_1_0_1
 		__HIV.Value;
 
 	private CqlValueSet Syphilis_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002", default);
 
     [CqlDeclaration("Syphilis")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002")]
@@ -84,7 +84,7 @@ public class TestRetrieve_1_0_1
 		__Syphilis.Value;
 
 	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012", default);
 
     [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012")]
@@ -92,7 +92,7 @@ public class TestRetrieve_1_0_1
 		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
 
 	private CqlValueSet Pregnancy_Test_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011", default);
 
     [CqlDeclaration("Pregnancy Test")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011")]
@@ -100,7 +100,7 @@ public class TestRetrieve_1_0_1
 		__Pregnancy_Test.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017", default);
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -108,7 +108,7 @@ public class TestRetrieve_1_0_1
 		__Pap_Test.Value;
 
 	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007", default);
 
     [CqlDeclaration("Lab Tests During Pregnancy")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007")]
@@ -116,7 +116,7 @@ public class TestRetrieve_1_0_1
 		__Lab_Tests_During_Pregnancy.Value;
 
 	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051", default);
 
     [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051")]
@@ -124,7 +124,7 @@ public class TestRetrieve_1_0_1
 		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
 
 	private CqlValueSet Chlamydia_Screening_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052", default);
 
     [CqlDeclaration("Chlamydia Screening")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052")]
@@ -132,7 +132,7 @@ public class TestRetrieve_1_0_1
 		__Chlamydia_Screening.Value;
 
 	private CqlValueSet Palliative_Care_Assessment_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default);
 
     [CqlDeclaration("Palliative Care Assessment")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225")]
@@ -140,7 +140,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Assessment.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450")]
@@ -148,7 +148,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224")]
@@ -156,7 +156,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -165,7 +165,7 @@ public class TestRetrieve_1_0_1
 	private CqlCode[] ICD_10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -177,8 +177,8 @@ public class TestRetrieve_1_0_1
 
 	private object MeasurementPeriod_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("TestRetrieve-1.0.1", "MeasurementPeriod", c_);
 
@@ -191,7 +191,7 @@ public class TestRetrieve_1_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("TestRetrieve", "1.0.1")]
 public class TestRetrieve_1_0_1
 {

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -68,7 +68,7 @@ public class TestRetrieve_1_0_1
     #endregion
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -76,7 +76,7 @@ public class TestRetrieve_1_0_1
 		__HIV.Value;
 
 	private CqlValueSet Syphilis_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002", default(string));
 
     [CqlDeclaration("Syphilis")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1002")]
@@ -84,7 +84,7 @@ public class TestRetrieve_1_0_1
 		__Syphilis.Value;
 
 	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012", default(string));
 
     [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1012")]
@@ -92,7 +92,7 @@ public class TestRetrieve_1_0_1
 		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
 
 	private CqlValueSet Pregnancy_Test_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011", default(string));
 
     [CqlDeclaration("Pregnancy Test")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1011")]
@@ -100,7 +100,7 @@ public class TestRetrieve_1_0_1
 		__Pregnancy_Test.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -108,7 +108,7 @@ public class TestRetrieve_1_0_1
 		__Pap_Test.Value;
 
 	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007", default(string));
 
     [CqlDeclaration("Lab Tests During Pregnancy")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1007")]
@@ -116,7 +116,7 @@ public class TestRetrieve_1_0_1
 		__Lab_Tests_During_Pregnancy.Value;
 
 	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051", default(string));
 
     [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1051")]
@@ -124,7 +124,7 @@ public class TestRetrieve_1_0_1
 		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
 
 	private CqlValueSet Chlamydia_Screening_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052", default(string));
 
     [CqlDeclaration("Chlamydia Screening")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1052")]
@@ -132,7 +132,7 @@ public class TestRetrieve_1_0_1
 		__Chlamydia_Screening.Value;
 
 	private CqlValueSet Palliative_Care_Assessment_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default(string));
 
     [CqlDeclaration("Palliative Care Assessment")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225")]
@@ -140,7 +140,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Assessment.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default(string));
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450")]
@@ -148,7 +148,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default(string));
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224")]
@@ -156,7 +156,7 @@ public class TestRetrieve_1_0_1
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -165,7 +165,7 @@ public class TestRetrieve_1_0_1
 	private CqlCode[] ICD_10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -177,8 +177,8 @@ public class TestRetrieve_1_0_1
 
 	private object MeasurementPeriod_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("TestRetrieve-1.0.1", "MeasurementPeriod", c_);
 
@@ -191,7 +191,7 @@ public class TestRetrieve_1_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
@@ -41,7 +41,7 @@ public class TestRetrieveInclude_1_0_1
         __Chlamydia = new Lazy<CqlValueSet>(this.Chlamydia_Value);
     }
 	private CqlValueSet Female_Administrative_Sex_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.560.100.2", null);
+		new CqlValueSet("2.16.840.1.113883.3.560.100.2", default(string));
 
     [CqlDeclaration("Female Administrative Sex")]
     [CqlValueSet("2.16.840.1.113883.3.560.100.2")]
@@ -49,7 +49,7 @@ public class TestRetrieveInclude_1_0_1
 		__Female_Administrative_Sex.Value;
 
 	private CqlValueSet Other_Female_Reproductive_Conditions_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006", default(string));
 
     [CqlDeclaration("Other Female Reproductive Conditions")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006")]
@@ -57,7 +57,7 @@ public class TestRetrieveInclude_1_0_1
 		__Other_Female_Reproductive_Conditions.Value;
 
 	private CqlValueSet Genital_Herpes_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049", default(string));
 
     [CqlDeclaration("Genital Herpes")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049")]
@@ -65,7 +65,7 @@ public class TestRetrieveInclude_1_0_1
 		__Genital_Herpes.Value;
 
 	private CqlValueSet Genococcal_Infections_and_Venereal_Diseases_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001", default(string));
 
     [CqlDeclaration("Genococcal Infections and Venereal Diseases")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001")]
@@ -73,7 +73,7 @@ public class TestRetrieveInclude_1_0_1
 		__Genococcal_Infections_and_Venereal_Diseases.Value;
 
 	private CqlValueSet Inflammatory_Diseases_of_Female_Reproductive_Organs_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004", default(string));
 
     [CqlDeclaration("Inflammatory Diseases of Female Reproductive Organs")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004")]
@@ -81,7 +81,7 @@ public class TestRetrieveInclude_1_0_1
 		__Inflammatory_Diseases_of_Female_Reproductive_Organs.Value;
 
 	private CqlValueSet Chlamydia_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003", null);
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003", default(string));
 
     [CqlDeclaration("Chlamydia")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003")]

--- a/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
@@ -41,7 +41,7 @@ public class TestRetrieveInclude_1_0_1
         __Chlamydia = new Lazy<CqlValueSet>(this.Chlamydia_Value);
     }
 	private CqlValueSet Female_Administrative_Sex_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.560.100.2", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.560.100.2", default);
 
     [CqlDeclaration("Female Administrative Sex")]
     [CqlValueSet("2.16.840.1.113883.3.560.100.2")]
@@ -49,7 +49,7 @@ public class TestRetrieveInclude_1_0_1
 		__Female_Administrative_Sex.Value;
 
 	private CqlValueSet Other_Female_Reproductive_Conditions_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006", default);
 
     [CqlDeclaration("Other Female Reproductive Conditions")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.111.12.1006")]
@@ -57,7 +57,7 @@ public class TestRetrieveInclude_1_0_1
 		__Other_Female_Reproductive_Conditions.Value;
 
 	private CqlValueSet Genital_Herpes_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049", default);
 
     [CqlDeclaration("Genital Herpes")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.110.12.1049")]
@@ -65,7 +65,7 @@ public class TestRetrieveInclude_1_0_1
 		__Genital_Herpes.Value;
 
 	private CqlValueSet Genococcal_Infections_and_Venereal_Diseases_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001", default);
 
     [CqlDeclaration("Genococcal Infections and Venereal Diseases")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1001")]
@@ -73,7 +73,7 @@ public class TestRetrieveInclude_1_0_1
 		__Genococcal_Infections_and_Venereal_Diseases.Value;
 
 	private CqlValueSet Inflammatory_Diseases_of_Female_Reproductive_Organs_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004", default);
 
     [CqlDeclaration("Inflammatory Diseases of Female Reproductive Organs")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1004")]
@@ -81,7 +81,7 @@ public class TestRetrieveInclude_1_0_1
 		__Inflammatory_Diseases_of_Female_Reproductive_Organs.Value;
 
 	private CqlValueSet Chlamydia_Value() => 
-		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003", default(string));
+		new CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003", default);
 
     [CqlDeclaration("Chlamydia")]
     [CqlValueSet("2.16.840.1.113883.3.464.1003.112.12.1003")]

--- a/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("TestRetrieveInclude", "1.0.1")]
 public class TestRetrieveInclude_1_0_1
 {

--- a/Cql/CoreTests/CqlBooleanTest.cs
+++ b/Cql/CoreTests/CqlBooleanTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Runtime;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests;
+
+[TestClass]
+internal class CqlBooleanTest
+{
+    [TestMethod]
+    public void SomethingTrueEqualsTrue_ShouldBeTrue()
+    {
+        CqlContext ctx = FhirCqlContext.ForBundle();
+        var lib = new CqlBooleanTest_1_0_000(ctx);
+        Assert.IsTrue(lib.SomethingTrueEqualsTrue());
+    }
+}

--- a/Cql/CoreTests/Infrastructure/TypeExtensionsTests.cs
+++ b/Cql/CoreTests/Infrastructure/TypeExtensionsTests.cs
@@ -35,6 +35,81 @@ public class TypeExtensionsTests
     private static readonly Type MyClassGenericDefinitionType = typeof(MyGenericClassDerived<>);
 
     [TestMethod]
+    public void IsObjectNullOrDefault_ShouldThrowNotSupportedException_WhenTypeArgumentNotObject()
+    {
+        // Don't use IsObjectNullOrDefault on specific types, it must be boxed to an object first
+
+        Assert.ThrowsException<NotSupportedException>(() => 0.IsObjectNullOrDefault());
+
+        Assert.ThrowsException<NotSupportedException>(() => default(int?).IsObjectNullOrDefault());
+    }
+
+    [TestMethod]
+    public void IsObjectNullOrDefault_ShouldReturnCorrectResults_ForObject()
+    {
+        object? obj = null;
+        Assert.IsTrue(obj.IsObjectNullOrDefault());
+
+        obj = new();
+        Assert.IsFalse(obj.IsObjectNullOrDefault());
+    }
+
+    [TestMethod]
+    public void IsObjectNullOrDefault_ShouldReturnCorrectResults_ForEnum()
+    {
+        TestEnum? testEnum = null;
+        Assert.IsTrue(testEnum.IsObjectNullOrDefault<object>());
+
+        testEnum = TestEnum.Zero; // default
+        Assert.IsTrue(testEnum.IsObjectNullOrDefault<object>());
+
+        testEnum = TestEnum.One;
+        Assert.IsFalse(testEnum.IsObjectNullOrDefault<object>());
+    }
+
+    [TestMethod]
+    public void IsObjectNullOrDefault_ShouldReturnCorrectResults_ForInt32()
+    {
+        int? testInt32 = null;
+        Assert.IsTrue(testInt32.IsObjectNullOrDefault<object>());
+
+        testInt32 = 0;
+        Assert.IsTrue(testInt32.IsObjectNullOrDefault<object>());
+
+        testInt32 = 1;
+        Assert.IsFalse(testInt32.IsObjectNullOrDefault<object>());
+    }
+
+    [TestMethod]
+    public void IsObjectNullOrDefault_ShouldReturnCorrectResults_ForGuids()
+    {
+        Guid? testGuid = null;
+        Assert.IsTrue(testGuid.IsObjectNullOrDefault<object>());
+
+        testGuid = Guid.Empty;
+        Assert.IsTrue(testGuid.IsObjectNullOrDefault<object>());
+
+        testGuid = Guid.NewGuid();
+        Assert.IsFalse(testGuid.IsObjectNullOrDefault<object>());
+    }
+
+    [TestMethod]
+    public void IsObjectNullOrDefault_ShouldReturnCorrectResults_ForStrings()
+    {
+        string? testString = null;
+        Assert.IsTrue(testString.IsObjectNullOrDefault<object>());
+
+        testString = "";
+        Assert.IsFalse(testString.IsObjectNullOrDefault<object>());
+    }
+
+    private enum TestEnum
+    {
+        Zero = 0,
+        One = 1
+    };
+
+    [TestMethod]
     public void IsNullableValueType_ShouldReturnCorrectResults()
     {
         // Arrange

--- a/Cql/CoreTests/Input/ELM/HL7/CqlBooleanTest.cql
+++ b/Cql/CoreTests/Input/ELM/HL7/CqlBooleanTest.cql
@@ -1,0 +1,3 @@
+library CqlBooleanTest version '1.0.000'
+
+define "SomethingTrueEqualsTrue": (1=1) = true

--- a/Cql/CoreTests/Input/ELM/HL7/CqlBooleanTest.json
+++ b/Cql/CoreTests/Input/ELM/HL7/CqlBooleanTest.json
@@ -1,0 +1,76 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "3.1.0",
+         "translatorOptions" : "EnableLocators,EnableResultTypes",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "CqlBooleanTest",
+         "version" : "1.0.000"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "3:1-3:46",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+            "name" : "SomethingTrueEqualsTrue",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "locator" : "3:35-3:46",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+               "type" : "Equal",
+               "signature" : [ {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               }, {
+                  "name" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "NamedTypeSpecifier"
+               } ],
+               "operand" : [ {
+                  "locator" : "3:35-3:39",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "type" : "Equal",
+                  "signature" : [ {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  }, {
+                     "name" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "type" : "NamedTypeSpecifier"
+                  } ],
+                  "operand" : [ {
+                     "locator" : "3:36",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  }, {
+                     "locator" : "3:38",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  } ]
+               }, {
+                  "locator" : "3:43-3:46",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "valueType" : "{urn:hl7-org:elm-types:r1}Boolean",
+                  "value" : "true",
+                  "type" : "Literal"
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
+++ b/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://hl7.org/fhirpath/tests" xsi:schemaLocation="http://hl7.org/fhirpath/tests ../../testSchema/testSchema.xsd"
+	name="CqlAgeTest" reference="https://cql.hl7.org/09-b-cqlreference.html#age">
+	<group name="Age">
+		<test name="CalculateAgeInYearsAt">
+			<expression>CalculateAgeInYearsAt(@1976-01-01, @2020-01-02)</expression>
+			<output>44</output>
+		</test>
+		<test name="CalculateAgeAt">
+			<expression>CalculateAgeInYearsAt(@1976-01-01, @2020-01-02)</expression>
+			<output>44</output>
+		</test>
+	</group>
+</tests>

--- a/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
+++ b/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
@@ -6,9 +6,29 @@
 			<expression>CalculateAgeInYearsAt(@1976-01-01, @2020-01-02)</expression>
 			<output>44</output>
 		</test>
+		<test name="CalculateAgeInMonthsAt">
+			<expression>CalculateAgeInMonthsAt(@1976-01-01, @2020-01-02)</expression>
+			<output>528</output>
+		</test>
+		<test name="CalculateAgeInWeeksAt">
+			<expression>CalculateAgeInWeeksAt(@1976-01-01, @2020-01-02)</expression>
+			<output>2296</output>
+		</test>
 		<test name="CalculateAgeInDaysAt">
 			<expression>CalculateAgeInDaysAt(@1976-01-01, @2020-01-02)</expression>
 			<output>16072</output>
+		</test>
+		<test name="CalculateAgeInHoursAt">
+			<expression>CalculateAgeInHoursAt(@1976-01-01, @2020-01-02)</expression>
+			<output>385728</output>
+		</test>
+		<test name="CalculateAgeInMinutesAt">
+			<expression>CalculateAgeInMinutesAt(@1976-01-01, @2020-01-02)</expression>
+			<output>23143680</output>
+		</test>
+		<test name="CalculateAgeInSecondsAt">
+			<expression>CalculateAgeInSecondsAt(@1976-01-01, @2020-01-02)</expression>
+			<output>1388620800</output>
 		</test>
 	</group>
 </tests>

--- a/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
+++ b/Cql/CqlToElmTests/Input/DQIC/CqlAgeTest.xml
@@ -6,9 +6,9 @@
 			<expression>CalculateAgeInYearsAt(@1976-01-01, @2020-01-02)</expression>
 			<output>44</output>
 		</test>
-		<test name="CalculateAgeAt">
-			<expression>CalculateAgeInYearsAt(@1976-01-01, @2020-01-02)</expression>
-			<output>44</output>
+		<test name="CalculateAgeInDaysAt">
+			<expression>CalculateAgeInDaysAt(@1976-01-01, @2020-01-02)</expression>
+			<output>16072</output>
 		</test>
 	</group>
 </tests>

--- a/Cql/CqlToElmTests/XmlTests.cs
+++ b/Cql/CqlToElmTests/XmlTests.cs
@@ -36,8 +36,10 @@ namespace Hl7.Cql.CqlToElm.Test
         [TestMethod]
         public void Run(TestCase testCase)
         {
+            string testFullName = $"{testCase.Category}: {testCase.TestName}";
+
             if (SkippedTests.DoesNotCompile.TryGetValue(testCase.TestName, out var reason))
-                Assert.Inconclusive($"Case {testCase.Category}: {testCase.TestName} skipped: {reason}");
+                Assert.Inconclusive($"Case {testFullName} skipped: {reason}");
 
             // If you want to test a particular case, you can uncomment the following lines
             // if (testCase.TestName != "AgeInYearsAt")
@@ -47,13 +49,13 @@ namespace Hl7.Cql.CqlToElm.Test
             var expressionErrors = expression.GetErrors();
             if (expressionErrors.Any())
             {
-                Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expression compiled with errors: {expressionErrors.First().message}");
+                Assert.Fail($"Case {testFullName} expression compiled with errors: {expressionErrors.First().message}");
                 return;
             }
 
             if (testCase.Expectation is null)
             {
-                Assert.Inconclusive($"Case {testCase.Category}: {testCase.TestName} is inconclusive; no expectation provided.");
+                Assert.Inconclusive($"Case {testFullName} is inconclusive; no expectation provided.");
                 return;
             }
 
@@ -61,13 +63,13 @@ namespace Hl7.Cql.CqlToElm.Test
             var expectationErrors = expectation.GetErrors();
             if (expectationErrors.Any())
             {
-                Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expectation compiled with errors: {expressionErrors.First().message}");
+                Assert.Fail($"Case {testFullName} expectation compiled with errors: {expressionErrors.First().message}");
                 return;
             }
 
             if (SkippedTests.DoesNotMatchExpectation.TryGetValue(testCase.TestName, out var doesNotMatchReason))
             {
-                Assert.Inconclusive($"Cannot evaluate case {testCase.Category}: {testCase.TestName}: {doesNotMatchReason}");
+                Assert.Inconclusive($"Cannot evaluate case {testFullName}: {testCase.TestName}: {doesNotMatchReason}");
                 return;
             }
 
@@ -79,7 +81,7 @@ namespace Hl7.Cql.CqlToElm.Test
             {
                 var expressionValue = LibraryExpressionBuilder.Lambda(expression).Compile().DynamicInvoke(CqlContext);
                 var expectationValue = LibraryExpressionBuilder.Lambda(expectation).Compile().DynamicInvoke(CqlContext);
-                Assert.Fail($"Expected {expectationValue}, but got {expressionValue}");
+                Assert.Fail($"Case {testFullName} assertion failed. Expected '{expectationValue}', but got '{expressionValue}'.");
             }
         }
 

--- a/Cql/CqlToElmTests/XmlTests.cs
+++ b/Cql/CqlToElmTests/XmlTests.cs
@@ -1,5 +1,4 @@
-﻿using FluentAssertions;
-using Hl7.Cql.CqlToElm.Builtin;
+﻿using Hl7.Cql.CqlToElm.Builtin;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Runtime;
@@ -7,13 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace Hl7.Cql.CqlToElm.Test
@@ -21,6 +16,9 @@ namespace Hl7.Cql.CqlToElm.Test
     [TestClass]
     public class XmlTests : Base
     {
+        private static XmlSerializer Serializer = new(typeof(Xml.Tests));
+        private static readonly DateTimeOffset NowValue = new(2020, 1, 2, 3, 4, 0, TimeSpan.Zero);
+
         [ClassInitialize]
 #pragma warning disable IDE0060 // Remove unused parameter
         public static void Initialize(TestContext context) => ClassInitialize(co =>
@@ -29,7 +27,7 @@ namespace Hl7.Cql.CqlToElm.Test
         });
 #pragma warning restore IDE0060 // Remove unused parameter
 
-        private static CqlContext CqlContext = FhirCqlContext.ForBundle();
+        private static CqlContext CqlContext = FhirCqlContext.ForBundle(now: NowValue);
         private static InvocationBuilder InvocationBuilder = Services.GetRequiredService<InvocationBuilder>();
         private static ElmFactory ElmFactory = Services.GetRequiredService<ElmFactory>();
 
@@ -40,31 +38,49 @@ namespace Hl7.Cql.CqlToElm.Test
         {
             if (SkippedTests.DoesNotCompile.TryGetValue(testCase.TestName, out var reason))
                 Assert.Inconclusive($"Case {testCase.Category}: {testCase.TestName} skipped: {reason}");
+
+            // If you want to test a particular case, you can uncomment the following lines
+            // if (testCase.TestName != "AgeInYearsAt")
+            //     Assert.Inconclusive("Skipped!");
+
             var expression = Expression(testCase.Expression);
             var expressionErrors = expression.GetErrors();
             if (expressionErrors.Any())
-                Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expression compiled with errors: {expressionErrors.First().message}");
-            if (testCase.Expectation is not null)
             {
-                var expectation = Expression(testCase.Expectation);
-                var expectationErrors = expectation.GetErrors();
-                if (expectationErrors.Any())
-                    Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expectation compiled with errors: {expressionErrors.First().message}");
-                if (SkippedTests.DoesNotMatchExpectation.TryGetValue(testCase.TestName, out var doesNotMatchReason))
-                    Assert.Inconclusive($"Cannot evaluate case {testCase.Category}: {testCase.TestName}: {doesNotMatchReason}");
-                Elm.Expression equal = Equals(expression, expectation);
-                var equalLambda = LibraryExpressionBuilder.Lambda(equal);
-                var equalDelegate = equalLambda.Compile();
-                var equalResult = (bool?)equalDelegate.DynamicInvoke(CqlContext);
-                if (equalResult != true)
-                {
-                    var expressionValue = LibraryExpressionBuilder.Lambda(expression).Compile().DynamicInvoke(CqlContext);
-                    var expectationValue = LibraryExpressionBuilder.Lambda(expectation).Compile().DynamicInvoke(CqlContext);
-                    Assert.Fail($"Expected {expectationValue}, but got {expressionValue}");
-                }
+                Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expression compiled with errors: {expressionErrors.First().message}");
+                return;
             }
-            else
+
+            if (testCase.Expectation is null)
+            {
                 Assert.Inconclusive($"Case {testCase.Category}: {testCase.TestName} is inconclusive; no expectation provided.");
+                return;
+            }
+
+            var expectation = Expression(testCase.Expectation);
+            var expectationErrors = expectation.GetErrors();
+            if (expectationErrors.Any())
+            {
+                Assert.Fail($"Case {testCase.Category}: {testCase.TestName} expectation compiled with errors: {expressionErrors.First().message}");
+                return;
+            }
+
+            if (SkippedTests.DoesNotMatchExpectation.TryGetValue(testCase.TestName, out var doesNotMatchReason))
+            {
+                Assert.Inconclusive($"Cannot evaluate case {testCase.Category}: {testCase.TestName}: {doesNotMatchReason}");
+                return;
+            }
+
+            Elm.Expression equal = Equals(expression, expectation);
+            var equalLambda = LibraryExpressionBuilder.Lambda(equal);
+            var equalDelegate = equalLambda.Compile();
+            var equalResult = (bool?)equalDelegate.DynamicInvoke(CqlContext);
+            if (equalResult != true)
+            {
+                var expressionValue = LibraryExpressionBuilder.Lambda(expression).Compile().DynamicInvoke(CqlContext);
+                var expectationValue = LibraryExpressionBuilder.Lambda(expectation).Compile().DynamicInvoke(CqlContext);
+                Assert.Fail($"Expected {expectationValue}, but got {expressionValue}");
+            }
         }
 
         private static Elm.Expression Equals(Elm.Expression expression, Elm.Expression expectation)
@@ -92,7 +108,6 @@ namespace Hl7.Cql.CqlToElm.Test
             return $"{tc.File}: {tc.Category}/{tc.TestName}";
         }
 
-        private static XmlSerializer Serializer = new(typeof(Xml.Tests));
         public static IEnumerable<object[]> GetTests()
         {
             var dir = new DirectoryInfo(@"Input\DQIC");

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -5,7 +5,7 @@ using Hl7.Cql.CodeGeneration.NET;
 using Microsoft.CodeAnalysis;
 
 var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
-	.FindParentDirectoryContaining("CqlAndDemo.sln")!;
+	.FindParentDirectoryContaining("*.sln")!;
 
 CSharpCodeWriterTypeFormat csTypeFormat = CSharpCodeWriterTypeFormat.Explicit;
 (string subDir, string measureSubDir)[] iteration = [

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -70,7 +70,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Encounter_to_Document_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834", default(string));
 
     [CqlDeclaration("Encounter to Document Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834")]
@@ -78,7 +78,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		__Encounter_to_Document_Medications.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -86,7 +86,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		__Medical_Reason.Value;
 
 	private CqlCode Documentation_of_current_medications__procedure__Value() => 
-		new CqlCode("428191000124101", "http://snomed.info/sct", null, null);
+		new CqlCode("428191000124101", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Documentation of current medications (procedure)")]
 	public CqlCode Documentation_of_current_medications__procedure_() => 
@@ -95,7 +95,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428191000124101", "http://snomed.info/sct", null, null),
+			new CqlCode("428191000124101", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -107,8 +107,8 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DocumentationofCurrentMedicationsFHIR-0.2.000", "Measurement Period", c_);
 
@@ -121,7 +121,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -178,7 +178,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 	private IEnumerable<Encounter> Qualifying_Encounter_during_day_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_to_Document_Medications();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter ValidEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = ValidEncounter?.StatusElement;
@@ -231,7 +231,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		{
 			CqlCode d_ = this.Documentation_of_current_medications__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
 			bool? g_(Procedure MedicationsDocumented)
 			{
 				DataType k_ = MedicationsDocumented?.Performed;
@@ -240,7 +240,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.End(m_);
 				Period o_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
 				Code<EventStatus> r_ = MedicationsDocumented?.StatusElement;
 				EventStatus? s_ = r_?.Value;
 				string t_ = context.Operators.Convert<string>(s_);
@@ -272,7 +272,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		{
 			CqlCode d_ = this.Documentation_of_current_medications__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
 			bool? g_(Procedure MedicationsNotDocumented)
 			{
 				bool? k_(Extension @this)
@@ -286,7 +286,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				};
 				IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MedicationsNotDocumented is DomainResource)
 						? ((MedicationsNotDocumented as DomainResource).Extension)
-						: null), k_);
+						: default(List<Extension>)), k_);
 				DataType m_(Extension @this)
 				{
 					DataType ai_ = @this?.Value;
@@ -298,7 +298,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
 				Period q_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, null);
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default(string));
 				Code<EventStatus> t_ = MedicationsNotDocumented?.StatusElement;
 				EventStatus? u_ = t_?.Value;
 				string v_ = context.Operators.Convert<string>(u_);

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -70,7 +70,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Encounter_to_Document_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834", default);
 
     [CqlDeclaration("Encounter to Document Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1834")]
@@ -78,7 +78,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		__Encounter_to_Document_Medications.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -86,7 +86,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		__Medical_Reason.Value;
 
 	private CqlCode Documentation_of_current_medications__procedure__Value() => 
-		new CqlCode("428191000124101", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428191000124101", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Documentation of current medications (procedure)")]
 	public CqlCode Documentation_of_current_medications__procedure_() => 
@@ -95,7 +95,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428191000124101", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428191000124101", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -107,8 +107,8 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DocumentationofCurrentMedicationsFHIR-0.2.000", "Measurement Period", c_);
 
@@ -121,7 +121,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -178,7 +178,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 	private IEnumerable<Encounter> Qualifying_Encounter_during_day_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_to_Document_Medications();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter ValidEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = ValidEncounter?.StatusElement;
@@ -231,7 +231,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		{
 			CqlCode d_ = this.Documentation_of_current_medications__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default);
 			bool? g_(Procedure MedicationsDocumented)
 			{
 				DataType k_ = MedicationsDocumented?.Performed;
@@ -240,7 +240,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.End(m_);
 				Period o_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default);
 				Code<EventStatus> r_ = MedicationsDocumented?.StatusElement;
 				EventStatus? s_ = r_?.Value;
 				string t_ = context.Operators.Convert<string>(s_);
@@ -272,7 +272,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 		{
 			CqlCode d_ = this.Documentation_of_current_medications__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default);
 			bool? g_(Procedure MedicationsNotDocumented)
 			{
 				bool? k_(Extension @this)
@@ -286,7 +286,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				};
 				IEnumerable<Extension> l_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MedicationsNotDocumented is DomainResource)
 						? ((MedicationsNotDocumented as DomainResource).Extension)
-						: default(List<Extension>)), k_);
+						: default), k_);
 				DataType m_(Extension @this)
 				{
 					DataType ai_ = @this?.Value;
@@ -298,7 +298,7 @@ public class DocumentationofCurrentMedicationsFHIR_0_2_000
 				CqlDateTime p_ = context.Operators.Convert<CqlDateTime>(o_);
 				Period q_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default(string));
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default);
 				Code<EventStatus> t_ = MedicationsNotDocumented?.StatusElement;
 				EventStatus? u_ = t_?.Value;
 				string v_ = context.Operators.Convert<string>(u_);

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DocumentationofCurrentMedicationsFHIR", "0.2.000")]
 public class DocumentationofCurrentMedicationsFHIR_0_2_000
 {

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -118,28 +118,28 @@ public class FHIRHelpers_4_3_000
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(null, w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(null, y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, null, true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, null, false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
 
 						return ad_;
 					}
@@ -261,11 +261,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -330,11 +330,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -379,7 +379,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((ratio is null))
 			{
-				return null;
+				return default(CqlRatio);
 			}
 			else
 			{
@@ -403,7 +403,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((coding is null))
 			{
-				return null;
+				return default(CqlCode);
 			}
 			else
 			{
@@ -431,7 +431,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((concept is null))
 			{
-				return null;
+				return default(CqlConcept);
 			}
 			else
 			{
@@ -461,7 +461,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((uri is null))
 			{
-				return null;
+				return default(CqlValueSet);
 			}
 			else
 			{
@@ -485,7 +485,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((reference is null))
 			{
-				return null;
+				return default(ResourceReference);
 			}
 			else
 			{

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -118,28 +118,28 @@ public class FHIRHelpers_4_3_000
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default, w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default, y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default, true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default, false, true);
 
 						return ad_;
 					}
@@ -261,11 +261,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -330,11 +330,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -379,7 +379,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((ratio is null))
 			{
-				return default(CqlRatio);
+				return default;
 			}
 			else
 			{
@@ -403,7 +403,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((coding is null))
 			{
-				return default(CqlCode);
+				return default;
 			}
 			else
 			{
@@ -431,7 +431,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((concept is null))
 			{
-				return default(CqlConcept);
+				return default;
 			}
 			else
 			{
@@ -461,7 +461,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((uri is null))
 			{
-				return default(CqlValueSet);
+				return default;
 			}
 			else
 			{
@@ -485,7 +485,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((reference is null))
 			{
-				return default(ResourceReference);
+				return default;
 			}
 			else
 			{

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIRHelpers", "4.3.000")]
 public class FHIRHelpers_4_3_000
 {

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -50,7 +50,7 @@ public class MultipleResourcesExample_0_0_1
     #endregion
 
 	private CqlValueSet Lung_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89", default);
 
     [CqlDeclaration("Lung Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89")]
@@ -58,7 +58,7 @@ public class MultipleResourcesExample_0_0_1
 		__Lung_Cancer.Value;
 
 	private CqlValueSet Condition_Clinical_Status_Value() => 
-		new CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical", default(string));
+		new CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical", default);
 
     [CqlDeclaration("Condition Clinical Status")]
     [CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical")]
@@ -66,7 +66,7 @@ public class MultipleResourcesExample_0_0_1
 		__Condition_Clinical_Status.Value;
 
 	private CqlCode Tobacco_Smoking_Status_Value() => 
-		new CqlCode("72166-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("72166-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("Tobacco Smoking Status")]
 	public CqlCode Tobacco_Smoking_Status() => 
@@ -75,7 +75,7 @@ public class MultipleResourcesExample_0_0_1
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("72166-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72166-2", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -87,7 +87,7 @@ public class MultipleResourcesExample_0_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -101,7 +101,7 @@ public class MultipleResourcesExample_0_0_1
 	{
 		CqlCode a_ = this.Tobacco_Smoking_Status();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation O)
 		{
 			Code<ObservationStatus> f_ = O?.StatusElement;
@@ -126,7 +126,7 @@ public class MultipleResourcesExample_0_0_1
 	private IEnumerable<Condition> Lung_cancer_diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Lung_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition C)
 		{
 			CodeableConcept e_ = C?.ClinicalStatus;

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("MultipleResourcesExample", "0.0.1")]
 public class MultipleResourcesExample_0_0_1
 {

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -50,7 +50,7 @@ public class MultipleResourcesExample_0_0_1
     #endregion
 
 	private CqlValueSet Lung_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89", default(string));
 
     [CqlDeclaration("Lung Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.89")]
@@ -58,7 +58,7 @@ public class MultipleResourcesExample_0_0_1
 		__Lung_Cancer.Value;
 
 	private CqlValueSet Condition_Clinical_Status_Value() => 
-		new CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical", null);
+		new CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical", default(string));
 
     [CqlDeclaration("Condition Clinical Status")]
     [CqlValueSet("http://utah.edu/fhir/lcs-cds/ValueSet/conditionclinical")]
@@ -66,7 +66,7 @@ public class MultipleResourcesExample_0_0_1
 		__Condition_Clinical_Status.Value;
 
 	private CqlCode Tobacco_Smoking_Status_Value() => 
-		new CqlCode("72166-2", "http://loinc.org", null, null);
+		new CqlCode("72166-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Tobacco Smoking Status")]
 	public CqlCode Tobacco_Smoking_Status() => 
@@ -75,7 +75,7 @@ public class MultipleResourcesExample_0_0_1
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("72166-2", "http://loinc.org", null, null),
+			new CqlCode("72166-2", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -87,7 +87,7 @@ public class MultipleResourcesExample_0_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -101,7 +101,7 @@ public class MultipleResourcesExample_0_0_1
 	{
 		CqlCode a_ = this.Tobacco_Smoking_Status();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation O)
 		{
 			Code<ObservationStatus> f_ = O?.StatusElement;
@@ -126,7 +126,7 @@ public class MultipleResourcesExample_0_0_1
 	private IEnumerable<Condition> Lung_cancer_diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Lung_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition C)
 		{
 			CodeableConcept e_ = C?.ClinicalStatus;

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -52,7 +52,7 @@ public class ParametersExample_0_0_1
     #endregion
 
 	private CqlValueSet Marital_Status_Value() => 
-		new CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status", default(string));
+		new CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status", default);
 
     [CqlDeclaration("Marital Status")]
     [CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status")]
@@ -72,7 +72,7 @@ public class ParametersExample_0_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ParametersExample", "0.0.1")]
 public class ParametersExample_0_0_1
 {

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -52,7 +52,7 @@ public class ParametersExample_0_0_1
     #endregion
 
 	private CqlValueSet Marital_Status_Value() => 
-		new CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status", null);
+		new CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status", default(string));
 
     [CqlDeclaration("Marital Status")]
     [CqlValueSet("http://hl7.org/fhir/ValueSet/marital-status")]
@@ -72,7 +72,7 @@ public class ParametersExample_0_0_1
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("QICoreCommon", "2.0.000")]
 public class QICoreCommon_2_0_000
 {

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -184,406 +184,406 @@ public class QICoreCommon_2_0_000
     #endregion
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode field_Value() => 
-		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("field")]
 	public CqlCode field() => 
 		__field.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_encounter_Value() => 
-		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient encounter")]
 	public CqlCode inpatient_encounter() => 
 		__inpatient_encounter.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode observation_encounter_Value() => 
-		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("observation encounter")]
 	public CqlCode observation_encounter() => 
 		__observation_encounter.Value;
 
 	private CqlCode pre_admission_Value() => 
-		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("pre-admission")]
 	public CqlCode pre_admission() => 
 		__pre_admission.Value;
 
 	private CqlCode short_stay_Value() => 
-		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("short stay")]
 	public CqlCode short_stay() => 
 		__short_stay.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode health_concern_Value() => 
-		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null);
+		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("health-concern")]
 	public CqlCode health_concern() => 
 		__health_concern.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode AD_Value() => 
-		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("AD")]
 	public CqlCode AD() => 
 		__AD.Value;
 
 	private CqlCode DD_Value() => 
-		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("DD")]
 	public CqlCode DD() => 
 		__DD.Value;
 
 	private CqlCode CC_Value() => 
-		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("CC")]
 	public CqlCode CC() => 
 		__CC.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode pre_op_Value() => 
-		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("pre-op")]
 	public CqlCode pre_op() => 
 		__pre_op.Value;
 
 	private CqlCode post_op_Value() => 
-		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("post-op")]
 	public CqlCode post_op() => 
 		__post_op.Value;
 
 	private CqlCode billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("billing")]
 	public CqlCode billing() => 
 		__billing.Value;
 
 	private CqlCode social_history_Value() => 
-		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("social-history")]
 	public CqlCode social_history() => 
 		__social_history.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode imaging_Value() => 
-		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("imaging")]
 	public CqlCode imaging() => 
 		__imaging.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode procedure_Value() => 
-		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("procedure")]
 	public CqlCode procedure() => 
 		__procedure.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode therapy_Value() => 
-		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("therapy")]
 	public CqlCode therapy() => 
 		__therapy.Value;
 
 	private CqlCode activity_Value() => 
-		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("activity")]
 	public CqlCode activity() => 
 		__activity.Value;
 
 	private CqlCode clinical_test_Value() => 
-		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null);
+		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string));
 
     [CqlDeclaration("clinical-test")]
 	public CqlCode clinical_test() => 
@@ -592,7 +592,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -605,7 +605,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -618,17 +618,17 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -641,8 +641,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -655,14 +655,14 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
 		];
 
 		return a_;
@@ -687,10 +687,10 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -703,12 +703,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -721,12 +721,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
 		];
 
 		return a_;
@@ -739,9 +739,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -754,9 +754,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -769,15 +769,15 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -790,7 +790,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null),
+			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -803,8 +803,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -817,7 +817,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null),
+			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -829,7 +829,7 @@ public class QICoreCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1316,7 +1316,7 @@ public class QICoreCommon_2_0_000
 		};
 		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
-				: null), a_);
+				: default(IEnumerable<Extension>)), a_);
 		bool? c_(Extension E)
 		{
 			DataType i_ = E?.Value;
@@ -2416,7 +2416,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);
@@ -2439,7 +2439,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -184,406 +184,406 @@ public class QICoreCommon_2_0_000
     #endregion
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode field_Value() => 
-		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("field")]
 	public CqlCode field() => 
 		__field.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_encounter_Value() => 
-		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient encounter")]
 	public CqlCode inpatient_encounter() => 
 		__inpatient_encounter.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode observation_encounter_Value() => 
-		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("observation encounter")]
 	public CqlCode observation_encounter() => 
 		__observation_encounter.Value;
 
 	private CqlCode pre_admission_Value() => 
-		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("pre-admission")]
 	public CqlCode pre_admission() => 
 		__pre_admission.Value;
 
 	private CqlCode short_stay_Value() => 
-		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("short stay")]
 	public CqlCode short_stay() => 
 		__short_stay.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode health_concern_Value() => 
-		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("health-concern")]
 	public CqlCode health_concern() => 
 		__health_concern.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode AD_Value() => 
-		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("AD")]
 	public CqlCode AD() => 
 		__AD.Value;
 
 	private CqlCode DD_Value() => 
-		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("DD")]
 	public CqlCode DD() => 
 		__DD.Value;
 
 	private CqlCode CC_Value() => 
-		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("CC")]
 	public CqlCode CC() => 
 		__CC.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode pre_op_Value() => 
-		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("pre-op")]
 	public CqlCode pre_op() => 
 		__pre_op.Value;
 
 	private CqlCode post_op_Value() => 
-		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("post-op")]
 	public CqlCode post_op() => 
 		__post_op.Value;
 
 	private CqlCode billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("billing")]
 	public CqlCode billing() => 
 		__billing.Value;
 
 	private CqlCode social_history_Value() => 
-		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("social-history")]
 	public CqlCode social_history() => 
 		__social_history.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode imaging_Value() => 
-		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("imaging")]
 	public CqlCode imaging() => 
 		__imaging.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode procedure_Value() => 
-		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("procedure")]
 	public CqlCode procedure() => 
 		__procedure.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode therapy_Value() => 
-		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("therapy")]
 	public CqlCode therapy() => 
 		__therapy.Value;
 
 	private CqlCode activity_Value() => 
-		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("activity")]
 	public CqlCode activity() => 
 		__activity.Value;
 
 	private CqlCode clinical_test_Value() => 
-		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string));
+		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default, default);
 
     [CqlDeclaration("clinical-test")]
 	public CqlCode clinical_test() => 
@@ -592,7 +592,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -605,7 +605,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -618,17 +618,17 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -641,8 +641,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
 		];
 
 		return a_;
@@ -655,14 +655,14 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
 		];
 
 		return a_;
@@ -687,10 +687,10 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
 		];
 
 		return a_;
@@ -703,12 +703,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -721,12 +721,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
 		];
 
 		return a_;
@@ -739,9 +739,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
 		];
 
 		return a_;
@@ -754,9 +754,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
 		];
 
 		return a_;
@@ -769,15 +769,15 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -790,7 +790,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string)),
+			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default, default),
 		];
 
 		return a_;
@@ -803,8 +803,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
 		];
 
 		return a_;
@@ -817,7 +817,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default, default),
 		];
 
 		return a_;
@@ -829,7 +829,7 @@ public class QICoreCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1316,7 +1316,7 @@ public class QICoreCommon_2_0_000
 		};
 		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
-				: default(IEnumerable<Extension>)), a_);
+				: default), a_);
 		bool? c_(Extension E)
 		{
 			DataType i_ = E?.Value;
@@ -2416,7 +2416,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);
@@ -2439,7 +2439,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -52,35 +52,35 @@ public class Status_1_6_000
     #endregion
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -89,10 +89,10 @@ public class Status_1_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -105,7 +105,7 @@ public class Status_1_6_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -117,7 +117,7 @@ public class Status_1_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -52,35 +52,35 @@ public class Status_1_6_000
     #endregion
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -89,10 +89,10 @@ public class Status_1_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -105,7 +105,7 @@ public class Status_1_6_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -117,7 +117,7 @@ public class Status_1_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Status", "1.6.000")]
 public class Status_1_6_000
 {

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElements_3_4_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElements_3_4_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElements_3_4_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElements_3_4_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElements_3_4_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -146,7 +146,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -171,7 +171,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), y_);
+					: default), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -199,7 +199,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), af_);
+					: default), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -226,7 +226,7 @@ public class SupplementalDataElements_3_4_000
 	private IEnumerable<(CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer_Type();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default);
 		(CqlConcept code, CqlInterval<CqlDateTime> period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -265,7 +265,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -295,7 +295,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -322,7 +322,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), w_);
+					: default), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -350,7 +350,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), ad_);
+					: default), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -408,7 +408,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(CqlCode);
+				return default;
 			}
 		};
 

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("SupplementalDataElements", "3.4.000")]
 public class SupplementalDataElements_3_4_000
 {

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElements_3_4_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElements_3_4_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElements_3_4_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElements_3_4_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElements_3_4_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -146,7 +146,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -171,7 +171,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), y_);
+					: default(List<Extension>)), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -199,7 +199,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), af_);
+					: default(List<Extension>)), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -226,7 +226,7 @@ public class SupplementalDataElements_3_4_000
 	private IEnumerable<(CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer_Type();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
 		(CqlConcept code, CqlInterval<CqlDateTime> period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -265,7 +265,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -295,7 +295,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -322,7 +322,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), w_);
+					: default(List<Extension>)), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -350,7 +350,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), ad_);
+					: default(List<Extension>)), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -408,7 +408,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(CqlCode);
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
@@ -96,7 +96,7 @@ public class AHAOverall_2_6_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -104,7 +104,7 @@ public class AHAOverall_2_6_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Ejection_Fraction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", default);
 
     [CqlDeclaration("Ejection Fraction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134")]
@@ -112,7 +112,7 @@ public class AHAOverall_2_6_000
 		__Ejection_Fraction.Value;
 
 	private CqlValueSet Heart_Failure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default);
 
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
@@ -120,7 +120,7 @@ public class AHAOverall_2_6_000
 		__Heart_Failure.Value;
 
 	private CqlValueSet Heart_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33", default);
 
     [CqlDeclaration("Heart Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33")]
@@ -128,7 +128,7 @@ public class AHAOverall_2_6_000
 		__Heart_Transplant.Value;
 
 	private CqlValueSet Heart_Transplant_Complications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56", default);
 
     [CqlDeclaration("Heart Transplant Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56")]
@@ -136,7 +136,7 @@ public class AHAOverall_2_6_000
 		__Heart_Transplant_Complications.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -144,7 +144,7 @@ public class AHAOverall_2_6_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Complications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58", default);
 
     [CqlDeclaration("Left Ventricular Assist Device Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58")]
@@ -152,7 +152,7 @@ public class AHAOverall_2_6_000
 		__Left_Ventricular_Assist_Device_Complications.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default);
 
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
@@ -160,7 +160,7 @@ public class AHAOverall_2_6_000
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
 	private CqlValueSet Moderate_or_Severe_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", default);
 
     [CqlDeclaration("Moderate or Severe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092")]
@@ -168,7 +168,7 @@ public class AHAOverall_2_6_000
 		__Moderate_or_Severe.Value;
 
 	private CqlValueSet Moderate_or_Severe_LVSD_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", default);
 
     [CqlDeclaration("Moderate or Severe LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090")]
@@ -176,7 +176,7 @@ public class AHAOverall_2_6_000
 		__Moderate_or_Severe_LVSD.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -184,7 +184,7 @@ public class AHAOverall_2_6_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -192,7 +192,7 @@ public class AHAOverall_2_6_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -200,7 +200,7 @@ public class AHAOverall_2_6_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default);
 
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
@@ -208,14 +208,14 @@ public class AHAOverall_2_6_000
 		__Patient_Provider_Interaction.Value;
 
 	private CqlCode Left_ventricular_systolic_dysfunction__disorder__Value() => 
-		new CqlCode("134401001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("134401001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Left ventricular systolic dysfunction (disorder)")]
 	public CqlCode Left_ventricular_systolic_dysfunction__disorder_() => 
 		__Left_ventricular_systolic_dysfunction__disorder_.Value;
 
 	private CqlCode allergy_entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-entered-in-error")]
 	public CqlCode allergy_entered_in_error() => 
@@ -224,7 +224,7 @@ public class AHAOverall_2_6_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("134401001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("134401001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -237,7 +237,7 @@ public class AHAOverall_2_6_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
 		];
 
 		return a_;
@@ -249,8 +249,8 @@ public class AHAOverall_2_6_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AHAOverall-2.6.000", "Measurement Period", c_);
 
@@ -263,7 +263,7 @@ public class AHAOverall_2_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -327,29 +327,29 @@ public class AHAOverall_2_6_000
 	private IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Office_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		IEnumerable<Encounter> o_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet s_ = this.Heart_Failure();
-			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
+			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default);
 			bool? u_(Condition HeartFailure)
 			{
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(HeartFailure);
 				Period z_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				bool? ab_ = context.Operators.Overlaps(y_, aa_, default(string));
+				bool? ab_ = context.Operators.Overlaps(y_, aa_, default);
 				bool? ac_ = this.isConfirmedActiveDiagnosis(HeartFailure);
 				bool? ad_ = context.Operators.And(ab_, ac_);
 
@@ -368,7 +368,7 @@ public class AHAOverall_2_6_000
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
 			Period af_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, default(string));
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, default);
 			bool? ai_ = this.isFinished(QualifyingEncounter);
 			bool? aj_ = context.Operators.And(ah_, ai_);
 
@@ -386,7 +386,7 @@ public class AHAOverall_2_6_000
 	private IEnumerable<object> Moderate_or_Severe_LVSD_Findings_Value()
 	{
 		CqlValueSet a_ = this.Ejection_Fraction();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation EjectionFraction)
 		{
 			DataType n_ = EjectionFraction?.Value;
@@ -409,11 +409,11 @@ public class AHAOverall_2_6_000
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		CqlValueSet e_ = this.Moderate_or_Severe_LVSD();
-		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
+		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default);
 		IEnumerable<object> g_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (f_ as IEnumerable<object>));
 		CqlCode h_ = this.Left_ventricular_systolic_dysfunction__disorder_();
 		IEnumerable<CqlCode> i_ = context.Operators.ToList<CqlCode>(h_);
-		IEnumerable<Condition> j_ = context.Operators.RetrieveByCodes<Condition>(i_, default(PropertyInfo));
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByCodes<Condition>(i_, default);
 		bool? k_(Condition LVSDDiagnosis)
 		{
 			CodeableConcept y_ = LVSDDiagnosis?.Severity;
@@ -449,7 +449,7 @@ public class AHAOverall_2_6_000
 				Period n_ = HFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime p_ = context.Operators.End(o_);
-				bool? q_ = context.Operators.Before(m_, p_, default(string));
+				bool? q_ = context.Operators.Before(m_, p_, default);
 
 				return q_;
 			};
@@ -472,7 +472,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Heart_Transplant_Complications_Value()
 	{
 		CqlValueSet a_ = this.Heart_Transplant_Complications();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition HeartTransplantComplications)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -486,7 +486,7 @@ public class AHAOverall_2_6_000
 				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(q_, t_, default(string));
+				bool? u_ = context.Operators.Before(q_, t_, default);
 
 				return u_;
 			};
@@ -517,7 +517,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Left_Ventricular_Assist_Device_Value()
 	{
 		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Placement();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_(Procedure LVADOutpatient)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -530,7 +530,7 @@ public class AHAOverall_2_6_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, default(string));
+				bool? t_ = context.Operators.Before(p_, s_, default);
 
 				return t_;
 			};
@@ -564,7 +564,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Left_Ventricular_Assist_Device_Complications_Value()
 	{
 		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Complications();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition LVADComplications)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -578,7 +578,7 @@ public class AHAOverall_2_6_000
 				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(q_, t_, default(string));
+				bool? u_ = context.Operators.Before(q_, t_, default);
 
 				return u_;
 			};
@@ -609,20 +609,20 @@ public class AHAOverall_2_6_000
 	private IEnumerable<Encounter> Qualifying_Outpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Office_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Patient_Provider_Interaction();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter ValidEncounter)
@@ -630,7 +630,7 @@ public class AHAOverall_2_6_000
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			Period u_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default(string));
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default);
 			bool? x_ = this.isFinished(ValidEncounter);
 			bool? y_ = context.Operators.And(w_, x_);
 
@@ -695,7 +695,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Heart_Transplant_Value()
 	{
 		CqlValueSet a_ = this.Heart_Transplant();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_(Procedure HeartTransplant)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -708,7 +708,7 @@ public class AHAOverall_2_6_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, default(string));
+				bool? t_ = context.Operators.Before(p_, s_, default);
 
 				return t_;
 			};
@@ -951,7 +951,7 @@ public class AHAOverall_2_6_000
 						return dk_;
 					};
 					IEnumerable<CqlInterval<CqlDateTime>> ca_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)by_, bz_);
-					IEnumerable<CqlInterval<CqlDateTime>> cb_ = context.Operators.Collapse(ca_, default(string));
+					IEnumerable<CqlInterval<CqlDateTime>> cb_ = context.Operators.Collapse(ca_, default);
 					object cc_(CqlInterval<CqlDateTime> @this)
 					{
 						CqlDateTime dl_ = context.Operators.Start(@this);

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AHAOverall", "2.6.000")]
 public class AHAOverall_2_6_000
 {

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.6.000.g.cs
@@ -96,7 +96,7 @@ public class AHAOverall_2_6_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -104,7 +104,7 @@ public class AHAOverall_2_6_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Ejection_Fraction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", default(string));
 
     [CqlDeclaration("Ejection Fraction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134")]
@@ -112,7 +112,7 @@ public class AHAOverall_2_6_000
 		__Ejection_Fraction.Value;
 
 	private CqlValueSet Heart_Failure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default(string));
 
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
@@ -120,7 +120,7 @@ public class AHAOverall_2_6_000
 		__Heart_Failure.Value;
 
 	private CqlValueSet Heart_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33", default(string));
 
     [CqlDeclaration("Heart Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.33")]
@@ -128,7 +128,7 @@ public class AHAOverall_2_6_000
 		__Heart_Transplant.Value;
 
 	private CqlValueSet Heart_Transplant_Complications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56", default(string));
 
     [CqlDeclaration("Heart Transplant Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.56")]
@@ -136,7 +136,7 @@ public class AHAOverall_2_6_000
 		__Heart_Transplant_Complications.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -144,7 +144,7 @@ public class AHAOverall_2_6_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Complications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58", default(string));
 
     [CqlDeclaration("Left Ventricular Assist Device Complications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.58")]
@@ -152,7 +152,7 @@ public class AHAOverall_2_6_000
 		__Left_Ventricular_Assist_Device_Complications.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default(string));
 
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
@@ -160,7 +160,7 @@ public class AHAOverall_2_6_000
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
 	private CqlValueSet Moderate_or_Severe_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", default(string));
 
     [CqlDeclaration("Moderate or Severe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092")]
@@ -168,7 +168,7 @@ public class AHAOverall_2_6_000
 		__Moderate_or_Severe.Value;
 
 	private CqlValueSet Moderate_or_Severe_LVSD_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", default(string));
 
     [CqlDeclaration("Moderate or Severe LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090")]
@@ -176,7 +176,7 @@ public class AHAOverall_2_6_000
 		__Moderate_or_Severe_LVSD.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -184,7 +184,7 @@ public class AHAOverall_2_6_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -192,7 +192,7 @@ public class AHAOverall_2_6_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -200,7 +200,7 @@ public class AHAOverall_2_6_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default(string));
 
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
@@ -208,14 +208,14 @@ public class AHAOverall_2_6_000
 		__Patient_Provider_Interaction.Value;
 
 	private CqlCode Left_ventricular_systolic_dysfunction__disorder__Value() => 
-		new CqlCode("134401001", "http://snomed.info/sct", null, null);
+		new CqlCode("134401001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Left ventricular systolic dysfunction (disorder)")]
 	public CqlCode Left_ventricular_systolic_dysfunction__disorder_() => 
 		__Left_ventricular_systolic_dysfunction__disorder_.Value;
 
 	private CqlCode allergy_entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-entered-in-error")]
 	public CqlCode allergy_entered_in_error() => 
@@ -224,7 +224,7 @@ public class AHAOverall_2_6_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("134401001", "http://snomed.info/sct", null, null),
+			new CqlCode("134401001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -237,7 +237,7 @@ public class AHAOverall_2_6_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -249,8 +249,8 @@ public class AHAOverall_2_6_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AHAOverall-2.6.000", "Measurement Period", c_);
 
@@ -263,7 +263,7 @@ public class AHAOverall_2_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -327,29 +327,29 @@ public class AHAOverall_2_6_000
 	private IEnumerable<Encounter> Heart_Failure_Outpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Office_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		IEnumerable<Encounter> o_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet s_ = this.Heart_Failure();
-			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
 			bool? u_(Condition HeartFailure)
 			{
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(HeartFailure);
 				Period z_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				bool? ab_ = context.Operators.Overlaps(y_, aa_, null);
+				bool? ab_ = context.Operators.Overlaps(y_, aa_, default(string));
 				bool? ac_ = this.isConfirmedActiveDiagnosis(HeartFailure);
 				bool? ad_ = context.Operators.And(ab_, ac_);
 
@@ -368,7 +368,7 @@ public class AHAOverall_2_6_000
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
 			Period af_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, null);
+			bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ae_, ag_, default(string));
 			bool? ai_ = this.isFinished(QualifyingEncounter);
 			bool? aj_ = context.Operators.And(ah_, ai_);
 
@@ -386,7 +386,7 @@ public class AHAOverall_2_6_000
 	private IEnumerable<object> Moderate_or_Severe_LVSD_Findings_Value()
 	{
 		CqlValueSet a_ = this.Ejection_Fraction();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation EjectionFraction)
 		{
 			DataType n_ = EjectionFraction?.Value;
@@ -409,11 +409,11 @@ public class AHAOverall_2_6_000
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		CqlValueSet e_ = this.Moderate_or_Severe_LVSD();
-		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
 		IEnumerable<object> g_ = context.Operators.Union<object>((d_ as IEnumerable<object>), (f_ as IEnumerable<object>));
 		CqlCode h_ = this.Left_ventricular_systolic_dysfunction__disorder_();
 		IEnumerable<CqlCode> i_ = context.Operators.ToList<CqlCode>(h_);
-		IEnumerable<Condition> j_ = context.Operators.RetrieveByCodes<Condition>(i_, null);
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByCodes<Condition>(i_, default(PropertyInfo));
 		bool? k_(Condition LVSDDiagnosis)
 		{
 			CodeableConcept y_ = LVSDDiagnosis?.Severity;
@@ -449,7 +449,7 @@ public class AHAOverall_2_6_000
 				Period n_ = HFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime p_ = context.Operators.End(o_);
-				bool? q_ = context.Operators.Before(m_, p_, null);
+				bool? q_ = context.Operators.Before(m_, p_, default(string));
 
 				return q_;
 			};
@@ -472,7 +472,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Heart_Transplant_Complications_Value()
 	{
 		CqlValueSet a_ = this.Heart_Transplant_Complications();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition HeartTransplantComplications)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -486,7 +486,7 @@ public class AHAOverall_2_6_000
 				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(q_, t_, null);
+				bool? u_ = context.Operators.Before(q_, t_, default(string));
 
 				return u_;
 			};
@@ -517,7 +517,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Left_Ventricular_Assist_Device_Value()
 	{
 		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Placement();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_(Procedure LVADOutpatient)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -530,7 +530,7 @@ public class AHAOverall_2_6_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, null);
+				bool? t_ = context.Operators.Before(p_, s_, default(string));
 
 				return t_;
 			};
@@ -564,7 +564,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Left_Ventricular_Assist_Device_Complications_Value()
 	{
 		CqlValueSet a_ = this.Left_Ventricular_Assist_Device_Complications();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition LVADComplications)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -578,7 +578,7 @@ public class AHAOverall_2_6_000
 				Period r_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(q_, t_, null);
+				bool? u_ = context.Operators.Before(q_, t_, default(string));
 
 				return u_;
 			};
@@ -609,20 +609,20 @@ public class AHAOverall_2_6_000
 	private IEnumerable<Encounter> Qualifying_Outpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Office_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Patient_Provider_Interaction();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter ValidEncounter)
@@ -630,7 +630,7 @@ public class AHAOverall_2_6_000
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			Period u_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_3_000.ToInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default(string));
 			bool? x_ = this.isFinished(ValidEncounter);
 			bool? y_ = context.Operators.And(w_, x_);
 
@@ -695,7 +695,7 @@ public class AHAOverall_2_6_000
 	private bool? Has_Heart_Transplant_Value()
 	{
 		CqlValueSet a_ = this.Heart_Transplant();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_(Procedure HeartTransplant)
 		{
 			IEnumerable<Encounter> h_ = this.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -708,7 +708,7 @@ public class AHAOverall_2_6_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, null);
+				bool? t_ = context.Operators.Before(p_, s_, default(string));
 
 				return t_;
 			};
@@ -951,7 +951,7 @@ public class AHAOverall_2_6_000
 						return dk_;
 					};
 					IEnumerable<CqlInterval<CqlDateTime>> ca_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>((IEnumerable<object>)by_, bz_);
-					IEnumerable<CqlInterval<CqlDateTime>> cb_ = context.Operators.Collapse(ca_, null);
+					IEnumerable<CqlInterval<CqlDateTime>> cb_ = context.Operators.Collapse(ca_, default(string));
 					object cc_(CqlInterval<CqlDateTime> @this)
 					{
 						CqlDateTime dl_ = context.Operators.Start(@this);

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ALARACTOQRFHIR", "0.1.001")]
 public class ALARACTOQRFHIR_0_1_001
 {

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
@@ -74,7 +74,7 @@ public class ALARACTOQRFHIR_0_1_001
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -82,21 +82,21 @@ public class ALARACTOQRFHIR_0_1_001
 		__Encounter_Inpatient.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", null, null);
+		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", null, null);
+		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", null, null);
+		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -105,9 +105,9 @@ public class ALARACTOQRFHIR_0_1_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96912-1", "http://loinc.org", null, null),
-			new CqlCode("96913-9", "http://loinc.org", null, null),
-			new CqlCode("96914-7", "http://loinc.org", null, null),
+			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -119,8 +119,8 @@ public class ALARACTOQRFHIR_0_1_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ALARACTOQRFHIR-0.1.001", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class ALARACTOQRFHIR_0_1_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -147,14 +147,14 @@ public class ALARACTOQRFHIR_0_1_001
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation CTScan)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = CTScan?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default(string));
 			Patient k_ = this.Patient();
 			Date l_ = k_?.BirthDateElement;
 			string m_ = l_?.Value;
@@ -182,14 +182,14 @@ public class ALARACTOQRFHIR_0_1_001
 		IEnumerable<Observation> c_(Observation CTScan)
 		{
 			CqlValueSet f_ = this.Encounter_Inpatient();
-			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 			bool? h_(Encounter InpatientEncounter)
 			{
 				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 				DataType m_ = CTScan?.Effective;
 				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
-				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
 
 				return p_;
 			};

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.1.001.g.cs
@@ -74,7 +74,7 @@ public class ALARACTOQRFHIR_0_1_001
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -82,21 +82,21 @@ public class ALARACTOQRFHIR_0_1_001
 		__Encounter_Inpatient.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("96912-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("96913-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("96914-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -105,9 +105,9 @@ public class ALARACTOQRFHIR_0_1_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96912-1", "http://loinc.org", default, default),
+			new CqlCode("96913-9", "http://loinc.org", default, default),
+			new CqlCode("96914-7", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -119,8 +119,8 @@ public class ALARACTOQRFHIR_0_1_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ALARACTOQRFHIR-0.1.001", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class ALARACTOQRFHIR_0_1_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -147,14 +147,14 @@ public class ALARACTOQRFHIR_0_1_001
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation CTScan)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = CTScan?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default(string));
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default);
 			Patient k_ = this.Patient();
 			Date l_ = k_?.BirthDateElement;
 			string m_ = l_?.Value;
@@ -182,14 +182,14 @@ public class ALARACTOQRFHIR_0_1_001
 		IEnumerable<Observation> c_(Observation CTScan)
 		{
 			CqlValueSet f_ = this.Encounter_Inpatient();
-			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 			bool? h_(Encounter InpatientEncounter)
 			{
 				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 				DataType m_ = CTScan?.Effective;
 				object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
-				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
+				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default);
 
 				return p_;
 			};

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
@@ -60,7 +60,7 @@ public class AdultOutpatientEncounters_4_8_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -68,7 +68,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -76,7 +76,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -84,7 +84,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -92,7 +92,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -100,7 +100,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -108,7 +108,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -128,7 +128,7 @@ public class AdultOutpatientEncounters_4_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -141,24 +141,24 @@ public class AdultOutpatientEncounters_4_8_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounter)

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AdultOutpatientEncounters", "4.8.000")]
 public class AdultOutpatientEncounters_4_8_000
 {

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.8.000.g.cs
@@ -60,7 +60,7 @@ public class AdultOutpatientEncounters_4_8_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -68,7 +68,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -76,7 +76,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -84,7 +84,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -92,7 +92,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -100,7 +100,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -108,7 +108,7 @@ public class AdultOutpatientEncounters_4_8_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -128,7 +128,7 @@ public class AdultOutpatientEncounters_4_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -141,24 +141,24 @@ public class AdultOutpatientEncounters_4_8_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounter)

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AdvancedIllnessandFrailty", "1.8.000")]
 public class AdvancedIllnessandFrailty_1_8_000
 {

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
@@ -96,7 +96,7 @@ public class AdvancedIllnessandFrailty_1_8_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -104,7 +104,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -112,7 +112,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -120,7 +120,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
 
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -128,7 +128,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -136,7 +136,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -144,7 +144,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -152,7 +152,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -160,7 +160,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -168,7 +168,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -176,7 +176,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Observation.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -184,21 +184,21 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Outpatient.Value;
 
 	private CqlCode Housing_status_Value() => 
-		new CqlCode("71802-3", "http://loinc.org", null, null);
+		new CqlCode("71802-3", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Housing status")]
 	public CqlCode Housing_status() => 
 		__Housing_status.Value;
 
 	private CqlCode Lives_in_a_nursing_home__finding__Value() => 
-		new CqlCode("160734000", "http://snomed.info/sct", null, null);
+		new CqlCode("160734000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Lives in a nursing home (finding)")]
 	public CqlCode Lives_in_a_nursing_home__finding_() => 
 		__Lives_in_a_nursing_home__finding_.Value;
 
 	private CqlCode Medical_equipment_used_Value() => 
-		new CqlCode("98181-1", "http://loinc.org", null, null);
+		new CqlCode("98181-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Medical equipment used")]
 	public CqlCode Medical_equipment_used() => 
@@ -207,8 +207,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71802-3", "http://loinc.org", null, null),
-			new CqlCode("98181-1", "http://loinc.org", null, null),
+			new CqlCode("71802-3", "http://loinc.org", default(string), default(string)),
+			new CqlCode("98181-1", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -221,7 +221,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("160734000", "http://snomed.info/sct", null, null),
+			new CqlCode("160734000", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -244,7 +244,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -257,8 +257,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
-		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
+		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
+		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
 		IEnumerable<DeviceRequest> e_ = context.Operators.Union<DeviceRequest>(b_, d_);
 		IEnumerable<DeviceRequest> f_ = Status_1_6_000.isDeviceOrder(e_);
 		bool? g_(DeviceRequest FrailtyDeviceOrder)
@@ -279,7 +279,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? i_ = context.Operators.Exists<DeviceRequest>(h_);
 		CqlCode j_ = this.Medical_equipment_used();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, null);
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default(PropertyInfo));
 		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
 		bool? n_(Observation EquipmentUsed)
 		{
@@ -301,7 +301,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? p_ = context.Operators.Exists<Observation>(o_);
 		bool? q_ = context.Operators.Or(i_, p_);
 		CqlValueSet r_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default(PropertyInfo));
 		bool? t_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.prevalenceInterval(FrailtyDiagnosis);
@@ -314,7 +314,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? v_ = context.Operators.Exists<Condition>(u_);
 		bool? w_ = context.Operators.Or(q_, v_);
 		CqlValueSet x_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
 		bool? aa_(Encounter FrailtyEncounter)
 		{
@@ -330,7 +330,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? ac_ = context.Operators.Exists<Encounter>(ab_);
 		bool? ad_ = context.Operators.Or(w_, ac_);
 		CqlValueSet ae_ = this.Frailty_Symptom();
-		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, null);
+		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default(PropertyInfo));
 		IEnumerable<Observation> ag_ = Status_1_6_000.isSymptom(af_);
 		bool? ah_(Observation FrailtySymptom)
 		{
@@ -356,14 +356,14 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		IEnumerable<Encounter> l_ = Status_1_6_000.isEncounterPerformed(k_);
@@ -446,7 +446,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
@@ -490,8 +490,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest DementiaMedication)
@@ -567,7 +567,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
@@ -606,7 +606,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
 		CqlCode j_ = this.Housing_status();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, null);
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default(PropertyInfo));
 		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
 		bool? n_(Observation HousingStatus)
 		{

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.8.000.g.cs
@@ -96,7 +96,7 @@ public class AdvancedIllnessandFrailty_1_8_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -104,7 +104,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -112,7 +112,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -120,7 +120,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default);
 
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -128,7 +128,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -136,7 +136,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -144,7 +144,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -152,7 +152,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -160,7 +160,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -168,7 +168,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -176,7 +176,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Observation.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -184,21 +184,21 @@ public class AdvancedIllnessandFrailty_1_8_000
 		__Outpatient.Value;
 
 	private CqlCode Housing_status_Value() => 
-		new CqlCode("71802-3", "http://loinc.org", default(string), default(string));
+		new CqlCode("71802-3", "http://loinc.org", default, default);
 
     [CqlDeclaration("Housing status")]
 	public CqlCode Housing_status() => 
 		__Housing_status.Value;
 
 	private CqlCode Lives_in_a_nursing_home__finding__Value() => 
-		new CqlCode("160734000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("160734000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Lives in a nursing home (finding)")]
 	public CqlCode Lives_in_a_nursing_home__finding_() => 
 		__Lives_in_a_nursing_home__finding_.Value;
 
 	private CqlCode Medical_equipment_used_Value() => 
-		new CqlCode("98181-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("98181-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Medical equipment used")]
 	public CqlCode Medical_equipment_used() => 
@@ -207,8 +207,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71802-3", "http://loinc.org", default(string), default(string)),
-			new CqlCode("98181-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71802-3", "http://loinc.org", default, default),
+			new CqlCode("98181-1", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -221,7 +221,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("160734000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("160734000", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -244,7 +244,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -257,8 +257,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
-		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
+		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default);
+		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default);
 		IEnumerable<DeviceRequest> e_ = context.Operators.Union<DeviceRequest>(b_, d_);
 		IEnumerable<DeviceRequest> f_ = Status_1_6_000.isDeviceOrder(e_);
 		bool? g_(DeviceRequest FrailtyDeviceOrder)
@@ -279,7 +279,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? i_ = context.Operators.Exists<DeviceRequest>(h_);
 		CqlCode j_ = this.Medical_equipment_used();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default(PropertyInfo));
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default);
 		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
 		bool? n_(Observation EquipmentUsed)
 		{
@@ -301,7 +301,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? p_ = context.Operators.Exists<Observation>(o_);
 		bool? q_ = context.Operators.Or(i_, p_);
 		CqlValueSet r_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default(PropertyInfo));
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default);
 		bool? t_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_0_000.prevalenceInterval(FrailtyDiagnosis);
@@ -314,7 +314,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? v_ = context.Operators.Exists<Condition>(u_);
 		bool? w_ = context.Operators.Or(q_, v_);
 		CqlValueSet x_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
 		bool? aa_(Encounter FrailtyEncounter)
 		{
@@ -330,7 +330,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? ac_ = context.Operators.Exists<Encounter>(ab_);
 		bool? ad_ = context.Operators.Or(w_, ac_);
 		CqlValueSet ae_ = this.Frailty_Symptom();
-		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default(PropertyInfo));
+		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default);
 		IEnumerable<Observation> ag_ = Status_1_6_000.isSymptom(af_);
 		bool? ah_(Observation FrailtySymptom)
 		{
@@ -356,14 +356,14 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		IEnumerable<Encounter> l_ = Status_1_6_000.isEncounterPerformed(k_);
@@ -446,7 +446,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
@@ -490,8 +490,8 @@ public class AdvancedIllnessandFrailty_1_8_000
 	private bool? Has_Dementia_Medications_in_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest DementiaMedication)
@@ -567,7 +567,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Has_Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
@@ -606,7 +606,7 @@ public class AdvancedIllnessandFrailty_1_8_000
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 66);
 		CqlCode j_ = this.Housing_status();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default(PropertyInfo));
+		IEnumerable<Observation> l_ = context.Operators.RetrieveByCodes<Observation>(k_, default);
 		IEnumerable<Observation> m_ = Status_1_6_000.isAssessmentPerformed(l_);
 		bool? n_(Observation HousingStatus)
 		{

--- a/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
@@ -76,28 +76,28 @@ public class AlaraCTFHIR_0_1_001
     #endregion
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("96912-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("96913-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("96914-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -106,10 +106,10 @@ public class AlaraCTFHIR_0_1_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
+			new CqlCode("96912-1", "http://loinc.org", default, default),
+			new CqlCode("96913-9", "http://loinc.org", default, default),
+			new CqlCode("96914-7", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -121,8 +121,8 @@ public class AlaraCTFHIR_0_1_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AlaraCTFHIR-0.1.001", "Measurement Period", c_);
 
@@ -135,7 +135,7 @@ public class AlaraCTFHIR_0_1_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -193,14 +193,14 @@ public class AlaraCTFHIR_0_1_001
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation CTScanResult)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = CTScanResult?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default(string));
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default);
 			Patient k_ = this.Patient();
 			Date l_ = k_?.BirthDateElement;
 			string m_ = l_?.Value;

--- a/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AlaraCTFHIR", "0.1.001")]
 public class AlaraCTFHIR_0_1_001
 {

--- a/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTFHIR-0.1.001.g.cs
@@ -76,28 +76,28 @@ public class AlaraCTFHIR_0_1_001
     #endregion
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", null, null);
+		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", null, null);
+		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", null, null);
+		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -106,10 +106,10 @@ public class AlaraCTFHIR_0_1_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
-			new CqlCode("96912-1", "http://loinc.org", null, null),
-			new CqlCode("96913-9", "http://loinc.org", null, null),
-			new CqlCode("96914-7", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -121,8 +121,8 @@ public class AlaraCTFHIR_0_1_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AlaraCTFHIR-0.1.001", "Measurement Period", c_);
 
@@ -135,7 +135,7 @@ public class AlaraCTFHIR_0_1_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -193,14 +193,14 @@ public class AlaraCTFHIR_0_1_001
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation CTScanResult)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = CTScanResult?.Effective;
 			object h_ = FHIRHelpers_4_3_000.ToValue(g_);
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, null);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, i_, default(string));
 			Patient k_ = this.Patient();
 			Date l_ = k_?.BirthDateElement;
 			string m_ = l_?.Value;

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AlaraCTIQRFHIR", "0.1.000")]
 public class AlaraCTIQRFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
@@ -74,7 +74,7 @@ public class AlaraCTIQRFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -82,21 +82,21 @@ public class AlaraCTIQRFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("96912-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("96913-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("96914-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -105,9 +105,9 @@ public class AlaraCTIQRFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96912-1", "http://loinc.org", default, default),
+			new CqlCode("96913-9", "http://loinc.org", default, default),
+			new CqlCode("96914-7", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -119,8 +119,8 @@ public class AlaraCTIQRFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AlaraCTIQRFHIR-0.1.000", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class AlaraCTIQRFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -146,13 +146,13 @@ public class AlaraCTIQRFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Period e_ = InpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 			Patient i_ = this.Patient();
 			Date j_ = i_?.BirthDateElement;
 			string k_ = j_?.Value;
@@ -222,7 +222,7 @@ public class AlaraCTIQRFHIR_0_1_000
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_(Observation CTScan)
 		{
 			IEnumerable<Encounter> f_ = this.Qualifying_Inpatient_Encounters();
@@ -234,11 +234,11 @@ public class AlaraCTIQRFHIR_0_1_000
 				CqlDateTime n_ = context.Operators.Start(m_);
 				Period o_ = InpatientEncounters?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default);
 				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 				object t_ = FHIRHelpers_4_3_000.ToValue(k_);
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
-				bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, default(string));
+				bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, default);
 				bool? w_ = context.Operators.And(q_, v_);
 
 				return w_;

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.1.000.g.cs
@@ -74,7 +74,7 @@ public class AlaraCTIQRFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -82,21 +82,21 @@ public class AlaraCTIQRFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlCode Calculated_CT_global_noise_Value() => 
-		new CqlCode("96912-1", "http://loinc.org", null, null);
+		new CqlCode("96912-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT global noise")]
 	public CqlCode Calculated_CT_global_noise() => 
 		__Calculated_CT_global_noise.Value;
 
 	private CqlCode Calculated_CT_size_adjusted_dose_Value() => 
-		new CqlCode("96913-9", "http://loinc.org", null, null);
+		new CqlCode("96913-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Calculated CT size-adjusted dose")]
 	public CqlCode Calculated_CT_size_adjusted_dose() => 
 		__Calculated_CT_size_adjusted_dose.Value;
 
 	private CqlCode CT_dose_and_image_quality_category_Value() => 
-		new CqlCode("96914-7", "http://loinc.org", null, null);
+		new CqlCode("96914-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("CT dose and image quality category")]
 	public CqlCode CT_dose_and_image_quality_category() => 
@@ -105,9 +105,9 @@ public class AlaraCTIQRFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96912-1", "http://loinc.org", null, null),
-			new CqlCode("96913-9", "http://loinc.org", null, null),
-			new CqlCode("96914-7", "http://loinc.org", null, null),
+			new CqlCode("96912-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96913-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("96914-7", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -119,8 +119,8 @@ public class AlaraCTIQRFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AlaraCTIQRFHIR-0.1.000", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class AlaraCTIQRFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -146,13 +146,13 @@ public class AlaraCTIQRFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Period e_ = InpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_3_000.ToInterval(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 			Patient i_ = this.Patient();
 			Date j_ = i_?.BirthDateElement;
 			string k_ = j_?.Value;
@@ -222,7 +222,7 @@ public class AlaraCTIQRFHIR_0_1_000
 	{
 		CqlCode a_ = this.CT_dose_and_image_quality_category();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_(Observation CTScan)
 		{
 			IEnumerable<Encounter> f_ = this.Qualifying_Inpatient_Encounters();
@@ -234,11 +234,11 @@ public class AlaraCTIQRFHIR_0_1_000
 				CqlDateTime n_ = context.Operators.Start(m_);
 				Period o_ = InpatientEncounters?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
 				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 				object t_ = FHIRHelpers_4_3_000.ToValue(k_);
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
-				bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, null);
+				bool? v_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, u_, default(string));
 				bool? w_ = context.Operators.And(q_, v_);
 
 				return w_;

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Antibiotic", "1.5.000")]
 public class Antibiotic_1_5_000
 {

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
@@ -54,7 +54,7 @@ public class Antibiotic_1_5_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -86,7 +86,7 @@ public class Antibiotic_1_5_000
 				CqlDateTime v_ = context.Operators.Start(u_);
 				CqlDate w_ = context.Operators.DateFrom(v_);
 				CqlInterval<CqlDate> x_ = context.Operators.Interval(r_, w_, true, true);
-				bool? y_ = context.Operators.In<CqlDate>(k_, x_, default(string));
+				bool? y_ = context.Operators.In<CqlDate>(k_, x_, default);
 
 				return y_;
 			};

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.5.000.g.cs
@@ -54,7 +54,7 @@ public class Antibiotic_1_5_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -86,7 +86,7 @@ public class Antibiotic_1_5_000
 				CqlDateTime v_ = context.Operators.Start(u_);
 				CqlDate w_ = context.Operators.DateFrom(v_);
 				CqlInterval<CqlDate> x_ = context.Operators.Interval(r_, w_, true, true);
-				bool? y_ = context.Operators.In<CqlDate>(k_, x_, null);
+				bool? y_ = context.Operators.In<CqlDate>(k_, x_, default(string));
 
 				return y_;
 			};

--- a/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR", "0.3.000")]
 public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 {

--- a/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -96,7 +96,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
     #endregion
 
 	private CqlValueSet Anticoagulant_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200", default(string));
 
     [CqlDeclaration("Anticoagulant Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200")]
@@ -104,7 +104,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Anticoagulant_Therapy.Value;
 
 	private CqlValueSet Atrial_Ablation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203", default(string));
 
     [CqlDeclaration("Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203")]
@@ -112,7 +112,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Atrial_Ablation.Value;
 
 	private CqlValueSet Atrial_Fibrillation_or_Flutter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202", default(string));
 
     [CqlDeclaration("Atrial Fibrillation or Flutter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202")]
@@ -120,7 +120,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Atrial_Fibrillation_or_Flutter.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -128,7 +128,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -136,7 +136,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -144,7 +144,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet History_of_Atrial_Ablation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76", default(string));
 
     [CqlDeclaration("History of Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76")]
@@ -152,7 +152,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__History_of_Atrial_Ablation.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -160,7 +160,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
 
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -168,7 +168,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -176,7 +176,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -185,8 +185,8 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000", "Measurement Period", c_);
 
@@ -199,7 +199,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -226,7 +226,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		bool? b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet l_ = this.Atrial_Ablation();
-			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default(PropertyInfo));
 			bool? n_(Procedure AtrialAblationProcedure)
 			{
 				Code<EventStatus> q_ = AtrialAblationProcedure?.StatusElement;
@@ -240,7 +240,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period y_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
 				CqlDateTime aa_ = context.Operators.Start(z_);
-				bool? ab_ = context.Operators.Before(x_, aa_, null);
+				bool? ab_ = context.Operators.Before(x_, aa_, default(string));
 				bool? ac_ = context.Operators.And(t_, ab_);
 
 				return ac_;
@@ -254,7 +254,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> e_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet ad_ = this.History_of_Atrial_Ablation();
-			IEnumerable<Condition> ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, null);
+			IEnumerable<Condition> ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, default(PropertyInfo));
 			bool? af_(Condition AtrialAblationDiagnosis)
 			{
 				CodeableConcept aj_ = AtrialAblationDiagnosis?.VerificationStatus;
@@ -272,7 +272,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period aw_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime ay_ = context.Operators.Start(ax_);
-				bool? az_ = context.Operators.Before(av_, ay_, null);
+				bool? az_ = context.Operators.Before(av_, ay_, default(string));
 				bool? ba_ = context.Operators.And(ar_, az_);
 
 				return ba_;
@@ -289,7 +289,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> i_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet bb_ = this.History_of_Atrial_Ablation();
-			IEnumerable<Observation> bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, null);
+			IEnumerable<Observation> bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, default(PropertyInfo));
 			bool? bd_(Observation AtrialAblationObservation)
 			{
 				Code<ObservationStatus> bh_ = AtrialAblationObservation?.StatusElement;
@@ -358,7 +358,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period bp_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_3_000.ToInterval(bp_);
 				CqlDateTime br_ = context.Operators.End(bq_);
-				bool? bs_ = context.Operators.SameOrBefore(bo_, br_, null);
+				bool? bs_ = context.Operators.SameOrBefore(bo_, br_, default(string));
 				bool? bt_ = context.Operators.And(bm_, bs_);
 
 				return bt_;
@@ -386,7 +386,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet h_ = this.Atrial_Fibrillation_or_Flutter();
-			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
 			bool? j_(Condition AtrialFibrillationFlutter)
 			{
 				CodeableConcept n_ = AtrialFibrillationFlutter?.VerificationStatus;
@@ -404,7 +404,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period aa_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
 				CqlDateTime ac_ = context.Operators.End(ab_);
-				bool? ad_ = context.Operators.SameOrBefore(z_, ac_, null);
+				bool? ad_ = context.Operators.SameOrBefore(z_, ac_, default(string));
 				bool? ae_ = context.Operators.And(v_, ad_);
 
 				return ae_;
@@ -472,7 +472,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
 
 				return p_;
 			};
@@ -547,8 +547,8 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
 			CqlValueSet d_ = this.Anticoagulant_Therapy();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAnticoagulant)
 			{
@@ -585,7 +585,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
 				Period ai_ = Encounter?.Period;
 				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, null);
+				bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, default(string));
 				bool? al_ = context.Operators.And(af_, ak_);
 
 				return al_;
@@ -609,7 +609,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 	private IEnumerable<MedicationRequest> Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Anticoagulant_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		bool? c_(MedicationRequest NoAnticoagulant)
 		{
 			List<CodeableConcept> e_ = NoAnticoagulant?.ReasonCode;
@@ -672,7 +672,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = Encounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};

--- a/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -96,7 +96,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
     #endregion
 
 	private CqlValueSet Anticoagulant_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200", default);
 
     [CqlDeclaration("Anticoagulant Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.200")]
@@ -104,7 +104,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Anticoagulant_Therapy.Value;
 
 	private CqlValueSet Atrial_Ablation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203", default);
 
     [CqlDeclaration("Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.203")]
@@ -112,7 +112,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Atrial_Ablation.Value;
 
 	private CqlValueSet Atrial_Fibrillation_or_Flutter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202", default);
 
     [CqlDeclaration("Atrial Fibrillation or Flutter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.202")]
@@ -120,7 +120,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Atrial_Fibrillation_or_Flutter.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -128,7 +128,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -136,7 +136,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -144,7 +144,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet History_of_Atrial_Ablation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76", default);
 
     [CqlDeclaration("History of Atrial Ablation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.76")]
@@ -152,7 +152,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__History_of_Atrial_Ablation.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -160,7 +160,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default);
 
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -168,7 +168,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -176,7 +176,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default);
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -185,8 +185,8 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000", "Measurement Period", c_);
 
@@ -199,7 +199,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -226,7 +226,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		bool? b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet l_ = this.Atrial_Ablation();
-			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default(PropertyInfo));
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default);
 			bool? n_(Procedure AtrialAblationProcedure)
 			{
 				Code<EventStatus> q_ = AtrialAblationProcedure?.StatusElement;
@@ -240,7 +240,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period y_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
 				CqlDateTime aa_ = context.Operators.Start(z_);
-				bool? ab_ = context.Operators.Before(x_, aa_, default(string));
+				bool? ab_ = context.Operators.Before(x_, aa_, default);
 				bool? ac_ = context.Operators.And(t_, ab_);
 
 				return ac_;
@@ -254,7 +254,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> e_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet ad_ = this.History_of_Atrial_Ablation();
-			IEnumerable<Condition> ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, default(PropertyInfo));
+			IEnumerable<Condition> ae_ = context.Operators.RetrieveByValueSet<Condition>(ad_, default);
 			bool? af_(Condition AtrialAblationDiagnosis)
 			{
 				CodeableConcept aj_ = AtrialAblationDiagnosis?.VerificationStatus;
@@ -272,7 +272,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period aw_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime ay_ = context.Operators.Start(ax_);
-				bool? az_ = context.Operators.Before(av_, ay_, default(string));
+				bool? az_ = context.Operators.Before(av_, ay_, default);
 				bool? ba_ = context.Operators.And(ar_, az_);
 
 				return ba_;
@@ -289,7 +289,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> i_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet bb_ = this.History_of_Atrial_Ablation();
-			IEnumerable<Observation> bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, default(PropertyInfo));
+			IEnumerable<Observation> bc_ = context.Operators.RetrieveByValueSet<Observation>(bb_, default);
 			bool? bd_(Observation AtrialAblationObservation)
 			{
 				Code<ObservationStatus> bh_ = AtrialAblationObservation?.StatusElement;
@@ -358,7 +358,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period bp_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> bq_ = FHIRHelpers_4_3_000.ToInterval(bp_);
 				CqlDateTime br_ = context.Operators.End(bq_);
-				bool? bs_ = context.Operators.SameOrBefore(bo_, br_, default(string));
+				bool? bs_ = context.Operators.SameOrBefore(bo_, br_, default);
 				bool? bt_ = context.Operators.And(bm_, bs_);
 
 				return bt_;
@@ -386,7 +386,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet h_ = this.Atrial_Fibrillation_or_Flutter();
-			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default);
 			bool? j_(Condition AtrialFibrillationFlutter)
 			{
 				CodeableConcept n_ = AtrialFibrillationFlutter?.VerificationStatus;
@@ -404,7 +404,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				Period aa_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_3_000.ToInterval(aa_);
 				CqlDateTime ac_ = context.Operators.End(ab_);
-				bool? ad_ = context.Operators.SameOrBefore(z_, ac_, default(string));
+				bool? ad_ = context.Operators.SameOrBefore(z_, ac_, default);
 				bool? ae_ = context.Operators.And(v_, ad_);
 
 				return ae_;
@@ -472,7 +472,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default);
 
 				return p_;
 			};
@@ -547,8 +547,8 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 		IEnumerable<Encounter> b_(Encounter Encounter)
 		{
 			CqlValueSet d_ = this.Anticoagulant_Therapy();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAnticoagulant)
 			{
@@ -585,7 +585,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(ag_);
 				Period ai_ = Encounter?.Period;
 				CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_3_000.ToInterval(ai_);
-				bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, default(string));
+				bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, default);
 				bool? al_ = context.Operators.And(af_, ak_);
 
 				return al_;
@@ -609,7 +609,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 	private IEnumerable<MedicationRequest> Documented_Reason_for_Not_Giving_Anticoagulant_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Anticoagulant_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		bool? c_(MedicationRequest NoAnticoagulant)
 		{
 			List<CodeableConcept> e_ = NoAnticoagulant?.ReasonCode;
@@ -672,7 +672,7 @@ public class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = Encounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AntidepressantMedicationManagementFHIR", "0.1.000")]
 public class AntidepressantMedicationManagementFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
@@ -114,7 +114,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -122,7 +122,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Antidepressant_Medication_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213", default);
 
     [CqlDeclaration("Antidepressant Medication")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213")]
@@ -130,7 +130,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Antidepressant_Medication.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -138,7 +138,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Major_Depression_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007", default);
 
     [CqlDeclaration("Major Depression")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007")]
@@ -146,7 +146,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Major_Depression.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -154,7 +154,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -162,7 +162,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -170,7 +170,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -178,7 +178,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -186,7 +186,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default);
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -194,7 +194,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default);
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -202,7 +202,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -211,8 +211,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AntidepressantMedicationManagementFHIR-0.1.000", "Measurement Period", c_);
 
@@ -225,7 +225,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -282,8 +282,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private CqlDate Earliest_Antidepressant_Dispensed_During_Intake_Period_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense Antidepressant)
@@ -328,7 +328,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private bool? Has_Initial_Major_Depression_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Major_Depression();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition MajorDepression)
 		{
 			CqlDate f_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
@@ -340,7 +340,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlDate m_ = context.Operators.Subtract(f_, l_);
 			CqlDate p_ = context.Operators.Add(f_, l_);
 			CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDate>(j_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDate>(j_, q_, default);
 			bool? t_ = context.Operators.Not((bool?)(f_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			bool? v_ = context.Operators.And(g_, u_);
@@ -360,32 +360,32 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Telephone_Visits();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Online_Assessments();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		bool? ad_(Encounter ValidEncounter)
@@ -400,7 +400,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlDate am_ = context.Operators.Subtract(ak_, al_);
 			CqlDate ap_ = context.Operators.Add(ak_, al_);
 			CqlInterval<CqlDate> aq_ = context.Operators.Interval(am_, ap_, true, true);
-			bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, default(string));
+			bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, default);
 			bool? at_ = context.Operators.Not((bool?)(ak_ is null));
 			bool? au_ = context.Operators.And(ar_, at_);
 
@@ -453,8 +453,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	{
 		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 		CqlValueSet b_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationRequest> c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default);
+		IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default);
 		IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(c_, e_);
 		IEnumerable<MedicationRequest> g_ = Status_1_6_000.Active_Medication(f_);
 		bool? h_(MedicationRequest ActiveAntidepressant)
@@ -487,7 +487,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlQuantity z_ = context.Operators.Quantity(105m, "days");
 			CqlDate aa_ = context.Operators.Subtract(l_, z_);
 			CqlInterval<CqlDate> ac_ = context.Operators.Interval(aa_, l_, true, false);
-			bool? ad_ = context.Operators.Overlaps(x_, ac_, default(string));
+			bool? ad_ = context.Operators.Overlaps(x_, ac_, default);
 			bool? ae_ = context.Operators.And(m_, ad_);
 
 			return ae_;
@@ -506,8 +506,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)
@@ -557,8 +557,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.000.g.cs
@@ -114,7 +114,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -122,7 +122,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Antidepressant_Medication_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213", default(string));
 
     [CqlDeclaration("Antidepressant Medication")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1213")]
@@ -130,7 +130,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Antidepressant_Medication.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -138,7 +138,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Major_Depression_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007", default(string));
 
     [CqlDeclaration("Major Depression")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1007")]
@@ -146,7 +146,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Major_Depression.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -154,7 +154,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -162,7 +162,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -170,7 +170,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -178,7 +178,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -186,7 +186,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -194,7 +194,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -202,7 +202,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -211,8 +211,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AntidepressantMedicationManagementFHIR-0.1.000", "Measurement Period", c_);
 
@@ -225,7 +225,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -282,8 +282,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private CqlDate Earliest_Antidepressant_Dispensed_During_Intake_Period_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense Antidepressant)
@@ -328,7 +328,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private bool? Has_Initial_Major_Depression_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Major_Depression();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition MajorDepression)
 		{
 			CqlDate f_ = this.Earliest_Antidepressant_Dispensed_During_Intake_Period();
@@ -340,7 +340,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlDate m_ = context.Operators.Subtract(f_, l_);
 			CqlDate p_ = context.Operators.Add(f_, l_);
 			CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDate>(j_, q_, null);
+			bool? r_ = context.Operators.In<CqlDate>(j_, q_, default(string));
 			bool? t_ = context.Operators.Not((bool?)(f_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			bool? v_ = context.Operators.And(g_, u_);
@@ -360,32 +360,32 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Telephone_Visits();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Online_Assessments();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		bool? ad_(Encounter ValidEncounter)
@@ -400,7 +400,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlDate am_ = context.Operators.Subtract(ak_, al_);
 			CqlDate ap_ = context.Operators.Add(ak_, al_);
 			CqlInterval<CqlDate> aq_ = context.Operators.Interval(am_, ap_, true, true);
-			bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, null);
+			bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, default(string));
 			bool? at_ = context.Operators.Not((bool?)(ak_ is null));
 			bool? au_ = context.Operators.And(ar_, at_);
 
@@ -453,8 +453,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	{
 		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 		CqlValueSet b_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationRequest> c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
-		IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, null);
+		IEnumerable<MedicationRequest> c_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(b_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(c_, e_);
 		IEnumerable<MedicationRequest> g_ = Status_1_6_000.Active_Medication(f_);
 		bool? h_(MedicationRequest ActiveAntidepressant)
@@ -487,7 +487,7 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 			CqlQuantity z_ = context.Operators.Quantity(105m, "days");
 			CqlDate aa_ = context.Operators.Subtract(l_, z_);
 			CqlInterval<CqlDate> ac_ = context.Operators.Interval(aa_, l_, true, false);
-			bool? ad_ = context.Operators.Overlaps(x_, ac_, null);
+			bool? ad_ = context.Operators.Overlaps(x_, ac_, default(string));
 			bool? ae_ = context.Operators.And(m_, ad_);
 
 			return ae_;
@@ -506,8 +506,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_114_Days_After_IPSD_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)
@@ -557,8 +557,8 @@ public class AntidepressantMedicationManagementFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> Antidepressant_Medication_Period_Between_IPSD_and_231_Days_After_IPSD_Value()
 	{
 		CqlValueSet a_ = this.Antidepressant_Medication();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = Status_1_6_000.Dispensed_Medication(e_);
 		CqlInterval<CqlDate> g_(MedicationDispense Antidepressant)

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -218,7 +218,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
     #endregion
 
 	private CqlValueSet Amenorrhea_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", default(string));
 
     [CqlDeclaration("Amenorrhea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022")]
@@ -226,7 +226,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Amenorrhea.Value;
 
 	private CqlValueSet Ankylosing_Spondylitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", default(string));
 
     [CqlDeclaration("Ankylosing Spondylitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045")]
@@ -234,7 +234,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Ankylosing_Spondylitis.Value;
 
 	private CqlValueSet Aromatase_Inhibitors_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", default(string));
 
     [CqlDeclaration("Aromatase Inhibitors")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265")]
@@ -242,7 +242,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Aromatase_Inhibitors.Value;
 
 	private CqlValueSet Bilateral_Oophorectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", default(string));
 
     [CqlDeclaration("Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471")]
@@ -250,7 +250,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Bilateral_Oophorectomy.Value;
 
 	private CqlValueSet Bone_Marrow_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", default(string));
 
     [CqlDeclaration("Bone Marrow Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336")]
@@ -258,7 +258,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Bone_Marrow_Transplant.Value;
 
 	private CqlValueSet Chemotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", default(string));
 
     [CqlDeclaration("Chemotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485")]
@@ -266,7 +266,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chemotherapy.Value;
 
 	private CqlValueSet Chronic_Liver_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", default(string));
 
     [CqlDeclaration("Chronic Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035")]
@@ -274,7 +274,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chronic_Liver_Disease.Value;
 
 	private CqlValueSet Chronic_Malnutrition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", default(string));
 
     [CqlDeclaration("Chronic Malnutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036")]
@@ -282,7 +282,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chronic_Malnutrition.Value;
 
 	private CqlValueSet Cushings_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", default(string));
 
     [CqlDeclaration("Cushings Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009")]
@@ -290,7 +290,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Cushings_Syndrome.Value;
 
 	private CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", default(string));
 
     [CqlDeclaration("DXA (Dual energy Xray Absorptiometry) Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051")]
@@ -298,7 +298,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__DXA__Dual_energy_Xray_Absorptiometry__Scan.Value;
 
 	private CqlValueSet Eating_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", default(string));
 
     [CqlDeclaration("Eating Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039")]
@@ -306,7 +306,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Eating_Disorders.Value;
 
 	private CqlValueSet Ehlers_Danlos_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", default(string));
 
     [CqlDeclaration("Ehlers Danlos Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047")]
@@ -314,7 +314,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Ehlers_Danlos_Syndrome.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -322,7 +322,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Evidence_of_Bilateral_Oophorectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", default(string));
 
     [CqlDeclaration("Evidence of Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048")]
@@ -330,7 +330,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Evidence_of_Bilateral_Oophorectomy.Value;
 
 	private CqlValueSet Gastric_Bypass_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", default(string));
 
     [CqlDeclaration("Gastric Bypass Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050")]
@@ -338,7 +338,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Gastric_Bypass_Surgery.Value;
 
 	private CqlValueSet Glucocorticoids__oral_only__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", default(string));
 
     [CqlDeclaration("Glucocorticoids (oral only)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266")]
@@ -346,7 +346,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Glucocorticoids__oral_only_.Value;
 
 	private CqlValueSet History_of_hip_fracture_in_parent_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", default(string));
 
     [CqlDeclaration("History of hip fracture in parent")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040")]
@@ -354,7 +354,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__History_of_hip_fracture_in_parent.Value;
 
 	private CqlValueSet Hyperparathyroidism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", default(string));
 
     [CqlDeclaration("Hyperparathyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016")]
@@ -362,7 +362,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Hyperparathyroidism.Value;
 
 	private CqlValueSet Hyperthyroidism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", default(string));
 
     [CqlDeclaration("Hyperthyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015")]
@@ -370,7 +370,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Hyperthyroidism.Value;
 
 	private CqlValueSet Kidney_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", default(string));
 
     [CqlDeclaration("Kidney Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012")]
@@ -378,7 +378,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Kidney_Transplant.Value;
 
 	private CqlValueSet Lupus_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", default(string));
 
     [CqlDeclaration("Lupus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010")]
@@ -386,7 +386,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Lupus.Value;
 
 	private CqlValueSet Major_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", default(string));
 
     [CqlDeclaration("Major Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075")]
@@ -394,7 +394,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Major_Transplant.Value;
 
 	private CqlValueSet Malabsorption_Syndromes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", default(string));
 
     [CqlDeclaration("Malabsorption Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050")]
@@ -402,7 +402,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Malabsorption_Syndromes.Value;
 
 	private CqlValueSet Marfans_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", default(string));
 
     [CqlDeclaration("Marfan's Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048")]
@@ -410,7 +410,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Marfans_Syndrome.Value;
 
 	private CqlValueSet Multiple_Myeloma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", default(string));
 
     [CqlDeclaration("Multiple Myeloma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011")]
@@ -418,7 +418,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Multiple_Myeloma.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -426,7 +426,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -434,7 +434,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Osteogenesis_Imperfecta_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", default(string));
 
     [CqlDeclaration("Osteogenesis Imperfecta")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044")]
@@ -442,7 +442,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteogenesis_Imperfecta.Value;
 
 	private CqlValueSet Osteopenia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", default(string));
 
     [CqlDeclaration("Osteopenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049")]
@@ -450,7 +450,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteopenia.Value;
 
 	private CqlValueSet Osteoporosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", default(string));
 
     [CqlDeclaration("Osteoporosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038")]
@@ -458,7 +458,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteoporosis.Value;
 
 	private CqlValueSet Osteoporotic_Fractures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", default(string));
 
     [CqlDeclaration("Osteoporotic Fractures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050")]
@@ -466,7 +466,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteoporotic_Fractures.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -474,7 +474,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Premature_Menopause_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", default(string));
 
     [CqlDeclaration("Premature Menopause")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013")]
@@ -482,7 +482,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Premature_Menopause.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -490,7 +490,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -498,7 +498,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psoriatic_Arthritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", default(string));
 
     [CqlDeclaration("Psoriatic Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046")]
@@ -506,7 +506,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Psoriatic_Arthritis.Value;
 
 	private CqlValueSet Rheumatoid_Arthritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", default(string));
 
     [CqlDeclaration("Rheumatoid Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005")]
@@ -514,7 +514,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Rheumatoid_Arthritis.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -522,7 +522,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Type_1_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", default(string));
 
     [CqlDeclaration("Type 1 Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020")]
@@ -530,7 +530,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Type_1_Diabetes.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", default(string));
 
     [CqlDeclaration("Unilateral Oophorectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028")]
@@ -538,7 +538,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", default(string));
 
     [CqlDeclaration("Unilateral Oophorectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032")]
@@ -546,7 +546,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", default(string));
 
     [CqlDeclaration("Unilateral Oophorectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035")]
@@ -554,70 +554,70 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy__Unspecified_Laterality.Value;
 
 	private CqlCode Alcoholic_drinks_per_drinking_day___Reported_Value() => 
-		new CqlCode("11287-0", "http://loinc.org", null, null);
+		new CqlCode("11287-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Alcoholic drinks per drinking day - Reported")]
 	public CqlCode Alcoholic_drinks_per_drinking_day___Reported() => 
 		__Alcoholic_drinks_per_drinking_day___Reported.Value;
 
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
-		new CqlCode("39156-5", "http://loinc.org", null, null);
+		new CqlCode("39156-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
 	private CqlCode Female_Value() => 
-		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string));
 
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
 	private CqlCode Left__qualifier_value__Value() => 
-		new CqlCode("7771000", "http://snomed.info/sct", null, null);
+		new CqlCode("7771000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Left (qualifier value)")]
 	public CqlCode Left__qualifier_value_() => 
 		__Left__qualifier_value_.Value;
 
 	private CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value() => 
-		new CqlCode("90265-0", "http://loinc.org", null, null);
+		new CqlCode("90265-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Major osteoporotic fracture 10-year probability [Likelihood] Fracture Risk Assessment")]
 	public CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment() => 
 		__Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment.Value;
 
 	private CqlCode Osteoporosis_Index_of_Risk_panel_Value() => 
-		new CqlCode("98133-2", "http://loinc.org", null, null);
+		new CqlCode("98133-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Osteoporosis Index of Risk panel")]
 	public CqlCode Osteoporosis_Index_of_Risk_panel() => 
 		__Osteoporosis_Index_of_Risk_panel.Value;
 
 	private CqlCode Osteoporosis_Risk_Assessment_Instrument_Value() => 
-		new CqlCode("98139-9", "http://loinc.org", null, null);
+		new CqlCode("98139-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Osteoporosis Risk Assessment Instrument")]
 	public CqlCode Osteoporosis_Risk_Assessment_Instrument() => 
 		__Osteoporosis_Risk_Assessment_Instrument.Value;
 
 	private CqlCode Osteoporosis_Self_Assessment_Tool_Value() => 
-		new CqlCode("98146-4", "http://loinc.org", null, null);
+		new CqlCode("98146-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Osteoporosis Self-Assessment Tool")]
 	public CqlCode Osteoporosis_Self_Assessment_Tool() => 
 		__Osteoporosis_Self_Assessment_Tool.Value;
 
 	private CqlCode Right__qualifier_value__Value() => 
-		new CqlCode("24028007", "http://snomed.info/sct", null, null);
+		new CqlCode("24028007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Right (qualifier value)")]
 	public CqlCode Right__qualifier_value_() => 
 		__Right__qualifier_value_.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -626,12 +626,12 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("11287-0", "http://loinc.org", null, null),
-			new CqlCode("39156-5", "http://loinc.org", null, null),
-			new CqlCode("90265-0", "http://loinc.org", null, null),
-			new CqlCode("98133-2", "http://loinc.org", null, null),
-			new CqlCode("98139-9", "http://loinc.org", null, null),
-			new CqlCode("98146-4", "http://loinc.org", null, null),
+			new CqlCode("11287-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("39156-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("90265-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("98133-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("98139-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("98146-4", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -644,7 +644,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] AdministrativeGender_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string)),
 		];
 
 		return a_;
@@ -657,8 +657,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("7771000", "http://snomed.info/sct", null, null),
-			new CqlCode("24028007", "http://snomed.info/sct", null, null),
+			new CqlCode("7771000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("24028007", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -671,7 +671,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -683,8 +683,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateDXAScansForWomenUnder65FHIR-0.0.000", "Measurement Period", c_);
 
@@ -697,7 +697,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -754,11 +754,11 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
-		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? g_(Encounter E)
 		{
 			List<CodeableConcept> x_ = E?.Type;
@@ -784,17 +784,17 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 		CqlValueSet i_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
 		CqlValueSet o_ = this.Online_Assessments();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
 		CqlValueSet s_ = this.Telephone_Visits();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
 		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
 		bool? v_(Encounter ValidEncounters)
 		{
@@ -826,7 +826,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 63, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -856,7 +856,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private Observation First_BMI_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIRatio)
 		{
@@ -864,7 +864,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			DataType i_ = BMIRatio?.Effective;
 			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default(string));
 			DataType m_ = BMIRatio?.Value;
 			Quantity n_ = context.Operators.Convert<Quantity>(m_);
 			CqlQuantity o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
@@ -923,7 +923,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		CqlCode a_ = this.Alcoholic_drinks_per_drinking_day___Reported();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation AverageDrinks)
 		{
@@ -932,7 +932,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToInterval(k_);
 			CqlDateTime m_ = context.Operators.Start(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
 			DataType p_ = AverageDrinks?.Value;
 			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
 			CqlQuantity r_ = context.Operators.Quantity(2m, "{drinks}/d");
@@ -979,14 +979,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Osteoporosis_Before_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Osteoporosis();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition OsteoporosisDiagnosis)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteoporosisDiagnosis);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
-			bool? j_ = context.Operators.Before(g_, i_, null);
+			bool? j_ = context.Operators.Before(g_, i_, default(string));
 
 			return j_;
 		};
@@ -1003,14 +1003,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Osteopenia_Before_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Osteopenia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition OsteopeniaDiagnosis)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteopeniaDiagnosis);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
-			bool? j_ = context.Operators.Before(g_, i_, null);
+			bool? j_ = context.Operators.Before(g_, i_, default(string));
 
 			return j_;
 		};
@@ -1040,7 +1040,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment_Value()
 	{
 		CqlValueSet a_ = this.History_of_hip_fracture_in_parent();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Survey_Observation(b_);
 		bool? d_(Observation ParentFractureHistory)
 		{
@@ -1050,7 +1050,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime i_ = context.Operators.Start(h_);
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
-			bool? l_ = context.Operators.Before(i_, k_, null);
+			bool? l_ = context.Operators.Before(i_, k_, default(string));
 
 			return l_;
 		};
@@ -1066,7 +1066,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Gastric_Bypass_Surgery();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure GastricBypass)
 		{
@@ -1076,14 +1076,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime ad_ = context.Operators.End(ac_);
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
 			CqlDateTime af_ = context.Operators.Start(ae_);
-			bool? ag_ = context.Operators.Before(ad_, af_, null);
+			bool? ag_ = context.Operators.Before(ad_, af_, default(string));
 
 			return ag_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlValueSet f_ = this.Aromatase_Inhibitors();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = Status_1_6_000.Active_Medication(j_);
 		bool? l_(MedicationRequest AromataseInhibitorActive)
@@ -1093,14 +1093,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
 			CqlInterval<CqlDateTime> ak_ = this.Measurement_Period();
 			CqlDateTime al_ = context.Operators.Start(ak_);
-			bool? am_ = context.Operators.Before(aj_, al_, null);
+			bool? am_ = context.Operators.Before(aj_, al_, default(string));
 
 			return am_;
 		};
 		IEnumerable<MedicationRequest> m_ = context.Operators.Where<MedicationRequest>(k_, l_);
 		IEnumerable<object> n_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (m_ as IEnumerable<object>));
-		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
 		IEnumerable<MedicationRequest> t_ = Status_1_6_000.Active_or_Completed_Medication_Request(s_);
 		bool? u_(MedicationRequest AromataseInhibitorOrder)
@@ -1119,7 +1119,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 				};
 				if (as_())
 				{
-					return null;
+					return default(CqlInterval<CqlDateTime>);
 				}
 				else
 				{
@@ -1131,7 +1131,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 					return az_;
 				}
 			};
-			bool? ar_ = context.Operators.Before(ap_, aq_(), null);
+			bool? ar_ = context.Operators.Before(ap_, aq_(), default(string));
 
 			return ar_;
 		};
@@ -1151,8 +1151,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private int? Glucocorticoid_Active_Medication_Duration_in_Days_Value()
 	{
 		CqlValueSet a_ = this.Glucocorticoids__oral_only_();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest OralGlucocorticoid)
@@ -1162,7 +1162,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
 			CqlDateTime p_ = context.Operators.End(o_);
-			bool? q_ = context.Operators.Before(n_, p_, null);
+			bool? q_ = context.Operators.Before(n_, p_, default(string));
 
 			return q_;
 		};
@@ -1257,16 +1257,16 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Double_or_Bilateral_Oophorectomy_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Oophorectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = this.ProcedureInPatientHistory(b_);
 		bool? d_ = context.Operators.Exists<Procedure>(c_);
 		CqlValueSet e_ = this.Evidence_of_Bilateral_Oophorectomy();
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
 		IEnumerable<Procedure> g_ = this.ProcedureInPatientHistory(f_);
 		bool? h_ = context.Operators.Exists<Procedure>(g_);
 		bool? i_ = context.Operators.Or(d_, h_);
 		CqlValueSet j_ = this.Unilateral_Oophorectomy__Unspecified_Laterality();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
 		bool? l_(Procedure UnilateralOophorectomy)
 		{
 			List<CodeableConcept> ad_ = UnilateralOophorectomy?.BodySite;
@@ -1292,11 +1292,11 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>(k_, l_);
 		CqlValueSet n_ = this.Unilateral_Oophorectomy_Right();
-		IEnumerable<Procedure> o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, null);
+		IEnumerable<Procedure> o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, default(PropertyInfo));
 		IEnumerable<Procedure> p_ = context.Operators.Union<Procedure>(m_, o_);
 		IEnumerable<Procedure> q_ = this.ProcedureInPatientHistory(p_);
 		bool? r_ = context.Operators.Exists<Procedure>(q_);
-		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
 		bool? u_(Procedure UnilateralOophorectomy)
 		{
 			List<CodeableConcept> an_ = UnilateralOophorectomy?.BodySite;
@@ -1322,7 +1322,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Procedure> v_ = context.Operators.Where<Procedure>(t_, u_);
 		CqlValueSet w_ = this.Unilateral_Oophorectomy_Left();
-		IEnumerable<Procedure> x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, null);
+		IEnumerable<Procedure> x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, default(PropertyInfo));
 		IEnumerable<Procedure> y_ = context.Operators.Union<Procedure>(v_, x_);
 		IEnumerable<Procedure> z_ = this.ProcedureInPatientHistory(y_);
 		bool? aa_ = context.Operators.Exists<Procedure>(z_);
@@ -1339,12 +1339,12 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Organ_Transplants_Value()
 	{
 		CqlValueSet a_ = this.Major_Transplant();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Kidney_Transplant();
-		IEnumerable<Procedure> d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, null);
+		IEnumerable<Procedure> d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default(PropertyInfo));
 		IEnumerable<Procedure> e_ = context.Operators.Union<Procedure>(b_, d_);
 		CqlValueSet f_ = this.Bone_Marrow_Transplant();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 		IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 		IEnumerable<Procedure> i_ = this.ProcedureInPatientHistory(h_);
 		bool? j_ = context.Operators.Exists<Procedure>(i_);
@@ -1360,69 +1360,69 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		bool? a_ = this.Has_90_or_More_Active_Glucocorticoid_Medication_Days();
 		CqlValueSet b_ = this.Osteoporotic_Fractures();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
 		CqlValueSet d_ = this.Malabsorption_Syndromes();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		CqlValueSet g_ = this.Chronic_Malnutrition();
-		IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default(PropertyInfo));
 		CqlValueSet i_ = this.Chronic_Liver_Disease();
-		IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
 		IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
 		IEnumerable<Condition> l_ = context.Operators.Union<Condition>(f_, k_);
 		CqlValueSet m_ = this.Rheumatoid_Arthritis();
-		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default(PropertyInfo));
 		CqlValueSet o_ = this.Hyperthyroidism();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
 		IEnumerable<Condition> r_ = context.Operators.Union<Condition>(l_, q_);
 		CqlValueSet s_ = this.Type_1_Diabetes();
-		IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+		IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
 		CqlValueSet u_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+		IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default(PropertyInfo));
 		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(t_, v_);
 		IEnumerable<Condition> x_ = context.Operators.Union<Condition>(r_, w_);
 		CqlValueSet y_ = this.Osteogenesis_Imperfecta();
-		IEnumerable<Condition> z_ = context.Operators.RetrieveByValueSet<Condition>(y_, null);
+		IEnumerable<Condition> z_ = context.Operators.RetrieveByValueSet<Condition>(y_, default(PropertyInfo));
 		CqlValueSet aa_ = this.Ankylosing_Spondylitis();
-		IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+		IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default(PropertyInfo));
 		IEnumerable<Condition> ac_ = context.Operators.Union<Condition>(z_, ab_);
 		IEnumerable<Condition> ad_ = context.Operators.Union<Condition>(x_, ac_);
 		CqlValueSet ae_ = this.Psoriatic_Arthritis();
-		IEnumerable<Condition> af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, null);
+		IEnumerable<Condition> af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, default(PropertyInfo));
 		CqlValueSet ag_ = this.Ehlers_Danlos_Syndrome();
-		IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+		IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default(PropertyInfo));
 		IEnumerable<Condition> ai_ = context.Operators.Union<Condition>(af_, ah_);
 		IEnumerable<Condition> aj_ = context.Operators.Union<Condition>(ad_, ai_);
 		CqlValueSet ak_ = this.Cushings_Syndrome();
-		IEnumerable<Condition> al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, null);
+		IEnumerable<Condition> al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, default(PropertyInfo));
 		CqlValueSet am_ = this.Hyperparathyroidism();
-		IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+		IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default(PropertyInfo));
 		IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(al_, an_);
 		IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(aj_, ao_);
 		CqlValueSet aq_ = this.Marfans_Syndrome();
-		IEnumerable<Condition> ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, null);
+		IEnumerable<Condition> ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, default(PropertyInfo));
 		CqlValueSet as_ = this.Lupus();
-		IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+		IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default(PropertyInfo));
 		IEnumerable<Condition> au_ = context.Operators.Union<Condition>(ar_, at_);
 		IEnumerable<Condition> av_ = context.Operators.Union<Condition>(ap_, au_);
 		CqlValueSet aw_ = this.Multiple_Myeloma();
-		IEnumerable<Condition> ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, null);
+		IEnumerable<Condition> ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, default(PropertyInfo));
 		CqlValueSet ay_ = this.Premature_Menopause();
-		IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+		IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default(PropertyInfo));
 		IEnumerable<Condition> ba_ = context.Operators.Union<Condition>(ax_, az_);
 		IEnumerable<Condition> bb_ = context.Operators.Union<Condition>(av_, ba_);
 		CqlValueSet bc_ = this.Eating_Disorders();
-		IEnumerable<Condition> bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, null);
+		IEnumerable<Condition> bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, default(PropertyInfo));
 		CqlValueSet be_ = this.Amenorrhea();
-		IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+		IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default(PropertyInfo));
 		IEnumerable<Condition> bg_ = context.Operators.Union<Condition>(bd_, bf_);
 		IEnumerable<Condition> bh_ = context.Operators.Union<Condition>(bb_, bg_);
 		IEnumerable<Condition> bi_ = this.DiagnosisInPatientHistory(bh_);
 		bool? bj_ = context.Operators.Exists<Condition>(bi_);
 		bool? bk_ = context.Operators.Or(a_, bj_);
 		CqlValueSet bl_ = this.Chemotherapy();
-		IEnumerable<Procedure> bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, null);
+		IEnumerable<Procedure> bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, default(PropertyInfo));
 		IEnumerable<Procedure> bn_ = this.ProcedureInPatientHistory(bm_);
 		bool? bo_ = context.Operators.Exists<Procedure>(bn_);
 		bool? bp_ = context.Operators.Or(bk_, bo_);
@@ -1458,7 +1458,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.DXA__Dual_energy_Xray_Absorptiometry__Scan();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest DXA)
 		{
@@ -1466,7 +1466,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			FhirDateTime i_ = DXA?.AuthoredOnElement;
 			CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval((j_ as object));
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, null);
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default(string));
 
 			return l_;
 		};
@@ -1503,7 +1503,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		CqlCode a_ = this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation FRAX)
 		{
@@ -1517,7 +1517,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		CqlCode g_ = this.Osteoporosis_Risk_Assessment_Instrument();
 		IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
-		IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+		IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default(PropertyInfo));
 		IEnumerable<Observation> j_ = Status_1_6_000.Final_Survey_Observation(i_);
 		bool? k_(Observation ORAI)
 		{
@@ -1531,7 +1531,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> m_ = context.Operators.Union<Observation>(f_, l_);
 		CqlCode n_ = this.Osteoporosis_Index_of_Risk_panel();
 		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
-		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default(PropertyInfo));
 		IEnumerable<Observation> q_ = Status_1_6_000.Final_Survey_Observation(p_);
 		bool? r_(Observation OSIRIS)
 		{
@@ -1545,7 +1545,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> s_ = context.Operators.Where<Observation>(q_, r_);
 		CqlCode t_ = this.Osteoporosis_Self_Assessment_Tool();
 		IEnumerable<CqlCode> u_ = context.Operators.ToList<CqlCode>(t_);
-		IEnumerable<Observation> v_ = context.Operators.RetrieveByCodes<Observation>(u_, null);
+		IEnumerable<Observation> v_ = context.Operators.RetrieveByCodes<Observation>(u_, default(PropertyInfo));
 		IEnumerable<Observation> w_ = Status_1_6_000.Final_Survey_Observation(v_);
 		bool? x_(Observation OST)
 		{
@@ -1569,7 +1569,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			ServiceRequest ax_ = context.Operators.First<ServiceRequest>(aw_);
 			FhirDateTime ay_ = ax_?.AuthoredOnElement;
 			CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
-			bool? ba_ = context.Operators.Before(av_, az_, null);
+			bool? ba_ = context.Operators.Before(av_, az_, default(string));
 
 			return ba_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -218,7 +218,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
     #endregion
 
 	private CqlValueSet Amenorrhea_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022", default);
 
     [CqlDeclaration("Amenorrhea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1022")]
@@ -226,7 +226,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Amenorrhea.Value;
 
 	private CqlValueSet Ankylosing_Spondylitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045", default);
 
     [CqlDeclaration("Ankylosing Spondylitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1045")]
@@ -234,7 +234,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Ankylosing_Spondylitis.Value;
 
 	private CqlValueSet Aromatase_Inhibitors_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265", default);
 
     [CqlDeclaration("Aromatase Inhibitors")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1265")]
@@ -242,7 +242,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Aromatase_Inhibitors.Value;
 
 	private CqlValueSet Bilateral_Oophorectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471", default);
 
     [CqlDeclaration("Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.471")]
@@ -250,7 +250,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Bilateral_Oophorectomy.Value;
 
 	private CqlValueSet Bone_Marrow_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336", default);
 
     [CqlDeclaration("Bone Marrow Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.336")]
@@ -258,7 +258,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Bone_Marrow_Transplant.Value;
 
 	private CqlValueSet Chemotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485", default);
 
     [CqlDeclaration("Chemotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.485")]
@@ -266,7 +266,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chemotherapy.Value;
 
 	private CqlValueSet Chronic_Liver_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035", default);
 
     [CqlDeclaration("Chronic Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1035")]
@@ -274,7 +274,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chronic_Liver_Disease.Value;
 
 	private CqlValueSet Chronic_Malnutrition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036", default);
 
     [CqlDeclaration("Chronic Malnutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1036")]
@@ -282,7 +282,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Chronic_Malnutrition.Value;
 
 	private CqlValueSet Cushings_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009", default);
 
     [CqlDeclaration("Cushings Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1009")]
@@ -290,7 +290,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Cushings_Syndrome.Value;
 
 	private CqlValueSet DXA__Dual_energy_Xray_Absorptiometry__Scan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051", default);
 
     [CqlDeclaration("DXA (Dual energy Xray Absorptiometry) Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1051")]
@@ -298,7 +298,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__DXA__Dual_energy_Xray_Absorptiometry__Scan.Value;
 
 	private CqlValueSet Eating_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039", default);
 
     [CqlDeclaration("Eating Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1039")]
@@ -306,7 +306,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Eating_Disorders.Value;
 
 	private CqlValueSet Ehlers_Danlos_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047", default);
 
     [CqlDeclaration("Ehlers Danlos Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1047")]
@@ -314,7 +314,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Ehlers_Danlos_Syndrome.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default);
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -322,7 +322,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Evidence_of_Bilateral_Oophorectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048", default);
 
     [CqlDeclaration("Evidence of Bilateral Oophorectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1048")]
@@ -330,7 +330,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Evidence_of_Bilateral_Oophorectomy.Value;
 
 	private CqlValueSet Gastric_Bypass_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050", default);
 
     [CqlDeclaration("Gastric Bypass Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1050")]
@@ -338,7 +338,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Gastric_Bypass_Surgery.Value;
 
 	private CqlValueSet Glucocorticoids__oral_only__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266", default);
 
     [CqlDeclaration("Glucocorticoids (oral only)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1266")]
@@ -346,7 +346,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Glucocorticoids__oral_only_.Value;
 
 	private CqlValueSet History_of_hip_fracture_in_parent_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040", default);
 
     [CqlDeclaration("History of hip fracture in parent")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1040")]
@@ -354,7 +354,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__History_of_hip_fracture_in_parent.Value;
 
 	private CqlValueSet Hyperparathyroidism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016", default);
 
     [CqlDeclaration("Hyperparathyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1016")]
@@ -362,7 +362,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Hyperparathyroidism.Value;
 
 	private CqlValueSet Hyperthyroidism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015", default);
 
     [CqlDeclaration("Hyperthyroidism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1015")]
@@ -370,7 +370,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Hyperthyroidism.Value;
 
 	private CqlValueSet Kidney_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012", default);
 
     [CqlDeclaration("Kidney Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.109.12.1012")]
@@ -378,7 +378,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Kidney_Transplant.Value;
 
 	private CqlValueSet Lupus_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010", default);
 
     [CqlDeclaration("Lupus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.117.12.1010")]
@@ -386,7 +386,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Lupus.Value;
 
 	private CqlValueSet Major_Transplant_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075", default);
 
     [CqlDeclaration("Major Transplant")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1075")]
@@ -394,7 +394,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Major_Transplant.Value;
 
 	private CqlValueSet Malabsorption_Syndromes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050", default);
 
     [CqlDeclaration("Malabsorption Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1050")]
@@ -402,7 +402,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Malabsorption_Syndromes.Value;
 
 	private CqlValueSet Marfans_Syndrome_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048", default);
 
     [CqlDeclaration("Marfan's Syndrome")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1048")]
@@ -410,7 +410,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Marfans_Syndrome.Value;
 
 	private CqlValueSet Multiple_Myeloma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011", default);
 
     [CqlDeclaration("Multiple Myeloma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1011")]
@@ -418,7 +418,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Multiple_Myeloma.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -426,7 +426,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -434,7 +434,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Osteogenesis_Imperfecta_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044", default);
 
     [CqlDeclaration("Osteogenesis Imperfecta")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1044")]
@@ -442,7 +442,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteogenesis_Imperfecta.Value;
 
 	private CqlValueSet Osteopenia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049", default);
 
     [CqlDeclaration("Osteopenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1049")]
@@ -450,7 +450,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteopenia.Value;
 
 	private CqlValueSet Osteoporosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038", default);
 
     [CqlDeclaration("Osteoporosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1038")]
@@ -458,7 +458,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteoporosis.Value;
 
 	private CqlValueSet Osteoporotic_Fractures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050", default);
 
     [CqlDeclaration("Osteoporotic Fractures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1050")]
@@ -466,7 +466,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Osteoporotic_Fractures.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -474,7 +474,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Premature_Menopause_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013", default);
 
     [CqlDeclaration("Premature Menopause")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1013")]
@@ -482,7 +482,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Premature_Menopause.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -490,7 +490,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -498,7 +498,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psoriatic_Arthritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046", default);
 
     [CqlDeclaration("Psoriatic Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1046")]
@@ -506,7 +506,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Psoriatic_Arthritis.Value;
 
 	private CqlValueSet Rheumatoid_Arthritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005", default);
 
     [CqlDeclaration("Rheumatoid Arthritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1005")]
@@ -514,7 +514,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Rheumatoid_Arthritis.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -522,7 +522,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Type_1_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020", default);
 
     [CqlDeclaration("Type 1 Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1020")]
@@ -530,7 +530,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Type_1_Diabetes.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028", default);
 
     [CqlDeclaration("Unilateral Oophorectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1028")]
@@ -538,7 +538,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032", default);
 
     [CqlDeclaration("Unilateral Oophorectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1032")]
@@ -546,7 +546,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Oophorectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035", default);
 
     [CqlDeclaration("Unilateral Oophorectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1035")]
@@ -554,70 +554,70 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		__Unilateral_Oophorectomy__Unspecified_Laterality.Value;
 
 	private CqlCode Alcoholic_drinks_per_drinking_day___Reported_Value() => 
-		new CqlCode("11287-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("11287-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("Alcoholic drinks per drinking day - Reported")]
 	public CqlCode Alcoholic_drinks_per_drinking_day___Reported() => 
 		__Alcoholic_drinks_per_drinking_day___Reported.Value;
 
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
-		new CqlCode("39156-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("39156-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
 	private CqlCode Female_Value() => 
-		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string));
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default, default);
 
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
 	private CqlCode Left__qualifier_value__Value() => 
-		new CqlCode("7771000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("7771000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Left (qualifier value)")]
 	public CqlCode Left__qualifier_value_() => 
 		__Left__qualifier_value_.Value;
 
 	private CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment_Value() => 
-		new CqlCode("90265-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("90265-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("Major osteoporotic fracture 10-year probability [Likelihood] Fracture Risk Assessment")]
 	public CqlCode Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment() => 
 		__Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment.Value;
 
 	private CqlCode Osteoporosis_Index_of_Risk_panel_Value() => 
-		new CqlCode("98133-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("98133-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("Osteoporosis Index of Risk panel")]
 	public CqlCode Osteoporosis_Index_of_Risk_panel() => 
 		__Osteoporosis_Index_of_Risk_panel.Value;
 
 	private CqlCode Osteoporosis_Risk_Assessment_Instrument_Value() => 
-		new CqlCode("98139-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("98139-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Osteoporosis Risk Assessment Instrument")]
 	public CqlCode Osteoporosis_Risk_Assessment_Instrument() => 
 		__Osteoporosis_Risk_Assessment_Instrument.Value;
 
 	private CqlCode Osteoporosis_Self_Assessment_Tool_Value() => 
-		new CqlCode("98146-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("98146-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Osteoporosis Self-Assessment Tool")]
 	public CqlCode Osteoporosis_Self_Assessment_Tool() => 
 		__Osteoporosis_Self_Assessment_Tool.Value;
 
 	private CqlCode Right__qualifier_value__Value() => 
-		new CqlCode("24028007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("24028007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Right (qualifier value)")]
 	public CqlCode Right__qualifier_value_() => 
 		__Right__qualifier_value_.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -626,12 +626,12 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("11287-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("39156-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("90265-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("98133-2", "http://loinc.org", default(string), default(string)),
-			new CqlCode("98139-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("98146-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11287-0", "http://loinc.org", default, default),
+			new CqlCode("39156-5", "http://loinc.org", default, default),
+			new CqlCode("90265-0", "http://loinc.org", default, default),
+			new CqlCode("98133-2", "http://loinc.org", default, default),
+			new CqlCode("98139-9", "http://loinc.org", default, default),
+			new CqlCode("98146-4", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -644,7 +644,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] AdministrativeGender_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string)),
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default, default),
 		];
 
 		return a_;
@@ -657,8 +657,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("7771000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("24028007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("7771000", "http://snomed.info/sct", default, default),
+			new CqlCode("24028007", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -671,7 +671,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -683,8 +683,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateDXAScansForWomenUnder65FHIR-0.0.000", "Measurement Period", c_);
 
@@ -697,7 +697,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -754,11 +754,11 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
-		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? g_(Encounter E)
 		{
 			List<CodeableConcept> x_ = E?.Type;
@@ -784,17 +784,17 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 		CqlValueSet i_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default);
 		CqlValueSet o_ = this.Online_Assessments();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
 		CqlValueSet s_ = this.Telephone_Visits();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default);
 		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
 		bool? v_(Encounter ValidEncounters)
 		{
@@ -826,7 +826,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 63, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -856,7 +856,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 
 	private Observation First_BMI_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIRatio)
 		{
@@ -864,7 +864,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			DataType i_ = BMIRatio?.Effective;
 			object j_ = FHIRHelpers_4_3_000.ToValue(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default(string));
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default);
 			DataType m_ = BMIRatio?.Value;
 			Quantity n_ = context.Operators.Convert<Quantity>(m_);
 			CqlQuantity o_ = FHIRHelpers_4_3_000.ToQuantity(n_);
@@ -923,7 +923,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		CqlCode a_ = this.Alcoholic_drinks_per_drinking_day___Reported();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation AverageDrinks)
 		{
@@ -932,7 +932,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToInterval(k_);
 			CqlDateTime m_ = context.Operators.Start(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
 			DataType p_ = AverageDrinks?.Value;
 			object q_ = FHIRHelpers_4_3_000.ToValue(p_);
 			CqlQuantity r_ = context.Operators.Quantity(2m, "{drinks}/d");
@@ -979,14 +979,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Osteoporosis_Before_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Osteoporosis();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition OsteoporosisDiagnosis)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteoporosisDiagnosis);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
-			bool? j_ = context.Operators.Before(g_, i_, default(string));
+			bool? j_ = context.Operators.Before(g_, i_, default);
 
 			return j_;
 		};
@@ -1003,14 +1003,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Osteopenia_Before_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Osteopenia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition OsteopeniaDiagnosis)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(OsteopeniaDiagnosis);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.Start(h_);
-			bool? j_ = context.Operators.Before(g_, i_, default(string));
+			bool? j_ = context.Operators.Before(g_, i_, default);
 
 			return j_;
 		};
@@ -1040,7 +1040,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<Observation> Parent_History_of_Hip_Fracture_Assessment_Value()
 	{
 		CqlValueSet a_ = this.History_of_hip_fracture_in_parent();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Survey_Observation(b_);
 		bool? d_(Observation ParentFractureHistory)
 		{
@@ -1050,7 +1050,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime i_ = context.Operators.Start(h_);
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 			CqlDateTime k_ = context.Operators.Start(j_);
-			bool? l_ = context.Operators.Before(i_, k_, default(string));
+			bool? l_ = context.Operators.Before(i_, k_, default);
 
 			return l_;
 		};
@@ -1066,7 +1066,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Risk_Factor_Any_Time_in_History_Prior_to_Measurement_Period_and_Do_Not_Need_to_be_Active_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Gastric_Bypass_Surgery();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure GastricBypass)
 		{
@@ -1076,14 +1076,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime ad_ = context.Operators.End(ac_);
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
 			CqlDateTime af_ = context.Operators.Start(ae_);
-			bool? ag_ = context.Operators.Before(ad_, af_, default(string));
+			bool? ag_ = context.Operators.Before(ad_, af_, default);
 
 			return ag_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlValueSet f_ = this.Aromatase_Inhibitors();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = Status_1_6_000.Active_Medication(j_);
 		bool? l_(MedicationRequest AromataseInhibitorActive)
@@ -1093,14 +1093,14 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime aj_ = context.Operators.ConvertDateToDateTime(ai_);
 			CqlInterval<CqlDateTime> ak_ = this.Measurement_Period();
 			CqlDateTime al_ = context.Operators.Start(ak_);
-			bool? am_ = context.Operators.Before(aj_, al_, default(string));
+			bool? am_ = context.Operators.Before(aj_, al_, default);
 
 			return am_;
 		};
 		IEnumerable<MedicationRequest> m_ = context.Operators.Where<MedicationRequest>(k_, l_);
 		IEnumerable<object> n_ = context.Operators.Union<object>((e_ as IEnumerable<object>), (m_ as IEnumerable<object>));
-		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
 		IEnumerable<MedicationRequest> t_ = Status_1_6_000.Active_or_Completed_Medication_Request(s_);
 		bool? u_(MedicationRequest AromataseInhibitorOrder)
@@ -1119,7 +1119,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 				};
 				if (as_())
 				{
-					return default(CqlInterval<CqlDateTime>);
+					return default;
 				}
 				else
 				{
@@ -1131,7 +1131,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 					return az_;
 				}
 			};
-			bool? ar_ = context.Operators.Before(ap_, aq_(), default(string));
+			bool? ar_ = context.Operators.Before(ap_, aq_(), default);
 
 			return ar_;
 		};
@@ -1151,8 +1151,8 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private int? Glucocorticoid_Active_Medication_Duration_in_Days_Value()
 	{
 		CqlValueSet a_ = this.Glucocorticoids__oral_only_();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest OralGlucocorticoid)
@@ -1162,7 +1162,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			CqlDateTime n_ = context.Operators.ConvertDateToDateTime(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
 			CqlDateTime p_ = context.Operators.End(o_);
-			bool? q_ = context.Operators.Before(n_, p_, default(string));
+			bool? q_ = context.Operators.Before(n_, p_, default);
 
 			return q_;
 		};
@@ -1257,16 +1257,16 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Double_or_Bilateral_Oophorectomy_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Oophorectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = this.ProcedureInPatientHistory(b_);
 		bool? d_ = context.Operators.Exists<Procedure>(c_);
 		CqlValueSet e_ = this.Evidence_of_Bilateral_Oophorectomy();
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default);
 		IEnumerable<Procedure> g_ = this.ProcedureInPatientHistory(f_);
 		bool? h_ = context.Operators.Exists<Procedure>(g_);
 		bool? i_ = context.Operators.Or(d_, h_);
 		CqlValueSet j_ = this.Unilateral_Oophorectomy__Unspecified_Laterality();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default);
 		bool? l_(Procedure UnilateralOophorectomy)
 		{
 			List<CodeableConcept> ad_ = UnilateralOophorectomy?.BodySite;
@@ -1292,11 +1292,11 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Procedure> m_ = context.Operators.Where<Procedure>(k_, l_);
 		CqlValueSet n_ = this.Unilateral_Oophorectomy_Right();
-		IEnumerable<Procedure> o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, default(PropertyInfo));
+		IEnumerable<Procedure> o_ = context.Operators.RetrieveByValueSet<Procedure>(n_, default);
 		IEnumerable<Procedure> p_ = context.Operators.Union<Procedure>(m_, o_);
 		IEnumerable<Procedure> q_ = this.ProcedureInPatientHistory(p_);
 		bool? r_ = context.Operators.Exists<Procedure>(q_);
-		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
+		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default);
 		bool? u_(Procedure UnilateralOophorectomy)
 		{
 			List<CodeableConcept> an_ = UnilateralOophorectomy?.BodySite;
@@ -1322,7 +1322,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		};
 		IEnumerable<Procedure> v_ = context.Operators.Where<Procedure>(t_, u_);
 		CqlValueSet w_ = this.Unilateral_Oophorectomy_Left();
-		IEnumerable<Procedure> x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, default(PropertyInfo));
+		IEnumerable<Procedure> x_ = context.Operators.RetrieveByValueSet<Procedure>(w_, default);
 		IEnumerable<Procedure> y_ = context.Operators.Union<Procedure>(v_, x_);
 		IEnumerable<Procedure> z_ = this.ProcedureInPatientHistory(y_);
 		bool? aa_ = context.Operators.Exists<Procedure>(z_);
@@ -1339,12 +1339,12 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private bool? Has_Organ_Transplants_Value()
 	{
 		CqlValueSet a_ = this.Major_Transplant();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		CqlValueSet c_ = this.Kidney_Transplant();
-		IEnumerable<Procedure> d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default(PropertyInfo));
+		IEnumerable<Procedure> d_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default);
 		IEnumerable<Procedure> e_ = context.Operators.Union<Procedure>(b_, d_);
 		CqlValueSet f_ = this.Bone_Marrow_Transplant();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 		IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 		IEnumerable<Procedure> i_ = this.ProcedureInPatientHistory(h_);
 		bool? j_ = context.Operators.Exists<Procedure>(i_);
@@ -1360,69 +1360,69 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		bool? a_ = this.Has_90_or_More_Active_Glucocorticoid_Medication_Days();
 		CqlValueSet b_ = this.Osteoporotic_Fractures();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default);
 		CqlValueSet d_ = this.Malabsorption_Syndromes();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		CqlValueSet g_ = this.Chronic_Malnutrition();
-		IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default(PropertyInfo));
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default);
 		CqlValueSet i_ = this.Chronic_Liver_Disease();
-		IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
+		IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default);
 		IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
 		IEnumerable<Condition> l_ = context.Operators.Union<Condition>(f_, k_);
 		CqlValueSet m_ = this.Rheumatoid_Arthritis();
-		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default(PropertyInfo));
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default);
 		CqlValueSet o_ = this.Hyperthyroidism();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
 		IEnumerable<Condition> r_ = context.Operators.Union<Condition>(l_, q_);
 		CqlValueSet s_ = this.Type_1_Diabetes();
-		IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
+		IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default);
 		CqlValueSet u_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default(PropertyInfo));
+		IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default);
 		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(t_, v_);
 		IEnumerable<Condition> x_ = context.Operators.Union<Condition>(r_, w_);
 		CqlValueSet y_ = this.Osteogenesis_Imperfecta();
-		IEnumerable<Condition> z_ = context.Operators.RetrieveByValueSet<Condition>(y_, default(PropertyInfo));
+		IEnumerable<Condition> z_ = context.Operators.RetrieveByValueSet<Condition>(y_, default);
 		CqlValueSet aa_ = this.Ankylosing_Spondylitis();
-		IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default(PropertyInfo));
+		IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default);
 		IEnumerable<Condition> ac_ = context.Operators.Union<Condition>(z_, ab_);
 		IEnumerable<Condition> ad_ = context.Operators.Union<Condition>(x_, ac_);
 		CqlValueSet ae_ = this.Psoriatic_Arthritis();
-		IEnumerable<Condition> af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, default(PropertyInfo));
+		IEnumerable<Condition> af_ = context.Operators.RetrieveByValueSet<Condition>(ae_, default);
 		CqlValueSet ag_ = this.Ehlers_Danlos_Syndrome();
-		IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default(PropertyInfo));
+		IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default);
 		IEnumerable<Condition> ai_ = context.Operators.Union<Condition>(af_, ah_);
 		IEnumerable<Condition> aj_ = context.Operators.Union<Condition>(ad_, ai_);
 		CqlValueSet ak_ = this.Cushings_Syndrome();
-		IEnumerable<Condition> al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, default(PropertyInfo));
+		IEnumerable<Condition> al_ = context.Operators.RetrieveByValueSet<Condition>(ak_, default);
 		CqlValueSet am_ = this.Hyperparathyroidism();
-		IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default(PropertyInfo));
+		IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default);
 		IEnumerable<Condition> ao_ = context.Operators.Union<Condition>(al_, an_);
 		IEnumerable<Condition> ap_ = context.Operators.Union<Condition>(aj_, ao_);
 		CqlValueSet aq_ = this.Marfans_Syndrome();
-		IEnumerable<Condition> ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, default(PropertyInfo));
+		IEnumerable<Condition> ar_ = context.Operators.RetrieveByValueSet<Condition>(aq_, default);
 		CqlValueSet as_ = this.Lupus();
-		IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default(PropertyInfo));
+		IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default);
 		IEnumerable<Condition> au_ = context.Operators.Union<Condition>(ar_, at_);
 		IEnumerable<Condition> av_ = context.Operators.Union<Condition>(ap_, au_);
 		CqlValueSet aw_ = this.Multiple_Myeloma();
-		IEnumerable<Condition> ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, default(PropertyInfo));
+		IEnumerable<Condition> ax_ = context.Operators.RetrieveByValueSet<Condition>(aw_, default);
 		CqlValueSet ay_ = this.Premature_Menopause();
-		IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default(PropertyInfo));
+		IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default);
 		IEnumerable<Condition> ba_ = context.Operators.Union<Condition>(ax_, az_);
 		IEnumerable<Condition> bb_ = context.Operators.Union<Condition>(av_, ba_);
 		CqlValueSet bc_ = this.Eating_Disorders();
-		IEnumerable<Condition> bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, default(PropertyInfo));
+		IEnumerable<Condition> bd_ = context.Operators.RetrieveByValueSet<Condition>(bc_, default);
 		CqlValueSet be_ = this.Amenorrhea();
-		IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default(PropertyInfo));
+		IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default);
 		IEnumerable<Condition> bg_ = context.Operators.Union<Condition>(bd_, bf_);
 		IEnumerable<Condition> bh_ = context.Operators.Union<Condition>(bb_, bg_);
 		IEnumerable<Condition> bi_ = this.DiagnosisInPatientHistory(bh_);
 		bool? bj_ = context.Operators.Exists<Condition>(bi_);
 		bool? bk_ = context.Operators.Or(a_, bj_);
 		CqlValueSet bl_ = this.Chemotherapy();
-		IEnumerable<Procedure> bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, default(PropertyInfo));
+		IEnumerable<Procedure> bm_ = context.Operators.RetrieveByValueSet<Procedure>(bl_, default);
 		IEnumerable<Procedure> bn_ = this.ProcedureInPatientHistory(bm_);
 		bool? bo_ = context.Operators.Exists<Procedure>(bn_);
 		bool? bp_ = context.Operators.Or(bk_, bo_);
@@ -1458,7 +1458,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	private IEnumerable<ServiceRequest> DXA_Scan_Order_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.DXA__Dual_energy_Xray_Absorptiometry__Scan();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest DXA)
 		{
@@ -1466,7 +1466,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			FhirDateTime i_ = DXA?.AuthoredOnElement;
 			CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 			CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval((j_ as object));
-			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default(string));
+			bool? l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, k_, default);
 
 			return l_;
 		};
@@ -1503,7 +1503,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 	{
 		CqlCode a_ = this.Major_osteoporotic_fracture_10_year_probability__Likelihood__Fracture_Risk_Assessment();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation FRAX)
 		{
@@ -1517,7 +1517,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		CqlCode g_ = this.Osteoporosis_Risk_Assessment_Instrument();
 		IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
-		IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default(PropertyInfo));
+		IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default);
 		IEnumerable<Observation> j_ = Status_1_6_000.Final_Survey_Observation(i_);
 		bool? k_(Observation ORAI)
 		{
@@ -1531,7 +1531,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> m_ = context.Operators.Union<Observation>(f_, l_);
 		CqlCode n_ = this.Osteoporosis_Index_of_Risk_panel();
 		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
-		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default(PropertyInfo));
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default);
 		IEnumerable<Observation> q_ = Status_1_6_000.Final_Survey_Observation(p_);
 		bool? r_(Observation OSIRIS)
 		{
@@ -1545,7 +1545,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 		IEnumerable<Observation> s_ = context.Operators.Where<Observation>(q_, r_);
 		CqlCode t_ = this.Osteoporosis_Self_Assessment_Tool();
 		IEnumerable<CqlCode> u_ = context.Operators.ToList<CqlCode>(t_);
-		IEnumerable<Observation> v_ = context.Operators.RetrieveByCodes<Observation>(u_, default(PropertyInfo));
+		IEnumerable<Observation> v_ = context.Operators.RetrieveByCodes<Observation>(u_, default);
 		IEnumerable<Observation> w_ = Status_1_6_000.Final_Survey_Observation(v_);
 		bool? x_(Observation OST)
 		{
@@ -1569,7 +1569,7 @@ public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 			ServiceRequest ax_ = context.Operators.First<ServiceRequest>(aw_);
 			FhirDateTime ay_ = ax_?.AuthoredOnElement;
 			CqlDateTime az_ = context.Operators.Convert<CqlDateTime>(ay_);
-			bool? ba_ = context.Operators.Before(av_, az_, default(string));
+			bool? ba_ = context.Operators.Before(av_, az_, default);
 
 			return ba_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AppropriateDXAScansForWomenUnder65FHIR", "0.0.000")]
 public class AppropriateDXAScansForWomenUnder65FHIR_0_0_000
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -136,7 +136,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_Pharyngitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", default);
 
     [CqlDeclaration("Acute Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011")]
@@ -144,7 +144,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Acute_Pharyngitis.Value;
 
 	private CqlValueSet Acute_Tonsillitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", default);
 
     [CqlDeclaration("Acute Tonsillitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012")]
@@ -152,7 +152,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Acute_Tonsillitis.Value;
 
 	private CqlValueSet Antibiotic_Medications_for_Pharyngitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default);
 
     [CqlDeclaration("Antibiotic Medications for Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
@@ -160,7 +160,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Antibiotic_Medications_for_Pharyngitis.Value;
 
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default);
 
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
@@ -168,7 +168,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default);
 
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
@@ -176,7 +176,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Discharge_Services_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", default);
 
     [CqlDeclaration("Discharge Services Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039")]
@@ -184,7 +184,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Discharge_Services_Observation_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -192,7 +192,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Group_A_Streptococcus_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", default);
 
     [CqlDeclaration("Group A Streptococcus Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012")]
@@ -200,7 +200,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Group_A_Streptococcus_Test.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -208,7 +208,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default);
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -216,7 +216,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Medical_Disability_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default);
 
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
@@ -224,7 +224,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Medical_Disability_Exam.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -232,7 +232,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -240,7 +240,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -248,7 +248,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -256,7 +256,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -264,7 +264,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default);
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -272,7 +272,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -280,7 +280,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -288,7 +288,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -296,7 +296,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -304,7 +304,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -312,14 +312,14 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value() => 
-		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Observation care discharge day management (This code is to be utilized to report all services provided to a patient on discharge from outpatient hospital observation status if the discharge is on other than the initial date of observation status. To report services to a patient designated as observation status or inpatient status and discharged on the same date, use the codes for Observation or Inpatient Care Services [including Admission and Discharge Services, 99234-99236 as appropriate.])")]
 	public CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___() => 
 		__Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -328,8 +328,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default, default),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -341,8 +341,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTestingforPharyngitisFHIR-0.1.000", "Measurement Period", c_);
 
@@ -355,7 +355,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -412,8 +412,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? d_(Encounter E)
 		{
 			List<CodeableConcept> bg_ = E?.Type;
@@ -439,37 +439,37 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		};
 		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(b_, e_);
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet i_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(f_, k_);
 		CqlValueSet m_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default);
 		CqlValueSet o_ = this.Medical_Disability_Exam();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
 		CqlValueSet s_ = this.Observation();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default);
 		CqlValueSet u_ = this.Office_Visit();
-		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default(PropertyInfo));
+		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(t_, v_);
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(r_, w_);
 		CqlValueSet y_ = this.Telephone_Visits();
-		IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
+		IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default);
 		CqlValueSet aa_ = this.Online_Assessments();
-		IEnumerable<Encounter> ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, default(PropertyInfo));
+		IEnumerable<Encounter> ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, default);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(z_, ab_);
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(x_, ac_);
 		CqlValueSet ae_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, default(PropertyInfo));
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, default);
 		CqlValueSet ag_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, default(PropertyInfo));
+		IEnumerable<Encounter> ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, default);
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(af_, ah_);
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ad_, ai_);
 		CqlValueSet ak_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, default(PropertyInfo));
+		IEnumerable<Encounter> al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, default);
 		bool? an_(Encounter E)
 		{
 			List<CodeableConcept> bq_ = E?.Type;
@@ -497,15 +497,15 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> ap_ = context.Operators.Union<Encounter>(al_, ao_);
 		IEnumerable<Encounter> aq_ = context.Operators.Union<Encounter>(aj_, ap_);
 		CqlValueSet ar_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, default(PropertyInfo));
+		IEnumerable<Encounter> as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, default);
 		CqlValueSet at_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, default(PropertyInfo));
+		IEnumerable<Encounter> au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, default);
 		IEnumerable<Encounter> av_ = context.Operators.Union<Encounter>(as_, au_);
 		IEnumerable<Encounter> aw_ = context.Operators.Union<Encounter>(aq_, av_);
 		CqlValueSet ax_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, default(PropertyInfo));
+		IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, default);
 		CqlValueSet az_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, default(PropertyInfo));
+		IEnumerable<Encounter> ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, default);
 		IEnumerable<Encounter> bb_ = context.Operators.Union<Encounter>(ay_, ba_);
 		IEnumerable<Encounter> bc_ = context.Operators.Union<Encounter>(aw_, bb_);
 		IEnumerable<Encounter> bd_ = Status_1_6_000.Finished_Encounter(bc_);
@@ -515,7 +515,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			Period cb_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_3_000.ToInterval(cb_);
 			CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.ToInterval((cc_ as object));
-			bool? ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, default(string));
+			bool? ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, default);
 
 			return ce_;
 		};
@@ -534,8 +534,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EDOrAmbulatoryVisit)
 		{
 			CqlValueSet d_ = this.Antibiotic_Medications_for_Pharyngitis();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			IEnumerable<MedicationRequest> i_ = Status_1_6_000.Active_Medication(h_);
 			bool? j_(MedicationRequest AntibioticOrdered)
@@ -550,7 +550,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 				CqlDateTime u_ = context.Operators.Subtract(s_, t_);
 				CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(r_);
 				CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-				bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, default(string));
+				bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, default);
 				CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(r_);
 				bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
 				bool? ac_ = context.Operators.And(y_, ab_);
@@ -576,9 +576,9 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Condition> Pharyngitis_or_Tonsillitis_Value()
 	{
 		CqlValueSet a_ = this.Acute_Pharyngitis();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Acute_Tonsillitis();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 
@@ -608,7 +608,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			Period m_ = tuple_ypyxedbbcqbdavhxvckuwmfh?.VisitWithAntibiotic?.Period;
 			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, default);
 
 			return p_;
 		};
@@ -687,16 +687,16 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.In_Hospice();
 		IEnumerable<Encounter> b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		CqlValueSet c_ = this.Antibiotic_Medications_for_Pharyngitis();
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default);
+		IEnumerable<MedicationRequest> f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default);
 		IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(d_, f_);
 		IEnumerable<Encounter> h_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, g_);
 		IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(a_, h_);
 		CqlValueSet k_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
+		IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default);
 		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, l_);
 		CqlValueSet o_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(i_, r_);
@@ -711,7 +711,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result_Value()
 	{
 		CqlValueSet a_ = this.Group_A_Streptococcus_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation GroupAStreptococcusTest)
 		{
@@ -787,7 +787,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(3, 17, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
+			bool? o_ = context.Operators.In<int?>(m_, n_, default);
 
 			return o_;
 		};
@@ -817,7 +817,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
+			bool? o_ = context.Operators.In<int?>(m_, n_, default);
 
 			return o_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AppropriateTestingforPharyngitisFHIR", "0.1.000")]
 public class AppropriateTestingforPharyngitisFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.000.g.cs
@@ -136,7 +136,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_Pharyngitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011", default(string));
 
     [CqlDeclaration("Acute Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1011")]
@@ -144,7 +144,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Acute_Pharyngitis.Value;
 
 	private CqlValueSet Acute_Tonsillitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012", default(string));
 
     [CqlDeclaration("Acute Tonsillitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1012")]
@@ -152,7 +152,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Acute_Tonsillitis.Value;
 
 	private CqlValueSet Antibiotic_Medications_for_Pharyngitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default(string));
 
     [CqlDeclaration("Antibiotic Medications for Pharyngitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
@@ -160,7 +160,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Antibiotic_Medications_for_Pharyngitis.Value;
 
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default(string));
 
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
@@ -168,7 +168,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default(string));
 
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
@@ -176,7 +176,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Discharge_Services_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039", default(string));
 
     [CqlDeclaration("Discharge Services Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1039")]
@@ -184,7 +184,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Discharge_Services_Observation_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -192,7 +192,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Group_A_Streptococcus_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012", default(string));
 
     [CqlDeclaration("Group A Streptococcus Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1012")]
@@ -200,7 +200,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Group_A_Streptococcus_Test.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -208,7 +208,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -216,7 +216,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Medical_Disability_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default(string));
 
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
@@ -224,7 +224,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Medical_Disability_Exam.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -232,7 +232,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -240,7 +240,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -248,7 +248,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -256,7 +256,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -264,7 +264,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -272,7 +272,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -280,7 +280,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -288,7 +288,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -296,7 +296,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -304,7 +304,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -312,14 +312,14 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate____Value() => 
-		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Observation care discharge day management (This code is to be utilized to report all services provided to a patient on discharge from outpatient hospital observation status if the discharge is on other than the initial date of observation status. To report services to a patient designated as observation status or inpatient status and discharged on the same date, use the codes for Observation or Inpatient Care Services [including Admission and Discharge Services, 99234-99236 as appropriate.])")]
 	public CqlCode Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___() => 
 		__Observation_care_discharge_day_management__This_code_is_to_be_utilized_to_report_all_services_provided_to_a_patient_on_discharge_from_outpatient_hospital_observation_status_if_the_discharge_is_on_other_than_the_initial_date_of_observation_status__To_report_services_to_a_patient_designated_as_observation_status_or_inpatient_status_and_discharged_on_the_same_date__use_the_codes_for_Observation_or_Inpatient_Care_Services__including_Admission_and_Discharge_Services__99234_99236_as_appropriate___.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -328,8 +328,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", null, null),
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99217", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -341,8 +341,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTestingforPharyngitisFHIR-0.1.000", "Measurement Period", c_);
 
@@ -355,7 +355,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -412,8 +412,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? d_(Encounter E)
 		{
 			List<CodeableConcept> bg_ = E?.Type;
@@ -439,37 +439,37 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		};
 		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(b_, e_);
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet i_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(f_, k_);
 		CqlValueSet m_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
 		CqlValueSet o_ = this.Medical_Disability_Exam();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(l_, q_);
 		CqlValueSet s_ = this.Observation();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
 		CqlValueSet u_ = this.Office_Visit();
-		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
+		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default(PropertyInfo));
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(t_, v_);
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(r_, w_);
 		CqlValueSet y_ = this.Telephone_Visits();
-		IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+		IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
 		CqlValueSet aa_ = this.Online_Assessments();
-		IEnumerable<Encounter> ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, null);
+		IEnumerable<Encounter> ab_ = context.Operators.RetrieveByValueSet<Encounter>(aa_, default(PropertyInfo));
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(z_, ab_);
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(x_, ac_);
 		CqlValueSet ae_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, null);
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(ae_, default(PropertyInfo));
 		CqlValueSet ag_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, null);
+		IEnumerable<Encounter> ah_ = context.Operators.RetrieveByValueSet<Encounter>(ag_, default(PropertyInfo));
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(af_, ah_);
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ad_, ai_);
 		CqlValueSet ak_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, null);
+		IEnumerable<Encounter> al_ = context.Operators.RetrieveByValueSet<Encounter>(ak_, default(PropertyInfo));
 		bool? an_(Encounter E)
 		{
 			List<CodeableConcept> bq_ = E?.Type;
@@ -497,15 +497,15 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> ap_ = context.Operators.Union<Encounter>(al_, ao_);
 		IEnumerable<Encounter> aq_ = context.Operators.Union<Encounter>(aj_, ap_);
 		CqlValueSet ar_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, null);
+		IEnumerable<Encounter> as_ = context.Operators.RetrieveByValueSet<Encounter>(ar_, default(PropertyInfo));
 		CqlValueSet at_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, null);
+		IEnumerable<Encounter> au_ = context.Operators.RetrieveByValueSet<Encounter>(at_, default(PropertyInfo));
 		IEnumerable<Encounter> av_ = context.Operators.Union<Encounter>(as_, au_);
 		IEnumerable<Encounter> aw_ = context.Operators.Union<Encounter>(aq_, av_);
 		CqlValueSet ax_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, null);
+		IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ax_, default(PropertyInfo));
 		CqlValueSet az_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, null);
+		IEnumerable<Encounter> ba_ = context.Operators.RetrieveByValueSet<Encounter>(az_, default(PropertyInfo));
 		IEnumerable<Encounter> bb_ = context.Operators.Union<Encounter>(ay_, ba_);
 		IEnumerable<Encounter> bc_ = context.Operators.Union<Encounter>(aw_, bb_);
 		IEnumerable<Encounter> bd_ = Status_1_6_000.Finished_Encounter(bc_);
@@ -515,7 +515,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			Period cb_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_3_000.ToInterval(cb_);
 			CqlInterval<CqlDateTime> cd_ = QICoreCommon_2_0_000.ToInterval((cc_ as object));
-			bool? ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, null);
+			bool? ce_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ca_, cd_, default(string));
 
 			return ce_;
 		};
@@ -534,8 +534,8 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EDOrAmbulatoryVisit)
 		{
 			CqlValueSet d_ = this.Antibiotic_Medications_for_Pharyngitis();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			IEnumerable<MedicationRequest> i_ = Status_1_6_000.Active_Medication(h_);
 			bool? j_(MedicationRequest AntibioticOrdered)
@@ -550,7 +550,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 				CqlDateTime u_ = context.Operators.Subtract(s_, t_);
 				CqlDateTime w_ = context.Operators.Convert<CqlDateTime>(r_);
 				CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
-				bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, null);
+				bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, default(string));
 				CqlDateTime aa_ = context.Operators.Convert<CqlDateTime>(r_);
 				bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
 				bool? ac_ = context.Operators.And(y_, ab_);
@@ -576,9 +576,9 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Condition> Pharyngitis_or_Tonsillitis_Value()
 	{
 		CqlValueSet a_ = this.Acute_Pharyngitis();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Acute_Tonsillitis();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 
@@ -608,7 +608,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			Period m_ = tuple_ypyxedbbcqbdavhxvckuwmfh?.VisitWithAntibiotic?.Period;
 			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_3_000.ToInterval(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
-			bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, default(string));
 
 			return p_;
 		};
@@ -687,16 +687,16 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.In_Hospice();
 		IEnumerable<Encounter> b_ = this.Encounter_With_Pharyngitis_or_Tonsillitis_With_Antibiotic();
 		CqlValueSet c_ = this.Antibiotic_Medications_for_Pharyngitis();
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
-		IEnumerable<MedicationRequest> f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, null);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> f_ = context.Operators.RetrieveByValueSet<MedicationRequest>(c_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> g_ = context.Operators.Union<MedicationRequest>(d_, f_);
 		IEnumerable<Encounter> h_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, g_);
 		IEnumerable<Encounter> i_ = context.Operators.Union<Encounter>(a_, h_);
 		CqlValueSet k_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+		IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
 		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, l_);
 		CqlValueSet o_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(i_, r_);
@@ -711,7 +711,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 	private IEnumerable<Observation> Group_A_Streptococcus_Lab_Test_With_Result_Value()
 	{
 		CqlValueSet a_ = this.Group_A_Streptococcus_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation GroupAStreptococcusTest)
 		{
@@ -787,7 +787,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(3, 17, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, null);
+			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
 
 			return o_;
 		};
@@ -817,7 +817,7 @@ public class AppropriateTestingforPharyngitisFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, null);
+			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
 
 			return o_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AppropriateTreatmentforSTEMIFHIR", "1.0.000")]
 public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -166,7 +166,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
     #endregion
 
 	private CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", default(string));
 
     [CqlDeclaration("Active Bleeding Excluding Menses or Bleeding Diathesis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036")]
@@ -174,7 +174,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis.Value;
 
 	private CqlValueSet Active_Peptic_Ulcer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", default(string));
 
     [CqlDeclaration("Active Peptic Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031")]
@@ -182,7 +182,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Active_Peptic_Ulcer.Value;
 
 	private CqlValueSet Adverse_reaction_to_thrombolytics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", default(string));
 
     [CqlDeclaration("Adverse reaction to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6")]
@@ -190,7 +190,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Adverse_reaction_to_thrombolytics.Value;
 
 	private CqlValueSet Allergy_to_thrombolytics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", default(string));
 
     [CqlDeclaration("Allergy to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5")]
@@ -198,7 +198,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Allergy_to_thrombolytics.Value;
 
 	private CqlValueSet Oral_Anticoagulant_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", default(string));
 
     [CqlDeclaration("Oral Anticoagulant Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045")]
@@ -206,7 +206,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Oral_Anticoagulant_Medications.Value;
 
 	private CqlValueSet Aortic_Dissection_and_Rupture_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", default(string));
 
     [CqlDeclaration("Aortic Dissection and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028")]
@@ -214,7 +214,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Aortic_Dissection_and_Rupture.Value;
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -222,7 +222,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__birth_date.Value;
 
 	private CqlValueSet Cardiopulmonary_Arrest_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", default(string));
 
     [CqlDeclaration("Cardiopulmonary Arrest")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048")]
@@ -230,7 +230,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Cardiopulmonary_Arrest.Value;
 
 	private CqlValueSet Cerebral_Vascular_Lesion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", default(string));
 
     [CqlDeclaration("Cerebral Vascular Lesion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025")]
@@ -238,7 +238,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Cerebral_Vascular_Lesion.Value;
 
 	private CqlValueSet Closed_Head_and_Facial_Trauma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", default(string));
 
     [CqlDeclaration("Closed Head and Facial Trauma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026")]
@@ -246,7 +246,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Closed_Head_and_Facial_Trauma.Value;
 
 	private CqlValueSet Dementia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", default(string));
 
     [CqlDeclaration("Dementia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043")]
@@ -254,7 +254,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Dementia.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -262,7 +262,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet ED_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", default(string));
 
     [CqlDeclaration("ED")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085")]
@@ -270,7 +270,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__ED.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -278,7 +278,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Endotracheal_Intubation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", default(string));
 
     [CqlDeclaration("Endotracheal Intubation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69")]
@@ -286,7 +286,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Endotracheal_Intubation.Value;
 
 	private CqlValueSet Fibrinolytic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", default(string));
 
     [CqlDeclaration("Fibrinolytic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020")]
@@ -294,7 +294,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Fibrinolytic_Therapy.Value;
 
 	private CqlValueSet Intracranial_or_Intraspinal_surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", default(string));
 
     [CqlDeclaration("Intracranial or Intraspinal surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2")]
@@ -302,7 +302,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Intracranial_or_Intraspinal_surgery.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", default(string));
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024")]
@@ -310,7 +310,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Major_Surgical_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", default(string));
 
     [CqlDeclaration("Major Surgical Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056")]
@@ -318,7 +318,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Major_Surgical_Procedure.Value;
 
 	private CqlValueSet Malignant_Intracranial_Neoplasm_Group_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", default(string));
 
     [CqlDeclaration("Malignant Intracranial Neoplasm Group")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3")]
@@ -326,7 +326,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Malignant_Intracranial_Neoplasm_Group.Value;
 
 	private CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", default(string));
 
     [CqlDeclaration("Insertion or Replacement of Mechanical Circulatory Assist Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052")]
@@ -334,7 +334,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device.Value;
 
 	private CqlValueSet Neurologic_impairment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", default(string));
 
     [CqlDeclaration("Neurologic impairment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012")]
@@ -342,7 +342,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Neurologic_impairment.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -350,7 +350,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Percutaneous_Coronary_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", default(string));
 
     [CqlDeclaration("Percutaneous Coronary Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5")]
@@ -358,7 +358,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Percutaneous_Coronary_Intervention.Value;
 
 	private CqlValueSet Pregnancy_ICD10_SNOMEDCT_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", default(string));
 
     [CqlDeclaration("Pregnancy ICD10 SNOMEDCT")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055")]
@@ -366,7 +366,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Pregnancy_ICD10_SNOMEDCT.Value;
 
 	private CqlValueSet STEMI_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", default(string));
 
     [CqlDeclaration("STEMI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017")]
@@ -374,7 +374,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__STEMI.Value;
 
 	private CqlValueSet Thrombolytic_medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", default(string));
 
     [CqlDeclaration("Thrombolytic medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4")]
@@ -382,35 +382,35 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Thrombolytic_medications.Value;
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Emergency_Department_Value() => 
-		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null);
+		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default(string), default(string));
 
     [CqlDeclaration("Emergency Department")]
 	public CqlCode Emergency_Department() => 
 		__Emergency_Department.Value;
 
 	private CqlCode Patient_transfer__procedure__Value() => 
-		new CqlCode("107724000", "http://snomed.info/sct", null, null);
+		new CqlCode("107724000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Patient transfer (procedure)")]
 	public CqlCode Patient_transfer__procedure_() => 
 		__Patient_transfer__procedure_.Value;
 
 	private CqlCode Streptokinase_adverse_reaction__disorder__Value() => 
-		new CqlCode("293571007", "http://snomed.info/sct", null, null);
+		new CqlCode("293571007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Streptokinase adverse reaction (disorder)")]
 	public CqlCode Streptokinase_adverse_reaction__disorder_() => 
 		__Streptokinase_adverse_reaction__disorder_.Value;
 
 	private CqlCode EMER_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("EMER")]
 	public CqlCode EMER() => 
@@ -419,7 +419,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -432,7 +432,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] HSLOC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", null, null),
+			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default(string), default(string)),
 		];
 
 		return a_;
@@ -445,8 +445,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("107724000", "http://snomed.info/sct", null, null),
-			new CqlCode("293571007", "http://snomed.info/sct", null, null),
+			new CqlCode("107724000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("293571007", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -459,7 +459,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -471,8 +471,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTreatmentforSTEMIFHIR-1.0.000", "Measurement Period", c_);
 
@@ -485,7 +485,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -498,7 +498,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value()
 	{
 		CqlValueSet a_ = this.ED();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EDEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = EDEncounter?.StatusElement;
@@ -537,7 +537,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
 			Period z_ = EDEncounter?.Period;
 			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, null);
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, default(string));
 			bool? ac_ = context.Operators.And(x_, ab_);
 
 			return ac_;
@@ -554,11 +554,11 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI_Value()
 	{
 		CqlValueSet a_ = this.ED();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_(Encounter EDEncounter)
 		{
 			CqlValueSet e_ = this.STEMI();
-			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
 			bool? g_(Condition DxSTEMI)
 			{
 				CodeableConcept k_ = DxSTEMI?.ClinicalStatus;
@@ -580,7 +580,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime aa_ = context.Operators.Start(z_);
 				Period ab_ = EDEncounter?.Period;
 				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, null);
+				bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, default(string));
 				bool? ae_ = context.Operators.And(y_, ad_);
 				CqlInterval<CqlDateTime> af_ = this.Measurement_Period();
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
@@ -662,7 +662,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Thrombolytic_medications();
-			IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, null);
+			IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, default(PropertyInfo));
 			bool? f_(AllergyIntolerance ThrombolyticAllergy)
 			{
 				CodeableConcept j_ = ThrombolyticAllergy?.ClinicalStatus;
@@ -675,7 +675,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
 				Period r_ = EDwSTEMI?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.Overlaps(q_, s_, null);
+				bool? t_ = context.Operators.Overlaps(q_, s_, default(string));
 				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;
@@ -702,7 +702,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Adverse_reaction_to_thrombolytics();
-			IEnumerable<AdverseEvent> e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, null);
+			IEnumerable<AdverseEvent> e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, default(PropertyInfo));
 			bool? f_(AdverseEvent ThrombolyticAdverseEvent)
 			{
 				FhirDateTime j_ = ThrombolyticAdverseEvent?.RecordedDateElement;
@@ -710,7 +710,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				Period l_ = EDwSTEMI?.Period;
 				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 				CqlDateTime n_ = context.Operators.End(m_);
-				bool? o_ = context.Operators.Before(k_, n_, null);
+				bool? o_ = context.Operators.Before(k_, n_, default(string));
 				Code<AdverseEvent.AdverseEventActuality> p_ = ThrombolyticAdverseEvent?.ActualityElement;
 				AdverseEvent.AdverseEventActuality? q_ = p_?.Value;
 				Code<AdverseEvent.AdverseEventActuality> r_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(q_);
@@ -741,20 +741,20 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			CqlValueSet f_ = this.Malignant_Intracranial_Neoplasm_Group();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Cerebral_Vascular_Lesion();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
 			CqlValueSet k_ = this.Dementia();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			CqlValueSet o_ = this.Pregnancy_ICD10_SNOMEDCT();
-			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 			CqlValueSet q_ = this.Allergy_to_thrombolytics();
-			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default(PropertyInfo));
 			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
 			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
 			bool? u_(Condition ActiveExclusionDx)
@@ -762,7 +762,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveExclusionDx);
 				Period z_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				bool? ab_ = context.Operators.OverlapsBefore(y_, aa_, null);
+				bool? ab_ = context.Operators.OverlapsBefore(y_, aa_, default(string));
 
 				return ab_;
 			};
@@ -788,8 +788,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Oral_Anticoagulant_Medications();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest OralAnticoagulant)
 			{
@@ -807,7 +807,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				Period x_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.SameOrBefore(w_, z_, null);
+				bool? aa_ = context.Operators.SameOrBefore(w_, z_, default(string));
 				bool? ab_ = context.Operators.And(u_, aa_);
 
 				return ab_;
@@ -834,12 +834,12 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Aortic_Dissection_and_Rupture();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			CqlValueSet f_ = this.Neurologic_impairment();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Cardiopulmonary_Arrest();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
 			IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
 			bool? l_(Condition ExclusionDiagnosis)
 			{
@@ -847,7 +847,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime q_ = context.Operators.Start(p_);
 				Period r_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
 				CqlDateTime v_ = context.Operators.Start(p_);
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime y_ = context.Operators.Start(x_);
@@ -856,7 +856,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime ad_ = context.Operators.Start(ac_);
 				CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(aa_, ad_, true, false);
-				bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, null);
+				bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, default(string));
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime ai_ = context.Operators.Start(ah_);
 				bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
@@ -887,7 +887,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Major_Surgical_Procedure();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure MajorSurgery)
 			{
 				DataType j_ = MajorSurgery?.Performed;
@@ -902,7 +902,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime u_ = context.Operators.Start(t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -937,9 +937,9 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Endotracheal_Intubation();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			CqlValueSet f_ = this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device();
-			IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+			IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 			IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 			bool? i_(Procedure AirwayProcedure)
 			{
@@ -949,7 +949,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime p_ = context.Operators.Start(o_);
 				Period q_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, null);
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default(string));
 				object u_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
 				CqlDateTime w_ = context.Operators.Start(v_);
@@ -960,7 +960,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime ae_ = context.Operators.Start(ad_);
 				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, false);
-				bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, null);
+				bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, default(string));
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime aj_ = context.Operators.Start(ai_);
 				bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
@@ -996,14 +996,14 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Ischemic_Stroke();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			CqlValueSet f_ = this.Closed_Head_and_Facial_Trauma();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Active_Peptic_Ulcer();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
 			CqlValueSet k_ = this.Cardiopulmonary_Arrest();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			bool? o_(Condition ExclusionCondition)
@@ -1018,7 +1018,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(u_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
 				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-				bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, null);
+				bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default(string));
 
 				return ad_;
 			};
@@ -1044,7 +1044,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Intracranial_or_Intraspinal_surgery();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure CranialorSpinalSurgery)
 			{
 				DataType j_ = CranialorSpinalSurgery?.Performed;
@@ -1059,7 +1059,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime u_ = context.Operators.Start(t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -1176,8 +1176,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Fibrinolytic_Therapy();
-			IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
-			IEnumerable<MedicationAdministration> g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, null);
+			IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default(PropertyInfo));
+			IEnumerable<MedicationAdministration> g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default(PropertyInfo));
 			IEnumerable<MedicationAdministration> h_ = context.Operators.Union<MedicationAdministration>(e_, g_);
 			bool? i_(MedicationAdministration Fibrinolytic)
 			{
@@ -1193,7 +1193,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlQuantity w_ = context.Operators.Quantity(30m, "minutes");
 				CqlDateTime x_ = context.Operators.Add(u_, w_);
 				CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, false, true);
-				bool? z_ = context.Operators.In<CqlDateTime>(t_, y_, null);
+				bool? z_ = context.Operators.In<CqlDateTime>(t_, y_, default(string));
 				bool? ab_ = context.Operators.Not((bool?)(u_ is null));
 				bool? ac_ = context.Operators.And(z_, ab_);
 				bool? ad_ = context.Operators.And(p_, ac_);
@@ -1222,7 +1222,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Percutaneous_Coronary_Intervention();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure PCI)
 			{
 				DataType j_ = PCI?.Performed;
@@ -1233,7 +1233,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlQuantity p_ = context.Operators.Quantity(90m, "minutes");
 				CqlDateTime q_ = context.Operators.Add(n_, p_);
 				CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, false, true);
-				bool? s_ = context.Operators.In<CqlDateTime>(m_, r_, null);
+				bool? s_ = context.Operators.In<CqlDateTime>(m_, r_, default(string));
 				bool? u_ = context.Operators.Not((bool?)(n_ is null));
 				bool? v_ = context.Operators.And(s_, u_);
 				Code<EventStatus> w_ = PCI?.StatusElement;
@@ -1275,7 +1275,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 			CqlQuantity m_ = context.Operators.Quantity(45m, "minutes");
 			CqlDateTime n_ = context.Operators.Add(l_, m_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(i_, n_, false, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(f_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(f_, o_, default(string));
 			CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(d_);
 			CqlDateTime s_ = context.Operators.Start(r_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.0.000.g.cs
@@ -166,7 +166,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
     #endregion
 
 	private CqlValueSet Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036", default);
 
     [CqlDeclaration("Active Bleeding Excluding Menses or Bleeding Diathesis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4036")]
@@ -174,7 +174,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis.Value;
 
 	private CqlValueSet Active_Peptic_Ulcer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031", default);
 
     [CqlDeclaration("Active Peptic Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4031")]
@@ -182,7 +182,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Active_Peptic_Ulcer.Value;
 
 	private CqlValueSet Adverse_reaction_to_thrombolytics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6", default);
 
     [CqlDeclaration("Adverse reaction to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.6")]
@@ -190,7 +190,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Adverse_reaction_to_thrombolytics.Value;
 
 	private CqlValueSet Allergy_to_thrombolytics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5", default);
 
     [CqlDeclaration("Allergy to thrombolytics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.5")]
@@ -198,7 +198,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Allergy_to_thrombolytics.Value;
 
 	private CqlValueSet Oral_Anticoagulant_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045", default);
 
     [CqlDeclaration("Oral Anticoagulant Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4045")]
@@ -206,7 +206,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Oral_Anticoagulant_Medications.Value;
 
 	private CqlValueSet Aortic_Dissection_and_Rupture_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028", default);
 
     [CqlDeclaration("Aortic Dissection and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4028")]
@@ -214,7 +214,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Aortic_Dissection_and_Rupture.Value;
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -222,7 +222,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__birth_date.Value;
 
 	private CqlValueSet Cardiopulmonary_Arrest_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048", default);
 
     [CqlDeclaration("Cardiopulmonary Arrest")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4048")]
@@ -230,7 +230,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Cardiopulmonary_Arrest.Value;
 
 	private CqlValueSet Cerebral_Vascular_Lesion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025", default);
 
     [CqlDeclaration("Cerebral Vascular Lesion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4025")]
@@ -238,7 +238,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Cerebral_Vascular_Lesion.Value;
 
 	private CqlValueSet Closed_Head_and_Facial_Trauma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026", default);
 
     [CqlDeclaration("Closed Head and Facial Trauma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4026")]
@@ -246,7 +246,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Closed_Head_and_Facial_Trauma.Value;
 
 	private CqlValueSet Dementia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043", default);
 
     [CqlDeclaration("Dementia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4043")]
@@ -254,7 +254,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Dementia.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -262,7 +262,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet ED_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085", default);
 
     [CqlDeclaration("ED")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1085")]
@@ -270,7 +270,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__ED.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -278,7 +278,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Endotracheal_Intubation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69", default);
 
     [CqlDeclaration("Endotracheal Intubation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.69")]
@@ -286,7 +286,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Endotracheal_Intubation.Value;
 
 	private CqlValueSet Fibrinolytic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020", default);
 
     [CqlDeclaration("Fibrinolytic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4020")]
@@ -294,7 +294,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Fibrinolytic_Therapy.Value;
 
 	private CqlValueSet Intracranial_or_Intraspinal_surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2", default);
 
     [CqlDeclaration("Intracranial or Intraspinal surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.2")]
@@ -302,7 +302,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Intracranial_or_Intraspinal_surgery.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024", default);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.104.12.1024")]
@@ -310,7 +310,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Major_Surgical_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056", default);
 
     [CqlDeclaration("Major Surgical Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4056")]
@@ -318,7 +318,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Major_Surgical_Procedure.Value;
 
 	private CqlValueSet Malignant_Intracranial_Neoplasm_Group_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3", default);
 
     [CqlDeclaration("Malignant Intracranial Neoplasm Group")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.3")]
@@ -326,7 +326,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Malignant_Intracranial_Neoplasm_Group.Value;
 
 	private CqlValueSet Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052", default);
 
     [CqlDeclaration("Insertion or Replacement of Mechanical Circulatory Assist Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4052")]
@@ -334,7 +334,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device.Value;
 
 	private CqlValueSet Neurologic_impairment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012", default);
 
     [CqlDeclaration("Neurologic impairment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1012")]
@@ -342,7 +342,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Neurologic_impairment.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -350,7 +350,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Percutaneous_Coronary_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5", default);
 
     [CqlDeclaration("Percutaneous Coronary Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.2000.5")]
@@ -358,7 +358,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Percutaneous_Coronary_Intervention.Value;
 
 	private CqlValueSet Pregnancy_ICD10_SNOMEDCT_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055", default);
 
     [CqlDeclaration("Pregnancy ICD10 SNOMEDCT")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4055")]
@@ -366,7 +366,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Pregnancy_ICD10_SNOMEDCT.Value;
 
 	private CqlValueSet STEMI_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017", default);
 
     [CqlDeclaration("STEMI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.3157.4017")]
@@ -374,7 +374,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__STEMI.Value;
 
 	private CqlValueSet Thrombolytic_medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4", default);
 
     [CqlDeclaration("Thrombolytic medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1170.4")]
@@ -382,35 +382,35 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		__Thrombolytic_medications.Value;
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Emergency_Department_Value() => 
-		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default(string), default(string));
+		new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default, default);
 
     [CqlDeclaration("Emergency Department")]
 	public CqlCode Emergency_Department() => 
 		__Emergency_Department.Value;
 
 	private CqlCode Patient_transfer__procedure__Value() => 
-		new CqlCode("107724000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("107724000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Patient transfer (procedure)")]
 	public CqlCode Patient_transfer__procedure_() => 
 		__Patient_transfer__procedure_.Value;
 
 	private CqlCode Streptokinase_adverse_reaction__disorder__Value() => 
-		new CqlCode("293571007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("293571007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Streptokinase adverse reaction (disorder)")]
 	public CqlCode Streptokinase_adverse_reaction__disorder_() => 
 		__Streptokinase_adverse_reaction__disorder_.Value;
 
 	private CqlCode EMER_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("EMER")]
 	public CqlCode EMER() => 
@@ -419,7 +419,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -432,7 +432,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] HSLOC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default(string), default(string)),
+			new CqlCode("1108-0", "https://www.cdc.gov/nhsn/cdaportal/terminology/codesystem/hsloc.html", default, default),
 		];
 
 		return a_;
@@ -445,8 +445,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("107724000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("293571007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("107724000", "http://snomed.info/sct", default, default),
+			new CqlCode("293571007", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -459,7 +459,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -471,8 +471,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTreatmentforSTEMIFHIR-1.0.000", "Measurement Period", c_);
 
@@ -485,7 +485,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -498,7 +498,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private IEnumerable<Encounter> ED_Encounter_with_Encounter_Diagnosis_of_STEMI_Value()
 	{
 		CqlValueSet a_ = this.ED();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EDEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = EDEncounter?.StatusElement;
@@ -537,7 +537,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 			CqlInterval<CqlDateTime> y_ = this.Measurement_Period();
 			Period z_ = EDEncounter?.Period;
 			CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, default(string));
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, aa_, default);
 			bool? ac_ = context.Operators.And(x_, ab_);
 
 			return ac_;
@@ -554,11 +554,11 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 	private IEnumerable<Encounter> ED_Encounter_with_Diagnosis_of_STEMI_Value()
 	{
 		CqlValueSet a_ = this.ED();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_(Encounter EDEncounter)
 		{
 			CqlValueSet e_ = this.STEMI();
-			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default);
 			bool? g_(Condition DxSTEMI)
 			{
 				CodeableConcept k_ = DxSTEMI?.ClinicalStatus;
@@ -580,7 +580,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime aa_ = context.Operators.Start(z_);
 				Period ab_ = EDEncounter?.Period;
 				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(ab_);
-				bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, default(string));
+				bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, default);
 				bool? ae_ = context.Operators.And(y_, ad_);
 				CqlInterval<CqlDateTime> af_ = this.Measurement_Period();
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(ab_);
@@ -662,7 +662,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Thrombolytic_medications();
-			IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, default(PropertyInfo));
+			IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(d_, default);
 			bool? f_(AllergyIntolerance ThrombolyticAllergy)
 			{
 				CodeableConcept j_ = ThrombolyticAllergy?.ClinicalStatus;
@@ -675,7 +675,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.toInterval(p_);
 				Period r_ = EDwSTEMI?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.Overlaps(q_, s_, default(string));
+				bool? t_ = context.Operators.Overlaps(q_, s_, default);
 				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;
@@ -702,7 +702,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Adverse_reaction_to_thrombolytics();
-			IEnumerable<AdverseEvent> e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, default(PropertyInfo));
+			IEnumerable<AdverseEvent> e_ = context.Operators.RetrieveByValueSet<AdverseEvent>(d_, default);
 			bool? f_(AdverseEvent ThrombolyticAdverseEvent)
 			{
 				FhirDateTime j_ = ThrombolyticAdverseEvent?.RecordedDateElement;
@@ -710,7 +710,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				Period l_ = EDwSTEMI?.Period;
 				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 				CqlDateTime n_ = context.Operators.End(m_);
-				bool? o_ = context.Operators.Before(k_, n_, default(string));
+				bool? o_ = context.Operators.Before(k_, n_, default);
 				Code<AdverseEvent.AdverseEventActuality> p_ = ThrombolyticAdverseEvent?.ActualityElement;
 				AdverseEvent.AdverseEventActuality? q_ = p_?.Value;
 				Code<AdverseEvent.AdverseEventActuality> r_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(q_);
@@ -741,20 +741,20 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Active_Bleeding_Excluding_Menses_or_Bleeding_Diathesis();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			CqlValueSet f_ = this.Malignant_Intracranial_Neoplasm_Group();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Cerebral_Vascular_Lesion();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default);
 			CqlValueSet k_ = this.Dementia();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default);
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			CqlValueSet o_ = this.Pregnancy_ICD10_SNOMEDCT();
-			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 			CqlValueSet q_ = this.Allergy_to_thrombolytics();
-			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default(PropertyInfo));
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default);
 			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
 			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
 			bool? u_(Condition ActiveExclusionDx)
@@ -762,7 +762,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveExclusionDx);
 				Period z_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(z_);
-				bool? ab_ = context.Operators.OverlapsBefore(y_, aa_, default(string));
+				bool? ab_ = context.Operators.OverlapsBefore(y_, aa_, default);
 
 				return ab_;
 			};
@@ -788,8 +788,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Oral_Anticoagulant_Medications();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest OralAnticoagulant)
 			{
@@ -807,7 +807,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				Period x_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.SameOrBefore(w_, z_, default(string));
+				bool? aa_ = context.Operators.SameOrBefore(w_, z_, default);
 				bool? ab_ = context.Operators.And(u_, aa_);
 
 				return ab_;
@@ -834,12 +834,12 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Aortic_Dissection_and_Rupture();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			CqlValueSet f_ = this.Neurologic_impairment();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Cardiopulmonary_Arrest();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default);
 			IEnumerable<Condition> k_ = context.Operators.Union<Condition>(h_, j_);
 			bool? l_(Condition ExclusionDiagnosis)
 			{
@@ -847,7 +847,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime q_ = context.Operators.Start(p_);
 				Period r_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
 				CqlDateTime v_ = context.Operators.Start(p_);
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime y_ = context.Operators.Start(x_);
@@ -856,7 +856,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime ad_ = context.Operators.Start(ac_);
 				CqlInterval<CqlDateTime> ae_ = context.Operators.Interval(aa_, ad_, true, false);
-				bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, default(string));
+				bool? af_ = context.Operators.In<CqlDateTime>(v_, ae_, default);
 				CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_3_000.ToInterval(r_);
 				CqlDateTime ai_ = context.Operators.Start(ah_);
 				bool? aj_ = context.Operators.Not((bool?)(ai_ is null));
@@ -887,7 +887,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Major_Surgical_Procedure();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure MajorSurgery)
 			{
 				DataType j_ = MajorSurgery?.Performed;
@@ -902,7 +902,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime u_ = context.Operators.Start(t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -937,9 +937,9 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Endotracheal_Intubation();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			CqlValueSet f_ = this.Insertion_or_Replacement_of_Mechanical_Circulatory_Assist_Device();
-			IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+			IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 			IEnumerable<Procedure> h_ = context.Operators.Union<Procedure>(e_, g_);
 			bool? i_(Procedure AirwayProcedure)
 			{
@@ -949,7 +949,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlDateTime p_ = context.Operators.Start(o_);
 				Period q_ = EDwithSTEMI?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
-				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default(string));
+				bool? s_ = context.Operators.In<CqlDateTime>(p_, r_, default);
 				object u_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> v_ = QICoreCommon_2_0_000.toInterval(u_);
 				CqlDateTime w_ = context.Operators.Start(v_);
@@ -960,7 +960,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime ae_ = context.Operators.Start(ad_);
 				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ab_, ae_, true, false);
-				bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, default(string));
+				bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, default);
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime aj_ = context.Operators.Start(ai_);
 				bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
@@ -996,14 +996,14 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwSTEMI)
 		{
 			CqlValueSet d_ = this.Ischemic_Stroke();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			CqlValueSet f_ = this.Closed_Head_and_Facial_Trauma();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Active_Peptic_Ulcer();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default);
 			CqlValueSet k_ = this.Cardiopulmonary_Arrest();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default);
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			bool? o_(Condition ExclusionCondition)
@@ -1018,7 +1018,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_3_000.ToInterval(u_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
 				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-				bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default(string));
+				bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default);
 
 				return ad_;
 			};
@@ -1044,7 +1044,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Intracranial_or_Intraspinal_surgery();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure CranialorSpinalSurgery)
 			{
 				DataType j_ = CranialorSpinalSurgery?.Performed;
@@ -1059,7 +1059,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime u_ = context.Operators.Start(t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, false);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
 				CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_3_000.ToInterval(n_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -1176,8 +1176,8 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Fibrinolytic_Therapy();
-			IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default(PropertyInfo));
-			IEnumerable<MedicationAdministration> g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default(PropertyInfo));
+			IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default);
+			IEnumerable<MedicationAdministration> g_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(d_, default);
 			IEnumerable<MedicationAdministration> h_ = context.Operators.Union<MedicationAdministration>(e_, g_);
 			bool? i_(MedicationAdministration Fibrinolytic)
 			{
@@ -1193,7 +1193,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlQuantity w_ = context.Operators.Quantity(30m, "minutes");
 				CqlDateTime x_ = context.Operators.Add(u_, w_);
 				CqlInterval<CqlDateTime> y_ = context.Operators.Interval(u_, x_, false, true);
-				bool? z_ = context.Operators.In<CqlDateTime>(t_, y_, default(string));
+				bool? z_ = context.Operators.In<CqlDateTime>(t_, y_, default);
 				bool? ab_ = context.Operators.Not((bool?)(u_ is null));
 				bool? ac_ = context.Operators.And(z_, ab_);
 				bool? ad_ = context.Operators.And(p_, ac_);
@@ -1222,7 +1222,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 		IEnumerable<Encounter> b_(Encounter EDwithSTEMI)
 		{
 			CqlValueSet d_ = this.Percutaneous_Coronary_Intervention();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure PCI)
 			{
 				DataType j_ = PCI?.Performed;
@@ -1233,7 +1233,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 				CqlQuantity p_ = context.Operators.Quantity(90m, "minutes");
 				CqlDateTime q_ = context.Operators.Add(n_, p_);
 				CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, false, true);
-				bool? s_ = context.Operators.In<CqlDateTime>(m_, r_, default(string));
+				bool? s_ = context.Operators.In<CqlDateTime>(m_, r_, default);
 				bool? u_ = context.Operators.Not((bool?)(n_ is null));
 				bool? v_ = context.Operators.And(s_, u_);
 				Code<EventStatus> w_ = PCI?.StatusElement;
@@ -1275,7 +1275,7 @@ public class AppropriateTreatmentforSTEMIFHIR_1_0_000
 			CqlQuantity m_ = context.Operators.Quantity(45m, "minutes");
 			CqlDateTime n_ = context.Operators.Add(l_, m_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(i_, n_, false, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(f_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(f_, o_, default);
 			CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(d_);
 			CqlDateTime s_ = context.Operators.Start(r_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default(string));
 
     [CqlDeclaration("Antibiotic Medications for Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
@@ -130,7 +130,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Antibiotic_Medications_for_Upper_Respiratory_Infection.Value;
 
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default(string));
 
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
@@ -138,7 +138,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default(string));
 
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
@@ -146,7 +146,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
 
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -154,7 +154,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -162,7 +162,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -170,7 +170,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Medical_Disability_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default(string));
 
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
@@ -178,7 +178,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Medical_Disability_Exam.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -186,7 +186,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -194,7 +194,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -202,7 +202,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -210,7 +210,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -218,7 +218,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -226,7 +226,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -234,7 +234,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -242,7 +242,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -250,7 +250,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -258,7 +258,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -266,7 +266,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Upper_Respiratory_Infection_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", default(string));
 
     [CqlDeclaration("Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022")]
@@ -274,7 +274,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Upper_Respiratory_Infection.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -283,7 +283,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -295,8 +295,8 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000", "Measurement Period", c_);
 
@@ -309,7 +309,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -366,49 +366,49 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Medical_Disability_Exam();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Observation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Office_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
 		CqlValueSet af_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
 		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
 		CqlValueSet aj_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default(PropertyInfo));
 		CqlValueSet al_ = this.Telephone_Visits();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
 		CqlValueSet ap_ = this.Online_Assessments();
-		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
-		IEnumerable<Encounter> ar_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default(PropertyInfo));
+		IEnumerable<Encounter> ar_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? as_(Encounter E)
 		{
 			List<CodeableConcept> az_ = E?.Type;
@@ -465,7 +465,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
 		CqlValueSet b_ = this.Upper_Respiratory_Infection();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		(Encounter QualifyingEncounters, Condition URI)? e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
@@ -484,7 +484,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			bool? q_ = context.Operators.In<CqlDateTime>(m_, p_, "day");
 			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-			bool? v_ = context.Operators.OverlapsBefore(l_, u_, null);
+			bool? v_ = context.Operators.OverlapsBefore(l_, u_, default(string));
 			bool? w_ = context.Operators.Or(q_, v_);
 
 			return w_;
@@ -564,16 +564,16 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Encounters_and_Assessments_with_Hospice_Patient();
 		IEnumerable<Encounter> b_ = this.Encounter_with_Upper_Respiratory_Infection();
 		CqlValueSet c_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, d_);
 		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(a_, e_);
 		CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
 		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, l_);
 		CqlValueSet o_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(f_, r_);
@@ -591,8 +591,8 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		IEnumerable<Encounter> c_(Encounter EncounterWithURI)
 		{
 			CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-			IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
-			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, null);
+			IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
 			bool? m_(MedicationRequest OrderedAntibiotic)
 			{
@@ -608,7 +608,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 				CqlQuantity aa_ = context.Operators.Quantity(3m, "days");
 				CqlDateTime ab_ = context.Operators.Add(z_, aa_);
 				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(v_, ab_, true, true);
-				bool? ad_ = context.Operators.In<CqlDateTime>(r_, ac_, null);
+				bool? ad_ = context.Operators.In<CqlDateTime>(r_, ac_, default(string));
 				CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(s_);
 				CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval((af_ as object));
 				CqlDateTime ah_ = context.Operators.Start(ag_);
@@ -688,7 +688,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, null);
+			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
 
 			return o_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Antibiotic_Medications_for_Upper_Respiratory_Infection_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001", default);
 
     [CqlDeclaration("Antibiotic Medications for Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1001")]
@@ -130,7 +130,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Antibiotic_Medications_for_Upper_Respiratory_Infection.Value;
 
 	private CqlValueSet Comorbid_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025", default);
 
     [CqlDeclaration("Comorbid Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1025")]
@@ -138,7 +138,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Comorbid_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Competing_Conditions_for_Respiratory_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017", default);
 
     [CqlDeclaration("Competing Conditions for Respiratory Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1017")]
@@ -146,7 +146,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Competing_Conditions_for_Respiratory_Conditions.Value;
 
 	private CqlValueSet Emergency_Department_Evaluation_and_Management_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default);
 
     [CqlDeclaration("Emergency Department Evaluation and Management Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -154,7 +154,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Emergency_Department_Evaluation_and_Management_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -162,7 +162,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default);
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -170,7 +170,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Medical_Disability_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073", default);
 
     [CqlDeclaration("Medical Disability Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1073")]
@@ -178,7 +178,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Medical_Disability_Exam.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -186,7 +186,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -194,7 +194,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -202,7 +202,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -210,7 +210,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -218,7 +218,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default);
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -226,7 +226,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -234,7 +234,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -242,7 +242,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -250,7 +250,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -258,7 +258,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -266,7 +266,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Upper_Respiratory_Infection_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022", default);
 
     [CqlDeclaration("Upper Respiratory Infection")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.102.12.1022")]
@@ -274,7 +274,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		__Upper_Respiratory_Infection.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -283,7 +283,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -295,8 +295,8 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000", "Measurement Period", c_);
 
@@ -309,7 +309,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -366,49 +366,49 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Emergency_Department_Evaluation_and_Management_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Medical_Disability_Exam();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Observation();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Office_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
 		CqlValueSet af_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default);
 		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
 		CqlValueSet aj_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default(PropertyInfo));
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default);
 		CqlValueSet al_ = this.Telephone_Visits();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default);
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
 		CqlValueSet ap_ = this.Online_Assessments();
-		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default(PropertyInfo));
-		IEnumerable<Encounter> ar_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default);
+		IEnumerable<Encounter> ar_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? as_(Encounter E)
 		{
 			List<CodeableConcept> az_ = E?.Type;
@@ -465,7 +465,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounters();
 		CqlValueSet b_ = this.Upper_Respiratory_Infection();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		(Encounter QualifyingEncounters, Condition URI)? e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
@@ -484,7 +484,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			bool? q_ = context.Operators.In<CqlDateTime>(m_, p_, "day");
 			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval((t_ as object));
-			bool? v_ = context.Operators.OverlapsBefore(l_, u_, default(string));
+			bool? v_ = context.Operators.OverlapsBefore(l_, u_, default);
 			bool? w_ = context.Operators.Or(q_, v_);
 
 			return w_;
@@ -564,16 +564,16 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Encounters_and_Assessments_with_Hospice_Patient();
 		IEnumerable<Encounter> b_ = this.Encounter_with_Upper_Respiratory_Infection();
 		CqlValueSet c_ = this.Comorbid_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Encounter> e_ = Antibiotic_1_5_000.Has_Comorbid_Condition_History(b_, d_);
 		IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(a_, e_);
 		CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default);
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default);
 		IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
 		IEnumerable<Encounter> m_ = Antibiotic_1_5_000.Has_Antibiotic_Medication_History(b_, l_);
 		CqlValueSet o_ = this.Competing_Conditions_for_Respiratory_Conditions();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 		IEnumerable<Encounter> q_ = Antibiotic_1_5_000.Has_Competing_Diagnosis_History(b_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(f_, r_);
@@ -591,8 +591,8 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 		IEnumerable<Encounter> c_(Encounter EncounterWithURI)
 		{
 			CqlValueSet h_ = this.Antibiotic_Medications_for_Upper_Respiratory_Infection();
-			IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default);
+			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(h_, default);
 			IEnumerable<MedicationRequest> l_ = context.Operators.Union<MedicationRequest>(i_, k_);
 			bool? m_(MedicationRequest OrderedAntibiotic)
 			{
@@ -608,7 +608,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 				CqlQuantity aa_ = context.Operators.Quantity(3m, "days");
 				CqlDateTime ab_ = context.Operators.Add(z_, aa_);
 				CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(v_, ab_, true, true);
-				bool? ad_ = context.Operators.In<CqlDateTime>(r_, ac_, default(string));
+				bool? ad_ = context.Operators.In<CqlDateTime>(r_, ac_, default);
 				CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_3_000.ToInterval(s_);
 				CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.ToInterval((af_ as object));
 				CqlDateTime ah_ = context.Operators.Start(ag_);
@@ -688,7 +688,7 @@ public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			int? m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			CqlInterval<int?> n_ = context.Operators.Interval(18, 64, true, true);
-			bool? o_ = context.Operators.In<int?>(m_, n_, default(string));
+			bool? o_ = context.Operators.In<int?>(m_, n_, default);
 
 			return o_;
 		};

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR", "0.1.000")]
 public class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
@@ -56,7 +56,7 @@ public class CQMCommon_2_0_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -64,7 +64,7 @@ public class CQMCommon_2_0_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -72,7 +72,7 @@ public class CQMCommon_2_0_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Intensive_Care_Unit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default);
 
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
@@ -80,7 +80,7 @@ public class CQMCommon_2_0_000
 		__Intensive_Care_Unit.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -88,7 +88,7 @@ public class CQMCommon_2_0_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Outpatient_Surgery_Service_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38", default);
 
     [CqlDeclaration("Outpatient Surgery Service")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38")]
@@ -96,7 +96,7 @@ public class CQMCommon_2_0_000
 		__Outpatient_Surgery_Service.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default);
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -105,8 +105,8 @@ public class CQMCommon_2_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
 
@@ -119,7 +119,7 @@ public class CQMCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -132,7 +132,7 @@ public class CQMCommon_2_0_000
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -200,7 +200,7 @@ public class CQMCommon_2_0_000
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -218,7 +218,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime v_ = context.Operators.Start(u_);
 			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default(string));
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default);
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime aa_ = context.Operators.Start(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -247,7 +247,7 @@ public class CQMCommon_2_0_000
 	public Encounter edVisit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -265,7 +265,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime v_ = context.Operators.Start(u_);
 			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default(string));
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default);
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime aa_ = context.Operators.Start(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -613,7 +613,7 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getLocation()` instead.")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default, default);
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -704,14 +704,14 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Outpatient_Surgery_Service();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastSurgeryOP)
 			{
 				Period ap_ = LastSurgeryOP?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
 				CqlDateTime ar_ = context.Operators.End(aq_);
 				CqlValueSet as_ = this.Emergency_Department_Visit();
-				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? au_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
@@ -722,7 +722,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
 					CqlDateTime dv_ = context.Operators.End(du_);
 					CqlValueSet dw_ = this.Observation_Services();
-					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? dy_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
@@ -740,7 +740,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime ge_ = context.Operators.Start(gd_);
 						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default(string));
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default);
 						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime gj_ = context.Operators.Start(gi_);
 						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
@@ -768,7 +768,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime ei_ = context.Operators.Start(eh_);
 					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? en_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
@@ -786,7 +786,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime he_ = context.Operators.Start(hd_);
 						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
-						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default(string));
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default);
 						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime hj_ = context.Operators.Start(hi_);
 						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
@@ -812,8 +812,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
 					CqlDateTime ex_ = context.Operators.Start(ew_);
 					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default(string));
-					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? fc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
@@ -831,7 +831,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ie_ = context.Operators.Start(id_);
 						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
-						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default(string));
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default);
 						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ij_ = context.Operators.Start(ii_);
 						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
@@ -877,7 +877,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
 				CqlDateTime bb_ = context.Operators.Start(ba_);
 				CqlValueSet bc_ = this.Observation_Services();
-				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? be_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
@@ -895,7 +895,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jh_ = context.Operators.Start(jg_);
 					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
-					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default(string));
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default);
 					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jm_ = context.Operators.Start(jl_);
 					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
@@ -923,7 +923,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? bt_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
@@ -934,7 +934,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
 					CqlDateTime jz_ = context.Operators.End(jy_);
 					CqlValueSet ka_ = this.Observation_Services();
-					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? kc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
@@ -952,7 +952,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mi_ = context.Operators.Start(mh_);
 						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default(string));
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default);
 						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mn_ = context.Operators.Start(mm_);
 						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
@@ -980,7 +980,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime km_ = context.Operators.Start(kl_);
 					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? kr_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
@@ -998,7 +998,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime ni_ = context.Operators.Start(nh_);
 						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default(string));
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default);
 						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime nn_ = context.Operators.Start(nm_);
 						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
@@ -1024,8 +1024,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
 					CqlDateTime lb_ = context.Operators.Start(la_);
 					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default(string));
-					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? lg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
@@ -1043,7 +1043,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime oi_ = context.Operators.Start(oh_);
 						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
-						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default(string));
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default);
 						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime on_ = context.Operators.Start(om_);
 						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
@@ -1088,7 +1088,7 @@ public class CQMCommon_2_0_000
 				Period by_ = bx_?.Period;
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
-				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? cd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
@@ -1106,7 +1106,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pl_ = context.Operators.Start(pk_);
 					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default(string));
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default);
 					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pq_ = context.Operators.Start(pp_);
 					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
@@ -1132,8 +1132,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
 				CqlDateTime cn_ = context.Operators.Start(cm_);
 				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default(string));
-				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? cs_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
@@ -1144,7 +1144,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
 					CqlDateTime qd_ = context.Operators.End(qc_);
 					CqlValueSet qe_ = this.Observation_Services();
-					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? qg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
@@ -1162,7 +1162,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sm_ = context.Operators.Start(sl_);
 						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default(string));
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default);
 						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sr_ = context.Operators.Start(sq_);
 						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
@@ -1190,7 +1190,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime qq_ = context.Operators.Start(qp_);
 					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? qv_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
@@ -1208,7 +1208,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tm_ = context.Operators.Start(tl_);
 						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default(string));
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default);
 						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tr_ = context.Operators.Start(tq_);
 						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
@@ -1234,8 +1234,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
 					CqlDateTime rf_ = context.Operators.Start(re_);
 					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default(string));
-					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? rk_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
@@ -1253,7 +1253,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime um_ = context.Operators.Start(ul_);
 						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
-						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default(string));
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default);
 						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime ur_ = context.Operators.Start(uq_);
 						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
@@ -1298,7 +1298,7 @@ public class CQMCommon_2_0_000
 				Period cx_ = cw_?.Period;
 				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
 				CqlDateTime cz_ = context.Operators.Start(cy_);
-				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? dc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
@@ -1316,7 +1316,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vp_ = context.Operators.Start(vo_);
 					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default(string));
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default);
 					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vu_ = context.Operators.Start(vt_);
 					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
@@ -1361,7 +1361,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
@@ -1372,7 +1372,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
 				CqlDateTime wk_ = context.Operators.End(wj_);
 				CqlValueSet wl_ = this.Observation_Services();
-				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? wn_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
@@ -1390,7 +1390,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yt_ = context.Operators.Start(ys_);
 					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default(string));
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default);
 					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yy_ = context.Operators.Start(yx_);
 					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
@@ -1418,7 +1418,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime wx_ = context.Operators.Start(ww_);
 				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? xc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
@@ -1436,7 +1436,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zt_ = context.Operators.Start(zs_);
 					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default(string));
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default);
 					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zy_ = context.Operators.Start(zx_);
 					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
@@ -1462,8 +1462,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
 				CqlDateTime xm_ = context.Operators.Start(xl_);
 				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default(string));
-				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? xr_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
@@ -1481,7 +1481,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azt_ = context.Operators.Start(azs_);
 					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default(string));
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default);
 					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azy_ = context.Operators.Start(azx_);
 					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
@@ -1527,7 +1527,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
 			CqlDateTime x_ = context.Operators.Start(w_);
 			CqlValueSet y_ = this.Observation_Services();
-			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default);
 			bool? aa_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
@@ -1545,7 +1545,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime bzw_ = context.Operators.Start(bzv_);
 				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default(string));
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default);
 				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime czb_ = context.Operators.Start(cza_);
 				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
@@ -1593,14 +1593,14 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Outpatient_Surgery_Service();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastSurgeryOP)
 			{
 				Period ap_ = LastSurgeryOP?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
 				CqlDateTime ar_ = context.Operators.End(aq_);
 				CqlValueSet as_ = this.Emergency_Department_Visit();
-				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? au_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
@@ -1611,7 +1611,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
 					CqlDateTime dv_ = context.Operators.End(du_);
 					CqlValueSet dw_ = this.Observation_Services();
-					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? dy_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
@@ -1629,7 +1629,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime ge_ = context.Operators.Start(gd_);
 						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default(string));
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default);
 						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime gj_ = context.Operators.Start(gi_);
 						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
@@ -1657,7 +1657,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime ei_ = context.Operators.Start(eh_);
 					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? en_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
@@ -1675,7 +1675,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime he_ = context.Operators.Start(hd_);
 						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
-						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default(string));
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default);
 						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime hj_ = context.Operators.Start(hi_);
 						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
@@ -1701,8 +1701,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
 					CqlDateTime ex_ = context.Operators.Start(ew_);
 					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default(string));
-					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default);
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default);
 					bool? fc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
@@ -1720,7 +1720,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ie_ = context.Operators.Start(id_);
 						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
-						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default(string));
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default);
 						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ij_ = context.Operators.Start(ii_);
 						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
@@ -1766,7 +1766,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
 				CqlDateTime bb_ = context.Operators.Start(ba_);
 				CqlValueSet bc_ = this.Observation_Services();
-				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? be_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
@@ -1784,7 +1784,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jh_ = context.Operators.Start(jg_);
 					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
-					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default(string));
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default);
 					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jm_ = context.Operators.Start(jl_);
 					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
@@ -1812,7 +1812,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? bt_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
@@ -1823,7 +1823,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
 					CqlDateTime jz_ = context.Operators.End(jy_);
 					CqlValueSet ka_ = this.Observation_Services();
-					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? kc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
@@ -1841,7 +1841,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mi_ = context.Operators.Start(mh_);
 						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default(string));
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default);
 						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mn_ = context.Operators.Start(mm_);
 						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
@@ -1869,7 +1869,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime km_ = context.Operators.Start(kl_);
 					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? kr_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
@@ -1887,7 +1887,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime ni_ = context.Operators.Start(nh_);
 						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default(string));
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default);
 						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime nn_ = context.Operators.Start(nm_);
 						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
@@ -1913,8 +1913,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
 					CqlDateTime lb_ = context.Operators.Start(la_);
 					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default(string));
-					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default);
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default);
 					bool? lg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
@@ -1932,7 +1932,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime oi_ = context.Operators.Start(oh_);
 						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
-						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default(string));
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default);
 						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime on_ = context.Operators.Start(om_);
 						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
@@ -1977,7 +1977,7 @@ public class CQMCommon_2_0_000
 				Period by_ = bx_?.Period;
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
-				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? cd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
@@ -1995,7 +1995,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pl_ = context.Operators.Start(pk_);
 					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default(string));
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default);
 					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pq_ = context.Operators.Start(pp_);
 					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
@@ -2021,8 +2021,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
 				CqlDateTime cn_ = context.Operators.Start(cm_);
 				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default(string));
-				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default);
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default);
 				bool? cs_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
@@ -2033,7 +2033,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
 					CqlDateTime qd_ = context.Operators.End(qc_);
 					CqlValueSet qe_ = this.Observation_Services();
-					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? qg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
@@ -2051,7 +2051,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sm_ = context.Operators.Start(sl_);
 						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default(string));
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default);
 						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sr_ = context.Operators.Start(sq_);
 						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
@@ -2079,7 +2079,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime qq_ = context.Operators.Start(qp_);
 					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? qv_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
@@ -2097,7 +2097,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tm_ = context.Operators.Start(tl_);
 						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default(string));
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default);
 						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tr_ = context.Operators.Start(tq_);
 						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
@@ -2123,8 +2123,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
 					CqlDateTime rf_ = context.Operators.Start(re_);
 					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default(string));
-					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default);
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default);
 					bool? rk_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
@@ -2142,7 +2142,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime um_ = context.Operators.Start(ul_);
 						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
-						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default(string));
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default);
 						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime ur_ = context.Operators.Start(uq_);
 						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
@@ -2187,7 +2187,7 @@ public class CQMCommon_2_0_000
 				Period cx_ = cw_?.Period;
 				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
 				CqlDateTime cz_ = context.Operators.Start(cy_);
-				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default);
 				bool? dc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
@@ -2205,7 +2205,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vp_ = context.Operators.Start(vo_);
 					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default(string));
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default);
 					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vu_ = context.Operators.Start(vt_);
 					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
@@ -2250,7 +2250,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
@@ -2261,7 +2261,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
 				CqlDateTime wk_ = context.Operators.End(wj_);
 				CqlValueSet wl_ = this.Observation_Services();
-				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? wn_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
@@ -2279,7 +2279,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yt_ = context.Operators.Start(ys_);
 					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default(string));
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default);
 					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yy_ = context.Operators.Start(yx_);
 					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
@@ -2307,7 +2307,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime wx_ = context.Operators.Start(ww_);
 				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? xc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
@@ -2325,7 +2325,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zt_ = context.Operators.Start(zs_);
 					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default(string));
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default);
 					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zy_ = context.Operators.Start(zx_);
 					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
@@ -2351,8 +2351,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
 				CqlDateTime xm_ = context.Operators.Start(xl_);
 				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default(string));
-				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default);
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default);
 				bool? xr_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
@@ -2370,7 +2370,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azt_ = context.Operators.Start(azs_);
 					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default(string));
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default);
 					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azy_ = context.Operators.Start(azx_);
 					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
@@ -2416,7 +2416,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
 			CqlDateTime x_ = context.Operators.Start(w_);
 			CqlValueSet y_ = this.Observation_Services();
-			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default);
 			bool? aa_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
@@ -2434,7 +2434,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime bzw_ = context.Operators.Start(bzv_);
 				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default(string));
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default);
 				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime czb_ = context.Operators.Start(cza_);
 				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
@@ -2483,7 +2483,7 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
@@ -2494,7 +2494,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 				CqlDateTime al_ = context.Operators.End(ak_);
 				CqlValueSet am_ = this.Observation_Services();
-				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? ao_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
@@ -2512,7 +2512,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cu_ = context.Operators.Start(ct_);
 					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default(string));
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default);
 					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cz_ = context.Operators.Start(cy_);
 					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
@@ -2540,7 +2540,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime ay_ = context.Operators.Start(ax_);
 				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? bd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
@@ -2558,7 +2558,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime du_ = context.Operators.Start(dt_);
 					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
-					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default(string));
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default);
 					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime dz_ = context.Operators.Start(dy_);
 					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
@@ -2584,8 +2584,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default(string));
-				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? bs_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
@@ -2603,7 +2603,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime eu_ = context.Operators.Start(et_);
 					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
-					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default(string));
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default);
 					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime ez_ = context.Operators.Start(ey_);
 					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
@@ -2649,7 +2649,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
@@ -2667,7 +2667,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime fx_ = context.Operators.Start(fw_);
 				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default(string));
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default);
 				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime gc_ = context.Operators.Start(gb_);
 				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
@@ -2715,7 +2715,7 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
@@ -2726,7 +2726,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 				CqlDateTime al_ = context.Operators.End(ak_);
 				CqlValueSet am_ = this.Observation_Services();
-				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? ao_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
@@ -2744,7 +2744,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cu_ = context.Operators.Start(ct_);
 					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default(string));
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default);
 					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cz_ = context.Operators.Start(cy_);
 					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
@@ -2772,7 +2772,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime ay_ = context.Operators.Start(ax_);
 				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? bd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
@@ -2790,7 +2790,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime du_ = context.Operators.Start(dt_);
 					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
-					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default(string));
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default);
 					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime dz_ = context.Operators.Start(dy_);
 					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
@@ -2816,8 +2816,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default(string));
-				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default);
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default);
 				bool? bs_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
@@ -2835,7 +2835,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime eu_ = context.Operators.Start(et_);
 					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
-					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default(string));
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default);
 					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime ez_ = context.Operators.Start(ey_);
 					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
@@ -2881,7 +2881,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
@@ -2899,7 +2899,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime fx_ = context.Operators.Start(fw_);
 				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default(string));
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default);
 				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime gc_ = context.Operators.Start(gb_);
 				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
@@ -2982,7 +2982,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;
@@ -3025,7 +3025,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;
@@ -3053,7 +3053,7 @@ public class CQMCommon_2_0_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -3083,7 +3083,7 @@ public class CQMCommon_2_0_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -3111,7 +3111,7 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getCondition()` instead")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -3133,7 +3133,7 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Condition resource for the given reference")]
 	public Condition getCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -3168,7 +3168,7 @@ public class CQMCommon_2_0_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? k_(Condition C)
 			{
 				Id n_ = C?.IdElement;
@@ -3208,7 +3208,7 @@ public class CQMCommon_2_0_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? k_(Condition C)
 			{
 				Id n_ = C?.IdElement;
@@ -3236,7 +3236,7 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Location resource specified by the given reference.")]
 	public Location getLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default, default);
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -3278,7 +3278,7 @@ public class CQMCommon_2_0_000
 			}
 			else
 			{
-				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default, default);
 				bool? i_(Medication M)
 				{
 					Id n_ = M?.IdElement;
@@ -3327,7 +3327,7 @@ public class CQMCommon_2_0_000
 			}
 			else
 			{
-				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default, default);
 				bool? i_(Medication M)
 				{
 					Id n_ = M?.IdElement;

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
@@ -56,7 +56,7 @@ public class CQMCommon_2_0_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -64,7 +64,7 @@ public class CQMCommon_2_0_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -72,7 +72,7 @@ public class CQMCommon_2_0_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Intensive_Care_Unit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default(string));
 
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
@@ -80,7 +80,7 @@ public class CQMCommon_2_0_000
 		__Intensive_Care_Unit.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -88,7 +88,7 @@ public class CQMCommon_2_0_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Outpatient_Surgery_Service_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38", default(string));
 
     [CqlDeclaration("Outpatient Surgery Service")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.38")]
@@ -96,7 +96,7 @@ public class CQMCommon_2_0_000
 		__Outpatient_Surgery_Service.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -105,8 +105,8 @@ public class CQMCommon_2_0_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CQMCommon-2.0.000", "Measurement Period", c_);
 
@@ -119,7 +119,7 @@ public class CQMCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -132,7 +132,7 @@ public class CQMCommon_2_0_000
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -200,7 +200,7 @@ public class CQMCommon_2_0_000
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -218,7 +218,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime v_ = context.Operators.Start(u_);
 			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default(string));
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime aa_ = context.Operators.Start(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -247,7 +247,7 @@ public class CQMCommon_2_0_000
 	public Encounter edVisit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -265,7 +265,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime v_ = context.Operators.Start(u_);
 			CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, null);
+			bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default(string));
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(o_);
 			CqlDateTime aa_ = context.Operators.Start(z_);
 			bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -613,7 +613,7 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getLocation()` instead.")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -704,14 +704,14 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Outpatient_Surgery_Service();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastSurgeryOP)
 			{
 				Period ap_ = LastSurgeryOP?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
 				CqlDateTime ar_ = context.Operators.End(aq_);
 				CqlValueSet as_ = this.Emergency_Department_Visit();
-				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? au_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
@@ -722,7 +722,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
 					CqlDateTime dv_ = context.Operators.End(du_);
 					CqlValueSet dw_ = this.Observation_Services();
-					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? dy_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
@@ -740,7 +740,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime ge_ = context.Operators.Start(gd_);
 						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default(string));
 						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime gj_ = context.Operators.Start(gi_);
 						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
@@ -768,7 +768,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime ei_ = context.Operators.Start(eh_);
 					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? en_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
@@ -786,7 +786,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime he_ = context.Operators.Start(hd_);
 						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
-						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default(string));
 						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime hj_ = context.Operators.Start(hi_);
 						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
@@ -812,8 +812,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
 					CqlDateTime ex_ = context.Operators.Start(ew_);
 					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default(string));
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? fc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
@@ -831,7 +831,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ie_ = context.Operators.Start(id_);
 						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
-						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default(string));
 						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ij_ = context.Operators.Start(ii_);
 						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
@@ -877,7 +877,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
 				CqlDateTime bb_ = context.Operators.Start(ba_);
 				CqlValueSet bc_ = this.Observation_Services();
-				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? be_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
@@ -895,7 +895,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jh_ = context.Operators.Start(jg_);
 					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
-					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default(string));
 					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jm_ = context.Operators.Start(jl_);
 					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
@@ -923,7 +923,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? bt_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
@@ -934,7 +934,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
 					CqlDateTime jz_ = context.Operators.End(jy_);
 					CqlValueSet ka_ = this.Observation_Services();
-					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? kc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
@@ -952,7 +952,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mi_ = context.Operators.Start(mh_);
 						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default(string));
 						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mn_ = context.Operators.Start(mm_);
 						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
@@ -980,7 +980,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime km_ = context.Operators.Start(kl_);
 					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? kr_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
@@ -998,7 +998,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime ni_ = context.Operators.Start(nh_);
 						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default(string));
 						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime nn_ = context.Operators.Start(nm_);
 						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
@@ -1024,8 +1024,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
 					CqlDateTime lb_ = context.Operators.Start(la_);
 					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default(string));
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? lg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
@@ -1043,7 +1043,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime oi_ = context.Operators.Start(oh_);
 						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
-						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default(string));
 						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime on_ = context.Operators.Start(om_);
 						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
@@ -1088,7 +1088,7 @@ public class CQMCommon_2_0_000
 				Period by_ = bx_?.Period;
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
-				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? cd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
@@ -1106,7 +1106,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pl_ = context.Operators.Start(pk_);
 					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default(string));
 					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pq_ = context.Operators.Start(pp_);
 					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
@@ -1132,8 +1132,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
 				CqlDateTime cn_ = context.Operators.Start(cm_);
 				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default(string));
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? cs_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
@@ -1144,7 +1144,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
 					CqlDateTime qd_ = context.Operators.End(qc_);
 					CqlValueSet qe_ = this.Observation_Services();
-					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? qg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
@@ -1162,7 +1162,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sm_ = context.Operators.Start(sl_);
 						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default(string));
 						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sr_ = context.Operators.Start(sq_);
 						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
@@ -1190,7 +1190,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime qq_ = context.Operators.Start(qp_);
 					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? qv_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
@@ -1208,7 +1208,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tm_ = context.Operators.Start(tl_);
 						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default(string));
 						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tr_ = context.Operators.Start(tq_);
 						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
@@ -1234,8 +1234,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
 					CqlDateTime rf_ = context.Operators.Start(re_);
 					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default(string));
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? rk_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
@@ -1253,7 +1253,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime um_ = context.Operators.Start(ul_);
 						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
-						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default(string));
 						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime ur_ = context.Operators.Start(uq_);
 						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
@@ -1298,7 +1298,7 @@ public class CQMCommon_2_0_000
 				Period cx_ = cw_?.Period;
 				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
 				CqlDateTime cz_ = context.Operators.Start(cy_);
-				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? dc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
@@ -1316,7 +1316,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vp_ = context.Operators.Start(vo_);
 					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default(string));
 					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vu_ = context.Operators.Start(vt_);
 					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
@@ -1361,7 +1361,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
@@ -1372,7 +1372,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
 				CqlDateTime wk_ = context.Operators.End(wj_);
 				CqlValueSet wl_ = this.Observation_Services();
-				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? wn_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
@@ -1390,7 +1390,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yt_ = context.Operators.Start(ys_);
 					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default(string));
 					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yy_ = context.Operators.Start(yx_);
 					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
@@ -1418,7 +1418,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime wx_ = context.Operators.Start(ww_);
 				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? xc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
@@ -1436,7 +1436,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zt_ = context.Operators.Start(zs_);
 					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default(string));
 					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zy_ = context.Operators.Start(zx_);
 					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
@@ -1462,8 +1462,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
 				CqlDateTime xm_ = context.Operators.Start(xl_);
 				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default(string));
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? xr_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
@@ -1481,7 +1481,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azt_ = context.Operators.Start(azs_);
 					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default(string));
 					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azy_ = context.Operators.Start(azx_);
 					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
@@ -1527,7 +1527,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
 			CqlDateTime x_ = context.Operators.Start(w_);
 			CqlValueSet y_ = this.Observation_Services();
-			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
 			bool? aa_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
@@ -1545,7 +1545,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime bzw_ = context.Operators.Start(bzv_);
 				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default(string));
 				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime czb_ = context.Operators.Start(cza_);
 				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
@@ -1593,14 +1593,14 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Outpatient_Surgery_Service();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastSurgeryOP)
 			{
 				Period ap_ = LastSurgeryOP?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
 				CqlDateTime ar_ = context.Operators.End(aq_);
 				CqlValueSet as_ = this.Emergency_Department_Visit();
-				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> at_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? au_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> dp_ = LastED?.StatusElement;
@@ -1611,7 +1611,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dt_);
 					CqlDateTime dv_ = context.Operators.End(du_);
 					CqlValueSet dw_ = this.Observation_Services();
-					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> dx_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? dy_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> fq_ = LastObs?.StatusElement;
@@ -1629,7 +1629,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> gd_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime ge_ = context.Operators.Start(gd_);
 						CqlInterval<CqlDateTime> gf_ = context.Operators.Interval(gb_, ge_, true, true);
-						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, null);
+						bool? gg_ = context.Operators.In<CqlDateTime>(fw_, gf_, default(string));
 						CqlInterval<CqlDateTime> gi_ = FHIRHelpers_4_3_000.ToInterval(fx_);
 						CqlDateTime gj_ = context.Operators.Start(gi_);
 						bool? gk_ = context.Operators.Not((bool?)(gj_ is null));
@@ -1657,7 +1657,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime ei_ = context.Operators.Start(eh_);
 					CqlQuantity ej_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ek_ = context.Operators.Subtract((ef_ ?? ei_), ej_);
-					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					IEnumerable<Encounter> em_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? en_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> gq_ = LastObs?.StatusElement;
@@ -1675,7 +1675,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> hd_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime he_ = context.Operators.Start(hd_);
 						CqlInterval<CqlDateTime> hf_ = context.Operators.Interval(hb_, he_, true, true);
-						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, null);
+						bool? hg_ = context.Operators.In<CqlDateTime>(gw_, hf_, default(string));
 						CqlInterval<CqlDateTime> hi_ = FHIRHelpers_4_3_000.ToInterval(gx_);
 						CqlDateTime hj_ = context.Operators.Start(hi_);
 						bool? hk_ = context.Operators.Not((bool?)(hj_ is null));
@@ -1701,8 +1701,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ew_ = FHIRHelpers_4_3_000.ToInterval(eg_);
 					CqlDateTime ex_ = context.Operators.Start(ew_);
 					CqlInterval<CqlDateTime> ey_ = context.Operators.Interval(ek_, (eu_ ?? ex_), true, true);
-					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, null);
-					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, null);
+					bool? ez_ = context.Operators.In<CqlDateTime>(dv_, ey_, default(string));
+					IEnumerable<Encounter> fb_ = context.Operators.RetrieveByValueSet<Encounter>(dw_, default(PropertyInfo));
 					bool? fc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> hq_ = LastObs?.StatusElement;
@@ -1720,7 +1720,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> id_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ie_ = context.Operators.Start(id_);
 						CqlInterval<CqlDateTime> if_ = context.Operators.Interval(ib_, ie_, true, true);
-						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, null);
+						bool? ig_ = context.Operators.In<CqlDateTime>(hw_, if_, default(string));
 						CqlInterval<CqlDateTime> ii_ = FHIRHelpers_4_3_000.ToInterval(hx_);
 						CqlDateTime ij_ = context.Operators.Start(ii_);
 						bool? ik_ = context.Operators.Not((bool?)(ij_ is null));
@@ -1766,7 +1766,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_3_000.ToInterval(az_);
 				CqlDateTime bb_ = context.Operators.Start(ba_);
 				CqlValueSet bc_ = this.Observation_Services();
-				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> bd_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? be_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> it_ = LastObs?.StatusElement;
@@ -1784,7 +1784,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jg_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jh_ = context.Operators.Start(jg_);
 					CqlInterval<CqlDateTime> ji_ = context.Operators.Interval(je_, jh_, true, true);
-					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, null);
+					bool? jj_ = context.Operators.In<CqlDateTime>(iz_, ji_, default(string));
 					CqlInterval<CqlDateTime> jl_ = FHIRHelpers_4_3_000.ToInterval(ja_);
 					CqlDateTime jm_ = context.Operators.Start(jl_);
 					bool? jn_ = context.Operators.Not((bool?)(jm_ is null));
@@ -1812,7 +1812,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlQuantity bp_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime bq_ = context.Operators.Subtract((bb_ ?? (bl_ ?? bo_)), bp_);
-				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				IEnumerable<Encounter> bs_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? bt_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> jt_ = LastED?.StatusElement;
@@ -1823,7 +1823,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> jy_ = FHIRHelpers_4_3_000.ToInterval(jx_);
 					CqlDateTime jz_ = context.Operators.End(jy_);
 					CqlValueSet ka_ = this.Observation_Services();
-					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kb_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? kc_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> lu_ = LastObs?.StatusElement;
@@ -1841,7 +1841,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> mh_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mi_ = context.Operators.Start(mh_);
 						CqlInterval<CqlDateTime> mj_ = context.Operators.Interval(mf_, mi_, true, true);
-						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, null);
+						bool? mk_ = context.Operators.In<CqlDateTime>(ma_, mj_, default(string));
 						CqlInterval<CqlDateTime> mm_ = FHIRHelpers_4_3_000.ToInterval(mb_);
 						CqlDateTime mn_ = context.Operators.Start(mm_);
 						bool? mo_ = context.Operators.Not((bool?)(mn_ is null));
@@ -1869,7 +1869,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime km_ = context.Operators.Start(kl_);
 					CqlQuantity kn_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime ko_ = context.Operators.Subtract((kj_ ?? km_), kn_);
-					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					IEnumerable<Encounter> kq_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? kr_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> mu_ = LastObs?.StatusElement;
@@ -1887,7 +1887,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> nh_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime ni_ = context.Operators.Start(nh_);
 						CqlInterval<CqlDateTime> nj_ = context.Operators.Interval(nf_, ni_, true, true);
-						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, null);
+						bool? nk_ = context.Operators.In<CqlDateTime>(na_, nj_, default(string));
 						CqlInterval<CqlDateTime> nm_ = FHIRHelpers_4_3_000.ToInterval(nb_);
 						CqlDateTime nn_ = context.Operators.Start(nm_);
 						bool? no_ = context.Operators.Not((bool?)(nn_ is null));
@@ -1913,8 +1913,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> la_ = FHIRHelpers_4_3_000.ToInterval(kk_);
 					CqlDateTime lb_ = context.Operators.Start(la_);
 					CqlInterval<CqlDateTime> lc_ = context.Operators.Interval(ko_, (ky_ ?? lb_), true, true);
-					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, null);
-					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, null);
+					bool? ld_ = context.Operators.In<CqlDateTime>(jz_, lc_, default(string));
+					IEnumerable<Encounter> lf_ = context.Operators.RetrieveByValueSet<Encounter>(ka_, default(PropertyInfo));
 					bool? lg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> nu_ = LastObs?.StatusElement;
@@ -1932,7 +1932,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> oh_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime oi_ = context.Operators.Start(oh_);
 						CqlInterval<CqlDateTime> oj_ = context.Operators.Interval(of_, oi_, true, true);
-						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, null);
+						bool? ok_ = context.Operators.In<CqlDateTime>(oa_, oj_, default(string));
 						CqlInterval<CqlDateTime> om_ = FHIRHelpers_4_3_000.ToInterval(ob_);
 						CqlDateTime on_ = context.Operators.Start(om_);
 						bool? oo_ = context.Operators.Not((bool?)(on_ is null));
@@ -1977,7 +1977,7 @@ public class CQMCommon_2_0_000
 				Period by_ = bx_?.Period;
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(by_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
-				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> cc_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? cd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> ox_ = LastObs?.StatusElement;
@@ -1995,7 +1995,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> pk_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pl_ = context.Operators.Start(pk_);
 					CqlInterval<CqlDateTime> pm_ = context.Operators.Interval(pi_, pl_, true, true);
-					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, null);
+					bool? pn_ = context.Operators.In<CqlDateTime>(pd_, pm_, default(string));
 					CqlInterval<CqlDateTime> pp_ = FHIRHelpers_4_3_000.ToInterval(pe_);
 					CqlDateTime pq_ = context.Operators.Start(pp_);
 					bool? pr_ = context.Operators.Not((bool?)(pq_ is null));
@@ -2021,8 +2021,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> cm_ = FHIRHelpers_4_3_000.ToInterval(bm_);
 				CqlDateTime cn_ = context.Operators.Start(cm_);
 				CqlInterval<CqlDateTime> co_ = context.Operators.Interval(bq_, (ca_ ?? (ck_ ?? cn_)), true, true);
-				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, null);
-				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, null);
+				bool? cp_ = context.Operators.In<CqlDateTime>(ar_, co_, default(string));
+				IEnumerable<Encounter> cr_ = context.Operators.RetrieveByValueSet<Encounter>(as_, default(PropertyInfo));
 				bool? cs_(Encounter LastED)
 				{
 					Code<Encounter.EncounterStatus> px_ = LastED?.StatusElement;
@@ -2033,7 +2033,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> qc_ = FHIRHelpers_4_3_000.ToInterval(qb_);
 					CqlDateTime qd_ = context.Operators.End(qc_);
 					CqlValueSet qe_ = this.Observation_Services();
-					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qf_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? qg_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ry_ = LastObs?.StatusElement;
@@ -2051,7 +2051,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> sl_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sm_ = context.Operators.Start(sl_);
 						CqlInterval<CqlDateTime> sn_ = context.Operators.Interval(sj_, sm_, true, true);
-						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, null);
+						bool? so_ = context.Operators.In<CqlDateTime>(se_, sn_, default(string));
 						CqlInterval<CqlDateTime> sq_ = FHIRHelpers_4_3_000.ToInterval(sf_);
 						CqlDateTime sr_ = context.Operators.Start(sq_);
 						bool? ss_ = context.Operators.Not((bool?)(sr_ is null));
@@ -2079,7 +2079,7 @@ public class CQMCommon_2_0_000
 					CqlDateTime qq_ = context.Operators.Start(qp_);
 					CqlQuantity qr_ = context.Operators.Quantity(1m, "hour");
 					CqlDateTime qs_ = context.Operators.Subtract((qn_ ?? qq_), qr_);
-					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					IEnumerable<Encounter> qu_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? qv_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> sy_ = LastObs?.StatusElement;
@@ -2097,7 +2097,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> tl_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tm_ = context.Operators.Start(tl_);
 						CqlInterval<CqlDateTime> tn_ = context.Operators.Interval(tj_, tm_, true, true);
-						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, null);
+						bool? to_ = context.Operators.In<CqlDateTime>(te_, tn_, default(string));
 						CqlInterval<CqlDateTime> tq_ = FHIRHelpers_4_3_000.ToInterval(tf_);
 						CqlDateTime tr_ = context.Operators.Start(tq_);
 						bool? ts_ = context.Operators.Not((bool?)(tr_ is null));
@@ -2123,8 +2123,8 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> re_ = FHIRHelpers_4_3_000.ToInterval(qo_);
 					CqlDateTime rf_ = context.Operators.Start(re_);
 					CqlInterval<CqlDateTime> rg_ = context.Operators.Interval(qs_, (rc_ ?? rf_), true, true);
-					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, null);
-					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, null);
+					bool? rh_ = context.Operators.In<CqlDateTime>(qd_, rg_, default(string));
+					IEnumerable<Encounter> rj_ = context.Operators.RetrieveByValueSet<Encounter>(qe_, default(PropertyInfo));
 					bool? rk_(Encounter LastObs)
 					{
 						Code<Encounter.EncounterStatus> ty_ = LastObs?.StatusElement;
@@ -2142,7 +2142,7 @@ public class CQMCommon_2_0_000
 						CqlInterval<CqlDateTime> ul_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime um_ = context.Operators.Start(ul_);
 						CqlInterval<CqlDateTime> un_ = context.Operators.Interval(uj_, um_, true, true);
-						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, null);
+						bool? uo_ = context.Operators.In<CqlDateTime>(ue_, un_, default(string));
 						CqlInterval<CqlDateTime> uq_ = FHIRHelpers_4_3_000.ToInterval(uf_);
 						CqlDateTime ur_ = context.Operators.Start(uq_);
 						bool? us_ = context.Operators.Not((bool?)(ur_ is null));
@@ -2187,7 +2187,7 @@ public class CQMCommon_2_0_000
 				Period cx_ = cw_?.Period;
 				CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cx_);
 				CqlDateTime cz_ = context.Operators.Start(cy_);
-				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, null);
+				IEnumerable<Encounter> db_ = context.Operators.RetrieveByValueSet<Encounter>(bc_, default(PropertyInfo));
 				bool? dc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> vb_ = LastObs?.StatusElement;
@@ -2205,7 +2205,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> vo_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vp_ = context.Operators.Start(vo_);
 					CqlInterval<CqlDateTime> vq_ = context.Operators.Interval(vm_, vp_, true, true);
-					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, null);
+					bool? vr_ = context.Operators.In<CqlDateTime>(vh_, vq_, default(string));
 					CqlInterval<CqlDateTime> vt_ = FHIRHelpers_4_3_000.ToInterval(vi_);
 					CqlDateTime vu_ = context.Operators.Start(vt_);
 					bool? vv_ = context.Operators.Not((bool?)(vu_ is null));
@@ -2250,7 +2250,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> we_ = LastED?.StatusElement;
@@ -2261,7 +2261,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> wj_ = FHIRHelpers_4_3_000.ToInterval(wi_);
 				CqlDateTime wk_ = context.Operators.End(wj_);
 				CqlValueSet wl_ = this.Observation_Services();
-				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> wm_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? wn_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> yf_ = LastObs?.StatusElement;
@@ -2279,7 +2279,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ys_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yt_ = context.Operators.Start(ys_);
 					CqlInterval<CqlDateTime> yu_ = context.Operators.Interval(yq_, yt_, true, true);
-					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, null);
+					bool? yv_ = context.Operators.In<CqlDateTime>(yl_, yu_, default(string));
 					CqlInterval<CqlDateTime> yx_ = FHIRHelpers_4_3_000.ToInterval(ym_);
 					CqlDateTime yy_ = context.Operators.Start(yx_);
 					bool? yz_ = context.Operators.Not((bool?)(yy_ is null));
@@ -2307,7 +2307,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime wx_ = context.Operators.Start(ww_);
 				CqlQuantity wy_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime wz_ = context.Operators.Subtract((wu_ ?? wx_), wy_);
-				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				IEnumerable<Encounter> xb_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? xc_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> zf_ = LastObs?.StatusElement;
@@ -2325,7 +2325,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> zs_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zt_ = context.Operators.Start(zs_);
 					CqlInterval<CqlDateTime> zu_ = context.Operators.Interval(zq_, zt_, true, true);
-					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, null);
+					bool? zv_ = context.Operators.In<CqlDateTime>(zl_, zu_, default(string));
 					CqlInterval<CqlDateTime> zx_ = FHIRHelpers_4_3_000.ToInterval(zm_);
 					CqlDateTime zy_ = context.Operators.Start(zx_);
 					bool? zz_ = context.Operators.Not((bool?)(zy_ is null));
@@ -2351,8 +2351,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> xl_ = FHIRHelpers_4_3_000.ToInterval(wv_);
 				CqlDateTime xm_ = context.Operators.Start(xl_);
 				CqlInterval<CqlDateTime> xn_ = context.Operators.Interval(wz_, (xj_ ?? xm_), true, true);
-				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, null);
-				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, null);
+				bool? xo_ = context.Operators.In<CqlDateTime>(wk_, xn_, default(string));
+				IEnumerable<Encounter> xq_ = context.Operators.RetrieveByValueSet<Encounter>(wl_, default(PropertyInfo));
 				bool? xr_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> azf_ = LastObs?.StatusElement;
@@ -2370,7 +2370,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> azs_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azt_ = context.Operators.Start(azs_);
 					CqlInterval<CqlDateTime> azu_ = context.Operators.Interval(azq_, azt_, true, true);
-					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, null);
+					bool? azv_ = context.Operators.In<CqlDateTime>(azl_, azu_, default(string));
 					CqlInterval<CqlDateTime> azx_ = FHIRHelpers_4_3_000.ToInterval(azm_);
 					CqlDateTime azy_ = context.Operators.Start(azx_);
 					bool? azz_ = context.Operators.Not((bool?)(azy_ is null));
@@ -2416,7 +2416,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_3_000.ToInterval(v_);
 			CqlDateTime x_ = context.Operators.Start(w_);
 			CqlValueSet y_ = this.Observation_Services();
-			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, null);
+			IEnumerable<Encounter> z_ = context.Operators.RetrieveByValueSet<Encounter>(y_, default(PropertyInfo));
 			bool? aa_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> bzi_ = LastObs?.StatusElement;
@@ -2434,7 +2434,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bzv_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime bzw_ = context.Operators.Start(bzv_);
 				CqlInterval<CqlDateTime> bzx_ = context.Operators.Interval(bzt_, bzw_, true, true);
-				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, null);
+				bool? bzy_ = context.Operators.In<CqlDateTime>(bzo_, bzx_, default(string));
 				CqlInterval<CqlDateTime> cza_ = FHIRHelpers_4_3_000.ToInterval(bzp_);
 				CqlDateTime czb_ = context.Operators.Start(cza_);
 				bool? czc_ = context.Operators.Not((bool?)(czb_ is null));
@@ -2483,7 +2483,7 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
@@ -2494,7 +2494,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 				CqlDateTime al_ = context.Operators.End(ak_);
 				CqlValueSet am_ = this.Observation_Services();
-				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? ao_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
@@ -2512,7 +2512,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cu_ = context.Operators.Start(ct_);
 					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default(string));
 					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cz_ = context.Operators.Start(cy_);
 					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
@@ -2540,7 +2540,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime ay_ = context.Operators.Start(ax_);
 				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? bd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
@@ -2558,7 +2558,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime du_ = context.Operators.Start(dt_);
 					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
-					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default(string));
 					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime dz_ = context.Operators.Start(dy_);
 					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
@@ -2584,8 +2584,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default(string));
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? bs_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
@@ -2603,7 +2603,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime eu_ = context.Operators.Start(et_);
 					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
-					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default(string));
 					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime ez_ = context.Operators.Start(ey_);
 					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
@@ -2649,7 +2649,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
@@ -2667,7 +2667,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime fx_ = context.Operators.Start(fw_);
 				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default(string));
 				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime gc_ = context.Operators.Start(gb_);
 				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
@@ -2715,7 +2715,7 @@ public class CQMCommon_2_0_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastED)
 			{
 				Code<Encounter.EncounterStatus> af_ = LastED?.StatusElement;
@@ -2726,7 +2726,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> ak_ = FHIRHelpers_4_3_000.ToInterval(aj_);
 				CqlDateTime al_ = context.Operators.End(ak_);
 				CqlValueSet am_ = this.Observation_Services();
-				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> an_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? ao_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> cg_ = LastObs?.StatusElement;
@@ -2744,7 +2744,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> ct_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cu_ = context.Operators.Start(ct_);
 					CqlInterval<CqlDateTime> cv_ = context.Operators.Interval(cr_, cu_, true, true);
-					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, null);
+					bool? cw_ = context.Operators.In<CqlDateTime>(cm_, cv_, default(string));
 					CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_3_000.ToInterval(cn_);
 					CqlDateTime cz_ = context.Operators.Start(cy_);
 					bool? da_ = context.Operators.Not((bool?)(cz_ is null));
@@ -2772,7 +2772,7 @@ public class CQMCommon_2_0_000
 				CqlDateTime ay_ = context.Operators.Start(ax_);
 				CqlQuantity az_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime ba_ = context.Operators.Subtract((av_ ?? ay_), az_);
-				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				IEnumerable<Encounter> bc_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? bd_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> dg_ = LastObs?.StatusElement;
@@ -2790,7 +2790,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> dt_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime du_ = context.Operators.Start(dt_);
 					CqlInterval<CqlDateTime> dv_ = context.Operators.Interval(dr_, du_, true, true);
-					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, null);
+					bool? dw_ = context.Operators.In<CqlDateTime>(dm_, dv_, default(string));
 					CqlInterval<CqlDateTime> dy_ = FHIRHelpers_4_3_000.ToInterval(dn_);
 					CqlDateTime dz_ = context.Operators.Start(dy_);
 					bool? ea_ = context.Operators.Not((bool?)(dz_ is null));
@@ -2816,8 +2816,8 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_3_000.ToInterval(aw_);
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(ba_, (bk_ ?? bn_), true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, null);
-				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(al_, bo_, default(string));
+				IEnumerable<Encounter> br_ = context.Operators.RetrieveByValueSet<Encounter>(am_, default(PropertyInfo));
 				bool? bs_(Encounter LastObs)
 				{
 					Code<Encounter.EncounterStatus> eg_ = LastObs?.StatusElement;
@@ -2835,7 +2835,7 @@ public class CQMCommon_2_0_000
 					CqlInterval<CqlDateTime> et_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime eu_ = context.Operators.Start(et_);
 					CqlInterval<CqlDateTime> ev_ = context.Operators.Interval(er_, eu_, true, true);
-					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, null);
+					bool? ew_ = context.Operators.In<CqlDateTime>(em_, ev_, default(string));
 					CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_3_000.ToInterval(en_);
 					CqlDateTime ez_ = context.Operators.Start(ey_);
 					bool? fa_ = context.Operators.Not((bool?)(ez_ is null));
@@ -2881,7 +2881,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Code<Encounter.EncounterStatus> fj_ = LastObs?.StatusElement;
@@ -2899,7 +2899,7 @@ public class CQMCommon_2_0_000
 				CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime fx_ = context.Operators.Start(fw_);
 				CqlInterval<CqlDateTime> fy_ = context.Operators.Interval(fu_, fx_, true, true);
-				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, null);
+				bool? fz_ = context.Operators.In<CqlDateTime>(fp_, fy_, default(string));
 				CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_3_000.ToInterval(fq_);
 				CqlDateTime gc_ = context.Operators.Start(gb_);
 				bool? gd_ = context.Operators.Not((bool?)(gc_ is null));
@@ -2982,7 +2982,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;
@@ -3025,7 +3025,7 @@ public class CQMCommon_2_0_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_3_000.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;
@@ -3053,7 +3053,7 @@ public class CQMCommon_2_0_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -3083,7 +3083,7 @@ public class CQMCommon_2_0_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -3111,7 +3111,7 @@ public class CQMCommon_2_0_000
     [CqlTag("deprecated", "This function is deprecated. Use the fluent function `getCondition()` instead")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -3133,7 +3133,7 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Condition resource for the given reference")]
 	public Condition getCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -3168,7 +3168,7 @@ public class CQMCommon_2_0_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? k_(Condition C)
 			{
 				Id n_ = C?.IdElement;
@@ -3208,7 +3208,7 @@ public class CQMCommon_2_0_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? k_(Condition C)
 			{
 				Id n_ = C?.IdElement;
@@ -3236,7 +3236,7 @@ public class CQMCommon_2_0_000
     [CqlTag("description", "Returns the Location resource specified by the given reference.")]
 	public Location getLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -3278,7 +3278,7 @@ public class CQMCommon_2_0_000
 			}
 			else
 			{
-				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
 				bool? i_(Medication M)
 				{
 					Id n_ = M?.IdElement;
@@ -3327,7 +3327,7 @@ public class CQMCommon_2_0_000
 			}
 			else
 			{
-				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> h_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
 				bool? i_(Medication M)
 				{
 					Id n_ = M?.IdElement;

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CQMCommon", "2.0.000")]
 public class CQMCommon_2_0_000
 {

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -80,7 +80,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Consultant_Report_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", default(string));
 
     [CqlDeclaration("Consultant Report")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006")]
@@ -88,7 +88,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Consultant_Report.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -96,7 +96,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -104,7 +104,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -112,7 +112,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -120,7 +120,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -128,7 +128,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -136,7 +136,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Referral_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", default(string));
 
     [CqlDeclaration("Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046")]
@@ -145,8 +145,8 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CRLReceiptofSpecialistReportFHIR-0.2.000", "Measurement Period", c_);
 
@@ -159,7 +159,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -172,20 +172,20 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private bool? Has_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter Encounter)
@@ -215,7 +215,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private (string ID, CqlDateTime AuthorDate)? First_Referral_during_First_10_Months_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Referral();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		bool? c_(ServiceRequest ReferralOrder)
 		{
 			Code<RequestStatus> j_ = ReferralOrder?.StatusElement;
@@ -363,7 +363,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value()
 	{
 		CqlValueSet a_ = this.Consultant_Report();
-		IEnumerable<Task> b_ = context.Operators.RetrieveByValueSet<Task>(a_, null);
+		IEnumerable<Task> b_ = context.Operators.RetrieveByValueSet<Task>(a_, default(PropertyInfo));
 		IEnumerable<Task> c_(Task ConsultantReportObtained)
 		{
 			(string ID, CqlDateTime AuthorDate)? f_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
@@ -379,7 +379,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.End(p_);
 				CqlDateTime r_ = FirstReferral?.AuthorDate;
-				bool? s_ = context.Operators.After(q_, r_, null);
+				bool? s_ = context.Operators.After(q_, r_, default(string));
 				bool? t_ = context.Operators.And(n_, s_);
 				Code<Task.TaskStatus> u_ = ConsultantReportObtained?.StatusElement;
 				Task.TaskStatus? v_ = u_?.Value;

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -80,7 +80,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Consultant_Report_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006", default);
 
     [CqlDeclaration("Consultant Report")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1006")]
@@ -88,7 +88,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Consultant_Report.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -96,7 +96,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -104,7 +104,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -112,7 +112,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -120,7 +120,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -128,7 +128,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -136,7 +136,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Referral_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046", default);
 
     [CqlDeclaration("Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1046")]
@@ -145,8 +145,8 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CRLReceiptofSpecialistReportFHIR-0.2.000", "Measurement Period", c_);
 
@@ -159,7 +159,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -172,20 +172,20 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private bool? Has_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter Encounter)
@@ -215,7 +215,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private (string ID, CqlDateTime AuthorDate)? First_Referral_during_First_10_Months_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Referral();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		bool? c_(ServiceRequest ReferralOrder)
 		{
 			Code<RequestStatus> j_ = ReferralOrder?.StatusElement;
@@ -363,7 +363,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 	private bool? Referring_Clinician_Receives_Consultant_Report_to_Close_Referral_Loop_Value()
 	{
 		CqlValueSet a_ = this.Consultant_Report();
-		IEnumerable<Task> b_ = context.Operators.RetrieveByValueSet<Task>(a_, default(PropertyInfo));
+		IEnumerable<Task> b_ = context.Operators.RetrieveByValueSet<Task>(a_, default);
 		IEnumerable<Task> c_(Task ConsultantReportObtained)
 		{
 			(string ID, CqlDateTime AuthorDate)? f_ = this.First_Referral_during_First_10_Months_of_Measurement_Period();
@@ -379,7 +379,7 @@ public class CRLReceiptofSpecialistReportFHIR_0_2_000
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.End(p_);
 				CqlDateTime r_ = FirstReferral?.AuthorDate;
-				bool? s_ = context.Operators.After(q_, r_, default(string));
+				bool? s_ = context.Operators.After(q_, r_, default);
 				bool? t_ = context.Operators.And(n_, s_);
 				Code<Task.TaskStatus> u_ = ConsultantReportObtained?.StatusElement;
 				Task.TaskStatus? v_ = u_?.Value;

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CRLReceiptofSpecialistReportFHIR", "0.2.000")]
 public class CRLReceiptofSpecialistReportFHIR_0_2_000
 {

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -182,7 +182,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_and_Subacute_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", default);
 
     [CqlDeclaration("Acute and Subacute Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241")]
@@ -190,7 +190,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Acute_and_Subacute_Iridocyclitis.Value;
 
 	private CqlValueSet Amblyopia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", default);
 
     [CqlDeclaration("Amblyopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448")]
@@ -198,7 +198,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Amblyopia.Value;
 
 	private CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", default);
 
     [CqlDeclaration("Best Corrected Visual Acuity Exam Using Snellen Chart")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560")]
@@ -206,7 +206,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart.Value;
 
 	private CqlValueSet Burn_Confined_to_Eye_and_Adnexa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", default);
 
     [CqlDeclaration("Burn Confined to Eye and Adnexa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409")]
@@ -214,7 +214,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Burn_Confined_to_Eye_and_Adnexa.Value;
 
 	private CqlValueSet Cataract_Congenital_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", default);
 
     [CqlDeclaration("Cataract Congenital")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412")]
@@ -222,7 +222,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Congenital.Value;
 
 	private CqlValueSet Cataract_Mature_or_Hypermature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", default);
 
     [CqlDeclaration("Cataract Mature or Hypermature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413")]
@@ -230,7 +230,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Mature_or_Hypermature.Value;
 
 	private CqlValueSet Cataract_Posterior_Polar_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", default);
 
     [CqlDeclaration("Cataract Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414")]
@@ -238,7 +238,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Posterior_Polar.Value;
 
 	private CqlValueSet Cataract_Secondary_to_Ocular_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", default);
 
     [CqlDeclaration("Cataract Secondary to Ocular Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410")]
@@ -246,7 +246,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Secondary_to_Ocular_Disorders.Value;
 
 	private CqlValueSet Cataract_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", default);
 
     [CqlDeclaration("Cataract Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411")]
@@ -254,7 +254,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Surgery.Value;
 
 	private CqlValueSet Central_Corneal_Ulcer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", default);
 
     [CqlDeclaration("Central Corneal Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428")]
@@ -262,7 +262,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Central_Corneal_Ulcer.Value;
 
 	private CqlValueSet Certain_Types_of_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", default);
 
     [CqlDeclaration("Certain Types of Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415")]
@@ -270,7 +270,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Certain_Types_of_Iridocyclitis.Value;
 
 	private CqlValueSet Choroidal_Degenerations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", default);
 
     [CqlDeclaration("Choroidal Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450")]
@@ -278,7 +278,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Degenerations.Value;
 
 	private CqlValueSet Choroidal_Detachment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", default);
 
     [CqlDeclaration("Choroidal Detachment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451")]
@@ -286,7 +286,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Detachment.Value;
 
 	private CqlValueSet Choroidal_Hemorrhage_and_Rupture_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", default);
 
     [CqlDeclaration("Choroidal Hemorrhage and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452")]
@@ -294,7 +294,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Hemorrhage_and_Rupture.Value;
 
 	private CqlValueSet Chronic_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", default);
 
     [CqlDeclaration("Chronic Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416")]
@@ -302,7 +302,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Chronic_Iridocyclitis.Value;
 
 	private CqlValueSet Cloudy_Cornea_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", default);
 
     [CqlDeclaration("Cloudy Cornea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417")]
@@ -310,7 +310,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cloudy_Cornea.Value;
 
 	private CqlValueSet Corneal_Edema_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", default);
 
     [CqlDeclaration("Corneal Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418")]
@@ -318,7 +318,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Corneal_Edema.Value;
 
 	private CqlValueSet Degeneration_of_Macula_and_Posterior_Pole_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", default);
 
     [CqlDeclaration("Degeneration of Macula and Posterior Pole")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453")]
@@ -326,7 +326,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Degeneration_of_Macula_and_Posterior_Pole.Value;
 
 	private CqlValueSet Degenerative_Disorders_of_Globe_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", default);
 
     [CqlDeclaration("Degenerative Disorders of Globe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454")]
@@ -334,7 +334,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Degenerative_Disorders_of_Globe.Value;
 
 	private CqlValueSet Diabetic_Macular_Edema_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", default);
 
     [CqlDeclaration("Diabetic Macular Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455")]
@@ -342,7 +342,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Diabetic_Macular_Edema.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default);
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -350,7 +350,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", default);
 
     [CqlDeclaration("Disorders of Cornea Including Corneal Opacity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419")]
@@ -358,7 +358,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Cornea_Including_Corneal_Opacity.Value;
 
 	private CqlValueSet Disorders_of_Optic_Chiasm_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", default);
 
     [CqlDeclaration("Disorders of Optic Chiasm")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457")]
@@ -366,7 +366,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Optic_Chiasm.Value;
 
 	private CqlValueSet Disorders_of_Visual_Cortex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", default);
 
     [CqlDeclaration("Disorders of Visual Cortex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458")]
@@ -374,7 +374,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Visual_Cortex.Value;
 
 	private CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", default);
 
     [CqlDeclaration("Disseminated Chorioretinitis and Disseminated Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459")]
@@ -382,7 +382,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis.Value;
 
 	private CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", default);
 
     [CqlDeclaration("Focal Chorioretinitis and Focal Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460")]
@@ -390,7 +390,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Focal_Chorioretinitis_and_Focal_Retinochoroiditis.Value;
 
 	private CqlValueSet Glaucoma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", default);
 
     [CqlDeclaration("Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423")]
@@ -398,7 +398,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Glaucoma.Value;
 
 	private CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", default);
 
     [CqlDeclaration("Glaucoma Associated with Congenital Anomalies and Dystrophies and Systemic Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461")]
@@ -406,7 +406,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes.Value;
 
 	private CqlValueSet Hereditary_Choroidal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", default);
 
     [CqlDeclaration("Hereditary Choroidal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462")]
@@ -414,7 +414,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Choroidal_Dystrophies.Value;
 
 	private CqlValueSet Hereditary_Corneal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", default);
 
     [CqlDeclaration("Hereditary Corneal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424")]
@@ -422,7 +422,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Corneal_Dystrophies.Value;
 
 	private CqlValueSet Hereditary_Retinal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", default);
 
     [CqlDeclaration("Hereditary Retinal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463")]
@@ -430,7 +430,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Retinal_Dystrophies.Value;
 
 	private CqlValueSet Hypotony_of_Eye_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", default);
 
     [CqlDeclaration("Hypotony of Eye")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426")]
@@ -438,7 +438,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hypotony_of_Eye.Value;
 
 	private CqlValueSet Injury_to_Optic_Nerve_and_Pathways_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", default);
 
     [CqlDeclaration("Injury to Optic Nerve and Pathways")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427")]
@@ -446,7 +446,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Injury_to_Optic_Nerve_and_Pathways.Value;
 
 	private CqlValueSet Macular_Scar_of_Posterior_Polar_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", default);
 
     [CqlDeclaration("Macular Scar of Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559")]
@@ -454,7 +454,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Macular_Scar_of_Posterior_Polar.Value;
 
 	private CqlValueSet Morgagnian_Cataract_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", default);
 
     [CqlDeclaration("Morgagnian Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558")]
@@ -462,7 +462,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Morgagnian_Cataract.Value;
 
 	private CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", default);
 
     [CqlDeclaration("Nystagmus and Other Irregular Eye Movements")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465")]
@@ -470,7 +470,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Nystagmus_and_Other_Irregular_Eye_Movements.Value;
 
 	private CqlValueSet Open_Wound_of_Eyeball_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", default);
 
     [CqlDeclaration("Open Wound of Eyeball")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430")]
@@ -478,7 +478,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Open_Wound_of_Eyeball.Value;
 
 	private CqlValueSet Optic_Atrophy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", default);
 
     [CqlDeclaration("Optic Atrophy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466")]
@@ -486,7 +486,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Optic_Atrophy.Value;
 
 	private CqlValueSet Optic_Neuritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", default);
 
     [CqlDeclaration("Optic Neuritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467")]
@@ -494,7 +494,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Optic_Neuritis.Value;
 
 	private CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", default);
 
     [CqlDeclaration("Other and Unspecified Forms of Chorioretinitis and Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468")]
@@ -502,7 +502,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis.Value;
 
 	private CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", default);
 
     [CqlDeclaration("Other Background Retinopathy and Retinal Vascular Changes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469")]
@@ -510,7 +510,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Background_Retinopathy_and_Retinal_Vascular_Changes.Value;
 
 	private CqlValueSet Other_Disorders_of_Optic_Nerve_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", default);
 
     [CqlDeclaration("Other Disorders of Optic Nerve")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471")]
@@ -518,7 +518,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Disorders_of_Optic_Nerve.Value;
 
 	private CqlValueSet Other_Endophthalmitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", default);
 
     [CqlDeclaration("Other Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473")]
@@ -526,7 +526,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Endophthalmitis.Value;
 
 	private CqlValueSet Other_Proliferative_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", default);
 
     [CqlDeclaration("Other Proliferative Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480")]
@@ -534,7 +534,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Proliferative_Retinopathy.Value;
 
 	private CqlValueSet Pathologic_Myopia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", default);
 
     [CqlDeclaration("Pathologic Myopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432")]
@@ -542,7 +542,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Pathologic_Myopia.Value;
 
 	private CqlValueSet Posterior_Lenticonus_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", default);
 
     [CqlDeclaration("Posterior Lenticonus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433")]
@@ -550,7 +550,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Posterior_Lenticonus.Value;
 
 	private CqlValueSet Prior_Penetrating_Keratoplasty_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", default);
 
     [CqlDeclaration("Prior Penetrating Keratoplasty")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475")]
@@ -558,7 +558,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Prior_Penetrating_Keratoplasty.Value;
 
 	private CqlValueSet Purulent_Endophthalmitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", default);
 
     [CqlDeclaration("Purulent Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477")]
@@ -566,7 +566,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Purulent_Endophthalmitis.Value;
 
 	private CqlValueSet Retinal_Detachment_with_Retinal_Defect_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", default);
 
     [CqlDeclaration("Retinal Detachment with Retinal Defect")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478")]
@@ -574,7 +574,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retinal_Detachment_with_Retinal_Defect.Value;
 
 	private CqlValueSet Retinal_Vascular_Occlusion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", default);
 
     [CqlDeclaration("Retinal Vascular Occlusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479")]
@@ -582,7 +582,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retinal_Vascular_Occlusion.Value;
 
 	private CqlValueSet Retrolental_Fibroplasias_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", default);
 
     [CqlDeclaration("Retrolental Fibroplasias")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438")]
@@ -590,7 +590,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retrolental_Fibroplasias.Value;
 
 	private CqlValueSet Scleritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", default);
 
     [CqlDeclaration("Scleritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1")]
@@ -598,7 +598,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Scleritis.Value;
 
 	private CqlValueSet Separation_of_Retinal_Layers_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", default);
 
     [CqlDeclaration("Separation of Retinal Layers")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482")]
@@ -606,7 +606,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Separation_of_Retinal_Layers.Value;
 
 	private CqlValueSet Traumatic_Cataract_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", default);
 
     [CqlDeclaration("Traumatic Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443")]
@@ -614,7 +614,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Traumatic_Cataract.Value;
 
 	private CqlValueSet Uveitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", default);
 
     [CqlDeclaration("Uveitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444")]
@@ -622,7 +622,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Uveitis.Value;
 
 	private CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", default);
 
     [CqlDeclaration("Vascular Disorders of Iris and Ciliary Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445")]
@@ -630,7 +630,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Vascular_Disorders_of_Iris_and_Ciliary_Body.Value;
 
 	private CqlValueSet Visual_Acuity_20_40_or_Better_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", default);
 
     [CqlDeclaration("Visual Acuity 20/40 or Better")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483")]
@@ -638,7 +638,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Visual_Acuity_20_40_or_Better.Value;
 
 	private CqlValueSet Visual_Field_Defects_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", default);
 
     [CqlDeclaration("Visual Field Defects")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446")]
@@ -646,7 +646,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Visual_Field_Defects.Value;
 
 	private CqlCode Best_corrected_visual_acuity__observable_entity__Value() => 
-		new CqlCode("419775003", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419775003", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Best corrected visual acuity (observable entity)")]
 	public CqlCode Best_corrected_visual_acuity__observable_entity_() => 
@@ -655,7 +655,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419775003", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419775003", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -667,8 +667,8 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Cataracts2040BCVAwithin90DaysFHIR-0.1.000", "Measurement Period", c_);
 
@@ -681,7 +681,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -694,21 +694,21 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 	private IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Cataract_Surgery();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure CataractSurgery)
 		{
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 			DataType f_ = CataractSurgery?.Performed;
 			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.toInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, default(string));
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, default);
 			object k_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
 			CqlDateTime m_ = context.Operators.Start(l_);
 			CqlDateTime o_ = context.Operators.End(e_);
 			CqlQuantity p_ = context.Operators.Quantity(92m, "days");
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-			bool? r_ = context.Operators.SameOrBefore(m_, q_, default(string));
+			bool? r_ = context.Operators.SameOrBefore(m_, q_, default);
 			bool? s_ = context.Operators.And(i_, r_);
 			Code<EventStatus> t_ = CataractSurgery?.StatusElement;
 			EventStatus? u_ = t_?.Value;
@@ -770,168 +770,168 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
 		{
 			CqlValueSet d_ = this.Acute_and_Subacute_Iridocyclitis();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			CqlValueSet f_ = this.Amblyopia();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Burn_Confined_to_Eye_and_Adnexa();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default);
 			CqlValueSet k_ = this.Cataract_Secondary_to_Ocular_Disorders();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default);
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			CqlValueSet o_ = this.Cataract_Congenital();
-			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 			CqlValueSet q_ = this.Cataract_Mature_or_Hypermature();
-			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default(PropertyInfo));
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default);
 			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
 			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
 			CqlValueSet u_ = this.Cataract_Posterior_Polar();
-			IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default(PropertyInfo));
+			IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default);
 			CqlValueSet w_ = this.Central_Corneal_Ulcer();
-			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default(PropertyInfo));
+			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default);
 			IEnumerable<Condition> y_ = context.Operators.Union<Condition>(v_, x_);
 			IEnumerable<Condition> z_ = context.Operators.Union<Condition>(t_, y_);
 			CqlValueSet aa_ = this.Certain_Types_of_Iridocyclitis();
-			IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default(PropertyInfo));
+			IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default);
 			CqlValueSet ac_ = this.Choroidal_Degenerations();
-			IEnumerable<Condition> ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, default(PropertyInfo));
+			IEnumerable<Condition> ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, default);
 			IEnumerable<Condition> ae_ = context.Operators.Union<Condition>(ab_, ad_);
 			IEnumerable<Condition> af_ = context.Operators.Union<Condition>(z_, ae_);
 			CqlValueSet ag_ = this.Choroidal_Detachment();
-			IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default(PropertyInfo));
+			IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default);
 			CqlValueSet ai_ = this.Choroidal_Hemorrhage_and_Rupture();
-			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default(PropertyInfo));
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default);
 			IEnumerable<Condition> ak_ = context.Operators.Union<Condition>(ah_, aj_);
 			IEnumerable<Condition> al_ = context.Operators.Union<Condition>(af_, ak_);
 			CqlValueSet am_ = this.Chronic_Iridocyclitis();
-			IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default(PropertyInfo));
+			IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default);
 			CqlValueSet ao_ = this.Cloudy_Cornea();
-			IEnumerable<Condition> ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, default(PropertyInfo));
+			IEnumerable<Condition> ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, default);
 			IEnumerable<Condition> aq_ = context.Operators.Union<Condition>(an_, ap_);
 			IEnumerable<Condition> ar_ = context.Operators.Union<Condition>(al_, aq_);
 			CqlValueSet as_ = this.Corneal_Edema();
-			IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default(PropertyInfo));
+			IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default);
 			CqlValueSet au_ = this.Disorders_of_Cornea_Including_Corneal_Opacity();
-			IEnumerable<Condition> av_ = context.Operators.RetrieveByValueSet<Condition>(au_, default(PropertyInfo));
+			IEnumerable<Condition> av_ = context.Operators.RetrieveByValueSet<Condition>(au_, default);
 			IEnumerable<Condition> aw_ = context.Operators.Union<Condition>(at_, av_);
 			IEnumerable<Condition> ax_ = context.Operators.Union<Condition>(ar_, aw_);
 			CqlValueSet ay_ = this.Degeneration_of_Macula_and_Posterior_Pole();
-			IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default(PropertyInfo));
+			IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default);
 			CqlValueSet ba_ = this.Degenerative_Disorders_of_Globe();
-			IEnumerable<Condition> bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, default(PropertyInfo));
+			IEnumerable<Condition> bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, default);
 			IEnumerable<Condition> bc_ = context.Operators.Union<Condition>(az_, bb_);
 			IEnumerable<Condition> bd_ = context.Operators.Union<Condition>(ax_, bc_);
 			CqlValueSet be_ = this.Diabetic_Macular_Edema();
-			IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default(PropertyInfo));
+			IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default);
 			CqlValueSet bg_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, default(PropertyInfo));
+			IEnumerable<Condition> bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, default);
 			IEnumerable<Condition> bi_ = context.Operators.Union<Condition>(bf_, bh_);
 			IEnumerable<Condition> bj_ = context.Operators.Union<Condition>(bd_, bi_);
 			CqlValueSet bk_ = this.Disorders_of_Optic_Chiasm();
-			IEnumerable<Condition> bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, default(PropertyInfo));
+			IEnumerable<Condition> bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, default);
 			CqlValueSet bm_ = this.Disorders_of_Visual_Cortex();
-			IEnumerable<Condition> bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, default(PropertyInfo));
+			IEnumerable<Condition> bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, default);
 			IEnumerable<Condition> bo_ = context.Operators.Union<Condition>(bl_, bn_);
 			IEnumerable<Condition> bp_ = context.Operators.Union<Condition>(bj_, bo_);
 			CqlValueSet bq_ = this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis();
-			IEnumerable<Condition> br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, default(PropertyInfo));
+			IEnumerable<Condition> br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, default);
 			CqlValueSet bs_ = this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis();
-			IEnumerable<Condition> bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, default(PropertyInfo));
+			IEnumerable<Condition> bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, default);
 			IEnumerable<Condition> bu_ = context.Operators.Union<Condition>(br_, bt_);
 			IEnumerable<Condition> bv_ = context.Operators.Union<Condition>(bp_, bu_);
 			CqlValueSet bw_ = this.Glaucoma();
-			IEnumerable<Condition> bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, default(PropertyInfo));
+			IEnumerable<Condition> bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, default);
 			CqlValueSet by_ = this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes();
-			IEnumerable<Condition> bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, default(PropertyInfo));
+			IEnumerable<Condition> bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, default);
 			IEnumerable<Condition> ca_ = context.Operators.Union<Condition>(bx_, bz_);
 			IEnumerable<Condition> cb_ = context.Operators.Union<Condition>(bv_, ca_);
 			CqlValueSet cc_ = this.Hereditary_Choroidal_Dystrophies();
-			IEnumerable<Condition> cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, default(PropertyInfo));
+			IEnumerable<Condition> cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, default);
 			CqlValueSet ce_ = this.Hereditary_Corneal_Dystrophies();
-			IEnumerable<Condition> cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, default(PropertyInfo));
+			IEnumerable<Condition> cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, default);
 			IEnumerable<Condition> cg_ = context.Operators.Union<Condition>(cd_, cf_);
 			IEnumerable<Condition> ch_ = context.Operators.Union<Condition>(cb_, cg_);
 			CqlValueSet ci_ = this.Hereditary_Retinal_Dystrophies();
-			IEnumerable<Condition> cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, default(PropertyInfo));
+			IEnumerable<Condition> cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, default);
 			CqlValueSet ck_ = this.Hypotony_of_Eye();
-			IEnumerable<Condition> cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, default(PropertyInfo));
+			IEnumerable<Condition> cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, default);
 			IEnumerable<Condition> cm_ = context.Operators.Union<Condition>(cj_, cl_);
 			IEnumerable<Condition> cn_ = context.Operators.Union<Condition>(ch_, cm_);
 			CqlValueSet co_ = this.Injury_to_Optic_Nerve_and_Pathways();
-			IEnumerable<Condition> cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, default(PropertyInfo));
+			IEnumerable<Condition> cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, default);
 			CqlValueSet cq_ = this.Macular_Scar_of_Posterior_Polar();
-			IEnumerable<Condition> cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, default(PropertyInfo));
+			IEnumerable<Condition> cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, default);
 			IEnumerable<Condition> cs_ = context.Operators.Union<Condition>(cp_, cr_);
 			IEnumerable<Condition> ct_ = context.Operators.Union<Condition>(cn_, cs_);
 			CqlValueSet cu_ = this.Morgagnian_Cataract();
-			IEnumerable<Condition> cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, default(PropertyInfo));
+			IEnumerable<Condition> cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, default);
 			CqlValueSet cw_ = this.Nystagmus_and_Other_Irregular_Eye_Movements();
-			IEnumerable<Condition> cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, default(PropertyInfo));
+			IEnumerable<Condition> cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, default);
 			IEnumerable<Condition> cy_ = context.Operators.Union<Condition>(cv_, cx_);
 			IEnumerable<Condition> cz_ = context.Operators.Union<Condition>(ct_, cy_);
 			CqlValueSet da_ = this.Open_Wound_of_Eyeball();
-			IEnumerable<Condition> db_ = context.Operators.RetrieveByValueSet<Condition>(da_, default(PropertyInfo));
+			IEnumerable<Condition> db_ = context.Operators.RetrieveByValueSet<Condition>(da_, default);
 			CqlValueSet dc_ = this.Optic_Atrophy();
-			IEnumerable<Condition> dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, default(PropertyInfo));
+			IEnumerable<Condition> dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, default);
 			IEnumerable<Condition> de_ = context.Operators.Union<Condition>(db_, dd_);
 			IEnumerable<Condition> df_ = context.Operators.Union<Condition>(cz_, de_);
 			CqlValueSet dg_ = this.Optic_Neuritis();
-			IEnumerable<Condition> dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, default(PropertyInfo));
+			IEnumerable<Condition> dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, default);
 			CqlValueSet di_ = this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis();
-			IEnumerable<Condition> dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, default(PropertyInfo));
+			IEnumerable<Condition> dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, default);
 			IEnumerable<Condition> dk_ = context.Operators.Union<Condition>(dh_, dj_);
 			IEnumerable<Condition> dl_ = context.Operators.Union<Condition>(df_, dk_);
 			CqlValueSet dm_ = this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes();
-			IEnumerable<Condition> dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, default(PropertyInfo));
+			IEnumerable<Condition> dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, default);
 			CqlValueSet do_ = this.Other_Disorders_of_Optic_Nerve();
-			IEnumerable<Condition> dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, default(PropertyInfo));
+			IEnumerable<Condition> dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, default);
 			IEnumerable<Condition> dq_ = context.Operators.Union<Condition>(dn_, dp_);
 			IEnumerable<Condition> dr_ = context.Operators.Union<Condition>(dl_, dq_);
 			CqlValueSet ds_ = this.Other_Endophthalmitis();
-			IEnumerable<Condition> dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, default(PropertyInfo));
+			IEnumerable<Condition> dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, default);
 			CqlValueSet du_ = this.Other_Proliferative_Retinopathy();
-			IEnumerable<Condition> dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, default(PropertyInfo));
+			IEnumerable<Condition> dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, default);
 			IEnumerable<Condition> dw_ = context.Operators.Union<Condition>(dt_, dv_);
 			IEnumerable<Condition> dx_ = context.Operators.Union<Condition>(dr_, dw_);
 			CqlValueSet dy_ = this.Pathologic_Myopia();
-			IEnumerable<Condition> dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, default(PropertyInfo));
+			IEnumerable<Condition> dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, default);
 			CqlValueSet ea_ = this.Posterior_Lenticonus();
-			IEnumerable<Condition> eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, default(PropertyInfo));
+			IEnumerable<Condition> eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, default);
 			IEnumerable<Condition> ec_ = context.Operators.Union<Condition>(dz_, eb_);
 			IEnumerable<Condition> ed_ = context.Operators.Union<Condition>(dx_, ec_);
 			CqlValueSet ee_ = this.Prior_Penetrating_Keratoplasty();
-			IEnumerable<Condition> ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, default(PropertyInfo));
+			IEnumerable<Condition> ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, default);
 			CqlValueSet eg_ = this.Purulent_Endophthalmitis();
-			IEnumerable<Condition> eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, default(PropertyInfo));
+			IEnumerable<Condition> eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, default);
 			IEnumerable<Condition> ei_ = context.Operators.Union<Condition>(ef_, eh_);
 			IEnumerable<Condition> ej_ = context.Operators.Union<Condition>(ed_, ei_);
 			CqlValueSet ek_ = this.Retinal_Detachment_with_Retinal_Defect();
-			IEnumerable<Condition> el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, default(PropertyInfo));
+			IEnumerable<Condition> el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, default);
 			CqlValueSet em_ = this.Retinal_Vascular_Occlusion();
-			IEnumerable<Condition> en_ = context.Operators.RetrieveByValueSet<Condition>(em_, default(PropertyInfo));
+			IEnumerable<Condition> en_ = context.Operators.RetrieveByValueSet<Condition>(em_, default);
 			IEnumerable<Condition> eo_ = context.Operators.Union<Condition>(el_, en_);
 			IEnumerable<Condition> ep_ = context.Operators.Union<Condition>(ej_, eo_);
 			CqlValueSet eq_ = this.Retrolental_Fibroplasias();
-			IEnumerable<Condition> er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, default(PropertyInfo));
+			IEnumerable<Condition> er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, default);
 			CqlValueSet es_ = this.Scleritis();
-			IEnumerable<Condition> et_ = context.Operators.RetrieveByValueSet<Condition>(es_, default(PropertyInfo));
+			IEnumerable<Condition> et_ = context.Operators.RetrieveByValueSet<Condition>(es_, default);
 			IEnumerable<Condition> eu_ = context.Operators.Union<Condition>(er_, et_);
 			IEnumerable<Condition> ev_ = context.Operators.Union<Condition>(ep_, eu_);
 			CqlValueSet ew_ = this.Separation_of_Retinal_Layers();
-			IEnumerable<Condition> ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, default(PropertyInfo));
+			IEnumerable<Condition> ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, default);
 			CqlValueSet ey_ = this.Traumatic_Cataract();
-			IEnumerable<Condition> ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, default(PropertyInfo));
+			IEnumerable<Condition> ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, default);
 			IEnumerable<Condition> fa_ = context.Operators.Union<Condition>(ex_, ez_);
 			IEnumerable<Condition> fb_ = context.Operators.Union<Condition>(ev_, fa_);
 			CqlValueSet fc_ = this.Uveitis();
-			IEnumerable<Condition> fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, default(PropertyInfo));
+			IEnumerable<Condition> fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, default);
 			CqlValueSet fe_ = this.Vascular_Disorders_of_Iris_and_Ciliary_Body();
-			IEnumerable<Condition> ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, default(PropertyInfo));
+			IEnumerable<Condition> ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, default);
 			IEnumerable<Condition> fg_ = context.Operators.Union<Condition>(fd_, ff_);
 			IEnumerable<Condition> fh_ = context.Operators.Union<Condition>(fb_, fg_);
 			CqlValueSet fi_ = this.Visual_Field_Defects();
-			IEnumerable<Condition> fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, default(PropertyInfo));
+			IEnumerable<Condition> fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, default);
 			IEnumerable<Condition> fk_ = context.Operators.Union<Condition>(fh_, fj_);
 			bool? fl_(Condition ComorbidDiagnosis)
 			{
@@ -939,7 +939,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 				DataType fq_ = CataractSurgeryPerformed?.Performed;
 				object fr_ = FHIRHelpers_4_3_000.ToValue(fq_);
 				CqlInterval<CqlDateTime> fs_ = QICoreCommon_2_0_000.toInterval(fr_);
-				bool? ft_ = context.Operators.OverlapsBefore(fp_, fs_, default(string));
+				bool? ft_ = context.Operators.OverlapsBefore(fp_, fs_, default);
 				bool? fu_ = QICoreCommon_2_0_000.isActive(ComorbidDiagnosis);
 				bool? fv_ = context.Operators.And(ft_, fu_);
 
@@ -968,9 +968,9 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		{
 			CqlCode d_ = this.Best_corrected_visual_acuity__observable_entity_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			CqlValueSet g_ = this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart();
-			IEnumerable<Observation> h_ = context.Operators.RetrieveByValueSet<Observation>(g_, default(PropertyInfo));
+			IEnumerable<Observation> h_ = context.Operators.RetrieveByValueSet<Observation>(g_, default);
 			IEnumerable<Observation> i_ = context.Operators.Union<Observation>(f_, h_);
 			bool? j_(Observation VisualAcuityExamPerformed)
 			{

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -182,7 +182,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_and_Subacute_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241", default(string));
 
     [CqlDeclaration("Acute and Subacute Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1241")]
@@ -190,7 +190,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Acute_and_Subacute_Iridocyclitis.Value;
 
 	private CqlValueSet Amblyopia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448", default(string));
 
     [CqlDeclaration("Amblyopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1448")]
@@ -198,7 +198,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Amblyopia.Value;
 
 	private CqlValueSet Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560", default(string));
 
     [CqlDeclaration("Best Corrected Visual Acuity Exam Using Snellen Chart")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1560")]
@@ -206,7 +206,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart.Value;
 
 	private CqlValueSet Burn_Confined_to_Eye_and_Adnexa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409", default(string));
 
     [CqlDeclaration("Burn Confined to Eye and Adnexa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1409")]
@@ -214,7 +214,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Burn_Confined_to_Eye_and_Adnexa.Value;
 
 	private CqlValueSet Cataract_Congenital_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412", default(string));
 
     [CqlDeclaration("Cataract Congenital")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1412")]
@@ -222,7 +222,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Congenital.Value;
 
 	private CqlValueSet Cataract_Mature_or_Hypermature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413", default(string));
 
     [CqlDeclaration("Cataract Mature or Hypermature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1413")]
@@ -230,7 +230,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Mature_or_Hypermature.Value;
 
 	private CqlValueSet Cataract_Posterior_Polar_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414", default(string));
 
     [CqlDeclaration("Cataract Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1414")]
@@ -238,7 +238,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Posterior_Polar.Value;
 
 	private CqlValueSet Cataract_Secondary_to_Ocular_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410", default(string));
 
     [CqlDeclaration("Cataract Secondary to Ocular Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1410")]
@@ -246,7 +246,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Secondary_to_Ocular_Disorders.Value;
 
 	private CqlValueSet Cataract_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411", default(string));
 
     [CqlDeclaration("Cataract Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1411")]
@@ -254,7 +254,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cataract_Surgery.Value;
 
 	private CqlValueSet Central_Corneal_Ulcer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428", default(string));
 
     [CqlDeclaration("Central Corneal Ulcer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1428")]
@@ -262,7 +262,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Central_Corneal_Ulcer.Value;
 
 	private CqlValueSet Certain_Types_of_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415", default(string));
 
     [CqlDeclaration("Certain Types of Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1415")]
@@ -270,7 +270,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Certain_Types_of_Iridocyclitis.Value;
 
 	private CqlValueSet Choroidal_Degenerations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450", default(string));
 
     [CqlDeclaration("Choroidal Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1450")]
@@ -278,7 +278,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Degenerations.Value;
 
 	private CqlValueSet Choroidal_Detachment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451", default(string));
 
     [CqlDeclaration("Choroidal Detachment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1451")]
@@ -286,7 +286,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Detachment.Value;
 
 	private CqlValueSet Choroidal_Hemorrhage_and_Rupture_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452", default(string));
 
     [CqlDeclaration("Choroidal Hemorrhage and Rupture")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1452")]
@@ -294,7 +294,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Choroidal_Hemorrhage_and_Rupture.Value;
 
 	private CqlValueSet Chronic_Iridocyclitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416", default(string));
 
     [CqlDeclaration("Chronic Iridocyclitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1416")]
@@ -302,7 +302,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Chronic_Iridocyclitis.Value;
 
 	private CqlValueSet Cloudy_Cornea_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417", default(string));
 
     [CqlDeclaration("Cloudy Cornea")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1417")]
@@ -310,7 +310,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Cloudy_Cornea.Value;
 
 	private CqlValueSet Corneal_Edema_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418", default(string));
 
     [CqlDeclaration("Corneal Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1418")]
@@ -318,7 +318,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Corneal_Edema.Value;
 
 	private CqlValueSet Degeneration_of_Macula_and_Posterior_Pole_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453", default(string));
 
     [CqlDeclaration("Degeneration of Macula and Posterior Pole")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1453")]
@@ -326,7 +326,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Degeneration_of_Macula_and_Posterior_Pole.Value;
 
 	private CqlValueSet Degenerative_Disorders_of_Globe_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454", default(string));
 
     [CqlDeclaration("Degenerative Disorders of Globe")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1454")]
@@ -334,7 +334,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Degenerative_Disorders_of_Globe.Value;
 
 	private CqlValueSet Diabetic_Macular_Edema_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455", default(string));
 
     [CqlDeclaration("Diabetic Macular Edema")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1455")]
@@ -342,7 +342,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Diabetic_Macular_Edema.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -350,7 +350,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Disorders_of_Cornea_Including_Corneal_Opacity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419", default(string));
 
     [CqlDeclaration("Disorders of Cornea Including Corneal Opacity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1419")]
@@ -358,7 +358,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Cornea_Including_Corneal_Opacity.Value;
 
 	private CqlValueSet Disorders_of_Optic_Chiasm_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457", default(string));
 
     [CqlDeclaration("Disorders of Optic Chiasm")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1457")]
@@ -366,7 +366,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Optic_Chiasm.Value;
 
 	private CqlValueSet Disorders_of_Visual_Cortex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458", default(string));
 
     [CqlDeclaration("Disorders of Visual Cortex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1458")]
@@ -374,7 +374,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disorders_of_Visual_Cortex.Value;
 
 	private CqlValueSet Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459", default(string));
 
     [CqlDeclaration("Disseminated Chorioretinitis and Disseminated Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1459")]
@@ -382,7 +382,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis.Value;
 
 	private CqlValueSet Focal_Chorioretinitis_and_Focal_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460", default(string));
 
     [CqlDeclaration("Focal Chorioretinitis and Focal Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1460")]
@@ -390,7 +390,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Focal_Chorioretinitis_and_Focal_Retinochoroiditis.Value;
 
 	private CqlValueSet Glaucoma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423", default(string));
 
     [CqlDeclaration("Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1423")]
@@ -398,7 +398,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Glaucoma.Value;
 
 	private CqlValueSet Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461", default(string));
 
     [CqlDeclaration("Glaucoma Associated with Congenital Anomalies and Dystrophies and Systemic Syndromes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1461")]
@@ -406,7 +406,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes.Value;
 
 	private CqlValueSet Hereditary_Choroidal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462", default(string));
 
     [CqlDeclaration("Hereditary Choroidal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1462")]
@@ -414,7 +414,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Choroidal_Dystrophies.Value;
 
 	private CqlValueSet Hereditary_Corneal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424", default(string));
 
     [CqlDeclaration("Hereditary Corneal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1424")]
@@ -422,7 +422,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Corneal_Dystrophies.Value;
 
 	private CqlValueSet Hereditary_Retinal_Dystrophies_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463", default(string));
 
     [CqlDeclaration("Hereditary Retinal Dystrophies")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1463")]
@@ -430,7 +430,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hereditary_Retinal_Dystrophies.Value;
 
 	private CqlValueSet Hypotony_of_Eye_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426", default(string));
 
     [CqlDeclaration("Hypotony of Eye")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1426")]
@@ -438,7 +438,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Hypotony_of_Eye.Value;
 
 	private CqlValueSet Injury_to_Optic_Nerve_and_Pathways_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427", default(string));
 
     [CqlDeclaration("Injury to Optic Nerve and Pathways")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1427")]
@@ -446,7 +446,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Injury_to_Optic_Nerve_and_Pathways.Value;
 
 	private CqlValueSet Macular_Scar_of_Posterior_Polar_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559", default(string));
 
     [CqlDeclaration("Macular Scar of Posterior Polar")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1559")]
@@ -454,7 +454,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Macular_Scar_of_Posterior_Polar.Value;
 
 	private CqlValueSet Morgagnian_Cataract_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558", default(string));
 
     [CqlDeclaration("Morgagnian Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1558")]
@@ -462,7 +462,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Morgagnian_Cataract.Value;
 
 	private CqlValueSet Nystagmus_and_Other_Irregular_Eye_Movements_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465", default(string));
 
     [CqlDeclaration("Nystagmus and Other Irregular Eye Movements")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1465")]
@@ -470,7 +470,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Nystagmus_and_Other_Irregular_Eye_Movements.Value;
 
 	private CqlValueSet Open_Wound_of_Eyeball_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430", default(string));
 
     [CqlDeclaration("Open Wound of Eyeball")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1430")]
@@ -478,7 +478,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Open_Wound_of_Eyeball.Value;
 
 	private CqlValueSet Optic_Atrophy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466", default(string));
 
     [CqlDeclaration("Optic Atrophy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1466")]
@@ -486,7 +486,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Optic_Atrophy.Value;
 
 	private CqlValueSet Optic_Neuritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467", default(string));
 
     [CqlDeclaration("Optic Neuritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1467")]
@@ -494,7 +494,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Optic_Neuritis.Value;
 
 	private CqlValueSet Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468", default(string));
 
     [CqlDeclaration("Other and Unspecified Forms of Chorioretinitis and Retinochoroiditis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1468")]
@@ -502,7 +502,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis.Value;
 
 	private CqlValueSet Other_Background_Retinopathy_and_Retinal_Vascular_Changes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469", default(string));
 
     [CqlDeclaration("Other Background Retinopathy and Retinal Vascular Changes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1469")]
@@ -510,7 +510,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Background_Retinopathy_and_Retinal_Vascular_Changes.Value;
 
 	private CqlValueSet Other_Disorders_of_Optic_Nerve_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471", default(string));
 
     [CqlDeclaration("Other Disorders of Optic Nerve")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1471")]
@@ -518,7 +518,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Disorders_of_Optic_Nerve.Value;
 
 	private CqlValueSet Other_Endophthalmitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473", default(string));
 
     [CqlDeclaration("Other Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1473")]
@@ -526,7 +526,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Endophthalmitis.Value;
 
 	private CqlValueSet Other_Proliferative_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480", default(string));
 
     [CqlDeclaration("Other Proliferative Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1480")]
@@ -534,7 +534,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Other_Proliferative_Retinopathy.Value;
 
 	private CqlValueSet Pathologic_Myopia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432", default(string));
 
     [CqlDeclaration("Pathologic Myopia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1432")]
@@ -542,7 +542,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Pathologic_Myopia.Value;
 
 	private CqlValueSet Posterior_Lenticonus_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433", default(string));
 
     [CqlDeclaration("Posterior Lenticonus")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1433")]
@@ -550,7 +550,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Posterior_Lenticonus.Value;
 
 	private CqlValueSet Prior_Penetrating_Keratoplasty_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475", default(string));
 
     [CqlDeclaration("Prior Penetrating Keratoplasty")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1475")]
@@ -558,7 +558,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Prior_Penetrating_Keratoplasty.Value;
 
 	private CqlValueSet Purulent_Endophthalmitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477", default(string));
 
     [CqlDeclaration("Purulent Endophthalmitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1477")]
@@ -566,7 +566,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Purulent_Endophthalmitis.Value;
 
 	private CqlValueSet Retinal_Detachment_with_Retinal_Defect_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478", default(string));
 
     [CqlDeclaration("Retinal Detachment with Retinal Defect")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1478")]
@@ -574,7 +574,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retinal_Detachment_with_Retinal_Defect.Value;
 
 	private CqlValueSet Retinal_Vascular_Occlusion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479", default(string));
 
     [CqlDeclaration("Retinal Vascular Occlusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1479")]
@@ -582,7 +582,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retinal_Vascular_Occlusion.Value;
 
 	private CqlValueSet Retrolental_Fibroplasias_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438", default(string));
 
     [CqlDeclaration("Retrolental Fibroplasias")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1438")]
@@ -590,7 +590,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Retrolental_Fibroplasias.Value;
 
 	private CqlValueSet Scleritis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1", default(string));
 
     [CqlDeclaration("Scleritis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1226.1")]
@@ -598,7 +598,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Scleritis.Value;
 
 	private CqlValueSet Separation_of_Retinal_Layers_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482", default(string));
 
     [CqlDeclaration("Separation of Retinal Layers")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1482")]
@@ -606,7 +606,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Separation_of_Retinal_Layers.Value;
 
 	private CqlValueSet Traumatic_Cataract_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443", default(string));
 
     [CqlDeclaration("Traumatic Cataract")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1443")]
@@ -614,7 +614,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Traumatic_Cataract.Value;
 
 	private CqlValueSet Uveitis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444", default(string));
 
     [CqlDeclaration("Uveitis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1444")]
@@ -622,7 +622,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Uveitis.Value;
 
 	private CqlValueSet Vascular_Disorders_of_Iris_and_Ciliary_Body_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445", default(string));
 
     [CqlDeclaration("Vascular Disorders of Iris and Ciliary Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1445")]
@@ -630,7 +630,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Vascular_Disorders_of_Iris_and_Ciliary_Body.Value;
 
 	private CqlValueSet Visual_Acuity_20_40_or_Better_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483", default(string));
 
     [CqlDeclaration("Visual Acuity 20/40 or Better")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1483")]
@@ -638,7 +638,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Visual_Acuity_20_40_or_Better.Value;
 
 	private CqlValueSet Visual_Field_Defects_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446", default(string));
 
     [CqlDeclaration("Visual Field Defects")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1446")]
@@ -646,7 +646,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		__Visual_Field_Defects.Value;
 
 	private CqlCode Best_corrected_visual_acuity__observable_entity__Value() => 
-		new CqlCode("419775003", "http://snomed.info/sct", null, null);
+		new CqlCode("419775003", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Best corrected visual acuity (observable entity)")]
 	public CqlCode Best_corrected_visual_acuity__observable_entity_() => 
@@ -655,7 +655,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419775003", "http://snomed.info/sct", null, null),
+			new CqlCode("419775003", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -667,8 +667,8 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Cataracts2040BCVAwithin90DaysFHIR-0.1.000", "Measurement Period", c_);
 
@@ -681,7 +681,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -694,21 +694,21 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 	private IEnumerable<Procedure> Cataract_Surgery_Between_January_and_September_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Cataract_Surgery();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure CataractSurgery)
 		{
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
 			DataType f_ = CataractSurgery?.Performed;
 			object g_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.toInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, null);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, default(string));
 			object k_ = FHIRHelpers_4_3_000.ToValue(f_);
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.toInterval(k_);
 			CqlDateTime m_ = context.Operators.Start(l_);
 			CqlDateTime o_ = context.Operators.End(e_);
 			CqlQuantity p_ = context.Operators.Quantity(92m, "days");
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
-			bool? r_ = context.Operators.SameOrBefore(m_, q_, null);
+			bool? r_ = context.Operators.SameOrBefore(m_, q_, default(string));
 			bool? s_ = context.Operators.And(i_, r_);
 			Code<EventStatus> t_ = CataractSurgery?.StatusElement;
 			EventStatus? u_ = t_?.Value;
@@ -770,168 +770,168 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		IEnumerable<Procedure> b_(Procedure CataractSurgeryPerformed)
 		{
 			CqlValueSet d_ = this.Acute_and_Subacute_Iridocyclitis();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			CqlValueSet f_ = this.Amblyopia();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 			CqlValueSet i_ = this.Burn_Confined_to_Eye_and_Adnexa();
-			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
+			IEnumerable<Condition> j_ = context.Operators.RetrieveByValueSet<Condition>(i_, default(PropertyInfo));
 			CqlValueSet k_ = this.Cataract_Secondary_to_Ocular_Disorders();
-			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, null);
+			IEnumerable<Condition> l_ = context.Operators.RetrieveByValueSet<Condition>(k_, default(PropertyInfo));
 			IEnumerable<Condition> m_ = context.Operators.Union<Condition>(j_, l_);
 			IEnumerable<Condition> n_ = context.Operators.Union<Condition>(h_, m_);
 			CqlValueSet o_ = this.Cataract_Congenital();
-			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+			IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 			CqlValueSet q_ = this.Cataract_Mature_or_Hypermature();
-			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, null);
+			IEnumerable<Condition> r_ = context.Operators.RetrieveByValueSet<Condition>(q_, default(PropertyInfo));
 			IEnumerable<Condition> s_ = context.Operators.Union<Condition>(p_, r_);
 			IEnumerable<Condition> t_ = context.Operators.Union<Condition>(n_, s_);
 			CqlValueSet u_ = this.Cataract_Posterior_Polar();
-			IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, null);
+			IEnumerable<Condition> v_ = context.Operators.RetrieveByValueSet<Condition>(u_, default(PropertyInfo));
 			CqlValueSet w_ = this.Central_Corneal_Ulcer();
-			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
+			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default(PropertyInfo));
 			IEnumerable<Condition> y_ = context.Operators.Union<Condition>(v_, x_);
 			IEnumerable<Condition> z_ = context.Operators.Union<Condition>(t_, y_);
 			CqlValueSet aa_ = this.Certain_Types_of_Iridocyclitis();
-			IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, null);
+			IEnumerable<Condition> ab_ = context.Operators.RetrieveByValueSet<Condition>(aa_, default(PropertyInfo));
 			CqlValueSet ac_ = this.Choroidal_Degenerations();
-			IEnumerable<Condition> ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, null);
+			IEnumerable<Condition> ad_ = context.Operators.RetrieveByValueSet<Condition>(ac_, default(PropertyInfo));
 			IEnumerable<Condition> ae_ = context.Operators.Union<Condition>(ab_, ad_);
 			IEnumerable<Condition> af_ = context.Operators.Union<Condition>(z_, ae_);
 			CqlValueSet ag_ = this.Choroidal_Detachment();
-			IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, null);
+			IEnumerable<Condition> ah_ = context.Operators.RetrieveByValueSet<Condition>(ag_, default(PropertyInfo));
 			CqlValueSet ai_ = this.Choroidal_Hemorrhage_and_Rupture();
-			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default(PropertyInfo));
 			IEnumerable<Condition> ak_ = context.Operators.Union<Condition>(ah_, aj_);
 			IEnumerable<Condition> al_ = context.Operators.Union<Condition>(af_, ak_);
 			CqlValueSet am_ = this.Chronic_Iridocyclitis();
-			IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, null);
+			IEnumerable<Condition> an_ = context.Operators.RetrieveByValueSet<Condition>(am_, default(PropertyInfo));
 			CqlValueSet ao_ = this.Cloudy_Cornea();
-			IEnumerable<Condition> ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, null);
+			IEnumerable<Condition> ap_ = context.Operators.RetrieveByValueSet<Condition>(ao_, default(PropertyInfo));
 			IEnumerable<Condition> aq_ = context.Operators.Union<Condition>(an_, ap_);
 			IEnumerable<Condition> ar_ = context.Operators.Union<Condition>(al_, aq_);
 			CqlValueSet as_ = this.Corneal_Edema();
-			IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, null);
+			IEnumerable<Condition> at_ = context.Operators.RetrieveByValueSet<Condition>(as_, default(PropertyInfo));
 			CqlValueSet au_ = this.Disorders_of_Cornea_Including_Corneal_Opacity();
-			IEnumerable<Condition> av_ = context.Operators.RetrieveByValueSet<Condition>(au_, null);
+			IEnumerable<Condition> av_ = context.Operators.RetrieveByValueSet<Condition>(au_, default(PropertyInfo));
 			IEnumerable<Condition> aw_ = context.Operators.Union<Condition>(at_, av_);
 			IEnumerable<Condition> ax_ = context.Operators.Union<Condition>(ar_, aw_);
 			CqlValueSet ay_ = this.Degeneration_of_Macula_and_Posterior_Pole();
-			IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, null);
+			IEnumerable<Condition> az_ = context.Operators.RetrieveByValueSet<Condition>(ay_, default(PropertyInfo));
 			CqlValueSet ba_ = this.Degenerative_Disorders_of_Globe();
-			IEnumerable<Condition> bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, null);
+			IEnumerable<Condition> bb_ = context.Operators.RetrieveByValueSet<Condition>(ba_, default(PropertyInfo));
 			IEnumerable<Condition> bc_ = context.Operators.Union<Condition>(az_, bb_);
 			IEnumerable<Condition> bd_ = context.Operators.Union<Condition>(ax_, bc_);
 			CqlValueSet be_ = this.Diabetic_Macular_Edema();
-			IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, null);
+			IEnumerable<Condition> bf_ = context.Operators.RetrieveByValueSet<Condition>(be_, default(PropertyInfo));
 			CqlValueSet bg_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, null);
+			IEnumerable<Condition> bh_ = context.Operators.RetrieveByValueSet<Condition>(bg_, default(PropertyInfo));
 			IEnumerable<Condition> bi_ = context.Operators.Union<Condition>(bf_, bh_);
 			IEnumerable<Condition> bj_ = context.Operators.Union<Condition>(bd_, bi_);
 			CqlValueSet bk_ = this.Disorders_of_Optic_Chiasm();
-			IEnumerable<Condition> bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, null);
+			IEnumerable<Condition> bl_ = context.Operators.RetrieveByValueSet<Condition>(bk_, default(PropertyInfo));
 			CqlValueSet bm_ = this.Disorders_of_Visual_Cortex();
-			IEnumerable<Condition> bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, null);
+			IEnumerable<Condition> bn_ = context.Operators.RetrieveByValueSet<Condition>(bm_, default(PropertyInfo));
 			IEnumerable<Condition> bo_ = context.Operators.Union<Condition>(bl_, bn_);
 			IEnumerable<Condition> bp_ = context.Operators.Union<Condition>(bj_, bo_);
 			CqlValueSet bq_ = this.Disseminated_Chorioretinitis_and_Disseminated_Retinochoroiditis();
-			IEnumerable<Condition> br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, null);
+			IEnumerable<Condition> br_ = context.Operators.RetrieveByValueSet<Condition>(bq_, default(PropertyInfo));
 			CqlValueSet bs_ = this.Focal_Chorioretinitis_and_Focal_Retinochoroiditis();
-			IEnumerable<Condition> bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, null);
+			IEnumerable<Condition> bt_ = context.Operators.RetrieveByValueSet<Condition>(bs_, default(PropertyInfo));
 			IEnumerable<Condition> bu_ = context.Operators.Union<Condition>(br_, bt_);
 			IEnumerable<Condition> bv_ = context.Operators.Union<Condition>(bp_, bu_);
 			CqlValueSet bw_ = this.Glaucoma();
-			IEnumerable<Condition> bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, null);
+			IEnumerable<Condition> bx_ = context.Operators.RetrieveByValueSet<Condition>(bw_, default(PropertyInfo));
 			CqlValueSet by_ = this.Glaucoma_Associated_with_Congenital_Anomalies_and_Dystrophies_and_Systemic_Syndromes();
-			IEnumerable<Condition> bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, null);
+			IEnumerable<Condition> bz_ = context.Operators.RetrieveByValueSet<Condition>(by_, default(PropertyInfo));
 			IEnumerable<Condition> ca_ = context.Operators.Union<Condition>(bx_, bz_);
 			IEnumerable<Condition> cb_ = context.Operators.Union<Condition>(bv_, ca_);
 			CqlValueSet cc_ = this.Hereditary_Choroidal_Dystrophies();
-			IEnumerable<Condition> cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, null);
+			IEnumerable<Condition> cd_ = context.Operators.RetrieveByValueSet<Condition>(cc_, default(PropertyInfo));
 			CqlValueSet ce_ = this.Hereditary_Corneal_Dystrophies();
-			IEnumerable<Condition> cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, null);
+			IEnumerable<Condition> cf_ = context.Operators.RetrieveByValueSet<Condition>(ce_, default(PropertyInfo));
 			IEnumerable<Condition> cg_ = context.Operators.Union<Condition>(cd_, cf_);
 			IEnumerable<Condition> ch_ = context.Operators.Union<Condition>(cb_, cg_);
 			CqlValueSet ci_ = this.Hereditary_Retinal_Dystrophies();
-			IEnumerable<Condition> cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, null);
+			IEnumerable<Condition> cj_ = context.Operators.RetrieveByValueSet<Condition>(ci_, default(PropertyInfo));
 			CqlValueSet ck_ = this.Hypotony_of_Eye();
-			IEnumerable<Condition> cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, null);
+			IEnumerable<Condition> cl_ = context.Operators.RetrieveByValueSet<Condition>(ck_, default(PropertyInfo));
 			IEnumerable<Condition> cm_ = context.Operators.Union<Condition>(cj_, cl_);
 			IEnumerable<Condition> cn_ = context.Operators.Union<Condition>(ch_, cm_);
 			CqlValueSet co_ = this.Injury_to_Optic_Nerve_and_Pathways();
-			IEnumerable<Condition> cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, null);
+			IEnumerable<Condition> cp_ = context.Operators.RetrieveByValueSet<Condition>(co_, default(PropertyInfo));
 			CqlValueSet cq_ = this.Macular_Scar_of_Posterior_Polar();
-			IEnumerable<Condition> cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, null);
+			IEnumerable<Condition> cr_ = context.Operators.RetrieveByValueSet<Condition>(cq_, default(PropertyInfo));
 			IEnumerable<Condition> cs_ = context.Operators.Union<Condition>(cp_, cr_);
 			IEnumerable<Condition> ct_ = context.Operators.Union<Condition>(cn_, cs_);
 			CqlValueSet cu_ = this.Morgagnian_Cataract();
-			IEnumerable<Condition> cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, null);
+			IEnumerable<Condition> cv_ = context.Operators.RetrieveByValueSet<Condition>(cu_, default(PropertyInfo));
 			CqlValueSet cw_ = this.Nystagmus_and_Other_Irregular_Eye_Movements();
-			IEnumerable<Condition> cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, null);
+			IEnumerable<Condition> cx_ = context.Operators.RetrieveByValueSet<Condition>(cw_, default(PropertyInfo));
 			IEnumerable<Condition> cy_ = context.Operators.Union<Condition>(cv_, cx_);
 			IEnumerable<Condition> cz_ = context.Operators.Union<Condition>(ct_, cy_);
 			CqlValueSet da_ = this.Open_Wound_of_Eyeball();
-			IEnumerable<Condition> db_ = context.Operators.RetrieveByValueSet<Condition>(da_, null);
+			IEnumerable<Condition> db_ = context.Operators.RetrieveByValueSet<Condition>(da_, default(PropertyInfo));
 			CqlValueSet dc_ = this.Optic_Atrophy();
-			IEnumerable<Condition> dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, null);
+			IEnumerable<Condition> dd_ = context.Operators.RetrieveByValueSet<Condition>(dc_, default(PropertyInfo));
 			IEnumerable<Condition> de_ = context.Operators.Union<Condition>(db_, dd_);
 			IEnumerable<Condition> df_ = context.Operators.Union<Condition>(cz_, de_);
 			CqlValueSet dg_ = this.Optic_Neuritis();
-			IEnumerable<Condition> dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, null);
+			IEnumerable<Condition> dh_ = context.Operators.RetrieveByValueSet<Condition>(dg_, default(PropertyInfo));
 			CqlValueSet di_ = this.Other_and_Unspecified_Forms_of_Chorioretinitis_and_Retinochoroiditis();
-			IEnumerable<Condition> dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, null);
+			IEnumerable<Condition> dj_ = context.Operators.RetrieveByValueSet<Condition>(di_, default(PropertyInfo));
 			IEnumerable<Condition> dk_ = context.Operators.Union<Condition>(dh_, dj_);
 			IEnumerable<Condition> dl_ = context.Operators.Union<Condition>(df_, dk_);
 			CqlValueSet dm_ = this.Other_Background_Retinopathy_and_Retinal_Vascular_Changes();
-			IEnumerable<Condition> dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, null);
+			IEnumerable<Condition> dn_ = context.Operators.RetrieveByValueSet<Condition>(dm_, default(PropertyInfo));
 			CqlValueSet do_ = this.Other_Disorders_of_Optic_Nerve();
-			IEnumerable<Condition> dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, null);
+			IEnumerable<Condition> dp_ = context.Operators.RetrieveByValueSet<Condition>(do_, default(PropertyInfo));
 			IEnumerable<Condition> dq_ = context.Operators.Union<Condition>(dn_, dp_);
 			IEnumerable<Condition> dr_ = context.Operators.Union<Condition>(dl_, dq_);
 			CqlValueSet ds_ = this.Other_Endophthalmitis();
-			IEnumerable<Condition> dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, null);
+			IEnumerable<Condition> dt_ = context.Operators.RetrieveByValueSet<Condition>(ds_, default(PropertyInfo));
 			CqlValueSet du_ = this.Other_Proliferative_Retinopathy();
-			IEnumerable<Condition> dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, null);
+			IEnumerable<Condition> dv_ = context.Operators.RetrieveByValueSet<Condition>(du_, default(PropertyInfo));
 			IEnumerable<Condition> dw_ = context.Operators.Union<Condition>(dt_, dv_);
 			IEnumerable<Condition> dx_ = context.Operators.Union<Condition>(dr_, dw_);
 			CqlValueSet dy_ = this.Pathologic_Myopia();
-			IEnumerable<Condition> dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, null);
+			IEnumerable<Condition> dz_ = context.Operators.RetrieveByValueSet<Condition>(dy_, default(PropertyInfo));
 			CqlValueSet ea_ = this.Posterior_Lenticonus();
-			IEnumerable<Condition> eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, null);
+			IEnumerable<Condition> eb_ = context.Operators.RetrieveByValueSet<Condition>(ea_, default(PropertyInfo));
 			IEnumerable<Condition> ec_ = context.Operators.Union<Condition>(dz_, eb_);
 			IEnumerable<Condition> ed_ = context.Operators.Union<Condition>(dx_, ec_);
 			CqlValueSet ee_ = this.Prior_Penetrating_Keratoplasty();
-			IEnumerable<Condition> ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, null);
+			IEnumerable<Condition> ef_ = context.Operators.RetrieveByValueSet<Condition>(ee_, default(PropertyInfo));
 			CqlValueSet eg_ = this.Purulent_Endophthalmitis();
-			IEnumerable<Condition> eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, null);
+			IEnumerable<Condition> eh_ = context.Operators.RetrieveByValueSet<Condition>(eg_, default(PropertyInfo));
 			IEnumerable<Condition> ei_ = context.Operators.Union<Condition>(ef_, eh_);
 			IEnumerable<Condition> ej_ = context.Operators.Union<Condition>(ed_, ei_);
 			CqlValueSet ek_ = this.Retinal_Detachment_with_Retinal_Defect();
-			IEnumerable<Condition> el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, null);
+			IEnumerable<Condition> el_ = context.Operators.RetrieveByValueSet<Condition>(ek_, default(PropertyInfo));
 			CqlValueSet em_ = this.Retinal_Vascular_Occlusion();
-			IEnumerable<Condition> en_ = context.Operators.RetrieveByValueSet<Condition>(em_, null);
+			IEnumerable<Condition> en_ = context.Operators.RetrieveByValueSet<Condition>(em_, default(PropertyInfo));
 			IEnumerable<Condition> eo_ = context.Operators.Union<Condition>(el_, en_);
 			IEnumerable<Condition> ep_ = context.Operators.Union<Condition>(ej_, eo_);
 			CqlValueSet eq_ = this.Retrolental_Fibroplasias();
-			IEnumerable<Condition> er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, null);
+			IEnumerable<Condition> er_ = context.Operators.RetrieveByValueSet<Condition>(eq_, default(PropertyInfo));
 			CqlValueSet es_ = this.Scleritis();
-			IEnumerable<Condition> et_ = context.Operators.RetrieveByValueSet<Condition>(es_, null);
+			IEnumerable<Condition> et_ = context.Operators.RetrieveByValueSet<Condition>(es_, default(PropertyInfo));
 			IEnumerable<Condition> eu_ = context.Operators.Union<Condition>(er_, et_);
 			IEnumerable<Condition> ev_ = context.Operators.Union<Condition>(ep_, eu_);
 			CqlValueSet ew_ = this.Separation_of_Retinal_Layers();
-			IEnumerable<Condition> ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, null);
+			IEnumerable<Condition> ex_ = context.Operators.RetrieveByValueSet<Condition>(ew_, default(PropertyInfo));
 			CqlValueSet ey_ = this.Traumatic_Cataract();
-			IEnumerable<Condition> ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, null);
+			IEnumerable<Condition> ez_ = context.Operators.RetrieveByValueSet<Condition>(ey_, default(PropertyInfo));
 			IEnumerable<Condition> fa_ = context.Operators.Union<Condition>(ex_, ez_);
 			IEnumerable<Condition> fb_ = context.Operators.Union<Condition>(ev_, fa_);
 			CqlValueSet fc_ = this.Uveitis();
-			IEnumerable<Condition> fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, null);
+			IEnumerable<Condition> fd_ = context.Operators.RetrieveByValueSet<Condition>(fc_, default(PropertyInfo));
 			CqlValueSet fe_ = this.Vascular_Disorders_of_Iris_and_Ciliary_Body();
-			IEnumerable<Condition> ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, null);
+			IEnumerable<Condition> ff_ = context.Operators.RetrieveByValueSet<Condition>(fe_, default(PropertyInfo));
 			IEnumerable<Condition> fg_ = context.Operators.Union<Condition>(fd_, ff_);
 			IEnumerable<Condition> fh_ = context.Operators.Union<Condition>(fb_, fg_);
 			CqlValueSet fi_ = this.Visual_Field_Defects();
-			IEnumerable<Condition> fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, null);
+			IEnumerable<Condition> fj_ = context.Operators.RetrieveByValueSet<Condition>(fi_, default(PropertyInfo));
 			IEnumerable<Condition> fk_ = context.Operators.Union<Condition>(fh_, fj_);
 			bool? fl_(Condition ComorbidDiagnosis)
 			{
@@ -939,7 +939,7 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 				DataType fq_ = CataractSurgeryPerformed?.Performed;
 				object fr_ = FHIRHelpers_4_3_000.ToValue(fq_);
 				CqlInterval<CqlDateTime> fs_ = QICoreCommon_2_0_000.toInterval(fr_);
-				bool? ft_ = context.Operators.OverlapsBefore(fp_, fs_, null);
+				bool? ft_ = context.Operators.OverlapsBefore(fp_, fs_, default(string));
 				bool? fu_ = QICoreCommon_2_0_000.isActive(ComorbidDiagnosis);
 				bool? fv_ = context.Operators.And(ft_, fu_);
 
@@ -968,9 +968,9 @@ public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 		{
 			CqlCode d_ = this.Best_corrected_visual_acuity__observable_entity_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			CqlValueSet g_ = this.Best_Corrected_Visual_Acuity_Exam_Using_Snellen_Chart();
-			IEnumerable<Observation> h_ = context.Operators.RetrieveByValueSet<Observation>(g_, null);
+			IEnumerable<Observation> h_ = context.Operators.RetrieveByValueSet<Observation>(g_, default(PropertyInfo));
 			IEnumerable<Observation> i_ = context.Operators.Union<Observation>(f_, h_);
 			bool? j_(Observation VisualAcuityExamPerformed)
 			{

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Cataracts2040BCVAwithin90DaysFHIR", "0.1.000")]
 public class Cataracts2040BCVAwithin90DaysFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -94,7 +94,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default(string));
 
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
@@ -102,7 +102,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Congenital_or_Acquired_Absence_of_Cervix.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -110,7 +110,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet HPV_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default(string));
 
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
@@ -118,7 +118,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__HPV_Test.Value;
 
 	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default(string));
 
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
@@ -126,7 +126,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Hysterectomy_with_No_Residual_Cervix.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -134,7 +134,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -142,7 +142,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -150,7 +150,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Pap_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -158,7 +158,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -166,7 +166,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -175,8 +175,8 @@ public class CervicalCancerScreeningFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.001", "Measurement Period", c_);
 
@@ -189,7 +189,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -202,20 +202,20 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Telephone_Visits();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		IEnumerable<Encounter> r_ = Status_1_6_000.isEncounterPerformed(q_);
@@ -249,7 +249,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -280,7 +280,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<object> Absence_of_Cervix_Value()
 	{
 		CqlValueSet a_ = this.Hysterectomy_with_No_Residual_Cervix();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure NoCervixProcedure)
 		{
@@ -290,20 +290,20 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			CqlDateTime n_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
 			CqlDateTime p_ = context.Operators.End(o_);
-			bool? q_ = context.Operators.SameOrBefore(n_, p_, null);
+			bool? q_ = context.Operators.SameOrBefore(n_, p_, default(string));
 
 			return q_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlValueSet f_ = this.Congenital_or_Acquired_Absence_of_Cervix();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		bool? h_(Condition NoCervixDiagnosis)
 		{
 			CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.prevalenceInterval(NoCervixDiagnosis);
 			CqlDateTime s_ = context.Operators.Start(r_);
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			CqlDateTime u_ = context.Operators.End(t_);
-			bool? v_ = context.Operators.SameOrBefore(s_, u_, null);
+			bool? v_ = context.Operators.SameOrBefore(s_, u_, default(string));
 
 			return v_;
 		};
@@ -336,7 +336,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation CervicalCytology)
 		{
@@ -419,7 +419,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation HPVTest)
 		{

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -94,7 +94,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default);
 
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
@@ -102,7 +102,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Congenital_or_Acquired_Absence_of_Cervix.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -110,7 +110,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet HPV_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default);
 
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
@@ -118,7 +118,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__HPV_Test.Value;
 
 	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default);
 
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
@@ -126,7 +126,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Hysterectomy_with_No_Residual_Cervix.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -134,7 +134,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -142,7 +142,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default);
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -150,7 +150,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Pap_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -158,7 +158,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -166,7 +166,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -175,8 +175,8 @@ public class CervicalCancerScreeningFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.001", "Measurement Period", c_);
 
@@ -189,7 +189,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -202,20 +202,20 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Telephone_Visits();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		IEnumerable<Encounter> r_ = Status_1_6_000.isEncounterPerformed(q_);
@@ -249,7 +249,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -280,7 +280,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<object> Absence_of_Cervix_Value()
 	{
 		CqlValueSet a_ = this.Hysterectomy_with_No_Residual_Cervix();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure NoCervixProcedure)
 		{
@@ -290,20 +290,20 @@ public class CervicalCancerScreeningFHIR_0_0_001
 			CqlDateTime n_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
 			CqlDateTime p_ = context.Operators.End(o_);
-			bool? q_ = context.Operators.SameOrBefore(n_, p_, default(string));
+			bool? q_ = context.Operators.SameOrBefore(n_, p_, default);
 
 			return q_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlValueSet f_ = this.Congenital_or_Acquired_Absence_of_Cervix();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		bool? h_(Condition NoCervixDiagnosis)
 		{
 			CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.prevalenceInterval(NoCervixDiagnosis);
 			CqlDateTime s_ = context.Operators.Start(r_);
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			CqlDateTime u_ = context.Operators.End(t_);
-			bool? v_ = context.Operators.SameOrBefore(s_, u_, default(string));
+			bool? v_ = context.Operators.SameOrBefore(s_, u_, default);
 
 			return v_;
 		};
@@ -336,7 +336,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation CervicalCytology)
 		{
@@ -419,7 +419,7 @@ public class CervicalCancerScreeningFHIR_0_0_001
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation HPVTest)
 		{

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CervicalCancerScreeningFHIR", "0.0.001")]
 public class CervicalCancerScreeningFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -114,7 +114,7 @@ public class CesareanBirthFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Abnormal_Presentation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105", default(string));
 
     [CqlDeclaration("Abnormal Presentation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105")]
@@ -122,7 +122,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Abnormal_Presentation.Value;
 
 	private CqlValueSet Cesarean_Birth_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282", default(string));
 
     [CqlDeclaration("Cesarean Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282")]
@@ -130,7 +130,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Cesarean_Birth.Value;
 
 	private CqlValueSet Delivery_of_Singleton_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99", default(string));
 
     [CqlDeclaration("Delivery of Singleton")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99")]
@@ -138,7 +138,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Delivery_of_Singleton.Value;
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -146,7 +146,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -154,7 +154,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Genital_Herpes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049", default(string));
 
     [CqlDeclaration("Genital Herpes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049")]
@@ -162,7 +162,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Genital_Herpes.Value;
 
 	private CqlValueSet Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37", default(string));
 
     [CqlDeclaration("Placenta Previa Accreta Increta Percreta or Vasa Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37")]
@@ -170,7 +170,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa.Value;
 
 	private CqlValueSet _37_to_42_Plus_Weeks_Gestation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68", default(string));
 
     [CqlDeclaration("37 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68")]
@@ -178,35 +178,35 @@ public class CesareanBirthFHIR_0_2_000
 		___37_to_42_Plus_Weeks_Gestation.Value;
 
 	private CqlCode ____Births_preterm_Value() => 
-		new CqlCode("11637-6", "http://loinc.org", null, null);
+		new CqlCode("11637-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("[#] Births.preterm")]
 	public CqlCode ____Births_preterm() => 
 		______Births_preterm.Value;
 
 	private CqlCode ____Births_term_Value() => 
-		new CqlCode("11639-2", "http://loinc.org", null, null);
+		new CqlCode("11639-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("[#] Births.term")]
 	public CqlCode ____Births_term() => 
 		______Births_term.Value;
 
 	private CqlCode ____Parity_Value() => 
-		new CqlCode("11977-6", "http://loinc.org", null, null);
+		new CqlCode("11977-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("[#] Parity")]
 	public CqlCode ____Parity() => 
 		______Parity.Value;
 
 	private CqlCode ____Pregnancies_Value() => 
-		new CqlCode("11996-6", "http://loinc.org", null, null);
+		new CqlCode("11996-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("[#] Pregnancies")]
 	public CqlCode ____Pregnancies() => 
 		______Pregnancies.Value;
 
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
-		new CqlCode("93857-1", "http://loinc.org", null, null);
+		new CqlCode("93857-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
@@ -215,11 +215,11 @@ public class CesareanBirthFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("11637-6", "http://loinc.org", null, null),
-			new CqlCode("11639-2", "http://loinc.org", null, null),
-			new CqlCode("11977-6", "http://loinc.org", null, null),
-			new CqlCode("11996-6", "http://loinc.org", null, null),
-			new CqlCode("93857-1", "http://loinc.org", null, null),
+			new CqlCode("11637-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11639-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11977-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11996-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("93857-1", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -231,8 +231,8 @@ public class CesareanBirthFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CesareanBirthFHIR-0.2.000", "Measurement Period", c_);
 
@@ -245,7 +245,7 @@ public class CesareanBirthFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -378,7 +378,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Pregnancies();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation Gravida)
 		{
 			DataType k_ = Gravida?.Value;
@@ -452,7 +452,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, false);
-			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, null);
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default(string));
 			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
 			bool? ae_ = context.Operators.And(ab_, ad_);
 			bool? af_ = context.Operators.And(t_, ae_);
@@ -531,7 +531,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Parity();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation Parity)
 		{
 			object k_()
@@ -591,7 +591,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = Parity?.StatusElement;
@@ -684,7 +684,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Births_preterm();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation PretermBirth)
 		{
 			object k_()
@@ -744,7 +744,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = PretermBirth?.StatusElement;
@@ -837,7 +837,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Births_term();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation TermBirth)
 		{
 			object k_()
@@ -897,7 +897,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = TermBirth?.StatusElement;
@@ -1025,7 +1025,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool n_()
 				{
 					CqlValueSet q_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(q_, null);
+					IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(q_, default(PropertyInfo));
 					bool? s_(Observation AbnormalPresentation)
 					{
 						object aa_()
@@ -1082,7 +1082,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ab_ = QICoreCommon_2_0_000.earliest(aa_());
 						CqlDateTime ac_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? ad_ = context.Operators.SameOrBefore(ab_, ac_, null);
+						bool? ad_ = context.Operators.SameOrBefore(ab_, ac_, default(string));
 						Code<ObservationStatus> ae_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? af_ = ae_?.Value;
 						Code<ObservationStatus> ag_ = context.Operators.Convert<Code<ObservationStatus>>(af_);
@@ -1167,7 +1167,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool o_()
 				{
 					CqlValueSet bx_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, null);
+					IEnumerable<Observation> by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, default(PropertyInfo));
 					bool? bz_(Observation AbnormalPresentation)
 					{
 						object ch_()
@@ -1224,7 +1224,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ci_ = QICoreCommon_2_0_000.earliest(ch_());
 						CqlDateTime cj_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? ck_ = context.Operators.SameOrBefore(ci_, cj_, null);
+						bool? ck_ = context.Operators.SameOrBefore(ci_, cj_, default(string));
 						Code<ObservationStatus> cl_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? cm_ = cl_?.Value;
 						Code<ObservationStatus> cn_ = context.Operators.Convert<Code<ObservationStatus>>(cm_);
@@ -1309,7 +1309,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool p_()
 				{
 					CqlValueSet ee_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, null);
+					IEnumerable<Observation> ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, default(PropertyInfo));
 					bool? eg_(Observation AbnormalPresentation)
 					{
 						object eo_()
@@ -1366,7 +1366,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ep_ = QICoreCommon_2_0_000.earliest(eo_());
 						CqlDateTime eq_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? er_ = context.Operators.SameOrBefore(ep_, eq_, null);
+						bool? er_ = context.Operators.SameOrBefore(ep_, eq_, default(string));
 						Code<ObservationStatus> es_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? et_ = es_?.Value;
 						Code<ObservationStatus> eu_ = context.Operators.Convert<Code<ObservationStatus>>(et_);
@@ -1451,7 +1451,7 @@ public class CesareanBirthFHIR_0_2_000
 				if (n_())
 				{
 					CqlValueSet gl_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, null);
+					IEnumerable<Observation> gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, default(PropertyInfo));
 					bool? gn_(Observation AbnormalPresentation)
 					{
 						object gu_()
@@ -1508,7 +1508,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime gv_ = QICoreCommon_2_0_000.earliest(gu_());
 						CqlDateTime gw_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? gx_ = context.Operators.SameOrBefore(gv_, gw_, null);
+						bool? gx_ = context.Operators.SameOrBefore(gv_, gw_, default(string));
 						Code<ObservationStatus> gy_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? gz_ = gy_?.Value;
 						Code<ObservationStatus> ha_ = context.Operators.Convert<Code<ObservationStatus>>(gz_);
@@ -1592,7 +1592,7 @@ public class CesareanBirthFHIR_0_2_000
 				else if (o_())
 				{
 					CqlValueSet ir_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, null);
+					IEnumerable<Observation> is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, default(PropertyInfo));
 					bool? it_(Observation AbnormalPresentation)
 					{
 						object ja_()
@@ -1649,7 +1649,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime jb_ = QICoreCommon_2_0_000.earliest(ja_());
 						CqlDateTime jc_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? jd_ = context.Operators.SameOrBefore(jb_, jc_, null);
+						bool? jd_ = context.Operators.SameOrBefore(jb_, jc_, default(string));
 						Code<ObservationStatus> je_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? jf_ = je_?.Value;
 						Code<ObservationStatus> jg_ = context.Operators.Convert<Code<ObservationStatus>>(jf_);
@@ -1733,7 +1733,7 @@ public class CesareanBirthFHIR_0_2_000
 				else if (p_())
 				{
 					CqlValueSet kx_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, null);
+					IEnumerable<Observation> ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, default(PropertyInfo));
 					bool? kz_(Observation AbnormalPresentation)
 					{
 						object lg_()
@@ -1790,7 +1790,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime lh_ = QICoreCommon_2_0_000.earliest(lg_());
 						CqlDateTime li_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? lj_ = context.Operators.SameOrBefore(lh_, li_, null);
+						bool? lj_ = context.Operators.SameOrBefore(lh_, li_, default(string));
 						Code<ObservationStatus> lk_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? ll_ = lk_?.Value;
 						Code<ObservationStatus> lm_ = context.Operators.Convert<Code<ObservationStatus>>(ll_);
@@ -1879,7 +1879,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlDateTime e_ = QICoreCommon_2_0_000.earliest(d_());
 			Period f_ = ThirtysevenWeeksPlusEncounter?.Period;
 			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			bool? h_ = context.Operators.In<CqlDateTime>(e_, g_, null);
+			bool? h_ = context.Operators.In<CqlDateTime>(e_, g_, default(string));
 			IEnumerable<Condition> i_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
 			bool? j_(Condition EncounterDiagnosis)
 			{
@@ -1990,14 +1990,14 @@ public class CesareanBirthFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter ThirtysevenWeeksPlusEncounter)
 		{
 			CqlValueSet d_ = this.Cesarean_Birth();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure CSection)
 			{
 				CqlInterval<CqlDateTime> j_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(ThirtysevenWeeksPlusEncounter);
 				DataType k_ = CSection?.Performed;
 				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
-				bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, null);
+				bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, default(string));
 				Code<EventStatus> o_ = CSection?.StatusElement;
 				EventStatus? p_ = o_?.Value;
 				string q_ = context.Operators.Convert<string>(p_);

--- a/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -114,7 +114,7 @@ public class CesareanBirthFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Abnormal_Presentation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105", default);
 
     [CqlDeclaration("Abnormal Presentation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.105")]
@@ -122,7 +122,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Abnormal_Presentation.Value;
 
 	private CqlValueSet Cesarean_Birth_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282", default);
 
     [CqlDeclaration("Cesarean Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.282")]
@@ -130,7 +130,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Cesarean_Birth.Value;
 
 	private CqlValueSet Delivery_of_Singleton_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99", default);
 
     [CqlDeclaration("Delivery of Singleton")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.99")]
@@ -138,7 +138,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Delivery_of_Singleton.Value;
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default);
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -146,7 +146,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -154,7 +154,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Genital_Herpes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049", default);
 
     [CqlDeclaration("Genital Herpes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1049")]
@@ -162,7 +162,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Genital_Herpes.Value;
 
 	private CqlValueSet Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37", default);
 
     [CqlDeclaration("Placenta Previa Accreta Increta Percreta or Vasa Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.37")]
@@ -170,7 +170,7 @@ public class CesareanBirthFHIR_0_2_000
 		__Placenta_Previa_Accreta_Increta_Percreta_or_Vasa_Previa.Value;
 
 	private CqlValueSet _37_to_42_Plus_Weeks_Gestation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68", default);
 
     [CqlDeclaration("37 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.68")]
@@ -178,35 +178,35 @@ public class CesareanBirthFHIR_0_2_000
 		___37_to_42_Plus_Weeks_Gestation.Value;
 
 	private CqlCode ____Births_preterm_Value() => 
-		new CqlCode("11637-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("11637-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("[#] Births.preterm")]
 	public CqlCode ____Births_preterm() => 
 		______Births_preterm.Value;
 
 	private CqlCode ____Births_term_Value() => 
-		new CqlCode("11639-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("11639-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("[#] Births.term")]
 	public CqlCode ____Births_term() => 
 		______Births_term.Value;
 
 	private CqlCode ____Parity_Value() => 
-		new CqlCode("11977-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("11977-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("[#] Parity")]
 	public CqlCode ____Parity() => 
 		______Parity.Value;
 
 	private CqlCode ____Pregnancies_Value() => 
-		new CqlCode("11996-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("11996-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("[#] Pregnancies")]
 	public CqlCode ____Pregnancies() => 
 		______Pregnancies.Value;
 
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
-		new CqlCode("93857-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("93857-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
@@ -215,11 +215,11 @@ public class CesareanBirthFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("11637-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("11639-2", "http://loinc.org", default(string), default(string)),
-			new CqlCode("11977-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("11996-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("93857-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11637-6", "http://loinc.org", default, default),
+			new CqlCode("11639-2", "http://loinc.org", default, default),
+			new CqlCode("11977-6", "http://loinc.org", default, default),
+			new CqlCode("11996-6", "http://loinc.org", default, default),
+			new CqlCode("93857-1", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -231,8 +231,8 @@ public class CesareanBirthFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CesareanBirthFHIR-0.2.000", "Measurement Period", c_);
 
@@ -245,7 +245,7 @@ public class CesareanBirthFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -378,7 +378,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Pregnancies();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation Gravida)
 		{
 			DataType k_ = Gravida?.Value;
@@ -452,7 +452,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, false);
-			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default(string));
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default);
 			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
 			bool? ae_ = context.Operators.And(ab_, ad_);
 			bool? af_ = context.Operators.And(t_, ae_);
@@ -531,7 +531,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Parity();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation Parity)
 		{
 			object k_()
@@ -591,7 +591,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = Parity?.StatusElement;
@@ -684,7 +684,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Births_preterm();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation PretermBirth)
 		{
 			object k_()
@@ -744,7 +744,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = PretermBirth?.StatusElement;
@@ -837,7 +837,7 @@ public class CesareanBirthFHIR_0_2_000
 	{
 		CqlCode a_ = this.____Births_term();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation TermBirth)
 		{
 			object k_()
@@ -897,7 +897,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
 			bool? t_ = context.Operators.Not((bool?)(m_ is null));
 			bool? u_ = context.Operators.And(r_, t_);
 			Code<ObservationStatus> v_ = TermBirth?.StatusElement;
@@ -1025,7 +1025,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool n_()
 				{
 					CqlValueSet q_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(q_, default(PropertyInfo));
+					IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(q_, default);
 					bool? s_(Observation AbnormalPresentation)
 					{
 						object aa_()
@@ -1082,7 +1082,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ab_ = QICoreCommon_2_0_000.earliest(aa_());
 						CqlDateTime ac_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? ad_ = context.Operators.SameOrBefore(ab_, ac_, default(string));
+						bool? ad_ = context.Operators.SameOrBefore(ab_, ac_, default);
 						Code<ObservationStatus> ae_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? af_ = ae_?.Value;
 						Code<ObservationStatus> ag_ = context.Operators.Convert<Code<ObservationStatus>>(af_);
@@ -1167,7 +1167,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool o_()
 				{
 					CqlValueSet bx_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, default(PropertyInfo));
+					IEnumerable<Observation> by_ = context.Operators.RetrieveByValueSet<Observation>(bx_, default);
 					bool? bz_(Observation AbnormalPresentation)
 					{
 						object ch_()
@@ -1224,7 +1224,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ci_ = QICoreCommon_2_0_000.earliest(ch_());
 						CqlDateTime cj_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? ck_ = context.Operators.SameOrBefore(ci_, cj_, default(string));
+						bool? ck_ = context.Operators.SameOrBefore(ci_, cj_, default);
 						Code<ObservationStatus> cl_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? cm_ = cl_?.Value;
 						Code<ObservationStatus> cn_ = context.Operators.Convert<Code<ObservationStatus>>(cm_);
@@ -1309,7 +1309,7 @@ public class CesareanBirthFHIR_0_2_000
 				bool p_()
 				{
 					CqlValueSet ee_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, default(PropertyInfo));
+					IEnumerable<Observation> ef_ = context.Operators.RetrieveByValueSet<Observation>(ee_, default);
 					bool? eg_(Observation AbnormalPresentation)
 					{
 						object eo_()
@@ -1366,7 +1366,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime ep_ = QICoreCommon_2_0_000.earliest(eo_());
 						CqlDateTime eq_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? er_ = context.Operators.SameOrBefore(ep_, eq_, default(string));
+						bool? er_ = context.Operators.SameOrBefore(ep_, eq_, default);
 						Code<ObservationStatus> es_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? et_ = es_?.Value;
 						Code<ObservationStatus> eu_ = context.Operators.Convert<Code<ObservationStatus>>(et_);
@@ -1451,7 +1451,7 @@ public class CesareanBirthFHIR_0_2_000
 				if (n_())
 				{
 					CqlValueSet gl_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, default(PropertyInfo));
+					IEnumerable<Observation> gm_ = context.Operators.RetrieveByValueSet<Observation>(gl_, default);
 					bool? gn_(Observation AbnormalPresentation)
 					{
 						object gu_()
@@ -1508,7 +1508,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime gv_ = QICoreCommon_2_0_000.earliest(gu_());
 						CqlDateTime gw_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? gx_ = context.Operators.SameOrBefore(gv_, gw_, default(string));
+						bool? gx_ = context.Operators.SameOrBefore(gv_, gw_, default);
 						Code<ObservationStatus> gy_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? gz_ = gy_?.Value;
 						Code<ObservationStatus> ha_ = context.Operators.Convert<Code<ObservationStatus>>(gz_);
@@ -1592,7 +1592,7 @@ public class CesareanBirthFHIR_0_2_000
 				else if (o_())
 				{
 					CqlValueSet ir_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, default(PropertyInfo));
+					IEnumerable<Observation> is_ = context.Operators.RetrieveByValueSet<Observation>(ir_, default);
 					bool? it_(Observation AbnormalPresentation)
 					{
 						object ja_()
@@ -1649,7 +1649,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime jb_ = QICoreCommon_2_0_000.earliest(ja_());
 						CqlDateTime jc_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? jd_ = context.Operators.SameOrBefore(jb_, jc_, default(string));
+						bool? jd_ = context.Operators.SameOrBefore(jb_, jc_, default);
 						Code<ObservationStatus> je_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? jf_ = je_?.Value;
 						Code<ObservationStatus> jg_ = context.Operators.Convert<Code<ObservationStatus>>(jf_);
@@ -1733,7 +1733,7 @@ public class CesareanBirthFHIR_0_2_000
 				else if (p_())
 				{
 					CqlValueSet kx_ = this.Abnormal_Presentation();
-					IEnumerable<Observation> ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, default(PropertyInfo));
+					IEnumerable<Observation> ky_ = context.Operators.RetrieveByValueSet<Observation>(kx_, default);
 					bool? kz_(Observation AbnormalPresentation)
 					{
 						object lg_()
@@ -1790,7 +1790,7 @@ public class CesareanBirthFHIR_0_2_000
 						};
 						CqlDateTime lh_ = QICoreCommon_2_0_000.earliest(lg_());
 						CqlDateTime li_ = PCMaternal_5_16_000.lastTimeOfDelivery(ThirtysevenWeeksPlusEncounter);
-						bool? lj_ = context.Operators.SameOrBefore(lh_, li_, default(string));
+						bool? lj_ = context.Operators.SameOrBefore(lh_, li_, default);
 						Code<ObservationStatus> lk_ = AbnormalPresentation?.StatusElement;
 						ObservationStatus? ll_ = lk_?.Value;
 						Code<ObservationStatus> lm_ = context.Operators.Convert<Code<ObservationStatus>>(ll_);
@@ -1879,7 +1879,7 @@ public class CesareanBirthFHIR_0_2_000
 			CqlDateTime e_ = QICoreCommon_2_0_000.earliest(d_());
 			Period f_ = ThirtysevenWeeksPlusEncounter?.Period;
 			CqlInterval<CqlDateTime> g_ = FHIRHelpers_4_3_000.ToInterval(f_);
-			bool? h_ = context.Operators.In<CqlDateTime>(e_, g_, default(string));
+			bool? h_ = context.Operators.In<CqlDateTime>(e_, g_, default);
 			IEnumerable<Condition> i_ = CQMCommon_2_0_000.encounterDiagnosis(ThirtysevenWeeksPlusEncounter);
 			bool? j_(Condition EncounterDiagnosis)
 			{
@@ -1990,14 +1990,14 @@ public class CesareanBirthFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter ThirtysevenWeeksPlusEncounter)
 		{
 			CqlValueSet d_ = this.Cesarean_Birth();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure CSection)
 			{
 				CqlInterval<CqlDateTime> j_ = PCMaternal_5_16_000.hospitalizationWithEDOBTriageObservation(ThirtysevenWeeksPlusEncounter);
 				DataType k_ = CSection?.Performed;
 				object l_ = FHIRHelpers_4_3_000.ToValue(k_);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.toInterval(l_);
-				bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, default(string));
+				bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, m_, default);
 				Code<EventStatus> o_ = CSection?.StatusElement;
 				EventStatus? p_ = o_?.Value;
 				string q_ = context.Operators.Convert<string>(p_);

--- a/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CesareanBirthFHIR", "0.2.000")]
 public class CesareanBirthFHIR_0_2_000
 {

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -94,7 +94,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
     #endregion
 
 	private CqlValueSet Group_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", default);
 
     [CqlDeclaration("Group Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187")]
@@ -102,7 +102,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Group_Psychotherapy.Value;
 
 	private CqlValueSet Major_Depressive_Disorder_Active_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", default);
 
     [CqlDeclaration("Major Depressive Disorder Active")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491")]
@@ -110,7 +110,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Major_Depressive_Disorder_Active.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -118,7 +118,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -126,7 +126,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default);
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -134,7 +134,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_for_Family_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", default);
 
     [CqlDeclaration("Psych Visit for Family Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018")]
@@ -142,7 +142,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_for_Family_Psychotherapy.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default);
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -150,7 +150,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychoanalysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default);
 
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
@@ -158,7 +158,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psychoanalysis.Value;
 
 	private CqlValueSet Telehealth_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default);
 
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
@@ -166,21 +166,21 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Telehealth_Services.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Suicide_risk_assessment__procedure__Value() => 
-		new CqlCode("225337009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("225337009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Suicide risk assessment (procedure)")]
 	public CqlCode Suicide_risk_assessment__procedure_() => 
 		__Suicide_risk_assessment__procedure_.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -189,7 +189,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -202,7 +202,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("225337009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("225337009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -215,7 +215,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -239,8 +239,8 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
@@ -253,7 +253,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -310,26 +310,26 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private IEnumerable<Encounter> Major_Depressive_Disorder_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Psych_Visit_for_Family_Psychotherapy();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Psychoanalysis();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Group_Psychotherapy();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Telehealth_Services();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -365,7 +365,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 			Period ap_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default);
 			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
@@ -431,7 +431,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		{
 			CqlCode d_ = this.Suicide_risk_assessment__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default);
 			bool? g_(Procedure SuicideRiskAssessment)
 			{
 				Code<EventStatus> k_ = SuicideRiskAssessment?.StatusElement;
@@ -443,7 +443,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 				DataType q_ = SuicideRiskAssessment?.Performed;
 				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
-				bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, default(string));
+				bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, default);
 				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR", "0.1.000")]
 public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -94,7 +94,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
     #endregion
 
 	private CqlValueSet Group_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187", default(string));
 
     [CqlDeclaration("Group Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1187")]
@@ -102,7 +102,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Group_Psychotherapy.Value;
 
 	private CqlValueSet Major_Depressive_Disorder_Active_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491", default(string));
 
     [CqlDeclaration("Major Depressive Disorder Active")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1491")]
@@ -110,7 +110,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Major_Depressive_Disorder_Active.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -118,7 +118,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -126,7 +126,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -134,7 +134,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_for_Family_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018", default(string));
 
     [CqlDeclaration("Psych Visit for Family Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1018")]
@@ -142,7 +142,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_for_Family_Psychotherapy.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -150,7 +150,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychoanalysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default(string));
 
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
@@ -158,7 +158,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Psychoanalysis.Value;
 
 	private CqlValueSet Telehealth_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default(string));
 
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
@@ -166,21 +166,21 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		__Telehealth_Services.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Suicide_risk_assessment__procedure__Value() => 
-		new CqlCode("225337009", "http://snomed.info/sct", null, null);
+		new CqlCode("225337009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Suicide risk assessment (procedure)")]
 	public CqlCode Suicide_risk_assessment__procedure_() => 
 		__Suicide_risk_assessment__procedure_.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -189,7 +189,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -202,7 +202,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("225337009", "http://snomed.info/sct", null, null),
+			new CqlCode("225337009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -215,7 +215,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -239,8 +239,8 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
@@ -253,7 +253,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -310,26 +310,26 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 	private IEnumerable<Encounter> Major_Depressive_Disorder_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Psych_Visit_for_Family_Psychotherapy();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Psychoanalysis();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Group_Psychotherapy();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Telehealth_Services();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -365,7 +365,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 			Period ap_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
 			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
@@ -431,7 +431,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 		{
 			CqlCode d_ = this.Suicide_risk_assessment__procedure_();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, null);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByCodes<Procedure>(e_, default(PropertyInfo));
 			bool? g_(Procedure SuicideRiskAssessment)
 			{
 				Code<EventStatus> k_ = SuicideRiskAssessment?.StatusElement;
@@ -443,7 +443,7 @@ public class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFH
 				DataType q_ = SuicideRiskAssessment?.Performed;
 				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
-				bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, null);
+				bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, default(string));
 				bool? u_ = context.Operators.And(n_, t_);
 
 				return u_;

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -296,7 +296,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", default(string));
 
     [CqlDeclaration("Anaphylactic Reaction to DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031")]
@@ -304,7 +304,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Anaphylactic_Reaction_to_DTaP_Vaccine.Value;
 
 	private CqlValueSet Disorders_of_the_Immune_System_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", default(string));
 
     [CqlDeclaration("Disorders of the Immune System")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001")]
@@ -312,7 +312,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Disorders_of_the_Immune_System.Value;
 
 	private CqlValueSet DTaP_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", default(string));
 
     [CqlDeclaration("DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214")]
@@ -320,7 +320,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__DTaP_Vaccine.Value;
 
 	private CqlValueSet DTaP_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", default(string));
 
     [CqlDeclaration("DTaP Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022")]
@@ -328,7 +328,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__DTaP_Vaccine_Administered.Value;
 
 	private CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", default(string));
 
     [CqlDeclaration("Encephalitis Due to Diphtheria, Tetanus or Pertussis Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164")]
@@ -336,7 +336,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -344,7 +344,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", default(string));
 
     [CqlDeclaration("Haemophilus Influenzae Type B (Hib) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043")]
@@ -352,7 +352,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered.Value;
 
 	private CqlValueSet Hepatitis_A_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default(string));
 
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
@@ -360,7 +360,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A.Value;
 
 	private CqlValueSet Hepatitis_A_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", default(string));
 
     [CqlDeclaration("Hepatitis A Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215")]
@@ -368,7 +368,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A_Vaccine.Value;
 
 	private CqlValueSet Hepatitis_A_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", default(string));
 
     [CqlDeclaration("Hepatitis A Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041")]
@@ -376,7 +376,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A_Vaccine_Administered.Value;
 
 	private CqlValueSet Hepatitis_B_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", default(string));
 
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025")]
@@ -384,7 +384,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B.Value;
 
 	private CqlValueSet Hepatitis_B_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", default(string));
 
     [CqlDeclaration("Hepatitis B Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216")]
@@ -392,7 +392,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B_Vaccine.Value;
 
 	private CqlValueSet Hepatitis_B_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", default(string));
 
     [CqlDeclaration("Hepatitis B Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042")]
@@ -400,7 +400,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B_Vaccine_Administered.Value;
 
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", default(string));
 
     [CqlDeclaration("Hib Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083")]
@@ -408,7 +408,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__3_dose_schedule_.Value;
 
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", default(string));
 
     [CqlDeclaration("Hib Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084")]
@@ -416,7 +416,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__3_dose_schedule__Administered.Value;
 
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", default(string));
 
     [CqlDeclaration("Hib Vaccine (4 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085")]
@@ -424,7 +424,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__4_dose_schedule_.Value;
 
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", default(string));
 
     [CqlDeclaration("Hib Vaccine (4 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086")]
@@ -432,7 +432,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__4_dose_schedule__Administered.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -440,7 +440,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -448,7 +448,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -456,7 +456,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", default(string));
 
     [CqlDeclaration("Inactivated Polio Vaccine (IPV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219")]
@@ -464,7 +464,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Inactivated_Polio_Vaccine__IPV_.Value;
 
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", default(string));
 
     [CqlDeclaration("Inactivated Polio Vaccine (IPV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045")]
@@ -472,7 +472,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Inactivated_Polio_Vaccine__IPV__Administered.Value;
 
 	private CqlValueSet Child_Influenza_Immunization_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", default(string));
 
     [CqlDeclaration("Child Influenza Immunization Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218")]
@@ -480,7 +480,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Child_Influenza_Immunization_Administered.Value;
 
 	private CqlValueSet Child_Influenza_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", default(string));
 
     [CqlDeclaration("Child Influenza Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044")]
@@ -488,7 +488,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Child_Influenza_Vaccine_Administered.Value;
 
 	private CqlValueSet Influenza_Virus_LAIV_Immunization_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", default(string));
 
     [CqlDeclaration("Influenza Virus LAIV Immunization")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087")]
@@ -496,7 +496,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Influenza_Virus_LAIV_Immunization.Value;
 
 	private CqlValueSet Influenza_Virus_LAIV_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", default(string));
 
     [CqlDeclaration("Influenza Virus LAIV Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088")]
@@ -504,7 +504,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Influenza_Virus_LAIV_Procedure.Value;
 
 	private CqlValueSet Intussusception_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", default(string));
 
     [CqlDeclaration("Intussusception")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056")]
@@ -512,7 +512,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Intussusception.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", default(string));
 
     [CqlDeclaration("Malignant Neoplasm of Lymphatic and Hematopoietic Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009")]
@@ -520,7 +520,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue.Value;
 
 	private CqlValueSet Measles_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", default(string));
 
     [CqlDeclaration("Measles")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053")]
@@ -528,7 +528,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles.Value;
 
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", default(string));
 
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224")]
@@ -536,7 +536,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles__Mumps_and_Rubella__MMR__Vaccine.Value;
 
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", default(string));
 
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031")]
@@ -544,7 +544,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles__Mumps_and_Rubella__MMR__Vaccine_Administered.Value;
 
 	private CqlValueSet Mumps_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", default(string));
 
     [CqlDeclaration("Mumps")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032")]
@@ -552,7 +552,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Mumps.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -560,7 +560,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -568,7 +568,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", default(string));
 
     [CqlDeclaration("Pneumococcal Conjugate Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221")]
@@ -576,7 +576,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Pneumococcal_Conjugate_Vaccine.Value;
 
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", default(string));
 
     [CqlDeclaration("Pneumococcal Conjugate Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046")]
@@ -584,7 +584,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Pneumococcal_Conjugate_Vaccine_Administered.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -592,7 +592,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -600,7 +600,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", default(string));
 
     [CqlDeclaration("Rotavirus Vaccine (2 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048")]
@@ -608,7 +608,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__2_dose_schedule__Administered.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", default(string));
 
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223")]
@@ -616,7 +616,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__3_dose_schedule_.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", default(string));
 
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047")]
@@ -624,7 +624,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__3_dose_schedule__Administered.Value;
 
 	private CqlValueSet Rubella_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", default(string));
 
     [CqlDeclaration("Rubella")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037")]
@@ -632,7 +632,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rubella.Value;
 
 	private CqlValueSet Severe_Combined_Immunodeficiency_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", default(string));
 
     [CqlDeclaration("Severe Combined Immunodeficiency")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007")]
@@ -640,7 +640,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Severe_Combined_Immunodeficiency.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -648,7 +648,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Varicella_Zoster_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", default(string));
 
     [CqlDeclaration("Varicella Zoster")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039")]
@@ -656,7 +656,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster.Value;
 
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", default(string));
 
     [CqlDeclaration("Varicella Zoster Vaccine (VZV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170")]
@@ -664,7 +664,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster_Vaccine__VZV_.Value;
 
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", default(string));
 
     [CqlDeclaration("Varicella Zoster Vaccine (VZV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040")]
@@ -672,84 +672,84 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster_Vaccine__VZV__Administered.Value;
 
 	private CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value() => 
-		new CqlCode("433621000124101", "http://snomed.info/sct", null, null);
+		new CqlCode("433621000124101", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis due to Haemophilus influenzae type b vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_.Value;
 
 	private CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value() => 
-		new CqlCode("428321000124101", "http://snomed.info/sct", null, null);
+		new CqlCode("428321000124101", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis due to Hepatitis B vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_.Value;
 
 	private CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value() => 
-		new CqlCode("428331000124103", "http://snomed.info/sct", null, null);
+		new CqlCode("428331000124103", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis due to rotavirus vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_rotavirus_vaccine__disorder_.Value;
 
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value() => 
-		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient that may not require the presence of a physician or other qualified health care professional")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional.Value;
 
 	private CqlCode rotavirus__live__monovalent_vaccine_Value() => 
-		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null);
+		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default(string), default(string));
 
     [CqlDeclaration("rotavirus, live, monovalent vaccine")]
 	public CqlCode rotavirus__live__monovalent_vaccine() => 
 		__rotavirus__live__monovalent_vaccine.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value() => 
-		new CqlCode("471311000124103", "http://snomed.info/sct", null, null);
+		new CqlCode("471311000124103", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Hepatitis A virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_.Value;
 
 	private CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value() => 
-		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null);
+		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default(string), default(string));
 
     [CqlDeclaration("Introduction of Serum, Toxoid and Vaccine into Muscle, Percutaneous Approach")]
 	public CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach() => 
 		__Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value() => 
-		new CqlCode("471361000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("471361000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Influenza virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value() => 
-		new CqlCode("471331000124109", "http://snomed.info/sct", null, null);
+		new CqlCode("471331000124109", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Measles morbillivirus and Mumps orthorubulavirus and Rubella virus antigens (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value() => 
-		new CqlCode("471141000124102", "http://snomed.info/sct", null, null);
+		new CqlCode("471141000124102", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Streptococcus pneumoniae antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value() => 
-		new CqlCode("471321000124106", "http://snomed.info/sct", null, null);
+		new CqlCode("471321000124106", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing human poliovirus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value() => 
-		new CqlCode("471341000124104", "http://snomed.info/sct", null, null);
+		new CqlCode("471341000124104", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Anaphylaxis caused by vaccine containing Human alphaherpesvirus 3 antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_() => 
@@ -758,15 +758,15 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("433621000124101", "http://snomed.info/sct", null, null),
-			new CqlCode("428321000124101", "http://snomed.info/sct", null, null),
-			new CqlCode("428331000124103", "http://snomed.info/sct", null, null),
-			new CqlCode("471311000124103", "http://snomed.info/sct", null, null),
-			new CqlCode("471361000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("471331000124109", "http://snomed.info/sct", null, null),
-			new CqlCode("471141000124102", "http://snomed.info/sct", null, null),
-			new CqlCode("471321000124106", "http://snomed.info/sct", null, null),
-			new CqlCode("471341000124104", "http://snomed.info/sct", null, null),
+			new CqlCode("433621000124101", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428321000124101", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428331000124103", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471311000124103", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471361000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471331000124109", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471141000124102", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471321000124106", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("471341000124104", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -779,7 +779,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -792,7 +792,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] CVX_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", null, null),
+			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default(string), default(string)),
 		];
 
 		return a_;
@@ -805,7 +805,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] ICD10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", null, null),
+			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default(string), default(string)),
 		];
 
 		return a_;
@@ -817,8 +817,8 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildhoodImmunizationStatusFHIR-0.1.000", "Measurement Period", c_);
 
@@ -831,7 +831,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -844,17 +844,17 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
-		IEnumerable<Encounter> l_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> l_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? m_(Encounter E)
 		{
 			List<CodeableConcept> y_ = E?.Type;
@@ -880,11 +880,11 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 		CqlValueSet o_ = this.Online_Assessments();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(k_, q_);
 		CqlValueSet s_ = this.Telephone_Visits();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, null);
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
 		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
 		IEnumerable<Encounter> v_ = Status_1_6_000.Finished_Encounter(u_);
 		bool? w_(Encounter ValidEncounters)
@@ -976,7 +976,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Severe_Combined_Immunodeficiency_Value()
 	{
 		CqlValueSet a_ = this.Severe_Combined_Immunodeficiency();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition SevereImmuneDisorder)
 		{
@@ -1001,7 +1001,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Immunodeficiency_Value()
 	{
 		CqlValueSet a_ = this.Disorders_of_the_Immune_System();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition ImmuneDisorder)
 		{
@@ -1026,7 +1026,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_HIV_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition HIV)
 		{
@@ -1051,7 +1051,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition LymphaticMalignantNeoplasm)
 		{
@@ -1076,7 +1076,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Intussusception_Value()
 	{
 		CqlValueSet a_ = this.Intussusception();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition IntussusceptionDisorder)
 		{
@@ -1142,7 +1142,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.DTaP_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization DTaPVaccination)
 		{
@@ -1170,7 +1170,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.DTaP_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure DTaPProcedure)
 		{
@@ -1246,9 +1246,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Anaphylactic_Reaction_to_DTaP_Vaccine();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 		bool? g_(Condition DTaPConditions)
@@ -1273,7 +1273,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Polio_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Inactivated_Polio_Vaccine__IPV_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PolioVaccination)
 		{
@@ -1301,7 +1301,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Inactivated_Polio_Vaccine__IPV__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PolioProcedure)
 		{
@@ -1375,7 +1375,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PolioConditions)
 		{
@@ -1430,7 +1430,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_MMR_Vaccination_Value()
 	{
 		CqlValueSet a_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization MMRVaccination)
 		{
@@ -1439,13 +1439,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure MMRProcedure)
 		{
@@ -1454,7 +1454,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
 
 			return w_;
 		};
@@ -1472,7 +1472,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition MMRConditions)
 		{
@@ -1496,7 +1496,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Measles_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Measles();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MeaslesDiagnosis)
 		{
@@ -1520,7 +1520,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Mumps_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Mumps();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MumpsDiagnosis)
 		{
@@ -1544,7 +1544,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Rubella_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Rubella();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition RubellaDiagnosis)
 		{
@@ -1568,7 +1568,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hib_Vaccine__3_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseHibVaccine)
 		{
@@ -1596,7 +1596,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hib_Vaccine__3_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseHibProcedure)
 		{
@@ -1635,7 +1635,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hib_Vaccine__4_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HibVaccine)
 		{
@@ -1663,7 +1663,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hib_Vaccine__4_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HibProcedure)
 		{
@@ -1723,7 +1723,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
 				CqlDate l_ = context.Operators.Subtract(AllHibDoses2, k_);
 				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllHibDoses2, false, false);
-				bool? n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, null);
+				bool? n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, default(string));
 
 				return n_;
 			};
@@ -1786,7 +1786,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition HibReaction)
 		{
@@ -1810,7 +1810,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_B_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisBVaccination)
 		{
@@ -1838,7 +1838,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hepatitis_B_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HepatitisBProcedure)
 		{
@@ -1912,7 +1912,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default(PropertyInfo));
 		IEnumerable<Procedure> d_ = Status_1_6_000.Completed_Procedure(c_);
 		bool? e_(Procedure NewBornVaccine)
 		{
@@ -2000,9 +2000,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		CqlValueSet d_ = this.Hepatitis_B();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepBConditions)
@@ -2027,7 +2027,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_Chicken_Pox_Vaccination_Value()
 	{
 		CqlValueSet a_ = this.Varicella_Zoster_Vaccine__VZV_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ChickenPoxVaccination)
 		{
@@ -2036,13 +2036,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Varicella_Zoster_Vaccine__VZV__Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure ChickenPoxProcedure)
 		{
@@ -2051,7 +2051,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
 
 			return w_;
 		};
@@ -2068,10 +2068,10 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Varicella_Zoster();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default(PropertyInfo));
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition VaricellaZoster)
@@ -2096,7 +2096,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Pneumococcal_Conjugate_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PneumococcalVaccination)
 		{
@@ -2124,7 +2124,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Pneumococcal_Conjugate_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PneumococcalProcedure)
 		{
@@ -2201,7 +2201,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PneumococcalReaction)
 		{
@@ -2225,7 +2225,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_Hepatitis_A_Vaccinations_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisAVaccination)
 		{
@@ -2234,13 +2234,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, null);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Hepatitis_A_Vaccine_Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure HepatitisAProcedure)
 		{
@@ -2249,7 +2249,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, null);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
 
 			return w_;
 		};
@@ -2266,10 +2266,10 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, null);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default(PropertyInfo));
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepatitisADiagnosis)
@@ -2295,7 +2295,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.rotavirus__live__monovalent_vaccine();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Immunization> c_ = context.Operators.RetrieveByCodes<Immunization>(b_, null);
+		IEnumerable<Immunization> c_ = context.Operators.RetrieveByCodes<Immunization>(b_, default(PropertyInfo));
 		IEnumerable<Immunization> d_ = Status_1_6_000.Completed_Immunization(c_);
 		bool? e_(Immunization TwoDoseRotavirusVaccine)
 		{
@@ -2323,7 +2323,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> h_ = context.Operators.Select<Immunization, CqlDate>(f_, g_);
 		CqlValueSet i_ = this.Rotavirus_Vaccine__2_dose_schedule__Administered();
-		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, null);
+		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, default(PropertyInfo));
 		IEnumerable<Procedure> k_ = Status_1_6_000.Completed_Procedure(j_);
 		bool? l_(Procedure TwoDoseRotavirusProcedure)
 		{
@@ -2362,7 +2362,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Rotavirus_Vaccine__3_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseRotavirusVaccine)
 		{
@@ -2390,7 +2390,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Rotavirus_Vaccine__3_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseRotavirusAdministered)
 		{
@@ -2450,7 +2450,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
 				CqlDate l_ = context.Operators.Subtract(AllRotavirusDoses2, k_);
 				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllRotavirusDoses2, false, false);
-				bool? n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, null);
+				bool? n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, default(string));
 
 				return n_;
 			};
@@ -2513,7 +2513,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_rotavirus_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition RotavirusConditions)
 		{
@@ -2557,7 +2557,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Child_Influenza_Immunization_Administered();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization InfluenzaVaccine)
 		{
@@ -2585,7 +2585,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Child_Influenza_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
@@ -2661,7 +2661,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> LAIV_Vaccinations_Value()
 	{
 		CqlValueSet a_ = this.Influenza_Virus_LAIV_Immunization();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, null);
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization LAIVVaccine)
 		{
@@ -2690,7 +2690,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Influenza_Virus_LAIV_Procedure();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
@@ -2746,7 +2746,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition InfluenzaConditions)
 		{

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ChildhoodImmunizationStatusFHIR", "0.1.000")]
 public class ChildhoodImmunizationStatusFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -296,7 +296,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Anaphylactic_Reaction_to_DTaP_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031", default);
 
     [CqlDeclaration("Anaphylactic Reaction to DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1031")]
@@ -304,7 +304,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Anaphylactic_Reaction_to_DTaP_Vaccine.Value;
 
 	private CqlValueSet Disorders_of_the_Immune_System_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001", default);
 
     [CqlDeclaration("Disorders of the Immune System")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1001")]
@@ -312,7 +312,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Disorders_of_the_Immune_System.Value;
 
 	private CqlValueSet DTaP_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214", default);
 
     [CqlDeclaration("DTaP Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1214")]
@@ -320,7 +320,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__DTaP_Vaccine.Value;
 
 	private CqlValueSet DTaP_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022", default);
 
     [CqlDeclaration("DTaP Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1022")]
@@ -328,7 +328,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__DTaP_Vaccine_Administered.Value;
 
 	private CqlValueSet Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164", default);
 
     [CqlDeclaration("Encephalitis Due to Diphtheria, Tetanus or Pertussis Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1164")]
@@ -336,7 +336,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -344,7 +344,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043", default);
 
     [CqlDeclaration("Haemophilus Influenzae Type B (Hib) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1043")]
@@ -352,7 +352,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Haemophilus_Influenzae_Type_B__Hib__Vaccine_Administered.Value;
 
 	private CqlValueSet Hepatitis_A_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default);
 
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
@@ -360,7 +360,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A.Value;
 
 	private CqlValueSet Hepatitis_A_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215", default);
 
     [CqlDeclaration("Hepatitis A Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1215")]
@@ -368,7 +368,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A_Vaccine.Value;
 
 	private CqlValueSet Hepatitis_A_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041", default);
 
     [CqlDeclaration("Hepatitis A Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1041")]
@@ -376,7 +376,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_A_Vaccine_Administered.Value;
 
 	private CqlValueSet Hepatitis_B_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025", default);
 
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1025")]
@@ -384,7 +384,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B.Value;
 
 	private CqlValueSet Hepatitis_B_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216", default);
 
     [CqlDeclaration("Hepatitis B Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1216")]
@@ -392,7 +392,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B_Vaccine.Value;
 
 	private CqlValueSet Hepatitis_B_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042", default);
 
     [CqlDeclaration("Hepatitis B Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1042")]
@@ -400,7 +400,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hepatitis_B_Vaccine_Administered.Value;
 
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083", default);
 
     [CqlDeclaration("Hib Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1083")]
@@ -408,7 +408,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__3_dose_schedule_.Value;
 
 	private CqlValueSet Hib_Vaccine__3_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084", default);
 
     [CqlDeclaration("Hib Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1084")]
@@ -416,7 +416,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__3_dose_schedule__Administered.Value;
 
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085", default);
 
     [CqlDeclaration("Hib Vaccine (4 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1085")]
@@ -424,7 +424,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__4_dose_schedule_.Value;
 
 	private CqlValueSet Hib_Vaccine__4_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086", default);
 
     [CqlDeclaration("Hib Vaccine (4 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1086")]
@@ -432,7 +432,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hib_Vaccine__4_dose_schedule__Administered.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -440,7 +440,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -448,7 +448,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -456,7 +456,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219", default);
 
     [CqlDeclaration("Inactivated Polio Vaccine (IPV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1219")]
@@ -464,7 +464,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Inactivated_Polio_Vaccine__IPV_.Value;
 
 	private CqlValueSet Inactivated_Polio_Vaccine__IPV__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045", default);
 
     [CqlDeclaration("Inactivated Polio Vaccine (IPV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1045")]
@@ -472,7 +472,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Inactivated_Polio_Vaccine__IPV__Administered.Value;
 
 	private CqlValueSet Child_Influenza_Immunization_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218", default);
 
     [CqlDeclaration("Child Influenza Immunization Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1218")]
@@ -480,7 +480,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Child_Influenza_Immunization_Administered.Value;
 
 	private CqlValueSet Child_Influenza_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044", default);
 
     [CqlDeclaration("Child Influenza Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1044")]
@@ -488,7 +488,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Child_Influenza_Vaccine_Administered.Value;
 
 	private CqlValueSet Influenza_Virus_LAIV_Immunization_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087", default);
 
     [CqlDeclaration("Influenza Virus LAIV Immunization")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1087")]
@@ -496,7 +496,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Influenza_Virus_LAIV_Immunization.Value;
 
 	private CqlValueSet Influenza_Virus_LAIV_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088", default);
 
     [CqlDeclaration("Influenza Virus LAIV Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1088")]
@@ -504,7 +504,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Influenza_Virus_LAIV_Procedure.Value;
 
 	private CqlValueSet Intussusception_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056", default);
 
     [CqlDeclaration("Intussusception")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.199.12.1056")]
@@ -512,7 +512,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Intussusception.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009", default);
 
     [CqlDeclaration("Malignant Neoplasm of Lymphatic and Hematopoietic Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1009")]
@@ -520,7 +520,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue.Value;
 
 	private CqlValueSet Measles_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053", default);
 
     [CqlDeclaration("Measles")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1053")]
@@ -528,7 +528,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles.Value;
 
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224", default);
 
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1224")]
@@ -536,7 +536,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles__Mumps_and_Rubella__MMR__Vaccine.Value;
 
 	private CqlValueSet Measles__Mumps_and_Rubella__MMR__Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031", default);
 
     [CqlDeclaration("Measles, Mumps and Rubella (MMR) Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1031")]
@@ -544,7 +544,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Measles__Mumps_and_Rubella__MMR__Vaccine_Administered.Value;
 
 	private CqlValueSet Mumps_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032", default);
 
     [CqlDeclaration("Mumps")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1032")]
@@ -552,7 +552,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Mumps.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -560,7 +560,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -568,7 +568,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221", default);
 
     [CqlDeclaration("Pneumococcal Conjugate Vaccine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1221")]
@@ -576,7 +576,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Pneumococcal_Conjugate_Vaccine.Value;
 
 	private CqlValueSet Pneumococcal_Conjugate_Vaccine_Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046", default);
 
     [CqlDeclaration("Pneumococcal Conjugate Vaccine Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1046")]
@@ -584,7 +584,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Pneumococcal_Conjugate_Vaccine_Administered.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -592,7 +592,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -600,7 +600,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__2_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048", default);
 
     [CqlDeclaration("Rotavirus Vaccine (2 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1048")]
@@ -608,7 +608,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__2_dose_schedule__Administered.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223", default);
 
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1223")]
@@ -616,7 +616,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__3_dose_schedule_.Value;
 
 	private CqlValueSet Rotavirus_Vaccine__3_dose_schedule__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047", default);
 
     [CqlDeclaration("Rotavirus Vaccine (3 dose schedule) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1047")]
@@ -624,7 +624,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rotavirus_Vaccine__3_dose_schedule__Administered.Value;
 
 	private CqlValueSet Rubella_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037", default);
 
     [CqlDeclaration("Rubella")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1037")]
@@ -632,7 +632,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Rubella.Value;
 
 	private CqlValueSet Severe_Combined_Immunodeficiency_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007", default);
 
     [CqlDeclaration("Severe Combined Immunodeficiency")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1007")]
@@ -640,7 +640,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Severe_Combined_Immunodeficiency.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -648,7 +648,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Varicella_Zoster_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039", default);
 
     [CqlDeclaration("Varicella Zoster")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1039")]
@@ -656,7 +656,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster.Value;
 
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170", default);
 
     [CqlDeclaration("Varicella Zoster Vaccine (VZV)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1170")]
@@ -664,7 +664,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster_Vaccine__VZV_.Value;
 
 	private CqlValueSet Varicella_Zoster_Vaccine__VZV__Administered_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040", default);
 
     [CqlDeclaration("Varicella Zoster Vaccine (VZV) Administered")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1040")]
@@ -672,84 +672,84 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		__Varicella_Zoster_Vaccine__VZV__Administered.Value;
 
 	private CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder__Value() => 
-		new CqlCode("433621000124101", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("433621000124101", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis due to Haemophilus influenzae type b vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_.Value;
 
 	private CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder__Value() => 
-		new CqlCode("428321000124101", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428321000124101", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis due to Hepatitis B vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_.Value;
 
 	private CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder__Value() => 
-		new CqlCode("428331000124103", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428331000124103", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis due to rotavirus vaccine (disorder)")]
 	public CqlCode Anaphylaxis_due_to_rotavirus_vaccine__disorder_() => 
 		__Anaphylaxis_due_to_rotavirus_vaccine__disorder_.Value;
 
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional_Value() => 
-		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient that may not require the presence of a physician or other qualified health care professional")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient_that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional.Value;
 
 	private CqlCode rotavirus__live__monovalent_vaccine_Value() => 
-		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default(string), default(string));
+		new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default, default);
 
     [CqlDeclaration("rotavirus, live, monovalent vaccine")]
 	public CqlCode rotavirus__live__monovalent_vaccine() => 
 		__rotavirus__live__monovalent_vaccine.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder__Value() => 
-		new CqlCode("471311000124103", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471311000124103", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Hepatitis A virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_.Value;
 
 	private CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach_Value() => 
-		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default(string), default(string));
+		new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default, default);
 
     [CqlDeclaration("Introduction of Serum, Toxoid and Vaccine into Muscle, Percutaneous Approach")]
 	public CqlCode Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach() => 
 		__Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder__Value() => 
-		new CqlCode("471361000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471361000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Influenza virus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder__Value() => 
-		new CqlCode("471331000124109", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471331000124109", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Measles morbillivirus and Mumps orthorubulavirus and Rubella virus antigens (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder__Value() => 
-		new CqlCode("471141000124102", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471141000124102", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing Streptococcus pneumoniae antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder__Value() => 
-		new CqlCode("471321000124106", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471321000124106", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine product containing human poliovirus antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_() => 
 		__Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_.Value;
 
 	private CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder__Value() => 
-		new CqlCode("471341000124104", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("471341000124104", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Anaphylaxis caused by vaccine containing Human alphaherpesvirus 3 antigen (disorder)")]
 	public CqlCode Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_() => 
@@ -758,15 +758,15 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("433621000124101", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428321000124101", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428331000124103", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471311000124103", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471361000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471331000124109", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471141000124102", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471321000124106", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("471341000124104", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("433621000124101", "http://snomed.info/sct", default, default),
+			new CqlCode("428321000124101", "http://snomed.info/sct", default, default),
+			new CqlCode("428331000124103", "http://snomed.info/sct", default, default),
+			new CqlCode("471311000124103", "http://snomed.info/sct", default, default),
+			new CqlCode("471361000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("471331000124109", "http://snomed.info/sct", default, default),
+			new CqlCode("471141000124102", "http://snomed.info/sct", default, default),
+			new CqlCode("471321000124106", "http://snomed.info/sct", default, default),
+			new CqlCode("471341000124104", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -779,7 +779,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -792,7 +792,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] CVX_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default(string), default(string)),
+			new CqlCode("119", "http://hl7.org/fhir/sid/cvx", default, default),
 		];
 
 		return a_;
@@ -805,7 +805,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private CqlCode[] ICD10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default(string), default(string)),
+			new CqlCode("3E0234Z", "http://www.cms.gov/Medicare/Coding/ICD10", default, default),
 		];
 
 		return a_;
@@ -817,8 +817,8 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildhoodImmunizationStatusFHIR-0.1.000", "Measurement Period", c_);
 
@@ -831,7 +831,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -844,17 +844,17 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
-		IEnumerable<Encounter> l_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> l_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? m_(Encounter E)
 		{
 			List<CodeableConcept> y_ = E?.Type;
@@ -880,11 +880,11 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<Encounter> n_ = context.Operators.Where<Encounter>(l_, m_);
 		CqlValueSet o_ = this.Online_Assessments();
-		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+		IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(n_, p_);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(k_, q_);
 		CqlValueSet s_ = this.Telephone_Visits();
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default(PropertyInfo));
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByValueSet<Encounter>(s_, default);
 		IEnumerable<Encounter> u_ = context.Operators.Union<Encounter>(r_, t_);
 		IEnumerable<Encounter> v_ = Status_1_6_000.Finished_Encounter(u_);
 		bool? w_(Encounter ValidEncounters)
@@ -976,7 +976,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Severe_Combined_Immunodeficiency_Value()
 	{
 		CqlValueSet a_ = this.Severe_Combined_Immunodeficiency();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition SevereImmuneDisorder)
 		{
@@ -1001,7 +1001,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Immunodeficiency_Value()
 	{
 		CqlValueSet a_ = this.Disorders_of_the_Immune_System();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition ImmuneDisorder)
 		{
@@ -1026,7 +1026,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_HIV_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition HIV)
 		{
@@ -1051,7 +1051,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Lymphoreticular_Cancer__Multiple_Myeloma_or_Leukemia_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Lymphatic_and_Hematopoietic_Tissue();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition LymphaticMalignantNeoplasm)
 		{
@@ -1076,7 +1076,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private bool? Has_Intussusception_Value()
 	{
 		CqlValueSet a_ = this.Intussusception();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition IntussusceptionDisorder)
 		{
@@ -1142,7 +1142,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> DTaP_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.DTaP_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization DTaPVaccination)
 		{
@@ -1170,7 +1170,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.DTaP_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure DTaPProcedure)
 		{
@@ -1246,9 +1246,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> DTaP_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Anaphylactic_Reaction_to_DTaP_Vaccine();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Encephalitis_Due_to_Diphtheria__Tetanus_or_Pertussis_Vaccine();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		IEnumerable<Condition> f_ = Status_1_6_000.Active_Condition(e_);
 		bool? g_(Condition DTaPConditions)
@@ -1273,7 +1273,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Polio_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Inactivated_Polio_Vaccine__IPV_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PolioVaccination)
 		{
@@ -1301,7 +1301,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Inactivated_Polio_Vaccine__IPV__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PolioProcedure)
 		{
@@ -1375,7 +1375,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_human_poliovirus_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PolioConditions)
 		{
@@ -1430,7 +1430,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_MMR_Vaccination_Value()
 	{
 		CqlValueSet a_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization MMRVaccination)
 		{
@@ -1439,13 +1439,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default);
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Measles__Mumps_and_Rubella__MMR__Vaccine_Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure MMRProcedure)
 		{
@@ -1454,7 +1454,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default);
 
 			return w_;
 		};
@@ -1472,7 +1472,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Measles_morbillivirus_and_Mumps_orthorubulavirus_and_Rubella_virus_antigens__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition MMRConditions)
 		{
@@ -1496,7 +1496,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Measles_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Measles();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MeaslesDiagnosis)
 		{
@@ -1520,7 +1520,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Mumps_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Mumps();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition MumpsDiagnosis)
 		{
@@ -1544,7 +1544,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Rubella_Indicators_Value()
 	{
 		CqlValueSet a_ = this.Rubella();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition RubellaDiagnosis)
 		{
@@ -1568,7 +1568,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hib_3_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hib_Vaccine__3_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseHibVaccine)
 		{
@@ -1596,7 +1596,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hib_Vaccine__3_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseHibProcedure)
 		{
@@ -1635,7 +1635,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hib_4_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hib_Vaccine__4_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HibVaccine)
 		{
@@ -1663,7 +1663,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hib_Vaccine__4_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HibProcedure)
 		{
@@ -1723,7 +1723,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
 				CqlDate l_ = context.Operators.Subtract(AllHibDoses2, k_);
 				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllHibDoses2, false, false);
-				bool? n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, default(string));
+				bool? n_ = context.Operators.In<CqlDate>(AllHibDoses1, m_, default);
 
 				return n_;
 			};
@@ -1786,7 +1786,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_Haemophilus_influenzae_type_b_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition HibReaction)
 		{
@@ -1810,7 +1810,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Hepatitis_B_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_B_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisBVaccination)
 		{
@@ -1838,7 +1838,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Hepatitis_B_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure HepatitisBProcedure)
 		{
@@ -1912,7 +1912,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Introduction_of_Serum__Toxoid_and_Vaccine_into_Muscle__Percutaneous_Approach();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default(PropertyInfo));
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default);
 		IEnumerable<Procedure> d_ = Status_1_6_000.Completed_Procedure(c_);
 		bool? e_(Procedure NewBornVaccine)
 		{
@@ -2000,9 +2000,9 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_Hepatitis_B_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		CqlValueSet d_ = this.Hepatitis_B();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepBConditions)
@@ -2027,7 +2027,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_Chicken_Pox_Vaccination_Value()
 	{
 		CqlValueSet a_ = this.Varicella_Zoster_Vaccine__VZV_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ChickenPoxVaccination)
 		{
@@ -2036,13 +2036,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default);
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Varicella_Zoster_Vaccine__VZV__Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure ChickenPoxProcedure)
 		{
@@ -2051,7 +2051,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default);
 
 			return w_;
 		};
@@ -2068,10 +2068,10 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Varicella_Zoster_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Varicella_Zoster();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_containing_Human_alphaherpesvirus_3_antigen__disorder_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default(PropertyInfo));
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default);
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition VaricellaZoster)
@@ -2096,7 +2096,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Pneumococcal_Conjugate_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Pneumococcal_Conjugate_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization PneumococcalVaccination)
 		{
@@ -2124,7 +2124,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Pneumococcal_Conjugate_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure PneumococcalProcedure)
 		{
@@ -2201,7 +2201,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Streptococcus_pneumoniae_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition PneumococcalReaction)
 		{
@@ -2225,7 +2225,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<object> One_Hepatitis_A_Vaccinations_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A_Vaccine();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization HepatitisAVaccination)
 		{
@@ -2234,13 +2234,13 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval((n_ as object));
 			CqlInterval<CqlDate> p_ = CQMCommon_2_0_000.ToDateInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default(string));
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDate>(l_, p_, default);
 
 			return q_;
 		};
 		IEnumerable<Immunization> e_ = context.Operators.Where<Immunization>(c_, d_);
 		CqlValueSet f_ = this.Hepatitis_A_Vaccine_Administered();
-		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+		IEnumerable<Procedure> g_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 		IEnumerable<Procedure> h_ = Status_1_6_000.Completed_Procedure(g_);
 		bool? i_(Procedure HepatitisAProcedure)
 		{
@@ -2249,7 +2249,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 			object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 			CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.ToInterval(t_);
 			CqlInterval<CqlDate> v_ = CQMCommon_2_0_000.ToDateInterval(u_);
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default(string));
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDate>(r_, v_, default);
 
 			return w_;
 		};
@@ -2266,10 +2266,10 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<Condition> Hepatitis_A_Numerator_Inclusion_Conditions_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlCode c_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Hepatitis_A_virus_antigen__disorder_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default(PropertyInfo));
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByCodes<Condition>(d_, default);
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(b_, e_);
 		IEnumerable<Condition> g_ = Status_1_6_000.Active_Condition(f_);
 		bool? h_(Condition HepatitisADiagnosis)
@@ -2295,7 +2295,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.rotavirus__live__monovalent_vaccine();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Immunization> c_ = context.Operators.RetrieveByCodes<Immunization>(b_, default(PropertyInfo));
+		IEnumerable<Immunization> c_ = context.Operators.RetrieveByCodes<Immunization>(b_, default);
 		IEnumerable<Immunization> d_ = Status_1_6_000.Completed_Immunization(c_);
 		bool? e_(Immunization TwoDoseRotavirusVaccine)
 		{
@@ -2323,7 +2323,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> h_ = context.Operators.Select<Immunization, CqlDate>(f_, g_);
 		CqlValueSet i_ = this.Rotavirus_Vaccine__2_dose_schedule__Administered();
-		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, default(PropertyInfo));
+		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(i_, default);
 		IEnumerable<Procedure> k_ = Status_1_6_000.Completed_Procedure(j_);
 		bool? l_(Procedure TwoDoseRotavirusProcedure)
 		{
@@ -2362,7 +2362,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Rotavirus_3_Dose_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Rotavirus_Vaccine__3_dose_schedule_();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization ThreeDoseRotavirusVaccine)
 		{
@@ -2390,7 +2390,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Rotavirus_Vaccine__3_dose_schedule__Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure ThreeDoseRotavirusAdministered)
 		{
@@ -2450,7 +2450,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 				CqlQuantity k_ = context.Operators.Quantity(1m, "day");
 				CqlDate l_ = context.Operators.Subtract(AllRotavirusDoses2, k_);
 				CqlInterval<CqlDate> m_ = context.Operators.Interval(l_, AllRotavirusDoses2, false, false);
-				bool? n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, default(string));
+				bool? n_ = context.Operators.In<CqlDate>(AllRotavirusDoses1, m_, default);
 
 				return n_;
 			};
@@ -2513,7 +2513,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_due_to_rotavirus_vaccine__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition RotavirusConditions)
 		{
@@ -2557,7 +2557,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> Influenza_Immunizations_or_Procedures_Value()
 	{
 		CqlValueSet a_ = this.Child_Influenza_Immunization_Administered();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization InfluenzaVaccine)
 		{
@@ -2585,7 +2585,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Child_Influenza_Vaccine_Administered();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
@@ -2661,7 +2661,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	private IEnumerable<CqlDate> LAIV_Vaccinations_Value()
 	{
 		CqlValueSet a_ = this.Influenza_Virus_LAIV_Immunization();
-		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default(PropertyInfo));
+		IEnumerable<Immunization> b_ = context.Operators.RetrieveByValueSet<Immunization>(a_, default);
 		IEnumerable<Immunization> c_ = Status_1_6_000.Completed_Immunization(b_);
 		bool? d_(Immunization LAIVVaccine)
 		{
@@ -2690,7 +2690,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 		};
 		IEnumerable<CqlDate> g_ = context.Operators.Select<Immunization, CqlDate>(e_, f_);
 		CqlValueSet h_ = this.Influenza_Virus_LAIV_Procedure();
-		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+		IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 		IEnumerable<Procedure> j_ = Status_1_6_000.Completed_Procedure(i_);
 		bool? k_(Procedure InfluenzaAdministration)
 		{
@@ -2746,7 +2746,7 @@ public class ChildhoodImmunizationStatusFHIR_0_1_000
 	{
 		CqlCode a_ = this.Anaphylaxis_caused_by_vaccine_product_containing_Influenza_virus_antigen__disorder_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		IEnumerable<Condition> d_ = Status_1_6_000.Active_Condition(c_);
 		bool? e_(Condition InfluenzaConditions)
 		{

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -90,7 +90,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default);
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -98,7 +98,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Dental_Caries_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", default);
 
     [CqlDeclaration("Dental Caries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004")]
@@ -106,7 +106,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Dental_Caries.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -114,7 +114,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -122,7 +122,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -130,7 +130,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -138,28 +138,28 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Hospice_care_ambulatory.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428361000124107", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("45755-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("373066001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -168,7 +168,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("45755-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -181,9 +181,9 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default, default),
+			new CqlCode("373066001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -195,8 +195,8 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001", "Measurement Period", c_);
 
@@ -209,7 +209,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -222,7 +222,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
@@ -253,7 +253,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -290,12 +290,12 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Dental_Caries();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition DentalCaries)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(DentalCaries);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 
 			return h_;
 		};

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ChildrenWhoHaveDentalDecayOrCavitiesFHIR", "0.0.001")]
 public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -90,7 +90,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -98,7 +98,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Dental_Caries_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004", default(string));
 
     [CqlDeclaration("Dental Caries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1004")]
@@ -106,7 +106,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Dental_Caries.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -114,7 +114,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -122,7 +122,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -130,7 +130,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -138,28 +138,28 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		__Hospice_care_ambulatory.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", null, null);
+		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -168,7 +168,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("45755-6", "http://loinc.org", null, null),
+			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -181,9 +181,9 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
-			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -195,8 +195,8 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001", "Measurement Period", c_);
 
@@ -209,7 +209,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -222,7 +222,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
@@ -253,7 +253,7 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -290,12 +290,12 @@ public class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Dental_Caries();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition DentalCaries)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(DentalCaries);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 
 			return h_;
 		};

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -146,7 +146,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Chlamydia_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", default(string));
 
     [CqlDeclaration("Chlamydia Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052")]
@@ -154,7 +154,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Chlamydia_Screening.Value;
 
 	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", default(string));
 
     [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012")]
@@ -162,7 +162,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
 
 	private CqlValueSet Contraceptive_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", default(string));
 
     [CqlDeclaration("Contraceptive Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080")]
@@ -170,7 +170,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Contraceptive_Medications.Value;
 
 	private CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", default(string));
 
     [CqlDeclaration("Diagnoses Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018")]
@@ -178,7 +178,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Diagnoses_Used_to_Indicate_Sexual_Activity.Value;
 
 	private CqlValueSet Diagnostic_Studies_During_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", default(string));
 
     [CqlDeclaration("Diagnostic Studies During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008")]
@@ -186,7 +186,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Diagnostic_Studies_During_Pregnancy.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -194,7 +194,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -202,7 +202,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Isotretinoin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", default(string));
 
     [CqlDeclaration("Isotretinoin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143")]
@@ -210,7 +210,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Isotretinoin.Value;
 
 	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", default(string));
 
     [CqlDeclaration("Lab Tests During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007")]
@@ -218,7 +218,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Lab_Tests_During_Pregnancy.Value;
 
 	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", default(string));
 
     [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051")]
@@ -226,7 +226,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -234,7 +234,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -242,7 +242,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -250,7 +250,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Pap_Test.Value;
 
 	private CqlValueSet Pregnancy_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", default(string));
 
     [CqlDeclaration("Pregnancy Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011")]
@@ -258,7 +258,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Pregnancy_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -266,7 +266,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -274,7 +274,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -282,7 +282,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -290,7 +290,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", default(string));
 
     [CqlDeclaration("Procedures Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017")]
@@ -298,7 +298,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Procedures_Used_to_Indicate_Sexual_Activity.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -306,7 +306,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet XRay_Study_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", default(string));
 
     [CqlDeclaration("XRay Study")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034")]
@@ -314,21 +314,21 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__XRay_Study.Value;
 
 	private CqlCode Female_Value() => 
-		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null);
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string));
 
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
 	private CqlCode Have_you_ever_had_vaginal_intercourse__PhenX__Value() => 
-		new CqlCode("64728-9", "http://loinc.org", null, null);
+		new CqlCode("64728-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Have you ever had vaginal intercourse [PhenX]")]
 	public CqlCode Have_you_ever_had_vaginal_intercourse__PhenX_() => 
 		__Have_you_ever_had_vaginal_intercourse__PhenX_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -337,7 +337,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] AdministrativeGender_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", null, null),
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string)),
 		];
 
 		return a_;
@@ -350,7 +350,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("64728-9", "http://loinc.org", null, null),
+			new CqlCode("64728-9", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -363,7 +363,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -375,8 +375,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChlamydiaScreeninginWomenFHIR-0.1.000", "Measurement Period", c_);
 
@@ -389,7 +389,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -446,26 +446,26 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Online_Assessments();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		IEnumerable<Encounter> x_ = Status_1_6_000.Finished_Encounter(w_);
@@ -492,7 +492,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	{
 		CqlCode a_ = this.Have_you_ever_had_vaginal_intercourse__PhenX_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation SexualActivityAssessment)
 		{
@@ -515,7 +515,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				};
 				if (s_())
 				{
-					return null;
+					return default(CqlInterval<CqlDateTime>);
 				}
 				else
 				{
@@ -527,7 +527,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 					return z_;
 				}
 			};
-			bool? q_ = context.Operators.SameOrBefore(o_, p_(), null);
+			bool? q_ = context.Operators.SameOrBefore(o_, p_(), default(string));
 			bool? r_ = context.Operators.And(l_, q_);
 
 			return r_;
@@ -545,18 +545,18 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Diagnoses_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Diagnoses_Used_to_Indicate_Sexual_Activity();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.HIV();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition SexualActivityDiagnosis)
 		{
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SexualActivityDiagnosis);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, null);
+			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
 
 			return n_;
 		};
@@ -573,8 +573,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Active_Contraceptive_Medications_Value()
 	{
 		CqlValueSet a_ = this.Contraceptive_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest ActiveContraceptives)
@@ -588,7 +588,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			bool? s_ = j_?.highClosed;
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, null);
+			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
 
 			return v_;
 		};
@@ -605,8 +605,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Ordered_Contraceptive_Medications_Value()
 	{
 		CqlValueSet a_ = this.Contraceptive_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest OrderedContraceptives)
@@ -632,12 +632,12 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Lab_Tests_During_Pregnancy();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Lab_Tests_for_Sexually_Transmitted_Infections();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> h_ = context.Operators.Union<ServiceRequest>(e_, g_);
 		IEnumerable<ServiceRequest> i_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(h_);
 		bool? j_(ServiceRequest LabOrders)
@@ -663,7 +663,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest PregnancyTest)
 		{
@@ -690,7 +690,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Diagnostic_Studies_During_Pregnancy();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest SexualActivityDiagnostics)
 		{
@@ -715,7 +715,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Procedures_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Procedures_Used_to_Indicate_Sexual_Activity();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ProceduresForSexualActivity)
 		{
@@ -748,7 +748,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -793,12 +793,12 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Pregnancy_Test_Exclusion_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		IEnumerable<ServiceRequest> d_(ServiceRequest PregnancyTest)
 		{
 			CqlValueSet m_ = this.XRay_Study();
-			IEnumerable<ServiceRequest> n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, null);
+			IEnumerable<ServiceRequest> n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, default(PropertyInfo));
 			IEnumerable<ServiceRequest> o_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(n_);
 			bool? p_(ServiceRequest XrayOrder)
 			{
@@ -825,7 +825,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
 				CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(x_);
 				CqlInterval<CqlDateTime> as_ = QICoreCommon_2_0_000.ToInterval((ar_ as object));
-				bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, null);
+				bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default(string));
 				bool? au_ = context.Operators.And(ao_, at_);
 
 				return au_;
@@ -838,13 +838,13 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			return s_;
 		};
 		IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> h_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(g_);
 		IEnumerable<ServiceRequest> i_(ServiceRequest PregnancyTestOrder)
 		{
 			CqlValueSet av_ = this.Isotretinoin();
-			IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-			IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+			IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
 			IEnumerable<MedicationRequest> ba_ = Status_1_6_000.Active_or_Completed_Medication_Request(az_);
 			bool? bb_(MedicationRequest AccutaneOrder)
@@ -872,7 +872,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlInterval<CqlDateTime> cb_ = this.Measurement_Period();
 				CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(bj_);
 				CqlInterval<CqlDateTime> ce_ = QICoreCommon_2_0_000.ToInterval((cd_ as object));
-				bool? cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, null);
+				bool? cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, default(string));
 				bool? cg_ = context.Operators.And(ca_, cf_);
 
 				return cg_;
@@ -932,7 +932,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Chlamydia_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation ChlamydiaTest)
 		{
@@ -1019,7 +1019,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -1039,7 +1039,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(21, 24, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -146,7 +146,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Chlamydia_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052", default);
 
     [CqlDeclaration("Chlamydia Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1052")]
@@ -154,7 +154,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Chlamydia_Screening.Value;
 
 	private CqlValueSet Complications_of_Pregnancy__Childbirth_and_the_Puerperium_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012", default);
 
     [CqlDeclaration("Complications of Pregnancy, Childbirth and the Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1012")]
@@ -162,7 +162,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Complications_of_Pregnancy__Childbirth_and_the_Puerperium.Value;
 
 	private CqlValueSet Contraceptive_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080", default);
 
     [CqlDeclaration("Contraceptive Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1080")]
@@ -170,7 +170,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Contraceptive_Medications.Value;
 
 	private CqlValueSet Diagnoses_Used_to_Indicate_Sexual_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018", default);
 
     [CqlDeclaration("Diagnoses Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1018")]
@@ -178,7 +178,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Diagnoses_Used_to_Indicate_Sexual_Activity.Value;
 
 	private CqlValueSet Diagnostic_Studies_During_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008", default);
 
     [CqlDeclaration("Diagnostic Studies During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1008")]
@@ -186,7 +186,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Diagnostic_Studies_During_Pregnancy.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -194,7 +194,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -202,7 +202,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Isotretinoin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143", default);
 
     [CqlDeclaration("Isotretinoin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1143")]
@@ -210,7 +210,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Isotretinoin.Value;
 
 	private CqlValueSet Lab_Tests_During_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007", default);
 
     [CqlDeclaration("Lab Tests During Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1007")]
@@ -218,7 +218,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Lab_Tests_During_Pregnancy.Value;
 
 	private CqlValueSet Lab_Tests_for_Sexually_Transmitted_Infections_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051", default);
 
     [CqlDeclaration("Lab Tests for Sexually Transmitted Infections")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1051")]
@@ -226,7 +226,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Lab_Tests_for_Sexually_Transmitted_Infections.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -234,7 +234,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -242,7 +242,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default);
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -250,7 +250,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Pap_Test.Value;
 
 	private CqlValueSet Pregnancy_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011", default);
 
     [CqlDeclaration("Pregnancy Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1011")]
@@ -258,7 +258,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Pregnancy_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -266,7 +266,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -274,7 +274,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -282,7 +282,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -290,7 +290,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Procedures_Used_to_Indicate_Sexual_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017", default);
 
     [CqlDeclaration("Procedures Used to Indicate Sexual Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1017")]
@@ -298,7 +298,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Procedures_Used_to_Indicate_Sexual_Activity.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -306,7 +306,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet XRay_Study_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034", default);
 
     [CqlDeclaration("XRay Study")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1034")]
@@ -314,21 +314,21 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		__XRay_Study.Value;
 
 	private CqlCode Female_Value() => 
-		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string));
+		new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default, default);
 
     [CqlDeclaration("Female")]
 	public CqlCode Female() => 
 		__Female.Value;
 
 	private CqlCode Have_you_ever_had_vaginal_intercourse__PhenX__Value() => 
-		new CqlCode("64728-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("64728-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Have you ever had vaginal intercourse [PhenX]")]
 	public CqlCode Have_you_ever_had_vaginal_intercourse__PhenX_() => 
 		__Have_you_ever_had_vaginal_intercourse__PhenX_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("373066001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -337,7 +337,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] AdministrativeGender_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default(string), default(string)),
+			new CqlCode("F", "http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender", default, default),
 		];
 
 		return a_;
@@ -350,7 +350,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("64728-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("64728-9", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -363,7 +363,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("373066001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -375,8 +375,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ChlamydiaScreeninginWomenFHIR-0.1.000", "Measurement Period", c_);
 
@@ -389,7 +389,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -446,26 +446,26 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Online_Assessments();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		IEnumerable<Encounter> x_ = Status_1_6_000.Finished_Encounter(w_);
@@ -492,7 +492,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	{
 		CqlCode a_ = this.Have_you_ever_had_vaginal_intercourse__PhenX_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation SexualActivityAssessment)
 		{
@@ -515,7 +515,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				};
 				if (s_())
 				{
-					return default(CqlInterval<CqlDateTime>);
+					return default;
 				}
 				else
 				{
@@ -527,7 +527,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 					return z_;
 				}
 			};
-			bool? q_ = context.Operators.SameOrBefore(o_, p_(), default(string));
+			bool? q_ = context.Operators.SameOrBefore(o_, p_(), default);
 			bool? r_ = context.Operators.And(l_, q_);
 
 			return r_;
@@ -545,18 +545,18 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Diagnoses_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Diagnoses_Used_to_Indicate_Sexual_Activity();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.HIV();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Complications_of_Pregnancy__Childbirth_and_the_Puerperium();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition SexualActivityDiagnosis)
 		{
 			CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.ToPrevalenceInterval(SexualActivityDiagnosis);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
+			bool? n_ = context.Operators.Overlaps(l_, m_, default);
 
 			return n_;
 		};
@@ -573,8 +573,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Active_Contraceptive_Medications_Value()
 	{
 		CqlValueSet a_ = this.Contraceptive_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_Medication(e_);
 		bool? g_(MedicationRequest ActiveContraceptives)
@@ -588,7 +588,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			bool? s_ = j_?.highClosed;
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(l_, o_, q_, s_);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
+			bool? v_ = context.Operators.Overlaps(t_, u_, default);
 
 			return v_;
 		};
@@ -605,8 +605,8 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Ordered_Contraceptive_Medications_Value()
 	{
 		CqlValueSet a_ = this.Contraceptive_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest OrderedContraceptives)
@@ -632,12 +632,12 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_But_Not_Pregnancy_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		CqlValueSet c_ = this.Lab_Tests_During_Pregnancy();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Lab_Tests_for_Sexually_Transmitted_Infections();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
 		IEnumerable<ServiceRequest> h_ = context.Operators.Union<ServiceRequest>(e_, g_);
 		IEnumerable<ServiceRequest> i_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(h_);
 		bool? j_(ServiceRequest LabOrders)
@@ -663,7 +663,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Laboratory_Tests_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest PregnancyTest)
 		{
@@ -690,7 +690,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Diagnostic_Studies_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Diagnostic_Studies_During_Pregnancy();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		bool? d_(ServiceRequest SexualActivityDiagnostics)
 		{
@@ -715,7 +715,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Procedures_Identifying_Sexual_Activity_Value()
 	{
 		CqlValueSet a_ = this.Procedures_Used_to_Indicate_Sexual_Activity();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ProceduresForSexualActivity)
 		{
@@ -748,7 +748,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -793,12 +793,12 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Has_Pregnancy_Test_Exclusion_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_Test();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(b_);
 		IEnumerable<ServiceRequest> d_(ServiceRequest PregnancyTest)
 		{
 			CqlValueSet m_ = this.XRay_Study();
-			IEnumerable<ServiceRequest> n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> n_ = context.Operators.RetrieveByValueSet<ServiceRequest>(m_, default);
 			IEnumerable<ServiceRequest> o_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(n_);
 			bool? p_(ServiceRequest XrayOrder)
 			{
@@ -825,7 +825,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
 				CqlDateTime ar_ = context.Operators.Convert<CqlDateTime>(x_);
 				CqlInterval<CqlDateTime> as_ = QICoreCommon_2_0_000.ToInterval((ar_ as object));
-				bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default(string));
+				bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
 				bool? au_ = context.Operators.And(ao_, at_);
 
 				return au_;
@@ -838,13 +838,13 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 			return s_;
 		};
 		IEnumerable<ServiceRequest> e_ = context.Operators.SelectMany<ServiceRequest, ServiceRequest>(c_, d_);
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> h_ = Status_1_6_000.Completed_or_Ongoing_Service_Request(g_);
 		IEnumerable<ServiceRequest> i_(ServiceRequest PregnancyTestOrder)
 		{
 			CqlValueSet av_ = this.Isotretinoin();
-			IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default);
+			IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default);
 			IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
 			IEnumerable<MedicationRequest> ba_ = Status_1_6_000.Active_or_Completed_Medication_Request(az_);
 			bool? bb_(MedicationRequest AccutaneOrder)
@@ -872,7 +872,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 				CqlInterval<CqlDateTime> cb_ = this.Measurement_Period();
 				CqlDateTime cd_ = context.Operators.Convert<CqlDateTime>(bj_);
 				CqlInterval<CqlDateTime> ce_ = QICoreCommon_2_0_000.ToInterval((cd_ as object));
-				bool? cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, default(string));
+				bool? cf_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cb_, ce_, default);
 				bool? cg_ = context.Operators.And(ca_, cf_);
 
 				return cg_;
@@ -932,7 +932,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Chlamydia_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation ChlamydiaTest)
 		{
@@ -1019,7 +1019,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(16, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -1039,7 +1039,7 @@ public class ChlamydiaScreeninginWomenFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(21, 24, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ChlamydiaScreeninginWomenFHIR", "0.1.000")]
 public class ChlamydiaScreeninginWomenFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ColonCancerScreeningFHIR", "0.1.000")]
 public class ColonCancerScreeningFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -104,7 +104,7 @@ public class ColonCancerScreeningFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default);
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -112,7 +112,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default);
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -120,7 +120,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__CT_Colonography.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default);
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -128,7 +128,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet sDNA_FIT_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default);
 
     [CqlDeclaration("sDNA FIT Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -136,7 +136,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__sDNA_FIT_Test.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default);
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -144,7 +144,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default);
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -152,7 +152,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default);
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -161,8 +161,8 @@ public class ColonCancerScreeningFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ColonCancerScreeningFHIR-0.1.000", "Measurement Period", c_);
 
@@ -175,7 +175,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -240,7 +240,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -266,7 +266,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition ColorectalCancer)
 		{
@@ -290,7 +290,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure Colectomy)
 		{
@@ -339,7 +339,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation FecalOccultResult)
 		{
@@ -417,7 +417,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.sDNA_FIT_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation sDNATest)
 		{
@@ -500,7 +500,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure FlexibleSigmoidoscopy)
 		{
@@ -530,7 +530,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Observation(b_);
 		bool? d_(Observation Colonography)
 		{
@@ -560,7 +560,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure Colonoscopy)
 		{
@@ -622,7 +622,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 49, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -642,7 +642,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -104,7 +104,7 @@ public class ColonCancerScreeningFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -112,7 +112,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -120,7 +120,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__CT_Colonography.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -128,7 +128,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet sDNA_FIT_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
 
     [CqlDeclaration("sDNA FIT Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -136,7 +136,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__sDNA_FIT_Test.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -144,7 +144,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -152,7 +152,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -161,8 +161,8 @@ public class ColonCancerScreeningFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ColonCancerScreeningFHIR-0.1.000", "Measurement Period", c_);
 
@@ -175,7 +175,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -240,7 +240,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -266,7 +266,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition ColorectalCancer)
 		{
@@ -290,7 +290,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure Colectomy)
 		{
@@ -339,7 +339,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation FecalOccultResult)
 		{
@@ -417,7 +417,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> Stool_DNA_with_FIT_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.sDNA_FIT_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Lab_Observation(b_);
 		bool? d_(Observation sDNATest)
 		{
@@ -500,7 +500,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure FlexibleSigmoidoscopy)
 		{
@@ -530,7 +530,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.Final_Observation(b_);
 		bool? d_(Observation Colonography)
 		{
@@ -560,7 +560,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure Colonoscopy)
 		{
@@ -622,7 +622,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(46, 49, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -642,7 +642,7 @@ public class ColonCancerScreeningFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(50, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
@@ -142,336 +142,336 @@ public class CumulativeMedicationDuration_4_0_000
     #endregion
 
 	private CqlCode HS_Value() => 
-		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("HS")]
 	public CqlCode HS() => 
 		__HS.Value;
 
 	private CqlCode WAKE_Value() => 
-		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("WAKE")]
 	public CqlCode WAKE() => 
 		__WAKE.Value;
 
 	private CqlCode C_Value() => 
-		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("C")]
 	public CqlCode C() => 
 		__C.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode CD_Value() => 
-		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CD")]
 	public CqlCode CD() => 
 		__CD.Value;
 
 	private CqlCode CV_Value() => 
-		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CV")]
 	public CqlCode CV() => 
 		__CV.Value;
 
 	private CqlCode AC_Value() => 
-		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("AC")]
 	public CqlCode AC() => 
 		__AC.Value;
 
 	private CqlCode ACM_Value() => 
-		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACM")]
 	public CqlCode ACM() => 
 		__ACM.Value;
 
 	private CqlCode ACD_Value() => 
-		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACD")]
 	public CqlCode ACD() => 
 		__ACD.Value;
 
 	private CqlCode ACV_Value() => 
-		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACV")]
 	public CqlCode ACV() => 
 		__ACV.Value;
 
 	private CqlCode PC_Value() => 
-		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PC")]
 	public CqlCode PC() => 
 		__PC.Value;
 
 	private CqlCode PCM_Value() => 
-		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCM")]
 	public CqlCode PCM() => 
 		__PCM.Value;
 
 	private CqlCode PCD_Value() => 
-		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCD")]
 	public CqlCode PCD() => 
 		__PCD.Value;
 
 	private CqlCode PCV_Value() => 
-		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCV")]
 	public CqlCode PCV() => 
 		__PCV.Value;
 
 	private CqlCode MORN_Value() => 
-		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN")]
 	public CqlCode MORN() => 
 		__MORN.Value;
 
 	private CqlCode MORN_early_Value() => 
-		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN.early")]
 	public CqlCode MORN_early() => 
 		__MORN_early.Value;
 
 	private CqlCode MORN_late_Value() => 
-		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN.late")]
 	public CqlCode MORN_late() => 
 		__MORN_late.Value;
 
 	private CqlCode NOON_Value() => 
-		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("NOON")]
 	public CqlCode NOON() => 
 		__NOON.Value;
 
 	private CqlCode AFT_Value() => 
-		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT")]
 	public CqlCode AFT() => 
 		__AFT.Value;
 
 	private CqlCode AFT_early_Value() => 
-		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT.early")]
 	public CqlCode AFT_early() => 
 		__AFT_early.Value;
 
 	private CqlCode AFT_late_Value() => 
-		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT.late")]
 	public CqlCode AFT_late() => 
 		__AFT_late.Value;
 
 	private CqlCode EVE_Value() => 
-		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE")]
 	public CqlCode EVE() => 
 		__EVE.Value;
 
 	private CqlCode EVE_early_Value() => 
-		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE.early")]
 	public CqlCode EVE_early() => 
 		__EVE_early.Value;
 
 	private CqlCode EVE_late_Value() => 
-		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE.late")]
 	public CqlCode EVE_late() => 
 		__EVE_late.Value;
 
 	private CqlCode NIGHT_Value() => 
-		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("NIGHT")]
 	public CqlCode NIGHT() => 
 		__NIGHT.Value;
 
 	private CqlCode PHS_Value() => 
-		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("PHS")]
 	public CqlCode PHS() => 
 		__PHS.Value;
 
 	private CqlCode Every_eight_hours__qualifier_value__Value() => 
-		new CqlCode("307469008", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("307469008", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every eight hours (qualifier value)")]
 	public CqlCode Every_eight_hours__qualifier_value_() => 
 		__Every_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_eight_to_twelve_hours__qualifier_value__Value() => 
-		new CqlCode("396140003", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396140003", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every eight to twelve hours (qualifier value)")]
 	public CqlCode Every_eight_to_twelve_hours__qualifier_value_() => 
 		__Every_eight_to_twelve_hours__qualifier_value_.Value;
 
 	private CqlCode Every_forty_eight_hours__qualifier_value__Value() => 
-		new CqlCode("396131002", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396131002", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every forty eight hours (qualifier value)")]
 	public CqlCode Every_forty_eight_hours__qualifier_value_() => 
 		__Every_forty_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_forty_hours__qualifier_value__Value() => 
-		new CqlCode("396130001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396130001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every forty hours (qualifier value)")]
 	public CqlCode Every_forty_hours__qualifier_value_() => 
 		__Every_forty_hours__qualifier_value_.Value;
 
 	private CqlCode Every_four_hours__qualifier_value__Value() => 
-		new CqlCode("225756002", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("225756002", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every four hours (qualifier value)")]
 	public CqlCode Every_four_hours__qualifier_value_() => 
 		__Every_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_seventy_two_hours__qualifier_value__Value() => 
-		new CqlCode("396143001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396143001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every seventy two hours (qualifier value)")]
 	public CqlCode Every_seventy_two_hours__qualifier_value_() => 
 		__Every_seventy_two_hours__qualifier_value_.Value;
 
 	private CqlCode Every_six_hours__qualifier_value__Value() => 
-		new CqlCode("307468000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("307468000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every six hours (qualifier value)")]
 	public CqlCode Every_six_hours__qualifier_value_() => 
 		__Every_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_six_to_eight_hours__qualifier_value__Value() => 
-		new CqlCode("396139000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396139000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every six to eight hours (qualifier value)")]
 	public CqlCode Every_six_to_eight_hours__qualifier_value_() => 
 		__Every_six_to_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_thirty_six_hours__qualifier_value__Value() => 
-		new CqlCode("396126004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396126004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every thirty six hours (qualifier value)")]
 	public CqlCode Every_thirty_six_hours__qualifier_value_() => 
 		__Every_thirty_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_three_to_four_hours__qualifier_value__Value() => 
-		new CqlCode("225754004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("225754004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every three to four hours (qualifier value)")]
 	public CqlCode Every_three_to_four_hours__qualifier_value_() => 
 		__Every_three_to_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_three_to_six_hours__qualifier_value__Value() => 
-		new CqlCode("396127008", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396127008", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every three to six hours (qualifier value)")]
 	public CqlCode Every_three_to_six_hours__qualifier_value_() => 
 		__Every_three_to_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_twelve_hours__qualifier_value__Value() => 
-		new CqlCode("307470009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("307470009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every twelve hours (qualifier value)")]
 	public CqlCode Every_twelve_hours__qualifier_value_() => 
 		__Every_twelve_hours__qualifier_value_.Value;
 
 	private CqlCode Every_twenty_four_hours__qualifier_value__Value() => 
-		new CqlCode("396125000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396125000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every twenty four hours (qualifier value)")]
 	public CqlCode Every_twenty_four_hours__qualifier_value_() => 
 		__Every_twenty_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_two_to_four_hours__qualifier_value__Value() => 
-		new CqlCode("225752000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("225752000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Every two to four hours (qualifier value)")]
 	public CqlCode Every_two_to_four_hours__qualifier_value_() => 
 		__Every_two_to_four_hours__qualifier_value_.Value;
 
 	private CqlCode Four_times_daily__qualifier_value__Value() => 
-		new CqlCode("307439001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("307439001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Four times daily (qualifier value)")]
 	public CqlCode Four_times_daily__qualifier_value_() => 
 		__Four_times_daily__qualifier_value_.Value;
 
 	private CqlCode Once_daily__qualifier_value__Value() => 
-		new CqlCode("229797004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("229797004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Once daily (qualifier value)")]
 	public CqlCode Once_daily__qualifier_value_() => 
 		__Once_daily__qualifier_value_.Value;
 
 	private CqlCode One_to_four_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396109005", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396109005", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("One to four times a day (qualifier value)")]
 	public CqlCode One_to_four_times_a_day__qualifier_value_() => 
 		__One_to_four_times_a_day__qualifier_value_.Value;
 
 	private CqlCode One_to_three_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396108002", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396108002", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("One to three times a day (qualifier value)")]
 	public CqlCode One_to_three_times_a_day__qualifier_value_() => 
 		__One_to_three_times_a_day__qualifier_value_.Value;
 
 	private CqlCode One_to_two_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396107007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396107007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("One to two times a day (qualifier value)")]
 	public CqlCode One_to_two_times_a_day__qualifier_value_() => 
 		__One_to_two_times_a_day__qualifier_value_.Value;
 
 	private CqlCode Three_times_daily__qualifier_value__Value() => 
-		new CqlCode("229798009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("229798009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Three times daily (qualifier value)")]
 	public CqlCode Three_times_daily__qualifier_value_() => 
 		__Three_times_daily__qualifier_value_.Value;
 
 	private CqlCode Twice_a_day__qualifier_value__Value() => 
-		new CqlCode("229799001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("229799001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Twice a day (qualifier value)")]
 	public CqlCode Twice_a_day__qualifier_value_() => 
 		__Twice_a_day__qualifier_value_.Value;
 
 	private CqlCode Two_to_four_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396111001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("396111001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Two to four times a day (qualifier value)")]
 	public CqlCode Two_to_four_times_a_day__qualifier_value_() => 
@@ -480,20 +480,20 @@ public class CumulativeMedicationDuration_4_0_000
 	private CqlCode[] V3TimingEvent_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
 		];
 
 		return a_;
@@ -506,18 +506,18 @@ public class CumulativeMedicationDuration_4_0_000
 	private CqlCode[] EventTiming_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default, default),
 		];
 
 		return a_;
@@ -540,7 +540,7 @@ public class CumulativeMedicationDuration_4_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1545,7 +1545,7 @@ public class CumulativeMedicationDuration_4_0_000
 	public CqlQuantity Quantity(decimal? value, string unit) => 
 		((context.Operators.Not((bool?)(value is null)) ?? false)
 			? (new CqlQuantity(value, unit))
-			: default(CqlQuantity));
+			: default);
 
     [CqlDeclaration("MedicationRequestPeriod")]
 	public CqlInterval<CqlDate> MedicationRequestPeriod(MedicationRequest Request)
@@ -2061,7 +2061,7 @@ public class CumulativeMedicationDuration_4_0_000
 			}
 			else
 			{
-				return default(int);
+				return default;
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CumulativeMedicationDuration", "4.0.000")]
 public class CumulativeMedicationDuration_4_0_000
 {

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.0.000.g.cs
@@ -142,336 +142,336 @@ public class CumulativeMedicationDuration_4_0_000
     #endregion
 
 	private CqlCode HS_Value() => 
-		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("HS")]
 	public CqlCode HS() => 
 		__HS.Value;
 
 	private CqlCode WAKE_Value() => 
-		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("WAKE")]
 	public CqlCode WAKE() => 
 		__WAKE.Value;
 
 	private CqlCode C_Value() => 
-		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("C")]
 	public CqlCode C() => 
 		__C.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode CD_Value() => 
-		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CD")]
 	public CqlCode CD() => 
 		__CD.Value;
 
 	private CqlCode CV_Value() => 
-		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CV")]
 	public CqlCode CV() => 
 		__CV.Value;
 
 	private CqlCode AC_Value() => 
-		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("AC")]
 	public CqlCode AC() => 
 		__AC.Value;
 
 	private CqlCode ACM_Value() => 
-		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACM")]
 	public CqlCode ACM() => 
 		__ACM.Value;
 
 	private CqlCode ACD_Value() => 
-		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACD")]
 	public CqlCode ACD() => 
 		__ACD.Value;
 
 	private CqlCode ACV_Value() => 
-		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACV")]
 	public CqlCode ACV() => 
 		__ACV.Value;
 
 	private CqlCode PC_Value() => 
-		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PC")]
 	public CqlCode PC() => 
 		__PC.Value;
 
 	private CqlCode PCM_Value() => 
-		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCM")]
 	public CqlCode PCM() => 
 		__PCM.Value;
 
 	private CqlCode PCD_Value() => 
-		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCD")]
 	public CqlCode PCD() => 
 		__PCD.Value;
 
 	private CqlCode PCV_Value() => 
-		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCV")]
 	public CqlCode PCV() => 
 		__PCV.Value;
 
 	private CqlCode MORN_Value() => 
-		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN")]
 	public CqlCode MORN() => 
 		__MORN.Value;
 
 	private CqlCode MORN_early_Value() => 
-		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN.early")]
 	public CqlCode MORN_early() => 
 		__MORN_early.Value;
 
 	private CqlCode MORN_late_Value() => 
-		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN.late")]
 	public CqlCode MORN_late() => 
 		__MORN_late.Value;
 
 	private CqlCode NOON_Value() => 
-		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("NOON")]
 	public CqlCode NOON() => 
 		__NOON.Value;
 
 	private CqlCode AFT_Value() => 
-		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT")]
 	public CqlCode AFT() => 
 		__AFT.Value;
 
 	private CqlCode AFT_early_Value() => 
-		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT.early")]
 	public CqlCode AFT_early() => 
 		__AFT_early.Value;
 
 	private CqlCode AFT_late_Value() => 
-		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT.late")]
 	public CqlCode AFT_late() => 
 		__AFT_late.Value;
 
 	private CqlCode EVE_Value() => 
-		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE")]
 	public CqlCode EVE() => 
 		__EVE.Value;
 
 	private CqlCode EVE_early_Value() => 
-		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE.early")]
 	public CqlCode EVE_early() => 
 		__EVE_early.Value;
 
 	private CqlCode EVE_late_Value() => 
-		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE.late")]
 	public CqlCode EVE_late() => 
 		__EVE_late.Value;
 
 	private CqlCode NIGHT_Value() => 
-		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("NIGHT")]
 	public CqlCode NIGHT() => 
 		__NIGHT.Value;
 
 	private CqlCode PHS_Value() => 
-		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("PHS")]
 	public CqlCode PHS() => 
 		__PHS.Value;
 
 	private CqlCode Every_eight_hours__qualifier_value__Value() => 
-		new CqlCode("307469008", "http://snomed.info/sct", null, null);
+		new CqlCode("307469008", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every eight hours (qualifier value)")]
 	public CqlCode Every_eight_hours__qualifier_value_() => 
 		__Every_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_eight_to_twelve_hours__qualifier_value__Value() => 
-		new CqlCode("396140003", "http://snomed.info/sct", null, null);
+		new CqlCode("396140003", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every eight to twelve hours (qualifier value)")]
 	public CqlCode Every_eight_to_twelve_hours__qualifier_value_() => 
 		__Every_eight_to_twelve_hours__qualifier_value_.Value;
 
 	private CqlCode Every_forty_eight_hours__qualifier_value__Value() => 
-		new CqlCode("396131002", "http://snomed.info/sct", null, null);
+		new CqlCode("396131002", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every forty eight hours (qualifier value)")]
 	public CqlCode Every_forty_eight_hours__qualifier_value_() => 
 		__Every_forty_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_forty_hours__qualifier_value__Value() => 
-		new CqlCode("396130001", "http://snomed.info/sct", null, null);
+		new CqlCode("396130001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every forty hours (qualifier value)")]
 	public CqlCode Every_forty_hours__qualifier_value_() => 
 		__Every_forty_hours__qualifier_value_.Value;
 
 	private CqlCode Every_four_hours__qualifier_value__Value() => 
-		new CqlCode("225756002", "http://snomed.info/sct", null, null);
+		new CqlCode("225756002", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every four hours (qualifier value)")]
 	public CqlCode Every_four_hours__qualifier_value_() => 
 		__Every_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_seventy_two_hours__qualifier_value__Value() => 
-		new CqlCode("396143001", "http://snomed.info/sct", null, null);
+		new CqlCode("396143001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every seventy two hours (qualifier value)")]
 	public CqlCode Every_seventy_two_hours__qualifier_value_() => 
 		__Every_seventy_two_hours__qualifier_value_.Value;
 
 	private CqlCode Every_six_hours__qualifier_value__Value() => 
-		new CqlCode("307468000", "http://snomed.info/sct", null, null);
+		new CqlCode("307468000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every six hours (qualifier value)")]
 	public CqlCode Every_six_hours__qualifier_value_() => 
 		__Every_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_six_to_eight_hours__qualifier_value__Value() => 
-		new CqlCode("396139000", "http://snomed.info/sct", null, null);
+		new CqlCode("396139000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every six to eight hours (qualifier value)")]
 	public CqlCode Every_six_to_eight_hours__qualifier_value_() => 
 		__Every_six_to_eight_hours__qualifier_value_.Value;
 
 	private CqlCode Every_thirty_six_hours__qualifier_value__Value() => 
-		new CqlCode("396126004", "http://snomed.info/sct", null, null);
+		new CqlCode("396126004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every thirty six hours (qualifier value)")]
 	public CqlCode Every_thirty_six_hours__qualifier_value_() => 
 		__Every_thirty_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_three_to_four_hours__qualifier_value__Value() => 
-		new CqlCode("225754004", "http://snomed.info/sct", null, null);
+		new CqlCode("225754004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every three to four hours (qualifier value)")]
 	public CqlCode Every_three_to_four_hours__qualifier_value_() => 
 		__Every_three_to_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_three_to_six_hours__qualifier_value__Value() => 
-		new CqlCode("396127008", "http://snomed.info/sct", null, null);
+		new CqlCode("396127008", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every three to six hours (qualifier value)")]
 	public CqlCode Every_three_to_six_hours__qualifier_value_() => 
 		__Every_three_to_six_hours__qualifier_value_.Value;
 
 	private CqlCode Every_twelve_hours__qualifier_value__Value() => 
-		new CqlCode("307470009", "http://snomed.info/sct", null, null);
+		new CqlCode("307470009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every twelve hours (qualifier value)")]
 	public CqlCode Every_twelve_hours__qualifier_value_() => 
 		__Every_twelve_hours__qualifier_value_.Value;
 
 	private CqlCode Every_twenty_four_hours__qualifier_value__Value() => 
-		new CqlCode("396125000", "http://snomed.info/sct", null, null);
+		new CqlCode("396125000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every twenty four hours (qualifier value)")]
 	public CqlCode Every_twenty_four_hours__qualifier_value_() => 
 		__Every_twenty_four_hours__qualifier_value_.Value;
 
 	private CqlCode Every_two_to_four_hours__qualifier_value__Value() => 
-		new CqlCode("225752000", "http://snomed.info/sct", null, null);
+		new CqlCode("225752000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Every two to four hours (qualifier value)")]
 	public CqlCode Every_two_to_four_hours__qualifier_value_() => 
 		__Every_two_to_four_hours__qualifier_value_.Value;
 
 	private CqlCode Four_times_daily__qualifier_value__Value() => 
-		new CqlCode("307439001", "http://snomed.info/sct", null, null);
+		new CqlCode("307439001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Four times daily (qualifier value)")]
 	public CqlCode Four_times_daily__qualifier_value_() => 
 		__Four_times_daily__qualifier_value_.Value;
 
 	private CqlCode Once_daily__qualifier_value__Value() => 
-		new CqlCode("229797004", "http://snomed.info/sct", null, null);
+		new CqlCode("229797004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Once daily (qualifier value)")]
 	public CqlCode Once_daily__qualifier_value_() => 
 		__Once_daily__qualifier_value_.Value;
 
 	private CqlCode One_to_four_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396109005", "http://snomed.info/sct", null, null);
+		new CqlCode("396109005", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("One to four times a day (qualifier value)")]
 	public CqlCode One_to_four_times_a_day__qualifier_value_() => 
 		__One_to_four_times_a_day__qualifier_value_.Value;
 
 	private CqlCode One_to_three_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396108002", "http://snomed.info/sct", null, null);
+		new CqlCode("396108002", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("One to three times a day (qualifier value)")]
 	public CqlCode One_to_three_times_a_day__qualifier_value_() => 
 		__One_to_three_times_a_day__qualifier_value_.Value;
 
 	private CqlCode One_to_two_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396107007", "http://snomed.info/sct", null, null);
+		new CqlCode("396107007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("One to two times a day (qualifier value)")]
 	public CqlCode One_to_two_times_a_day__qualifier_value_() => 
 		__One_to_two_times_a_day__qualifier_value_.Value;
 
 	private CqlCode Three_times_daily__qualifier_value__Value() => 
-		new CqlCode("229798009", "http://snomed.info/sct", null, null);
+		new CqlCode("229798009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Three times daily (qualifier value)")]
 	public CqlCode Three_times_daily__qualifier_value_() => 
 		__Three_times_daily__qualifier_value_.Value;
 
 	private CqlCode Twice_a_day__qualifier_value__Value() => 
-		new CqlCode("229799001", "http://snomed.info/sct", null, null);
+		new CqlCode("229799001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Twice a day (qualifier value)")]
 	public CqlCode Twice_a_day__qualifier_value_() => 
 		__Twice_a_day__qualifier_value_.Value;
 
 	private CqlCode Two_to_four_times_a_day__qualifier_value__Value() => 
-		new CqlCode("396111001", "http://snomed.info/sct", null, null);
+		new CqlCode("396111001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Two to four times a day (qualifier value)")]
 	public CqlCode Two_to_four_times_a_day__qualifier_value_() => 
@@ -480,20 +480,20 @@ public class CumulativeMedicationDuration_4_0_000
 	private CqlCode[] V3TimingEvent_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
+			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
 		];
 
 		return a_;
@@ -506,18 +506,18 @@ public class CumulativeMedicationDuration_4_0_000
 	private CqlCode[] EventTiming_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null),
+			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string)),
 		];
 
 		return a_;
@@ -540,7 +540,7 @@ public class CumulativeMedicationDuration_4_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1545,7 +1545,7 @@ public class CumulativeMedicationDuration_4_0_000
 	public CqlQuantity Quantity(decimal? value, string unit) => 
 		((context.Operators.Not((bool?)(value is null)) ?? false)
 			? (new CqlQuantity(value, unit))
-			: null);
+			: default(CqlQuantity));
 
     [CqlDeclaration("MedicationRequestPeriod")]
 	public CqlInterval<CqlDate> MedicationRequestPeriod(MedicationRequest Request)
@@ -2061,7 +2061,7 @@ public class CumulativeMedicationDuration_4_0_000
 			}
 			else
 			{
-				return default;
+				return default(int);
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -130,7 +130,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -138,7 +138,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default(string));
 
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
@@ -146,7 +146,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Level_of_Severity_of_Retinopathy_Findings.Value;
 
 	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default(string));
 
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
@@ -154,7 +154,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_Edema_Findings_Present.Value;
 
 	private CqlValueSet Macular_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default(string));
 
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
@@ -162,7 +162,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_Exam.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -170,7 +170,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -178,7 +178,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -186,7 +186,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -194,7 +194,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -202,7 +202,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -210,7 +210,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Patient_Reason.Value;
 
 	private CqlValueSet Macular_edema_absent__situation__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", default(string));
 
     [CqlDeclaration("Macular edema absent (situation)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391")]
@@ -218,49 +218,49 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_edema_absent__situation_.Value;
 
 	private CqlCode Healthcare_professional__occupation__Value() => 
-		new CqlCode("223366009", "http://snomed.info/sct", null, null);
+		new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Healthcare professional (occupation)")]
 	public CqlCode Healthcare_professional__occupation_() => 
 		__Healthcare_professional__occupation_.Value;
 
 	private CqlCode Medical_practitioner__occupation__Value() => 
-		new CqlCode("158965000", "http://snomed.info/sct", null, null);
+		new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Medical practitioner (occupation)")]
 	public CqlCode Medical_practitioner__occupation_() => 
 		__Medical_practitioner__occupation_.Value;
 
 	private CqlCode Ophthalmologist__occupation__Value() => 
-		new CqlCode("422234006", "http://snomed.info/sct", null, null);
+		new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Ophthalmologist (occupation)")]
 	public CqlCode Ophthalmologist__occupation_() => 
 		__Ophthalmologist__occupation_.Value;
 
 	private CqlCode Optometrist__occupation__Value() => 
-		new CqlCode("28229004", "http://snomed.info/sct", null, null);
+		new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Optometrist (occupation)")]
 	public CqlCode Optometrist__occupation_() => 
 		__Optometrist__occupation_.Value;
 
 	private CqlCode Physician__occupation__Value() => 
-		new CqlCode("309343006", "http://snomed.info/sct", null, null);
+		new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Physician (occupation)")]
 	public CqlCode Physician__occupation_() => 
 		__Physician__occupation_.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -269,11 +269,11 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("223366009", "http://snomed.info/sct", null, null),
-			new CqlCode("158965000", "http://snomed.info/sct", null, null),
-			new CqlCode("422234006", "http://snomed.info/sct", null, null),
-			new CqlCode("28229004", "http://snomed.info/sct", null, null),
-			new CqlCode("309343006", "http://snomed.info/sct", null, null),
+			new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -286,8 +286,8 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -299,8 +299,8 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000", "Measurement Period", c_);
 
@@ -313,7 +313,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -370,25 +370,25 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;
 			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
@@ -418,13 +418,13 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			bool? f_(Condition DiabeticRetinopathy)
 			{
 				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(DiabeticRetinopathy);
 				Period k_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.Overlaps(j_, l_, null);
+				bool? m_ = context.Operators.Overlaps(j_, l_, default(string));
 				bool? n_ = QICoreCommon_2_0_000.isActive(DiabeticRetinopathy);
 				bool? o_ = context.Operators.And(m_, n_);
 				CodeableConcept p_ = DiabeticRetinopathy?.VerificationStatus;
@@ -488,7 +488,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private IEnumerable<Observation> Macular_Exam_Performed_Value()
 	{
 		CqlValueSet a_ = this.Macular_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
 			IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter();
@@ -499,7 +499,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				DataType n_ = MacularExam?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
 
 				return q_;
 			};
@@ -569,7 +569,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, null);
+				bool? r_ = context.Operators.After(n_, q_, default(string));
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -618,7 +618,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, null);
+				bool? r_ = context.Operators.After(n_, q_, default(string));
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -667,7 +667,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, null);
+				bool? r_ = context.Operators.After(n_, q_, default(string));
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -742,7 +742,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LevelOfSeverityNotCommunicated is DomainResource)
 						? ((LevelOfSeverityNotCommunicated as DomainResource).Extension)
-						: null), q_);
+						: default(List<Extension>)), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -754,7 +754,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
 
 				return y_;
 			};
@@ -811,7 +811,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaAbsentNotCommunicated is DomainResource)
 						? ((MacularEdemaAbsentNotCommunicated as DomainResource).Extension)
-						: null), q_);
+						: default(List<Extension>)), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -823,7 +823,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
 
 				return y_;
 			};
@@ -880,7 +880,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaPresentNotCommunicated is DomainResource)
 						? ((MacularEdemaPresentNotCommunicated as DomainResource).Extension)
-						: null), q_);
+						: default(List<Extension>)), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -892,7 +892,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, null);
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
 
 				return y_;
 			};

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.1.000")]
 public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -130,7 +130,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default);
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -138,7 +138,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default);
 
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
@@ -146,7 +146,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Level_of_Severity_of_Retinopathy_Findings.Value;
 
 	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default);
 
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
@@ -154,7 +154,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_Edema_Findings_Present.Value;
 
 	private CqlValueSet Macular_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default);
 
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
@@ -162,7 +162,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_Exam.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -170,7 +170,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -178,7 +178,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -186,7 +186,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -194,7 +194,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -202,7 +202,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default);
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -210,7 +210,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Patient_Reason.Value;
 
 	private CqlValueSet Macular_edema_absent__situation__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391", default);
 
     [CqlDeclaration("Macular edema absent (situation)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.2.1391")]
@@ -218,49 +218,49 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		__Macular_edema_absent__situation_.Value;
 
 	private CqlCode Healthcare_professional__occupation__Value() => 
-		new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("223366009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Healthcare professional (occupation)")]
 	public CqlCode Healthcare_professional__occupation_() => 
 		__Healthcare_professional__occupation_.Value;
 
 	private CqlCode Medical_practitioner__occupation__Value() => 
-		new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("158965000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Medical practitioner (occupation)")]
 	public CqlCode Medical_practitioner__occupation_() => 
 		__Medical_practitioner__occupation_.Value;
 
 	private CqlCode Ophthalmologist__occupation__Value() => 
-		new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("422234006", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Ophthalmologist (occupation)")]
 	public CqlCode Ophthalmologist__occupation_() => 
 		__Ophthalmologist__occupation_.Value;
 
 	private CqlCode Optometrist__occupation__Value() => 
-		new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("28229004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Optometrist (occupation)")]
 	public CqlCode Optometrist__occupation_() => 
 		__Optometrist__occupation_.Value;
 
 	private CqlCode Physician__occupation__Value() => 
-		new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("309343006", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Physician (occupation)")]
 	public CqlCode Physician__occupation_() => 
 		__Physician__occupation_.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -269,11 +269,11 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("223366009", "http://snomed.info/sct", default, default),
+			new CqlCode("158965000", "http://snomed.info/sct", default, default),
+			new CqlCode("422234006", "http://snomed.info/sct", default, default),
+			new CqlCode("28229004", "http://snomed.info/sct", default, default),
+			new CqlCode("309343006", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -286,8 +286,8 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -299,8 +299,8 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000", "Measurement Period", c_);
 
@@ -313,7 +313,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -370,25 +370,25 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default);
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;
 			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
@@ -418,13 +418,13 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			bool? f_(Condition DiabeticRetinopathy)
 			{
 				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(DiabeticRetinopathy);
 				Period k_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.Overlaps(j_, l_, default(string));
+				bool? m_ = context.Operators.Overlaps(j_, l_, default);
 				bool? n_ = QICoreCommon_2_0_000.isActive(DiabeticRetinopathy);
 				bool? o_ = context.Operators.And(m_, n_);
 				CodeableConcept p_ = DiabeticRetinopathy?.VerificationStatus;
@@ -488,7 +488,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 	private IEnumerable<Observation> Macular_Exam_Performed_Value()
 	{
 		CqlValueSet a_ = this.Macular_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
 			IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter();
@@ -499,7 +499,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				DataType n_ = MacularExam?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default);
 
 				return q_;
 			};
@@ -569,7 +569,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, default(string));
+				bool? r_ = context.Operators.After(n_, q_, default);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -618,7 +618,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, default(string));
+				bool? r_ = context.Operators.After(n_, q_, default);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -667,7 +667,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, default(string));
+				bool? r_ = context.Operators.After(n_, q_, default);
 				CqlDateTime t_ = context.Operators.Convert<CqlDateTime>(m_);
 				CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
 				bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, "day");
@@ -742,7 +742,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LevelOfSeverityNotCommunicated is DomainResource)
 						? ((LevelOfSeverityNotCommunicated as DomainResource).Extension)
-						: default(List<Extension>)), q_);
+						: default), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -754,7 +754,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default);
 
 				return y_;
 			};
@@ -811,7 +811,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaAbsentNotCommunicated is DomainResource)
 						? ((MacularEdemaAbsentNotCommunicated as DomainResource).Extension)
-						: default(List<Extension>)), q_);
+						: default), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -823,7 +823,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default);
 
 				return y_;
 			};
@@ -880,7 +880,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				};
 				IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((MacularEdemaPresentNotCommunicated is DomainResource)
 						? ((MacularEdemaPresentNotCommunicated as DomainResource).Extension)
-						: default(List<Extension>)), q_);
+						: default), q_);
 				DataType s_(Extension @this)
 				{
 					DataType ad_ = @this?.Value;
@@ -892,7 +892,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000
 				CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
 				Period w_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_3_000.ToInterval(w_);
-				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default(string));
+				bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default);
 
 				return y_;
 			};

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Behavioral_Neuropsych_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", default(string));
 
     [CqlDeclaration("Behavioral/Neuropsych Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023")]
@@ -110,7 +110,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Behavioral_Neuropsych_Assessment.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -118,7 +118,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Cognitive_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", default(string));
 
     [CqlDeclaration("Cognitive Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332")]
@@ -126,7 +126,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Cognitive_Assessment.Value;
 
 	private CqlValueSet Dementia_and_Mental_Degenerations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", default(string));
 
     [CqlDeclaration("Dementia & Mental Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005")]
@@ -134,7 +134,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Dementia_and_Mental_Degenerations.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -142,7 +142,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -150,7 +150,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -158,7 +158,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -166,7 +166,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -174,7 +174,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -182,7 +182,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default(string));
 
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
@@ -190,7 +190,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Patient_Provider_Interaction.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -198,7 +198,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Patient_Reason.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -206,7 +206,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -214,7 +214,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", default(string));
 
     [CqlDeclaration("Standardized Tools Score for Assessment of Cognition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006")]
@@ -235,8 +235,8 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DementiaCognitiveAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
@@ -249,7 +249,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -262,30 +262,30 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_to_Assess_Cognition_Value()
 	{
 		CqlValueSet a_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Behavioral_Neuropsych_Assessment();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Office_Visit();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		IEnumerable<Encounter> z_ = context.Operators.Union<Encounter>(w_, y_);
 
 		return z_;
@@ -301,13 +301,13 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EncounterAssessCognition)
 		{
 			CqlValueSet d_ = this.Dementia_and_Mental_Degenerations();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			bool? f_(Condition Dementia)
 			{
 				CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 				Period k_ = EncounterAssessCognition?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default(string));
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(k_);
 				bool? q_ = context.Operators.Overlaps(n_, p_, "day");
@@ -354,14 +354,14 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Encounter_to_Assess_Cognition();
 		CqlValueSet b_ = this.Patient_Provider_Interaction();
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, null);
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, default(PropertyInfo));
 		IEnumerable<Encounter> d_ = context.Operators.Union<Encounter>(a_, c_);
 		bool? e_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			Period h_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, null);
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, default(string));
 			Code<Encounter.EncounterStatus> k_ = ValidEncounter?.StatusElement;
 			Encounter.EncounterStatus? l_ = k_?.Value;
 			Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
@@ -409,9 +409,9 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
 		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Cognitive_Assessment();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CognitiveAssessment)
 		{
@@ -490,9 +490,9 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
 		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Cognitive_Assessment();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation NoCognitiveAssessment)
 		{
@@ -504,7 +504,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterDementia?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
 
 				return t_;
 			};
@@ -529,7 +529,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoCognitiveAssessment is DomainResource)
 					? ((NoCognitiveAssessment as DomainResource).Extension)
-					: null), u_);
+					: default(List<Extension>)), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DementiaCognitiveAssessmentFHIR", "0.1.000")]
 public class DementiaCognitiveAssessmentFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Behavioral_Neuropsych_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023", default);
 
     [CqlDeclaration("Behavioral/Neuropsych Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1023")]
@@ -110,7 +110,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Behavioral_Neuropsych_Assessment.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -118,7 +118,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Cognitive_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332", default);
 
     [CqlDeclaration("Cognitive Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1332")]
@@ -126,7 +126,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Cognitive_Assessment.Value;
 
 	private CqlValueSet Dementia_and_Mental_Degenerations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005", default);
 
     [CqlDeclaration("Dementia & Mental Degenerations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1005")]
@@ -134,7 +134,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Dementia_and_Mental_Degenerations.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default);
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -142,7 +142,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -150,7 +150,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -158,7 +158,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default);
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -166,7 +166,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -174,7 +174,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -182,7 +182,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Provider_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", default);
 
     [CqlDeclaration("Patient Provider Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012")]
@@ -190,7 +190,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Patient_Provider_Interaction.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default);
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -198,7 +198,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Patient_Reason.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default);
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -206,7 +206,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default);
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -214,7 +214,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Standardized_Tools_Score_for_Assessment_of_Cognition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006", default);
 
     [CqlDeclaration("Standardized Tools Score for Assessment of Cognition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1006")]
@@ -235,8 +235,8 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DementiaCognitiveAssessmentFHIR-0.1.000", "Measurement Period", c_);
 
@@ -249,7 +249,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -262,30 +262,30 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_to_Assess_Cognition_Value()
 	{
 		CqlValueSet a_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Behavioral_Neuropsych_Assessment();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Office_Visit();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		IEnumerable<Encounter> z_ = context.Operators.Union<Encounter>(w_, y_);
 
 		return z_;
@@ -301,13 +301,13 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EncounterAssessCognition)
 		{
 			CqlValueSet d_ = this.Dementia_and_Mental_Degenerations();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			bool? f_(Condition Dementia)
 			{
 				CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
 				Period k_ = EncounterAssessCognition?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(k_);
 				bool? q_ = context.Operators.Overlaps(n_, p_, "day");
@@ -354,14 +354,14 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Encounter_to_Assess_Cognition();
 		CqlValueSet b_ = this.Patient_Provider_Interaction();
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, default(PropertyInfo));
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(b_, default);
 		IEnumerable<Encounter> d_ = context.Operators.Union<Encounter>(a_, c_);
 		bool? e_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			Period h_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_3_000.ToInterval(h_);
-			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, default(string));
+			bool? j_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, i_, default);
 			Code<Encounter.EncounterStatus> k_ = ValidEncounter?.StatusElement;
 			Encounter.EncounterStatus? l_ = k_?.Value;
 			Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
@@ -409,9 +409,9 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Observation> Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
 		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		CqlValueSet c_ = this.Cognitive_Assessment();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default);
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CognitiveAssessment)
 		{
@@ -490,9 +490,9 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 	private IEnumerable<Observation> Patient_Reason_for_Not_Performing_Assessment_of_Cognition_Using_Standardized_Tools_or_Alternate_Methods_Value()
 	{
 		CqlValueSet a_ = this.Standardized_Tools_Score_for_Assessment_of_Cognition();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		CqlValueSet c_ = this.Cognitive_Assessment();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default);
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation NoCognitiveAssessment)
 		{
@@ -504,7 +504,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterDementia?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
 
 				return t_;
 			};
@@ -529,7 +529,7 @@ public class DementiaCognitiveAssessmentFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoCognitiveAssessment is DomainResource)
 					? ((NoCognitiveAssessment as DomainResource).Extension)
-					: default(List<Extension>)), u_);
+					: default), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -106,7 +106,7 @@ public class DiabetesEyeExamFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -114,7 +114,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -122,7 +122,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Diabetes.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default);
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -130,7 +130,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -138,7 +138,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -146,7 +146,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -154,7 +154,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -162,7 +162,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -170,7 +170,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -178,7 +178,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -186,7 +186,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -194,7 +194,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -202,7 +202,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Retinal_or_Dilated_Eye_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", default);
 
     [CqlDeclaration("Retinal or Dilated Eye Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088")]
@@ -210,7 +210,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Retinal_or_Dilated_Eye_Exam.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -219,8 +219,8 @@ public class DiabetesEyeExamFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DiabetesEyeExamFHIR-0.0.001", "Measurement Period", c_);
 
@@ -233,7 +233,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -246,24 +246,24 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounters)
@@ -295,17 +295,17 @@ public class DiabetesEyeExamFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
 		CqlValueSet n_ = this.Diabetes();
-		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default(PropertyInfo));
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default);
 		bool? p_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
+			bool? v_ = context.Operators.Overlaps(t_, u_, default);
 
 			return v_;
 		};
@@ -351,12 +351,12 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private bool? Diabetic_Retinopathy_Overlapping_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Diabetic_Retinopathy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Retinopathy)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(Retinopathy);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 
 			return h_;
 		};
@@ -373,7 +373,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{
@@ -397,7 +397,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value()
 	{
 		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DiabetesEyeExamFHIR", "0.0.001")]
 public class DiabetesEyeExamFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.001.g.cs
@@ -106,7 +106,7 @@ public class DiabetesEyeExamFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -114,7 +114,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -122,7 +122,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Diabetes.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -130,7 +130,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -138,7 +138,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -146,7 +146,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -154,7 +154,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -162,7 +162,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -170,7 +170,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -178,7 +178,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -186,7 +186,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -194,7 +194,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -202,7 +202,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Retinal_or_Dilated_Eye_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088", default(string));
 
     [CqlDeclaration("Retinal or Dilated Eye Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.115.12.1088")]
@@ -210,7 +210,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 		__Retinal_or_Dilated_Eye_Exam.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -219,8 +219,8 @@ public class DiabetesEyeExamFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DiabetesEyeExamFHIR-0.0.001", "Measurement Period", c_);
 
@@ -233,7 +233,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -246,24 +246,24 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.isEncounterPerformed(t_);
 		bool? v_(Encounter ValidEncounters)
@@ -295,17 +295,17 @@ public class DiabetesEyeExamFHIR_0_0_001
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
 		CqlValueSet n_ = this.Diabetes();
-		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, null);
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default(PropertyInfo));
 		bool? p_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.prevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, null);
+			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
 
 			return v_;
 		};
@@ -351,12 +351,12 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private bool? Diabetic_Retinopathy_Overlapping_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Diabetic_Retinopathy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Retinopathy)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(Retinopathy);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 
 			return h_;
 		};
@@ -373,7 +373,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{
@@ -397,7 +397,7 @@ public class DiabetesEyeExamFHIR_0_0_001
 	private IEnumerable<Observation> Retinal_Exam_in_Measurement_Period_or_Year_Prior_Value()
 	{
 		CqlValueSet a_ = this.Retinal_or_Dilated_Eye_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation RetinalExam)
 		{

--- a/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -86,7 +86,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
     #endregion
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -94,7 +94,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 		__Diabetes.Value;
 
 	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default(string));
 
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
@@ -103,8 +103,8 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000", "Measurement Period", c_);
 
@@ -117,7 +117,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -182,17 +182,17 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
 		CqlValueSet n_ = this.Diabetes();
-		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, null);
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default(PropertyInfo));
 		bool? p_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, null);
+			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
 
 			return v_;
 		};
@@ -238,7 +238,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 	private Observation Most_Recent_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation RecentHbA1c)
 		{
@@ -353,7 +353,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 	private bool? Has_No_Record_Of_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation NoHbA1c)
 		{

--- a/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR", "0.1.000")]
 public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000.g.cs
@@ -86,7 +86,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
     #endregion
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -94,7 +94,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 		__Diabetes.Value;
 
 	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default);
 
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
@@ -103,8 +103,8 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.1.000", "Measurement Period", c_);
 
@@ -117,7 +117,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -182,17 +182,17 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_8_000.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
 		CqlValueSet n_ = this.Diabetes();
-		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default(PropertyInfo));
+		IEnumerable<Condition> o_ = context.Operators.RetrieveByValueSet<Condition>(n_, default);
 		bool? p_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> t_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> u_ = this.Measurement_Period();
-			bool? v_ = context.Operators.Overlaps(t_, u_, default(string));
+			bool? v_ = context.Operators.Overlaps(t_, u_, default);
 
 			return v_;
 		};
@@ -238,7 +238,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 	private Observation Most_Recent_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation RecentHbA1c)
 		{
@@ -353,7 +353,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_1_000
 	private bool? Has_No_Record_Of_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isLaboratoryTestPerformed(b_);
 		bool? d_(Observation NoHbA1c)
 		{

--- a/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -86,7 +86,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
     #endregion
 
 	private CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", default(string));
 
     [CqlDeclaration("Antithrombotic Therapy for Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62")]
@@ -94,7 +94,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Antithrombotic_Therapy_for_Ischemic_Stroke.Value;
 
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
 
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -102,7 +102,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -110,7 +110,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Patient_Refusal.Value;
 
 	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default(string));
 
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
@@ -119,8 +119,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.9.000", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -180,7 +180,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
 
 				return p_;
 			};
@@ -219,8 +219,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAntithrombotic)
 			{
@@ -228,7 +228,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 				Period o_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, null);
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
 
 				return q_;
 			};
@@ -251,8 +251,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Antithrombotic)
 		{
@@ -300,8 +300,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest NoAntithromboticDischarge)
 		{
@@ -365,7 +365,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};
@@ -388,8 +388,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Pharmacological)
 		{
@@ -446,7 +446,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};

--- a/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -86,7 +86,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
     #endregion
 
 	private CqlValueSet Antithrombotic_Therapy_for_Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62", default);
 
     [CqlDeclaration("Antithrombotic Therapy for Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.62")]
@@ -94,7 +94,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Antithrombotic_Therapy_for_Ischemic_Stroke.Value;
 
 	private CqlValueSet Medical_Reason_For_Not_Providing_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default);
 
     [CqlDeclaration("Medical Reason For Not Providing Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -102,7 +102,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Medical_Reason_For_Not_Providing_Treatment.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default);
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -110,7 +110,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		__Patient_Refusal.Value;
 
 	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default);
 
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
@@ -119,8 +119,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.9.000", "Measurement Period", c_);
 
@@ -133,7 +133,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -180,7 +180,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(Encounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default);
 
 				return p_;
 			};
@@ -219,8 +219,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
 			CqlValueSet d_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			bool? i_(MedicationRequest DischargeAntithrombotic)
 			{
@@ -228,7 +228,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 				Period o_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.ToInterval(o_);
-				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default(string));
+				bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default);
 
 				return q_;
 			};
@@ -251,8 +251,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Antithrombotic)
 		{
@@ -300,8 +300,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Reason_for_Not_Giving_Antithrombotic_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy_for_Ischemic_Stroke();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest NoAntithromboticDischarge)
 		{
@@ -365,7 +365,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};
@@ -388,8 +388,8 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest Pharmacological)
 		{
@@ -446,7 +446,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_9_000
 				CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};

--- a/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.9.000")]
 public class DischargedonAntithromboticTherapyFHIR_0_9_000
 {

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -118,28 +118,28 @@ public class FHIRHelpers_4_3_000
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(null, w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(null, y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, null, true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, null, false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
 
 						return ad_;
 					}
@@ -261,11 +261,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -330,11 +330,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else if (b_())
 			{
@@ -379,7 +379,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((ratio is null))
 			{
-				return null;
+				return default(CqlRatio);
 			}
 			else
 			{
@@ -403,7 +403,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((coding is null))
 			{
-				return null;
+				return default(CqlCode);
 			}
 			else
 			{
@@ -431,7 +431,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((concept is null))
 			{
-				return null;
+				return default(CqlConcept);
 			}
 			else
 			{
@@ -461,7 +461,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((uri is null))
 			{
-				return null;
+				return default(CqlValueSet);
 			}
 			else
 			{
@@ -485,7 +485,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((reference is null))
 			{
-				return null;
+				return default(ResourceReference);
 			}
 			else
 			{

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -118,28 +118,28 @@ public class FHIRHelpers_4_3_000
 					if (c_())
 					{
 						CqlQuantity w_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default(CqlQuantity), w_, true, false);
+						CqlInterval<CqlQuantity> x_ = context.Operators.Interval(default, w_, true, false);
 
 						return x_;
 					}
 					else if (d_())
 					{
 						CqlQuantity y_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default(CqlQuantity), y_, true, true);
+						CqlInterval<CqlQuantity> z_ = context.Operators.Interval(default, y_, true, true);
 
 						return z_;
 					}
 					else if (e_())
 					{
 						CqlQuantity aa_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default(CqlQuantity), true, true);
+						CqlInterval<CqlQuantity> ab_ = context.Operators.Interval(aa_, default, true, true);
 
 						return ab_;
 					}
 					else if (f_())
 					{
 						CqlQuantity ac_ = this.ToQuantityIgnoringComparator(quantity);
-						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default(CqlQuantity), false, true);
+						CqlInterval<CqlQuantity> ad_ = context.Operators.Interval(ac_, default, false, true);
 
 						return ad_;
 					}
@@ -261,11 +261,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -330,11 +330,11 @@ public class FHIRHelpers_4_3_000
 			};
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if ((quantity?.ValueElement is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else if (b_())
 			{
@@ -379,7 +379,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((ratio is null))
 			{
-				return default(CqlRatio);
+				return default;
 			}
 			else
 			{
@@ -403,7 +403,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((coding is null))
 			{
-				return default(CqlCode);
+				return default;
 			}
 			else
 			{
@@ -431,7 +431,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((concept is null))
 			{
-				return default(CqlConcept);
+				return default;
 			}
 			else
 			{
@@ -461,7 +461,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((uri is null))
 			{
-				return default(CqlValueSet);
+				return default;
 			}
 			else
 			{
@@ -485,7 +485,7 @@ public class FHIRHelpers_4_3_000
 		{
 			if ((reference is null))
 			{
-				return default(ResourceReference);
+				return default;
 			}
 			else
 			{

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIRHelpers", "4.3.000")]
 public class FHIRHelpers_4_3_000
 {

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -100,7 +100,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -108,7 +108,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Audiology_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", default(string));
 
     [CqlDeclaration("Audiology Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066")]
@@ -116,7 +116,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Audiology_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -124,7 +124,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default(string));
 
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
@@ -132,7 +132,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Discharge_Services_Nursing_Facility.Value;
 
 	private CqlValueSet Falls_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", default(string));
 
     [CqlDeclaration("Falls Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028")]
@@ -140,7 +140,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Falls_Screening.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -148,7 +148,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -156,7 +156,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -164,7 +164,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -172,7 +172,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -180,7 +180,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -188,7 +188,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default(string));
 
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
@@ -196,7 +196,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Physical_Therapy_Evaluation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -204,7 +204,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -212,7 +212,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -220,7 +220,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -229,8 +229,8 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FallsScreeningForFutureFallRiskFHIR-0.1.000", "Measurement Period", c_);
 
@@ -243,7 +243,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -300,48 +300,48 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Discharge_Services_Nursing_Facility();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Audiology_Visit();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
 		CqlValueSet af_ = this.Telephone_Visits();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
 		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
 		CqlValueSet aj_ = this.Online_Assessments();
-		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, null);
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default(PropertyInfo));
 		CqlValueSet al_ = this.Physical_Therapy_Evaluation();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
 		CqlValueSet ap_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, null);
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default(PropertyInfo));
 		IEnumerable<Encounter> ar_ = context.Operators.Union<Encounter>(ao_, aq_);
 		IEnumerable<Encounter> as_ = Status_1_6_000.Finished_Encounter(ar_);
 		bool? at_(Encounter ValidEncounter)
@@ -410,7 +410,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Falls_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation FallsScreening)
 		{

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -100,7 +100,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -108,7 +108,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Audiology_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066", default);
 
     [CqlDeclaration("Audiology Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1066")]
@@ -116,7 +116,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Audiology_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -124,7 +124,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default);
 
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
@@ -132,7 +132,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Discharge_Services_Nursing_Facility.Value;
 
 	private CqlValueSet Falls_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028", default);
 
     [CqlDeclaration("Falls Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1028")]
@@ -140,7 +140,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Falls_Screening.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -148,7 +148,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -156,7 +156,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default);
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -164,7 +164,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -172,7 +172,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -180,7 +180,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -188,7 +188,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default);
 
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
@@ -196,7 +196,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Physical_Therapy_Evaluation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -204,7 +204,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -212,7 +212,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -220,7 +220,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -229,8 +229,8 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FallsScreeningForFutureFallRiskFHIR-0.1.000", "Measurement Period", c_);
 
@@ -243,7 +243,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -300,48 +300,48 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Discharge_Services_Nursing_Facility();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Audiology_Visit();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
 		CqlValueSet af_ = this.Telephone_Visits();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default);
 		IEnumerable<Encounter> ah_ = context.Operators.Union<Encounter>(ae_, ag_);
 		IEnumerable<Encounter> ai_ = context.Operators.Union<Encounter>(ac_, ah_);
 		CqlValueSet aj_ = this.Online_Assessments();
-		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default(PropertyInfo));
+		IEnumerable<Encounter> ak_ = context.Operators.RetrieveByValueSet<Encounter>(aj_, default);
 		CqlValueSet al_ = this.Physical_Therapy_Evaluation();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default);
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = context.Operators.Union<Encounter>(ai_, an_);
 		CqlValueSet ap_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default(PropertyInfo));
+		IEnumerable<Encounter> aq_ = context.Operators.RetrieveByValueSet<Encounter>(ap_, default);
 		IEnumerable<Encounter> ar_ = context.Operators.Union<Encounter>(ao_, aq_);
 		IEnumerable<Encounter> as_ = Status_1_6_000.Finished_Encounter(ar_);
 		bool? at_(Encounter ValidEncounter)
@@ -410,7 +410,7 @@ public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Falls_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation FallsScreening)
 		{

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FallsScreeningForFutureFallRiskFHIR", "0.1.000")]
 public class FallsScreeningForFutureFallRiskFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR", "0.1.000")]
 public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -166,7 +166,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", default(string));
 
     [CqlDeclaration("Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003")]
@@ -174,7 +174,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Ambulatory.Value;
 
 	private CqlValueSet Atomoxetine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", default(string));
 
     [CqlDeclaration("Atomoxetine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170")]
@@ -182,7 +182,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Atomoxetine.Value;
 
 	private CqlValueSet Behavioral_Health_Follow_up_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", default(string));
 
     [CqlDeclaration("Behavioral Health Follow up Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054")]
@@ -190,7 +190,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Behavioral_Health_Follow_up_Visit.Value;
 
 	private CqlValueSet Clonidine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", default(string));
 
     [CqlDeclaration("Clonidine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171")]
@@ -198,7 +198,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Clonidine.Value;
 
 	private CqlValueSet Dexmethylphenidate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", default(string));
 
     [CqlDeclaration("Dexmethylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172")]
@@ -206,7 +206,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Dexmethylphenidate.Value;
 
 	private CqlValueSet Dextroamphetamine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", default(string));
 
     [CqlDeclaration("Dextroamphetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173")]
@@ -214,7 +214,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Dextroamphetamine.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -222,7 +222,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Guanfacine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", default(string));
 
     [CqlDeclaration("Guanfacine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252")]
@@ -230,7 +230,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Guanfacine.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -238,7 +238,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -246,7 +246,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Lisdexamfetamine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", default(string));
 
     [CqlDeclaration("Lisdexamfetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174")]
@@ -254,7 +254,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Lisdexamfetamine.Value;
 
 	private CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", default(string));
 
     [CqlDeclaration("Mental Behavioral and Neurodevelopmental Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203")]
@@ -262,7 +262,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Mental_Behavioral_and_Neurodevelopmental_Disorders.Value;
 
 	private CqlValueSet Methylphenidate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", default(string));
 
     [CqlDeclaration("Methylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176")]
@@ -270,7 +270,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Methylphenidate.Value;
 
 	private CqlValueSet Narcolepsy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", default(string));
 
     [CqlDeclaration("Narcolepsy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011")]
@@ -278,7 +278,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Narcolepsy.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -286,7 +286,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -294,7 +294,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -302,7 +302,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -310,7 +310,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -318,7 +318,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -326,7 +326,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -334,7 +334,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -342,7 +342,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -350,7 +350,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychotherapy_and_Pharmacologic_Management_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", default(string));
 
     [CqlDeclaration("Psychotherapy and Pharmacologic Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055")]
@@ -358,7 +358,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psychotherapy_and_Pharmacologic_Management.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -366,14 +366,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value() => 
-		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("24 HR dexmethylphenidate hydrochloride 40 MG Extended Release Oral Capsule")]
 	public CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule() => 
 		___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule.Value;
 
 	private CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value() => 
-		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("methamphetamine hydrochloride 5 MG Oral Tablet")]
 	public CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet() => 
@@ -382,8 +382,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private CqlCode[] RXNORM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
 		];
 
 		return a_;
@@ -395,8 +395,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000", "Measurement Period", c_);
 
@@ -409,7 +409,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -468,44 +468,44 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<(CqlDate startDate, nint _)?> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value()
 	{
 		CqlValueSet a_ = this.Atomoxetine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Clonidine();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.Dexmethylphenidate();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		CqlValueSet r_ = this.Dextroamphetamine();
-		IEnumerable<MedicationRequest> s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> v_ = context.Operators.Union<MedicationRequest>(s_, u_);
 		IEnumerable<MedicationRequest> w_ = context.Operators.Union<MedicationRequest>(q_, v_);
 		CqlValueSet x_ = this.Lisdexamfetamine();
-		IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		IEnumerable<MedicationRequest> aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(y_, aa_);
 		IEnumerable<MedicationRequest> ac_ = context.Operators.Union<MedicationRequest>(w_, ab_);
 		CqlCode ad_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 		IEnumerable<CqlCode> ae_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, null);
+		IEnumerable<MedicationRequest> af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, default(PropertyInfo));
 		IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, null);
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> aj_ = context.Operators.Union<MedicationRequest>(af_, ai_);
 		IEnumerable<MedicationRequest> ak_ = context.Operators.Union<MedicationRequest>(ac_, aj_);
 		CqlValueSet al_ = this.Methylphenidate();
-		IEnumerable<MedicationRequest> am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		IEnumerable<MedicationRequest> ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(am_, ao_);
 		IEnumerable<MedicationRequest> aq_ = context.Operators.Union<MedicationRequest>(ak_, ap_);
 		CqlValueSet ar_ = this.Guanfacine();
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
 		IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(aq_, av_);
 		bool? ax_(MedicationRequest ADHDMedications)
@@ -514,42 +514,42 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlDate dg_ = context.Operators.Start(df_);
 			CqlDateTime dh_ = context.Operators.ConvertDateToDateTime(dg_);
 			CqlInterval<CqlDateTime> di_ = this.Intake_Period();
-			bool? dj_ = context.Operators.In<CqlDateTime>(dh_, di_, null);
+			bool? dj_ = context.Operators.In<CqlDateTime>(dh_, di_, default(string));
 
 			return dj_;
 		};
 		IEnumerable<MedicationRequest> ay_ = context.Operators.Where<MedicationRequest>(aw_, ax_);
-		IEnumerable<MedicationRequest> ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(ba_, bc_);
-		IEnumerable<MedicationRequest> bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bi_ = context.Operators.Union<MedicationRequest>(bf_, bh_);
 		IEnumerable<MedicationRequest> bj_ = context.Operators.Union<MedicationRequest>(bd_, bi_);
-		IEnumerable<MedicationRequest> bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		IEnumerable<MedicationRequest> bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bo_ = context.Operators.Union<MedicationRequest>(bl_, bn_);
 		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bj_, bo_);
-		IEnumerable<MedicationRequest> br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
-		IEnumerable<MedicationRequest> bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, null);
+		IEnumerable<MedicationRequest> br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bu_ = context.Operators.Union<MedicationRequest>(br_, bt_);
 		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bp_, bu_);
-		IEnumerable<MedicationRequest> bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
-		IEnumerable<MedicationRequest> bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+		IEnumerable<MedicationRequest> bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> ca_ = context.Operators.Union<MedicationRequest>(bx_, bz_);
 		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(bv_, ca_);
 		IEnumerable<CqlCode> cd_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, null);
+		IEnumerable<MedicationRequest> ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, default(PropertyInfo));
 		IEnumerable<CqlCode> cg_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, null);
+		IEnumerable<MedicationRequest> ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> ci_ = context.Operators.Union<MedicationRequest>(ce_, ch_);
 		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cb_, ci_);
-		IEnumerable<MedicationRequest> cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
-		IEnumerable<MedicationRequest> cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, null);
+		IEnumerable<MedicationRequest> cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> co_ = context.Operators.Union<MedicationRequest>(cl_, cn_);
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cj_, co_);
-		IEnumerable<MedicationRequest> cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		IEnumerable<MedicationRequest> ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cu_ = context.Operators.Union<MedicationRequest>(cr_, ct_);
 		IEnumerable<MedicationRequest> cv_ = context.Operators.Union<MedicationRequest>(cp_, cu_);
 		bool? cw_(MedicationRequest ADHDMedications)
@@ -558,7 +558,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlDate dl_ = context.Operators.Start(dk_);
 			CqlDateTime dm_ = context.Operators.ConvertDateToDateTime(dl_);
 			CqlInterval<CqlDateTime> dn_ = this.Intake_Period();
-			bool? do_ = context.Operators.In<CqlDateTime>(dm_, dn_, null);
+			bool? do_ = context.Operators.In<CqlDateTime>(dm_, dn_, default(string));
 
 			return do_;
 		};
@@ -566,44 +566,44 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<MedicationRequest> cy_(MedicationRequest ADHDMedicationOrder)
 		{
 			CqlValueSet dp_ = this.Atomoxetine();
-			IEnumerable<MedicationRequest> dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
-			IEnumerable<MedicationRequest> ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, null);
+			IEnumerable<MedicationRequest> dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> dt_ = context.Operators.Union<MedicationRequest>(dq_, ds_);
 			CqlValueSet du_ = this.Clonidine();
-			IEnumerable<MedicationRequest> dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
-			IEnumerable<MedicationRequest> dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, null);
+			IEnumerable<MedicationRequest> dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> dy_ = context.Operators.Union<MedicationRequest>(dv_, dx_);
 			IEnumerable<MedicationRequest> dz_ = context.Operators.Union<MedicationRequest>(dt_, dy_);
 			CqlValueSet ea_ = this.Dexmethylphenidate();
-			IEnumerable<MedicationRequest> eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
-			IEnumerable<MedicationRequest> ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, null);
+			IEnumerable<MedicationRequest> eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> ee_ = context.Operators.Union<MedicationRequest>(eb_, ed_);
 			IEnumerable<MedicationRequest> ef_ = context.Operators.Union<MedicationRequest>(dz_, ee_);
 			CqlValueSet eg_ = this.Dextroamphetamine();
-			IEnumerable<MedicationRequest> eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
-			IEnumerable<MedicationRequest> ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, null);
+			IEnumerable<MedicationRequest> eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> ek_ = context.Operators.Union<MedicationRequest>(eh_, ej_);
 			IEnumerable<MedicationRequest> el_ = context.Operators.Union<MedicationRequest>(ef_, ek_);
 			CqlValueSet em_ = this.Lisdexamfetamine();
-			IEnumerable<MedicationRequest> en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
-			IEnumerable<MedicationRequest> ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, null);
+			IEnumerable<MedicationRequest> en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> eq_ = context.Operators.Union<MedicationRequest>(en_, ep_);
 			IEnumerable<MedicationRequest> er_ = context.Operators.Union<MedicationRequest>(el_, eq_);
 			CqlCode es_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 			IEnumerable<CqlCode> et_ = context.Operators.ToList<CqlCode>(es_);
-			IEnumerable<MedicationRequest> eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, null);
+			IEnumerable<MedicationRequest> eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, default(PropertyInfo));
 			IEnumerable<CqlCode> ew_ = context.Operators.ToList<CqlCode>(es_);
-			IEnumerable<MedicationRequest> ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, null);
+			IEnumerable<MedicationRequest> ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> ey_ = context.Operators.Union<MedicationRequest>(eu_, ex_);
 			IEnumerable<MedicationRequest> ez_ = context.Operators.Union<MedicationRequest>(er_, ey_);
 			CqlValueSet fa_ = this.Methylphenidate();
-			IEnumerable<MedicationRequest> fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
-			IEnumerable<MedicationRequest> fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, null);
+			IEnumerable<MedicationRequest> fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> fe_ = context.Operators.Union<MedicationRequest>(fb_, fd_);
 			IEnumerable<MedicationRequest> ff_ = context.Operators.Union<MedicationRequest>(ez_, fe_);
 			CqlValueSet fg_ = this.Guanfacine();
-			IEnumerable<MedicationRequest> fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
-			IEnumerable<MedicationRequest> fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, null);
+			IEnumerable<MedicationRequest> fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> fk_ = context.Operators.Union<MedicationRequest>(fh_, fj_);
 			IEnumerable<MedicationRequest> fl_ = context.Operators.Union<MedicationRequest>(ff_, fk_);
 			bool? fm_(MedicationRequest ActiveADHDMedication)
@@ -619,7 +619,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 				CqlDateTime fz_ = context.Operators.ConvertDateToDateTime(fy_);
 				CqlDate ga_ = context.Operators.DateFrom(fz_);
 				CqlInterval<CqlDate> gb_ = context.Operators.Interval(fw_, ga_, true, false);
-				bool? gc_ = context.Operators.Overlaps(fq_, gb_, null);
+				bool? gc_ = context.Operators.Overlaps(fq_, gb_, default(string));
 
 				return gc_;
 			};
@@ -697,14 +697,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		bool? l_(Encounter ValidEncounters)
@@ -757,7 +757,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? j_(Condition C)
 			{
 				Id m_ = C?.IdElement;
@@ -783,7 +783,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter InpatientStay)
 		{
 			IEnumerable<Condition> e_ = this.PrincipalDiagnosis(InpatientStay);
@@ -889,14 +889,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Condition> Narcolepsy_Exclusion_Value()
 	{
 		CqlValueSet a_ = this.Narcolepsy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Narcolepsy)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Narcolepsy);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -926,20 +926,20 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Numerator_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Behavioral_Health_Follow_up_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Psychotherapy_and_Pharmacologic_Management();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		bool? p_(Encounter PsychPharmManagement)
 		{
 			List<Encounter.LocationComponent> ao_ = PsychPharmManagement?.Location;
@@ -969,25 +969,25 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(k_, r_);
 		CqlValueSet t_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		CqlValueSet v_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		CqlValueSet ab_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default(PropertyInfo));
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
 		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
 		CqlValueSet af_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
 		CqlValueSet ah_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default(PropertyInfo));
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
 		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
 		CqlValueSet al_ = this.Telephone_Visits();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 
 		return an_;
@@ -1040,8 +1040,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value()
 	{
 		CqlValueSet a_ = this.Atomoxetine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? f_(MedicationRequest AtomoxetineMed)
 		{
@@ -1076,8 +1076,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> m_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(k_, l_);
 		IEnumerable<CqlInterval<CqlDate>> n_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(m_);
 		CqlValueSet o_ = this.Clonidine();
-		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
-		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, null);
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? t_(MedicationRequest ClonidineMed)
 		{
@@ -1113,8 +1113,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> ab_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(aa_);
 		IEnumerable<CqlInterval<CqlDate>> ac_ = context.Operators.Union<CqlInterval<CqlDate>>(n_, ab_);
 		CqlValueSet ad_ = this.Dexmethylphenidate();
-		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
-		IEnumerable<MedicationRequest> ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(ae_, ag_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? ai_(MedicationRequest DexmethylphenidateMed)
 		{
@@ -1149,8 +1149,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> ap_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(an_, ao_);
 		IEnumerable<CqlInterval<CqlDate>> aq_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ap_);
 		CqlValueSet ar_ = this.Dextroamphetamine();
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
-		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, null);
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? aw_(MedicationRequest DextroamphetamineMed)
 		{
@@ -1187,8 +1187,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> bf_ = context.Operators.Union<CqlInterval<CqlDate>>(aq_, be_);
 		IEnumerable<CqlInterval<CqlDate>> bg_ = context.Operators.Union<CqlInterval<CqlDate>>(ac_, bf_);
 		CqlValueSet bh_ = this.Lisdexamfetamine();
-		IEnumerable<MedicationRequest> bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
-		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, null);
+		IEnumerable<MedicationRequest> bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bl_ = context.Operators.Union<MedicationRequest>(bi_, bk_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? bm_(MedicationRequest LisdexamfetamineMed)
 		{
@@ -1223,8 +1223,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> bt_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(br_, bs_);
 		IEnumerable<CqlInterval<CqlDate>> bu_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bt_);
 		CqlValueSet bv_ = this.Methylphenidate();
-		IEnumerable<MedicationRequest> bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
-		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, null);
+		IEnumerable<MedicationRequest> bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bz_ = context.Operators.Union<MedicationRequest>(bw_, by_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? ca_(MedicationRequest MethylphenidateMed)
 		{
@@ -1261,8 +1261,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> cj_ = context.Operators.Union<CqlInterval<CqlDate>>(bu_, ci_);
 		IEnumerable<CqlInterval<CqlDate>> ck_ = context.Operators.Union<CqlInterval<CqlDate>>(bg_, cj_);
 		CqlValueSet cl_ = this.Guanfacine();
-		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? cq_(MedicationRequest GuanfacineMed)
 		{
@@ -1298,9 +1298,9 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> cy_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(cx_);
 		CqlCode cz_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 		IEnumerable<CqlCode> da_ = context.Operators.ToList<CqlCode>(cz_);
-		IEnumerable<MedicationRequest> db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, null);
+		IEnumerable<MedicationRequest> db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, default(PropertyInfo));
 		IEnumerable<CqlCode> dd_ = context.Operators.ToList<CqlCode>(cz_);
-		IEnumerable<MedicationRequest> de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, null);
+		IEnumerable<MedicationRequest> de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(db_, de_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? dg_(MedicationRequest MethamphetamineMed)
 		{
@@ -1511,7 +1511,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter OnlineAssessment)
 		{
 			Period g_ = OnlineAssessment?.Period;

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000.g.cs
@@ -166,7 +166,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003", default);
 
     [CqlDeclaration("Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1003")]
@@ -174,7 +174,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Ambulatory.Value;
 
 	private CqlValueSet Atomoxetine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170", default);
 
     [CqlDeclaration("Atomoxetine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1170")]
@@ -182,7 +182,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Atomoxetine.Value;
 
 	private CqlValueSet Behavioral_Health_Follow_up_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054", default);
 
     [CqlDeclaration("Behavioral Health Follow up Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1054")]
@@ -190,7 +190,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Behavioral_Health_Follow_up_Visit.Value;
 
 	private CqlValueSet Clonidine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171", default);
 
     [CqlDeclaration("Clonidine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1171")]
@@ -198,7 +198,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Clonidine.Value;
 
 	private CqlValueSet Dexmethylphenidate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172", default);
 
     [CqlDeclaration("Dexmethylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1172")]
@@ -206,7 +206,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Dexmethylphenidate.Value;
 
 	private CqlValueSet Dextroamphetamine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173", default);
 
     [CqlDeclaration("Dextroamphetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1173")]
@@ -214,7 +214,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Dextroamphetamine.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -222,7 +222,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Guanfacine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252", default);
 
     [CqlDeclaration("Guanfacine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.11.1252")]
@@ -230,7 +230,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Guanfacine.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -238,7 +238,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Initial_Hospital_Observation_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002", default);
 
     [CqlDeclaration("Initial Hospital Observation Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1002")]
@@ -246,7 +246,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Initial_Hospital_Observation_Care.Value;
 
 	private CqlValueSet Lisdexamfetamine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174", default);
 
     [CqlDeclaration("Lisdexamfetamine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1174")]
@@ -254,7 +254,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Lisdexamfetamine.Value;
 
 	private CqlValueSet Mental_Behavioral_and_Neurodevelopmental_Disorders_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203", default);
 
     [CqlDeclaration("Mental Behavioral and Neurodevelopmental Disorders")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1203")]
@@ -262,7 +262,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Mental_Behavioral_and_Neurodevelopmental_Disorders.Value;
 
 	private CqlValueSet Methylphenidate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176", default);
 
     [CqlDeclaration("Methylphenidate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1176")]
@@ -270,7 +270,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Methylphenidate.Value;
 
 	private CqlValueSet Narcolepsy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011", default);
 
     [CqlDeclaration("Narcolepsy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.114.12.1011")]
@@ -278,7 +278,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Narcolepsy.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -286,7 +286,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -294,7 +294,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -302,7 +302,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default);
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -310,7 +310,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -318,7 +318,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -326,7 +326,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -334,7 +334,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default);
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -342,7 +342,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default);
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -350,7 +350,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychotherapy_and_Pharmacologic_Management_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055", default);
 
     [CqlDeclaration("Psychotherapy and Pharmacologic Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1055")]
@@ -358,7 +358,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Psychotherapy_and_Pharmacologic_Management.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -366,14 +366,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule_Value() => 
-		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("24 HR dexmethylphenidate hydrochloride 40 MG Extended Release Oral Capsule")]
 	public CqlCode _24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule() => 
 		___24_HR_dexmethylphenidate_hydrochloride_40_MG_Extended_Release_Oral_Capsule.Value;
 
 	private CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet_Value() => 
-		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("methamphetamine hydrochloride 5 MG Oral Tablet")]
 	public CqlCode methamphetamine_hydrochloride_5_MG_Oral_Tablet() => 
@@ -382,8 +382,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private CqlCode[] RXNORM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1006608", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("977860", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
 		];
 
 		return a_;
@@ -395,8 +395,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.000", "Measurement Period", c_);
 
@@ -409,7 +409,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -468,44 +468,44 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<(CqlDate startDate, nint _)?> ADHD_Medication_Prescribed_During_Intake_Period_and_Not_Previously_on_ADHD_Medication_Value()
 	{
 		CqlValueSet a_ = this.Atomoxetine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Clonidine();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.Dexmethylphenidate();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		CqlValueSet r_ = this.Dextroamphetamine();
-		IEnumerable<MedicationRequest> s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> s_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default);
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default);
 		IEnumerable<MedicationRequest> v_ = context.Operators.Union<MedicationRequest>(s_, u_);
 		IEnumerable<MedicationRequest> w_ = context.Operators.Union<MedicationRequest>(q_, v_);
 		CqlValueSet x_ = this.Lisdexamfetamine();
-		IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default);
+		IEnumerable<MedicationRequest> aa_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default);
 		IEnumerable<MedicationRequest> ab_ = context.Operators.Union<MedicationRequest>(y_, aa_);
 		IEnumerable<MedicationRequest> ac_ = context.Operators.Union<MedicationRequest>(w_, ab_);
 		CqlCode ad_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 		IEnumerable<CqlCode> ae_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> af_ = context.Operators.RetrieveByCodes<MedicationRequest>(ae_, default);
 		IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByCodes<MedicationRequest>(ah_, default);
 		IEnumerable<MedicationRequest> aj_ = context.Operators.Union<MedicationRequest>(af_, ai_);
 		IEnumerable<MedicationRequest> ak_ = context.Operators.Union<MedicationRequest>(ac_, aj_);
 		CqlValueSet al_ = this.Methylphenidate();
-		IEnumerable<MedicationRequest> am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> am_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default);
+		IEnumerable<MedicationRequest> ao_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default);
 		IEnumerable<MedicationRequest> ap_ = context.Operators.Union<MedicationRequest>(am_, ao_);
 		IEnumerable<MedicationRequest> aq_ = context.Operators.Union<MedicationRequest>(ak_, ap_);
 		CqlValueSet ar_ = this.Guanfacine();
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
 		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
 		IEnumerable<MedicationRequest> aw_ = context.Operators.Union<MedicationRequest>(aq_, av_);
 		bool? ax_(MedicationRequest ADHDMedications)
@@ -514,42 +514,42 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlDate dg_ = context.Operators.Start(df_);
 			CqlDateTime dh_ = context.Operators.ConvertDateToDateTime(dg_);
 			CqlInterval<CqlDateTime> di_ = this.Intake_Period();
-			bool? dj_ = context.Operators.In<CqlDateTime>(dh_, di_, default(string));
+			bool? dj_ = context.Operators.In<CqlDateTime>(dh_, di_, default);
 
 			return dj_;
 		};
 		IEnumerable<MedicationRequest> ay_ = context.Operators.Where<MedicationRequest>(aw_, ax_);
-		IEnumerable<MedicationRequest> ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ba_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> bc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> bd_ = context.Operators.Union<MedicationRequest>(ba_, bc_);
-		IEnumerable<MedicationRequest> bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bf_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> bh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> bi_ = context.Operators.Union<MedicationRequest>(bf_, bh_);
 		IEnumerable<MedicationRequest> bj_ = context.Operators.Union<MedicationRequest>(bd_, bi_);
-		IEnumerable<MedicationRequest> bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
+		IEnumerable<MedicationRequest> bn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
 		IEnumerable<MedicationRequest> bo_ = context.Operators.Union<MedicationRequest>(bl_, bn_);
 		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bj_, bo_);
-		IEnumerable<MedicationRequest> br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> br_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default);
+		IEnumerable<MedicationRequest> bt_ = context.Operators.RetrieveByValueSet<MedicationRequest>(r_, default);
 		IEnumerable<MedicationRequest> bu_ = context.Operators.Union<MedicationRequest>(br_, bt_);
 		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bp_, bu_);
-		IEnumerable<MedicationRequest> bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default);
+		IEnumerable<MedicationRequest> bz_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default);
 		IEnumerable<MedicationRequest> ca_ = context.Operators.Union<MedicationRequest>(bx_, bz_);
 		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(bv_, ca_);
 		IEnumerable<CqlCode> cd_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ce_ = context.Operators.RetrieveByCodes<MedicationRequest>(cd_, default);
 		IEnumerable<CqlCode> cg_ = context.Operators.ToList<CqlCode>(ad_);
-		IEnumerable<MedicationRequest> ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ch_ = context.Operators.RetrieveByCodes<MedicationRequest>(cg_, default);
 		IEnumerable<MedicationRequest> ci_ = context.Operators.Union<MedicationRequest>(ce_, ch_);
 		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cb_, ci_);
-		IEnumerable<MedicationRequest> cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cl_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default);
+		IEnumerable<MedicationRequest> cn_ = context.Operators.RetrieveByValueSet<MedicationRequest>(al_, default);
 		IEnumerable<MedicationRequest> co_ = context.Operators.Union<MedicationRequest>(cl_, cn_);
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cj_, co_);
-		IEnumerable<MedicationRequest> cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cr_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
+		IEnumerable<MedicationRequest> ct_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
 		IEnumerable<MedicationRequest> cu_ = context.Operators.Union<MedicationRequest>(cr_, ct_);
 		IEnumerable<MedicationRequest> cv_ = context.Operators.Union<MedicationRequest>(cp_, cu_);
 		bool? cw_(MedicationRequest ADHDMedications)
@@ -558,7 +558,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 			CqlDate dl_ = context.Operators.Start(dk_);
 			CqlDateTime dm_ = context.Operators.ConvertDateToDateTime(dl_);
 			CqlInterval<CqlDateTime> dn_ = this.Intake_Period();
-			bool? do_ = context.Operators.In<CqlDateTime>(dm_, dn_, default(string));
+			bool? do_ = context.Operators.In<CqlDateTime>(dm_, dn_, default);
 
 			return do_;
 		};
@@ -566,44 +566,44 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<MedicationRequest> cy_(MedicationRequest ADHDMedicationOrder)
 		{
 			CqlValueSet dp_ = this.Atomoxetine();
-			IEnumerable<MedicationRequest> dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> dq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default);
+			IEnumerable<MedicationRequest> ds_ = context.Operators.RetrieveByValueSet<MedicationRequest>(dp_, default);
 			IEnumerable<MedicationRequest> dt_ = context.Operators.Union<MedicationRequest>(dq_, ds_);
 			CqlValueSet du_ = this.Clonidine();
-			IEnumerable<MedicationRequest> dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> dv_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default);
+			IEnumerable<MedicationRequest> dx_ = context.Operators.RetrieveByValueSet<MedicationRequest>(du_, default);
 			IEnumerable<MedicationRequest> dy_ = context.Operators.Union<MedicationRequest>(dv_, dx_);
 			IEnumerable<MedicationRequest> dz_ = context.Operators.Union<MedicationRequest>(dt_, dy_);
 			CqlValueSet ea_ = this.Dexmethylphenidate();
-			IEnumerable<MedicationRequest> eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> eb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default);
+			IEnumerable<MedicationRequest> ed_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ea_, default);
 			IEnumerable<MedicationRequest> ee_ = context.Operators.Union<MedicationRequest>(eb_, ed_);
 			IEnumerable<MedicationRequest> ef_ = context.Operators.Union<MedicationRequest>(dz_, ee_);
 			CqlValueSet eg_ = this.Dextroamphetamine();
-			IEnumerable<MedicationRequest> eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> eh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default);
+			IEnumerable<MedicationRequest> ej_ = context.Operators.RetrieveByValueSet<MedicationRequest>(eg_, default);
 			IEnumerable<MedicationRequest> ek_ = context.Operators.Union<MedicationRequest>(eh_, ej_);
 			IEnumerable<MedicationRequest> el_ = context.Operators.Union<MedicationRequest>(ef_, ek_);
 			CqlValueSet em_ = this.Lisdexamfetamine();
-			IEnumerable<MedicationRequest> en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> en_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default);
+			IEnumerable<MedicationRequest> ep_ = context.Operators.RetrieveByValueSet<MedicationRequest>(em_, default);
 			IEnumerable<MedicationRequest> eq_ = context.Operators.Union<MedicationRequest>(en_, ep_);
 			IEnumerable<MedicationRequest> er_ = context.Operators.Union<MedicationRequest>(el_, eq_);
 			CqlCode es_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 			IEnumerable<CqlCode> et_ = context.Operators.ToList<CqlCode>(es_);
-			IEnumerable<MedicationRequest> eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> eu_ = context.Operators.RetrieveByCodes<MedicationRequest>(et_, default);
 			IEnumerable<CqlCode> ew_ = context.Operators.ToList<CqlCode>(es_);
-			IEnumerable<MedicationRequest> ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> ex_ = context.Operators.RetrieveByCodes<MedicationRequest>(ew_, default);
 			IEnumerable<MedicationRequest> ey_ = context.Operators.Union<MedicationRequest>(eu_, ex_);
 			IEnumerable<MedicationRequest> ez_ = context.Operators.Union<MedicationRequest>(er_, ey_);
 			CqlValueSet fa_ = this.Methylphenidate();
-			IEnumerable<MedicationRequest> fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> fb_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default);
+			IEnumerable<MedicationRequest> fd_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fa_, default);
 			IEnumerable<MedicationRequest> fe_ = context.Operators.Union<MedicationRequest>(fb_, fd_);
 			IEnumerable<MedicationRequest> ff_ = context.Operators.Union<MedicationRequest>(ez_, fe_);
 			CqlValueSet fg_ = this.Guanfacine();
-			IEnumerable<MedicationRequest> fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> fh_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default);
+			IEnumerable<MedicationRequest> fj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(fg_, default);
 			IEnumerable<MedicationRequest> fk_ = context.Operators.Union<MedicationRequest>(fh_, fj_);
 			IEnumerable<MedicationRequest> fl_ = context.Operators.Union<MedicationRequest>(ff_, fk_);
 			bool? fm_(MedicationRequest ActiveADHDMedication)
@@ -619,7 +619,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 				CqlDateTime fz_ = context.Operators.ConvertDateToDateTime(fy_);
 				CqlDate ga_ = context.Operators.DateFrom(fz_);
 				CqlInterval<CqlDate> gb_ = context.Operators.Interval(fw_, ga_, true, false);
-				bool? gc_ = context.Operators.Overlaps(fq_, gb_, default(string));
+				bool? gc_ = context.Operators.Overlaps(fq_, gb_, default);
 
 				return gc_;
 			};
@@ -697,14 +697,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		bool? l_(Encounter ValidEncounters)
@@ -757,7 +757,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<Encounter.DiagnosisComponent> c_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)a_, b_);
 		Condition d_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? j_(Condition C)
 			{
 				Id m_ = C?.IdElement;
@@ -783,7 +783,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Inpatient_Stay_with_Qualifying_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter InpatientStay)
 		{
 			IEnumerable<Condition> e_ = this.PrincipalDiagnosis(InpatientStay);
@@ -889,14 +889,14 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Condition> Narcolepsy_Exclusion_Value()
 	{
 		CqlValueSet a_ = this.Narcolepsy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Narcolepsy)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Narcolepsy);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -926,20 +926,20 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Numerator_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Initial_Hospital_Observation_Care();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Behavioral_Health_Follow_up_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Psychotherapy_and_Pharmacologic_Management();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		bool? p_(Encounter PsychPharmManagement)
 		{
 			List<Encounter.LocationComponent> ao_ = PsychPharmManagement?.Location;
@@ -969,25 +969,25 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(m_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(k_, r_);
 		CqlValueSet t_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		CqlValueSet v_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default);
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		CqlValueSet z_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		CqlValueSet ab_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default(PropertyInfo));
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default);
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
 		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
 		CqlValueSet af_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default);
 		CqlValueSet ah_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default(PropertyInfo));
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default);
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
 		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
 		CqlValueSet al_ = this.Telephone_Visits();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default);
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 
 		return an_;
@@ -1040,8 +1040,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<CqlInterval<CqlDate>> ADHD_Medications_Taken_on_IPSD_or_During_Continuation_and_Maintenance_Phase_Value()
 	{
 		CqlValueSet a_ = this.Atomoxetine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? f_(MedicationRequest AtomoxetineMed)
 		{
@@ -1076,8 +1076,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> m_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(k_, l_);
 		IEnumerable<CqlInterval<CqlDate>> n_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(m_);
 		CqlValueSet o_ = this.Clonidine();
-		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> p_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default);
+		IEnumerable<MedicationRequest> r_ = context.Operators.RetrieveByValueSet<MedicationRequest>(o_, default);
 		IEnumerable<MedicationRequest> s_ = context.Operators.Union<MedicationRequest>(p_, r_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? t_(MedicationRequest ClonidineMed)
 		{
@@ -1113,8 +1113,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> ab_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(aa_);
 		IEnumerable<CqlInterval<CqlDate>> ac_ = context.Operators.Union<CqlInterval<CqlDate>>(n_, ab_);
 		CqlValueSet ad_ = this.Dexmethylphenidate();
-		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default);
+		IEnumerable<MedicationRequest> ag_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, default);
 		IEnumerable<MedicationRequest> ah_ = context.Operators.Union<MedicationRequest>(ae_, ag_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? ai_(MedicationRequest DexmethylphenidateMed)
 		{
@@ -1149,8 +1149,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> ap_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(an_, ao_);
 		IEnumerable<CqlInterval<CqlDate>> aq_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(ap_);
 		CqlValueSet ar_ = this.Dextroamphetamine();
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
+		IEnumerable<MedicationRequest> au_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ar_, default);
 		IEnumerable<MedicationRequest> av_ = context.Operators.Union<MedicationRequest>(as_, au_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? aw_(MedicationRequest DextroamphetamineMed)
 		{
@@ -1187,8 +1187,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> bf_ = context.Operators.Union<CqlInterval<CqlDate>>(aq_, be_);
 		IEnumerable<CqlInterval<CqlDate>> bg_ = context.Operators.Union<CqlInterval<CqlDate>>(ac_, bf_);
 		CqlValueSet bh_ = this.Lisdexamfetamine();
-		IEnumerable<MedicationRequest> bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bi_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default);
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bh_, default);
 		IEnumerable<MedicationRequest> bl_ = context.Operators.Union<MedicationRequest>(bi_, bk_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? bm_(MedicationRequest LisdexamfetamineMed)
 		{
@@ -1223,8 +1223,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> bt_ = context.Operators.Select<(CqlInterval<CqlDate> period, CqlDate periodStart)?, CqlInterval<CqlDate>>(br_, bs_);
 		IEnumerable<CqlInterval<CqlDate>> bu_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(bt_);
 		CqlValueSet bv_ = this.Methylphenidate();
-		IEnumerable<MedicationRequest> bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default);
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bv_, default);
 		IEnumerable<MedicationRequest> bz_ = context.Operators.Union<MedicationRequest>(bw_, by_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? ca_(MedicationRequest MethylphenidateMed)
 		{
@@ -1261,8 +1261,8 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> cj_ = context.Operators.Union<CqlInterval<CqlDate>>(bu_, ci_);
 		IEnumerable<CqlInterval<CqlDate>> ck_ = context.Operators.Union<CqlInterval<CqlDate>>(bg_, cj_);
 		CqlValueSet cl_ = this.Guanfacine();
-		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default);
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default);
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? cq_(MedicationRequest GuanfacineMed)
 		{
@@ -1298,9 +1298,9 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 		IEnumerable<CqlInterval<CqlDate>> cy_ = CumulativeMedicationDuration_4_0_000.RolloutIntervals(cx_);
 		CqlCode cz_ = this.methamphetamine_hydrochloride_5_MG_Oral_Tablet();
 		IEnumerable<CqlCode> da_ = context.Operators.ToList<CqlCode>(cz_);
-		IEnumerable<MedicationRequest> db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> db_ = context.Operators.RetrieveByCodes<MedicationRequest>(da_, default);
 		IEnumerable<CqlCode> dd_ = context.Operators.ToList<CqlCode>(cz_);
-		IEnumerable<MedicationRequest> de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> de_ = context.Operators.RetrieveByCodes<MedicationRequest>(dd_, default);
 		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(db_, de_);
 		(CqlInterval<CqlDate> period, CqlDate periodStart)? dg_(MedicationRequest MethamphetamineMed)
 		{
@@ -1511,7 +1511,7 @@ public class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_000
 	private IEnumerable<CqlDate> Online_Assessment_31_to_300_Days_into_Continuation_and_Maintenance_Phase_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter OnlineAssessment)
 		{
 			Period g_ = OnlineAssessment?.Period;

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FunctionalStatusAssessmentforTotalHipReplacementFHIR", "0.0.008")]
 public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 {

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -192,7 +192,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -200,7 +200,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -208,7 +208,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Ethnicity.Value;
 
 	private CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", default(string));
 
     [CqlDeclaration("Lower Body Fractures Excluding Ankle and Foot")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178")]
@@ -216,7 +216,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Lower_Body_Fractures_Excluding_Ankle_and_Foot.Value;
 
 	private CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", default(string));
 
     [CqlDeclaration("Malignant Neoplasms of Lower and Unspecified Limbs")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180")]
@@ -224,7 +224,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs.Value;
 
 	private CqlValueSet Mechanical_Complications_Excluding_Upper_Body_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", default(string));
 
     [CqlDeclaration("Mechanical Complications Excluding Upper Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182")]
@@ -232,7 +232,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Mechanical_Complications_Excluding_Upper_Body.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -240,7 +240,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Office_Visit.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -248,7 +248,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -256,7 +256,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -264,7 +264,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Partial_Arthroplasty_of_Hip_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", default(string));
 
     [CqlDeclaration("Partial Arthroplasty of Hip")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184")]
@@ -272,7 +272,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Partial_Arthroplasty_of_Hip.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -280,7 +280,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Payer.Value;
 
 	private CqlValueSet Primary_THA_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", default(string));
 
     [CqlDeclaration("Primary THA Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006")]
@@ -288,7 +288,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Primary_THA_Procedure.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -296,7 +296,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Race.Value;
 
 	private CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", default(string));
 
     [CqlDeclaration("Removal, Revision and Supplement Procedures of the Lower Body and Spine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189")]
@@ -304,7 +304,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -312,140 +312,140 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Telephone_Visits.Value;
 
 	private CqlCode Activities_of_daily_living_score__HOOS__Value() => 
-		new CqlCode("72095-3", "http://loinc.org", null, null);
+		new CqlCode("72095-3", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Activities of daily living score [HOOS]")]
 	public CqlCode Activities_of_daily_living_score__HOOS_() => 
 		__Activities_of_daily_living_score__HOOS_.Value;
 
 	private CqlCode Dead__finding__Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", null, null);
+		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Pain_score__HOOS__Value() => 
-		new CqlCode("72097-9", "http://loinc.org", null, null);
+		new CqlCode("72097-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Pain score [HOOS]")]
 	public CqlCode Pain_score__HOOS_() => 
 		__Pain_score__HOOS_.Value;
 
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
-		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
-		new CqlCode("71969-0", "http://loinc.org", null, null);
+		new CqlCode("71969-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
-		new CqlCode("71971-6", "http://loinc.org", null, null);
+		new CqlCode("71971-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
 	private CqlCode Quality_of_life_score__HOOS__Value() => 
-		new CqlCode("72093-8", "http://loinc.org", null, null);
+		new CqlCode("72093-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Quality of life score [HOOS]")]
 	public CqlCode Quality_of_life_score__HOOS_() => 
 		__Quality_of_life_score__HOOS_.Value;
 
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
-		new CqlCode("702956004", "http://snomed.info/sct", null, null);
+		new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
 	private CqlCode Sport_recreation_score__HOOS__Value() => 
-		new CqlCode("72094-6", "http://loinc.org", null, null);
+		new CqlCode("72094-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Sport-recreation score [HOOS]")]
 	public CqlCode Sport_recreation_score__HOOS_() => 
 		__Sport_recreation_score__HOOS_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode Symptoms_score__HOOS__Value() => 
-		new CqlCode("72096-1", "http://loinc.org", null, null);
+		new CqlCode("72096-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Symptoms score [HOOS]")]
 	public CqlCode Symptoms_score__HOOS_() => 
 		__Symptoms_score__HOOS_.Value;
 
 	private CqlCode Total_interval_score__HOOSJR__Value() => 
-		new CqlCode("82323-7", "http://loinc.org", null, null);
+		new CqlCode("82323-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Total interval score [HOOSJR]")]
 	public CqlCode Total_interval_score__HOOSJR_() => 
 		__Total_interval_score__HOOSJR_.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72026-8", "http://loinc.org", null, null);
+		new CqlCode("72026-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72028-4", "http://loinc.org", null, null);
+		new CqlCode("72028-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72025-0", "http://loinc.org", null, null);
+		new CqlCode("72025-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72027-6", "http://loinc.org", null, null);
+		new CqlCode("72027-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -454,19 +454,19 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("72095-3", "http://loinc.org", null, null),
-			new CqlCode("45755-6", "http://loinc.org", null, null),
-			new CqlCode("72097-9", "http://loinc.org", null, null),
-			new CqlCode("71969-0", "http://loinc.org", null, null),
-			new CqlCode("71971-6", "http://loinc.org", null, null),
-			new CqlCode("72093-8", "http://loinc.org", null, null),
-			new CqlCode("72094-6", "http://loinc.org", null, null),
-			new CqlCode("72096-1", "http://loinc.org", null, null),
-			new CqlCode("82323-7", "http://loinc.org", null, null),
-			new CqlCode("72026-8", "http://loinc.org", null, null),
-			new CqlCode("72028-4", "http://loinc.org", null, null),
-			new CqlCode("72025-0", "http://loinc.org", null, null),
-			new CqlCode("72027-6", "http://loinc.org", null, null),
+			new CqlCode("72095-3", "http://loinc.org", default(string), default(string)),
+			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72097-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71969-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71971-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72093-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72094-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72096-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("82323-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72026-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72028-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72025-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72027-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -479,7 +479,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -504,11 +504,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("702956004", "http://snomed.info/sct", null, null),
-			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -521,7 +521,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", null, null),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default(string), default(string)),
 		];
 
 		return a_;
@@ -533,8 +533,8 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008", "Measurement Period", c_);
 
@@ -547,7 +547,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -620,11 +620,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Office_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
-		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? g_(Encounter E)
 		{
 			List<CodeableConcept> t_ = E?.Type;
@@ -650,11 +650,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		};
 		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 		CqlValueSet i_ = this.Telephone_Visits();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, null);
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Online_Assessments();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
 		IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(l_, n_);
 		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter ValidEncounters)
@@ -715,7 +715,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Primary_THA_Procedure();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure THAProcedure)
 		{
@@ -778,12 +778,12 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Severe_cognitive_impairment__finding_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		bool? d_(Condition Dementia)
 		{
 			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.Overlaps(g_, h_, null);
+			bool? i_ = context.Operators.Overlaps(g_, h_, default(string));
 
 			return i_;
 		};
@@ -803,7 +803,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot();
-			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
 			bool? g_(Condition LowerBodyFracture)
 			{
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(LowerBodyFracture);
@@ -818,7 +818,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
 				CqlDateTime v_ = context.Operators.Start(u_);
 				CqlInterval<CqlDateTime> w_ = context.Operators.Interval(r_, v_, true, true);
-				bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, null);
+				bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, default(string));
 				object z_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval(z_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
@@ -847,7 +847,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Partial_Hip_Arthroplasty_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		IEnumerable<Procedure> d_(Procedure PartialTHAProcedure)
 		{
@@ -887,7 +887,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine();
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
 			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure RevisionTHAProcedure)
 			{
@@ -921,7 +921,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition MalignantNeoplasm)
 		{
 			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
@@ -931,7 +931,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType l_ = THAProcedure?.Performed;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.Overlaps(k_, n_, null);
+				bool? o_ = context.Operators.Overlaps(k_, n_, default(string));
 
 				return o_;
 			};
@@ -955,7 +955,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Mechanical_Complication_Value()
 	{
 		CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition MechanicalComplications)
 		{
 			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
@@ -965,7 +965,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType l_ = THAProcedure?.Performed;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.Overlaps(k_, n_, null);
+				bool? o_ = context.Operators.Overlaps(k_, n_, default(string));
 
 				return o_;
 			};
@@ -992,7 +992,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Primary_THA_Procedure();
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, null);
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
 			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure ElectiveTHAProcedure)
 			{
@@ -1105,23 +1105,23 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Quality_of_life_score__HOOS_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
 		CqlCode e_ = this.Sport_recreation_score__HOOS_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.isAssessmentPerformed(g_);
 		CqlCode i_ = this.Activities_of_daily_living_score__HOOS_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
 		IEnumerable<Observation> l_ = Status_1_6_000.isAssessmentPerformed(k_);
 		CqlCode m_ = this.Symptoms_score__HOOS_();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
 		IEnumerable<Observation> p_ = Status_1_6_000.isAssessmentPerformed(o_);
 		CqlCode q_ = this.Pain_score__HOOS_();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
 		IEnumerable<Observation> t_ = Status_1_6_000.isAssessmentPerformed(s_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation>> u_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_);
 		(Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)? v_(ValueTuple<Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -1336,7 +1336,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Total_interval_score__HOOSJR_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation HOOSJr)
 		{
 			DataType h_ = HOOSJr?.Value;
@@ -1453,10 +1453,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		CqlCode d_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
@@ -1607,10 +1607,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
@@ -1761,10 +1761,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -192,7 +192,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -200,7 +200,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -208,7 +208,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Ethnicity.Value;
 
 	private CqlValueSet Lower_Body_Fractures_Excluding_Ankle_and_Foot_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178", default);
 
     [CqlDeclaration("Lower Body Fractures Excluding Ankle and Foot")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1178")]
@@ -216,7 +216,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Lower_Body_Fractures_Excluding_Ankle_and_Foot.Value;
 
 	private CqlValueSet Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180", default);
 
     [CqlDeclaration("Malignant Neoplasms of Lower and Unspecified Limbs")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1180")]
@@ -224,7 +224,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs.Value;
 
 	private CqlValueSet Mechanical_Complications_Excluding_Upper_Body_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182", default);
 
     [CqlDeclaration("Mechanical Complications Excluding Upper Body")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1182")]
@@ -232,7 +232,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Mechanical_Complications_Excluding_Upper_Body.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -240,7 +240,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Office_Visit.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -248,7 +248,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -256,7 +256,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -264,7 +264,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Partial_Arthroplasty_of_Hip_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184", default);
 
     [CqlDeclaration("Partial Arthroplasty of Hip")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1184")]
@@ -272,7 +272,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Partial_Arthroplasty_of_Hip.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -280,7 +280,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Payer.Value;
 
 	private CqlValueSet Primary_THA_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006", default);
 
     [CqlDeclaration("Primary THA Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1006")]
@@ -288,7 +288,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Primary_THA_Procedure.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -296,7 +296,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Race.Value;
 
 	private CqlValueSet Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189", default);
 
     [CqlDeclaration("Removal, Revision and Supplement Procedures of the Lower Body and Spine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1189")]
@@ -304,7 +304,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -312,140 +312,140 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		__Telephone_Visits.Value;
 
 	private CqlCode Activities_of_daily_living_score__HOOS__Value() => 
-		new CqlCode("72095-3", "http://loinc.org", default(string), default(string));
+		new CqlCode("72095-3", "http://loinc.org", default, default);
 
     [CqlDeclaration("Activities of daily living score [HOOS]")]
 	public CqlCode Activities_of_daily_living_score__HOOS_() => 
 		__Activities_of_daily_living_score__HOOS_.Value;
 
 	private CqlCode Dead__finding__Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("45755-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Pain_score__HOOS__Value() => 
-		new CqlCode("72097-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("72097-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Pain score [HOOS]")]
 	public CqlCode Pain_score__HOOS_() => 
 		__Pain_score__HOOS_.Value;
 
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
-		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
-		new CqlCode("71969-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("71969-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
-		new CqlCode("71971-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("71971-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
 	private CqlCode Quality_of_life_score__HOOS__Value() => 
-		new CqlCode("72093-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("72093-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Quality of life score [HOOS]")]
 	public CqlCode Quality_of_life_score__HOOS_() => 
 		__Quality_of_life_score__HOOS_.Value;
 
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
-		new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("702956004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
 	private CqlCode Sport_recreation_score__HOOS__Value() => 
-		new CqlCode("72094-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("72094-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Sport-recreation score [HOOS]")]
 	public CqlCode Sport_recreation_score__HOOS_() => 
 		__Sport_recreation_score__HOOS_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode Symptoms_score__HOOS__Value() => 
-		new CqlCode("72096-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("72096-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Symptoms score [HOOS]")]
 	public CqlCode Symptoms_score__HOOS_() => 
 		__Symptoms_score__HOOS_.Value;
 
 	private CqlCode Total_interval_score__HOOSJR__Value() => 
-		new CqlCode("82323-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("82323-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("Total interval score [HOOSJR]")]
 	public CqlCode Total_interval_score__HOOSJR_() => 
 		__Total_interval_score__HOOSJR_.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72026-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("72026-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72028-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("72028-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72025-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("72025-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72027-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("72027-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("373066001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -454,19 +454,19 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("72095-3", "http://loinc.org", default(string), default(string)),
-			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72097-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71969-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71971-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72093-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72094-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72096-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("82323-7", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72026-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72028-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72025-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72027-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72095-3", "http://loinc.org", default, default),
+			new CqlCode("45755-6", "http://loinc.org", default, default),
+			new CqlCode("72097-9", "http://loinc.org", default, default),
+			new CqlCode("71969-0", "http://loinc.org", default, default),
+			new CqlCode("71971-6", "http://loinc.org", default, default),
+			new CqlCode("72093-8", "http://loinc.org", default, default),
+			new CqlCode("72094-6", "http://loinc.org", default, default),
+			new CqlCode("72096-1", "http://loinc.org", default, default),
+			new CqlCode("82323-7", "http://loinc.org", default, default),
+			new CqlCode("72026-8", "http://loinc.org", default, default),
+			new CqlCode("72028-4", "http://loinc.org", default, default),
+			new CqlCode("72025-0", "http://loinc.org", default, default),
+			new CqlCode("72027-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -479,7 +479,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -504,11 +504,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("702956004", "http://snomed.info/sct", default, default),
+			new CqlCode("373066001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -521,7 +521,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/v3-ObservationCategory", default, default),
 		];
 
 		return a_;
@@ -533,8 +533,8 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008", "Measurement Period", c_);
 
@@ -547,7 +547,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -620,11 +620,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Office_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
-		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? g_(Encounter E)
 		{
 			List<CodeableConcept> t_ = E?.Type;
@@ -650,11 +650,11 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		};
 		IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
 		CqlValueSet i_ = this.Telephone_Visits();
-		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default(PropertyInfo));
+		IEnumerable<Encounter> j_ = context.Operators.RetrieveByValueSet<Encounter>(i_, default);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(h_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Online_Assessments();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default);
 		IEnumerable<Encounter> o_ = context.Operators.Union<Encounter>(l_, n_);
 		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter ValidEncounters)
@@ -715,7 +715,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private IEnumerable<Procedure> Total_Hip_Arthroplasty_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Primary_THA_Procedure();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure THAProcedure)
 		{
@@ -778,12 +778,12 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Severe_cognitive_impairment__finding_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		bool? d_(Condition Dementia)
 		{
 			CqlInterval<CqlDateTime> g_ = QICoreCommon_2_0_000.prevalenceInterval(Dementia);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.Overlaps(g_, h_, default(string));
+			bool? i_ = context.Operators.Overlaps(g_, h_, default);
 
 			return i_;
 		};
@@ -803,7 +803,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Lower_Body_Fractures_Excluding_Ankle_and_Foot();
-			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
+			IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default);
 			bool? g_(Condition LowerBodyFracture)
 			{
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(LowerBodyFracture);
@@ -818,7 +818,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
 				CqlDateTime v_ = context.Operators.Start(u_);
 				CqlInterval<CqlDateTime> w_ = context.Operators.Interval(r_, v_, true, true);
-				bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, default(string));
+				bool? x_ = context.Operators.In<CqlDateTime>(l_, w_, default);
 				object z_ = FHIRHelpers_4_3_000.ToValue(m_);
 				CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.toInterval(z_);
 				CqlDateTime ab_ = context.Operators.Start(aa_);
@@ -847,7 +847,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Partial_Hip_Arthroplasty_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Partial_Arthroplasty_of_Hip();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		IEnumerable<Procedure> d_(Procedure PartialTHAProcedure)
 		{
@@ -887,7 +887,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Removal__Revision_and_Supplement_Procedures_of_the_Lower_Body_and_Spine();
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default);
 			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure RevisionTHAProcedure)
 			{
@@ -921,7 +921,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Malignant_Neoplasm_of_Lower_and_Unspecified_Limbs_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasms_of_Lower_and_Unspecified_Limbs();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition MalignantNeoplasm)
 		{
 			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
@@ -931,7 +931,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType l_ = THAProcedure?.Performed;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.Overlaps(k_, n_, default(string));
+				bool? o_ = context.Operators.Overlaps(k_, n_, default);
 
 				return o_;
 			};
@@ -955,7 +955,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	private bool? Has_Mechanical_Complication_Value()
 	{
 		CqlValueSet a_ = this.Mechanical_Complications_Excluding_Upper_Body();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition MechanicalComplications)
 		{
 			IEnumerable<Procedure> f_ = this.Total_Hip_Arthroplasty_Procedure();
@@ -965,7 +965,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 				DataType l_ = THAProcedure?.Performed;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.Overlaps(k_, n_, default(string));
+				bool? o_ = context.Operators.Overlaps(k_, n_, default);
 
 				return o_;
 			};
@@ -992,7 +992,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 		IEnumerable<Procedure> b_(Procedure THAProcedure)
 		{
 			CqlValueSet e_ = this.Primary_THA_Procedure();
-			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default(PropertyInfo));
+			IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(e_, default);
 			IEnumerable<Procedure> g_ = Status_1_6_000.isProcedurePerformed(f_);
 			bool? h_(Procedure ElectiveTHAProcedure)
 			{
@@ -1105,23 +1105,23 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Quality_of_life_score__HOOS_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
 		CqlCode e_ = this.Sport_recreation_score__HOOS_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.isAssessmentPerformed(g_);
 		CqlCode i_ = this.Activities_of_daily_living_score__HOOS_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default);
 		IEnumerable<Observation> l_ = Status_1_6_000.isAssessmentPerformed(k_);
 		CqlCode m_ = this.Symptoms_score__HOOS_();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default);
 		IEnumerable<Observation> p_ = Status_1_6_000.isAssessmentPerformed(o_);
 		CqlCode q_ = this.Pain_score__HOOS_();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default);
 		IEnumerable<Observation> t_ = Status_1_6_000.isAssessmentPerformed(s_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation>> u_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_);
 		(Observation HOOSLifeQuality, Observation HOOSSport, Observation HOOSActivityScore, Observation HOOSSymptoms, Observation HOOSPain)? v_(ValueTuple<Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -1336,7 +1336,7 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.Total_interval_score__HOOSJR_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation HOOSJr)
 		{
 			DataType h_ = HOOSJr?.Value;
@@ -1453,10 +1453,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		CqlCode d_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
@@ -1607,10 +1607,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{
@@ -1761,10 +1761,10 @@ public class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		CqlCode d_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+		IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 		IEnumerable<ValueTuple<Observation, Observation>> g_ = context.Operators.CrossJoin<Observation, Observation>(c_, f_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? h_(ValueTuple<Observation, Observation> _valueTuple)
 		{

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FunctionalStatusAssessmentsforHeartFailureFHIR", "0.1.000")]
 public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -182,7 +182,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Heart_Failure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default(string));
 
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
@@ -190,7 +190,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Heart_Failure.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -198,7 +198,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -206,7 +206,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -214,210 +214,210 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Emotional_score__MLHFQ__Value() => 
-		new CqlCode("85609-6", "http://loinc.org", null, null);
+		new CqlCode("85609-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Emotional score [MLHFQ]")]
 	public CqlCode Emotional_score__MLHFQ_() => 
 		__Emotional_score__MLHFQ_.Value;
 
 	private CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value() => 
-		new CqlCode("86923-0", "http://loinc.org", null, null);
+		new CqlCode("86923-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Kansas City Cardiomyopathy Questionnaire - 12 item [KCCQ-12]")]
 	public CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_() => 
 		__Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_.Value;
 
 	private CqlCode Overall_summary_score__KCCQ_12__Value() => 
-		new CqlCode("86924-8", "http://loinc.org", null, null);
+		new CqlCode("86924-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Overall summary score [KCCQ-12]")]
 	public CqlCode Overall_summary_score__KCCQ_12_() => 
 		__Overall_summary_score__KCCQ_12_.Value;
 
 	private CqlCode Overall_summary_score__KCCQ__Value() => 
-		new CqlCode("71940-1", "http://loinc.org", null, null);
+		new CqlCode("71940-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Overall summary score [KCCQ]")]
 	public CqlCode Overall_summary_score__KCCQ_() => 
 		__Overall_summary_score__KCCQ_.Value;
 
 	private CqlCode Physical_limitation_score__KCCQ__Value() => 
-		new CqlCode("72195-1", "http://loinc.org", null, null);
+		new CqlCode("72195-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Physical limitation score [KCCQ]")]
 	public CqlCode Physical_limitation_score__KCCQ_() => 
 		__Physical_limitation_score__KCCQ_.Value;
 
 	private CqlCode Physical_score__MLHFQ__Value() => 
-		new CqlCode("85618-7", "http://loinc.org", null, null);
+		new CqlCode("85618-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Physical score [MLHFQ]")]
 	public CqlCode Physical_score__MLHFQ_() => 
 		__Physical_score__MLHFQ_.Value;
 
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
-		new CqlCode("71969-0", "http://loinc.org", null, null);
+		new CqlCode("71969-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
-		new CqlCode("71971-6", "http://loinc.org", null, null);
+		new CqlCode("71971-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
 	private CqlCode PROMIS_29_Anxiety_score_T_score_Value() => 
-		new CqlCode("71967-4", "http://loinc.org", null, null);
+		new CqlCode("71967-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Anxiety score T-score")]
 	public CqlCode PROMIS_29_Anxiety_score_T_score() => 
 		__PROMIS_29_Anxiety_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Depression_score_T_score_Value() => 
-		new CqlCode("71965-8", "http://loinc.org", null, null);
+		new CqlCode("71965-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Depression score T-score")]
 	public CqlCode PROMIS_29_Depression_score_T_score() => 
 		__PROMIS_29_Depression_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Fatigue_score_T_score_Value() => 
-		new CqlCode("71963-3", "http://loinc.org", null, null);
+		new CqlCode("71963-3", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Fatigue score T-score")]
 	public CqlCode PROMIS_29_Fatigue_score_T_score() => 
 		__PROMIS_29_Fatigue_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Pain_interference_score_T_score_Value() => 
-		new CqlCode("71961-7", "http://loinc.org", null, null);
+		new CqlCode("71961-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Pain interference score T-score")]
 	public CqlCode PROMIS_29_Pain_interference_score_T_score() => 
 		__PROMIS_29_Pain_interference_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Physical_function_score_T_score_Value() => 
-		new CqlCode("71959-1", "http://loinc.org", null, null);
+		new CqlCode("71959-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Physical function score T-score")]
 	public CqlCode PROMIS_29_Physical_function_score_T_score() => 
 		__PROMIS_29_Physical_function_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value() => 
-		new CqlCode("71957-5", "http://loinc.org", null, null);
+		new CqlCode("71957-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Satisfaction with participation in social roles score T-score")]
 	public CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score() => 
 		__PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Sleep_disturbance_score_T_score_Value() => 
-		new CqlCode("71955-9", "http://loinc.org", null, null);
+		new CqlCode("71955-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("PROMIS-29 Sleep disturbance score T-score")]
 	public CqlCode PROMIS_29_Sleep_disturbance_score_T_score() => 
 		__PROMIS_29_Sleep_disturbance_score_T_score.Value;
 
 	private CqlCode Quality_of_life_score__KCCQ__Value() => 
-		new CqlCode("72189-4", "http://loinc.org", null, null);
+		new CqlCode("72189-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Quality of life score [KCCQ]")]
 	public CqlCode Quality_of_life_score__KCCQ_() => 
 		__Quality_of_life_score__KCCQ_.Value;
 
 	private CqlCode Self_efficacy_score__KCCQ__Value() => 
-		new CqlCode("72190-2", "http://loinc.org", null, null);
+		new CqlCode("72190-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Self-efficacy score [KCCQ]")]
 	public CqlCode Self_efficacy_score__KCCQ_() => 
 		__Self_efficacy_score__KCCQ_.Value;
 
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
-		new CqlCode("702956004", "http://snomed.info/sct", null, null);
+		new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
 	private CqlCode Social_limitation_score__KCCQ__Value() => 
-		new CqlCode("72196-9", "http://loinc.org", null, null);
+		new CqlCode("72196-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Social limitation score [KCCQ]")]
 	public CqlCode Social_limitation_score__KCCQ_() => 
 		__Social_limitation_score__KCCQ_.Value;
 
 	private CqlCode Symptom_stability_score__KCCQ__Value() => 
-		new CqlCode("72194-4", "http://loinc.org", null, null);
+		new CqlCode("72194-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Symptom stability score [KCCQ]")]
 	public CqlCode Symptom_stability_score__KCCQ_() => 
 		__Symptom_stability_score__KCCQ_.Value;
 
 	private CqlCode Total_score__MLHFQ__Value() => 
-		new CqlCode("71938-5", "http://loinc.org", null, null);
+		new CqlCode("71938-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Total score [MLHFQ]")]
 	public CqlCode Total_score__MLHFQ_() => 
 		__Total_score__MLHFQ_.Value;
 
 	private CqlCode Total_symptom_score__KCCQ__Value() => 
-		new CqlCode("72191-0", "http://loinc.org", null, null);
+		new CqlCode("72191-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Total symptom score [KCCQ]")]
 	public CqlCode Total_symptom_score__KCCQ_() => 
 		__Total_symptom_score__KCCQ_.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72026-8", "http://loinc.org", null, null);
+		new CqlCode("72026-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72028-4", "http://loinc.org", null, null);
+		new CqlCode("72028-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72025-0", "http://loinc.org", null, null);
+		new CqlCode("72025-0", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72027-6", "http://loinc.org", null, null);
+		new CqlCode("72027-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("71990-6", "http://loinc.org", null, null);
+		new CqlCode("71990-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72008-6", "http://loinc.org", null, null);
+		new CqlCode("72008-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("71989-8", "http://loinc.org", null, null);
+		new CqlCode("71989-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_36_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72007-8", "http://loinc.org", null, null);
+		new CqlCode("72007-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
@@ -426,35 +426,35 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("85609-6", "http://loinc.org", null, null),
-			new CqlCode("86923-0", "http://loinc.org", null, null),
-			new CqlCode("86924-8", "http://loinc.org", null, null),
-			new CqlCode("71940-1", "http://loinc.org", null, null),
-			new CqlCode("72195-1", "http://loinc.org", null, null),
-			new CqlCode("85618-7", "http://loinc.org", null, null),
-			new CqlCode("71969-0", "http://loinc.org", null, null),
-			new CqlCode("71971-6", "http://loinc.org", null, null),
-			new CqlCode("71967-4", "http://loinc.org", null, null),
-			new CqlCode("71965-8", "http://loinc.org", null, null),
-			new CqlCode("71963-3", "http://loinc.org", null, null),
-			new CqlCode("71961-7", "http://loinc.org", null, null),
-			new CqlCode("71959-1", "http://loinc.org", null, null),
-			new CqlCode("71957-5", "http://loinc.org", null, null),
-			new CqlCode("71955-9", "http://loinc.org", null, null),
-			new CqlCode("72189-4", "http://loinc.org", null, null),
-			new CqlCode("72190-2", "http://loinc.org", null, null),
-			new CqlCode("72196-9", "http://loinc.org", null, null),
-			new CqlCode("72194-4", "http://loinc.org", null, null),
-			new CqlCode("71938-5", "http://loinc.org", null, null),
-			new CqlCode("72191-0", "http://loinc.org", null, null),
-			new CqlCode("72026-8", "http://loinc.org", null, null),
-			new CqlCode("72028-4", "http://loinc.org", null, null),
-			new CqlCode("72025-0", "http://loinc.org", null, null),
-			new CqlCode("72027-6", "http://loinc.org", null, null),
-			new CqlCode("71990-6", "http://loinc.org", null, null),
-			new CqlCode("72008-6", "http://loinc.org", null, null),
-			new CqlCode("71989-8", "http://loinc.org", null, null),
-			new CqlCode("72007-8", "http://loinc.org", null, null),
+			new CqlCode("85609-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("86923-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("86924-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71940-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72195-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("85618-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71969-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71971-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71967-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71965-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71963-3", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71961-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71959-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71957-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71955-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72189-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72190-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72196-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72194-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71938-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72191-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72026-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72028-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72025-0", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72027-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71990-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72008-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71989-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("72007-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -467,7 +467,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("702956004", "http://snomed.info/sct", null, null),
+			new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -479,8 +479,8 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000", "Measurement Period", c_);
 
@@ -493,7 +493,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -550,12 +550,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Online_Assessments();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
 		IEnumerable<Encounter> i_ = Status_1_6_000.Finished_Encounter(h_);
 		bool? j_(Encounter ValidEncounter)
@@ -628,12 +628,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		CqlValueSet j_ = this.Heart_Failure();
-		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, null);
+		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default(PropertyInfo));
 		bool? l_(Condition HeartFailure)
 		{
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HeartFailure);
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
-			bool? u_ = context.Operators.OverlapsBefore(s_, t_, null);
+			bool? u_ = context.Operators.OverlapsBefore(s_, t_, default(string));
 
 			return u_;
 		};
@@ -667,12 +667,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 		CqlCode b_ = this.Severe_cognitive_impairment__finding_();
 		IEnumerable<CqlCode> c_ = context.Operators.ToList<CqlCode>(b_);
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByCodes<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByCodes<Condition>(c_, default(PropertyInfo));
 		bool? e_(Condition Dementia)
 		{
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dementia);
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
-			bool? k_ = context.Operators.Overlaps(i_, j_, null);
+			bool? k_ = context.Operators.Overlaps(i_, j_, default(string));
 
 			return k_;
 		};
@@ -691,11 +691,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -829,31 +829,31 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.PROMIS_29_Sleep_disturbance_score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		CqlCode i_ = this.PROMIS_29_Physical_function_score_T_score();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
 		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
 		CqlCode m_ = this.PROMIS_29_Pain_interference_score_T_score();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
 		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
 		CqlCode q_ = this.PROMIS_29_Fatigue_score_T_score();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
 		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
 		CqlCode u_ = this.PROMIS_29_Depression_score_T_score();
 		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default(PropertyInfo));
 		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
 		CqlCode y_ = this.PROMIS_29_Anxiety_score_T_score();
 		IEnumerable<CqlCode> z_ = context.Operators.ToList<CqlCode>(y_);
-		IEnumerable<Observation> aa_ = context.Operators.RetrieveByCodes<Observation>(z_, null);
+		IEnumerable<Observation> aa_ = context.Operators.RetrieveByCodes<Observation>(z_, default(PropertyInfo));
 		IEnumerable<Observation> ab_ = Status_1_6_000.Final_Survey_Observation(aa_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>> ac_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_, ab_);
 		(Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)? ad_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -1092,11 +1092,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1230,11 +1230,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1368,11 +1368,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1506,11 +1506,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1644,11 +1644,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Physical_score__MLHFQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Emotional_score__MLHFQ_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation MLHFQPhysical, Observation MLHFQEmotional)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1782,11 +1782,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Overall_summary_score__KCCQ_12_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation KCCQ12Item, Observation KCCQ12Summary)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1920,27 +1920,27 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Quality_of_life_score__KCCQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Symptom_stability_score__KCCQ_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		CqlCode i_ = this.Self_efficacy_score__KCCQ_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
 		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
 		CqlCode m_ = this.Total_symptom_score__KCCQ_();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, null);
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
 		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
 		CqlCode q_ = this.Physical_limitation_score__KCCQ_();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, null);
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
 		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
 		CqlCode u_ = this.Social_limitation_score__KCCQ_();
 		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, null);
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default(PropertyInfo));
 		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>> y_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_);
 		(Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)? z_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -2158,7 +2158,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Overall_summary_score__KCCQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation KCCQSummaryScore)
 		{

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -182,7 +182,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Heart_Failure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376", default);
 
     [CqlDeclaration("Heart Failure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.376")]
@@ -190,7 +190,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Heart_Failure.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -198,7 +198,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -206,7 +206,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -214,210 +214,210 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Emotional_score__MLHFQ__Value() => 
-		new CqlCode("85609-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("85609-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Emotional score [MLHFQ]")]
 	public CqlCode Emotional_score__MLHFQ_() => 
 		__Emotional_score__MLHFQ_.Value;
 
 	private CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12__Value() => 
-		new CqlCode("86923-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("86923-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("Kansas City Cardiomyopathy Questionnaire - 12 item [KCCQ-12]")]
 	public CqlCode Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_() => 
 		__Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_.Value;
 
 	private CqlCode Overall_summary_score__KCCQ_12__Value() => 
-		new CqlCode("86924-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("86924-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Overall summary score [KCCQ-12]")]
 	public CqlCode Overall_summary_score__KCCQ_12_() => 
 		__Overall_summary_score__KCCQ_12_.Value;
 
 	private CqlCode Overall_summary_score__KCCQ__Value() => 
-		new CqlCode("71940-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("71940-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Overall summary score [KCCQ]")]
 	public CqlCode Overall_summary_score__KCCQ_() => 
 		__Overall_summary_score__KCCQ_.Value;
 
 	private CqlCode Physical_limitation_score__KCCQ__Value() => 
-		new CqlCode("72195-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("72195-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Physical limitation score [KCCQ]")]
 	public CqlCode Physical_limitation_score__KCCQ_() => 
 		__Physical_limitation_score__KCCQ_.Value;
 
 	private CqlCode Physical_score__MLHFQ__Value() => 
-		new CqlCode("85618-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("85618-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("Physical score [MLHFQ]")]
 	public CqlCode Physical_score__MLHFQ_() => 
 		__Physical_score__MLHFQ_.Value;
 
 	private CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score_Value() => 
-		new CqlCode("71969-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("71969-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-10 Global Mental Health (GMH) score T-score")]
 	public CqlCode PROMIS_10_Global_Mental_Health__GMH__score_T_score() => 
 		__PROMIS_10_Global_Mental_Health__GMH__score_T_score.Value;
 
 	private CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score_Value() => 
-		new CqlCode("71971-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("71971-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-10 Global Physical Health (GPH) score T-score")]
 	public CqlCode PROMIS_10_Global_Physical_Health__GPH__score_T_score() => 
 		__PROMIS_10_Global_Physical_Health__GPH__score_T_score.Value;
 
 	private CqlCode PROMIS_29_Anxiety_score_T_score_Value() => 
-		new CqlCode("71967-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("71967-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Anxiety score T-score")]
 	public CqlCode PROMIS_29_Anxiety_score_T_score() => 
 		__PROMIS_29_Anxiety_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Depression_score_T_score_Value() => 
-		new CqlCode("71965-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("71965-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Depression score T-score")]
 	public CqlCode PROMIS_29_Depression_score_T_score() => 
 		__PROMIS_29_Depression_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Fatigue_score_T_score_Value() => 
-		new CqlCode("71963-3", "http://loinc.org", default(string), default(string));
+		new CqlCode("71963-3", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Fatigue score T-score")]
 	public CqlCode PROMIS_29_Fatigue_score_T_score() => 
 		__PROMIS_29_Fatigue_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Pain_interference_score_T_score_Value() => 
-		new CqlCode("71961-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("71961-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Pain interference score T-score")]
 	public CqlCode PROMIS_29_Pain_interference_score_T_score() => 
 		__PROMIS_29_Pain_interference_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Physical_function_score_T_score_Value() => 
-		new CqlCode("71959-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("71959-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Physical function score T-score")]
 	public CqlCode PROMIS_29_Physical_function_score_T_score() => 
 		__PROMIS_29_Physical_function_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score_Value() => 
-		new CqlCode("71957-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("71957-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Satisfaction with participation in social roles score T-score")]
 	public CqlCode PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score() => 
 		__PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score.Value;
 
 	private CqlCode PROMIS_29_Sleep_disturbance_score_T_score_Value() => 
-		new CqlCode("71955-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("71955-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("PROMIS-29 Sleep disturbance score T-score")]
 	public CqlCode PROMIS_29_Sleep_disturbance_score_T_score() => 
 		__PROMIS_29_Sleep_disturbance_score_T_score.Value;
 
 	private CqlCode Quality_of_life_score__KCCQ__Value() => 
-		new CqlCode("72189-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("72189-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Quality of life score [KCCQ]")]
 	public CqlCode Quality_of_life_score__KCCQ_() => 
 		__Quality_of_life_score__KCCQ_.Value;
 
 	private CqlCode Self_efficacy_score__KCCQ__Value() => 
-		new CqlCode("72190-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("72190-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("Self-efficacy score [KCCQ]")]
 	public CqlCode Self_efficacy_score__KCCQ_() => 
 		__Self_efficacy_score__KCCQ_.Value;
 
 	private CqlCode Severe_cognitive_impairment__finding__Value() => 
-		new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("702956004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Severe cognitive impairment (finding)")]
 	public CqlCode Severe_cognitive_impairment__finding_() => 
 		__Severe_cognitive_impairment__finding_.Value;
 
 	private CqlCode Social_limitation_score__KCCQ__Value() => 
-		new CqlCode("72196-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("72196-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Social limitation score [KCCQ]")]
 	public CqlCode Social_limitation_score__KCCQ_() => 
 		__Social_limitation_score__KCCQ_.Value;
 
 	private CqlCode Symptom_stability_score__KCCQ__Value() => 
-		new CqlCode("72194-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("72194-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Symptom stability score [KCCQ]")]
 	public CqlCode Symptom_stability_score__KCCQ_() => 
 		__Symptom_stability_score__KCCQ_.Value;
 
 	private CqlCode Total_score__MLHFQ__Value() => 
-		new CqlCode("71938-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("71938-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Total score [MLHFQ]")]
 	public CqlCode Total_score__MLHFQ_() => 
 		__Total_score__MLHFQ_.Value;
 
 	private CqlCode Total_symptom_score__KCCQ__Value() => 
-		new CqlCode("72191-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("72191-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("Total symptom score [KCCQ]")]
 	public CqlCode Total_symptom_score__KCCQ_() => 
 		__Total_symptom_score__KCCQ_.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72026-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("72026-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72028-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("72028-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("72025-0", "http://loinc.org", default(string), default(string));
+		new CqlCode("72025-0", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72027-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("72027-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-12 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
 		__VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("71990-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("71990-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - oblique method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___oblique_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72008-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("72008-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-36 Mental component summary (MCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score() => 
 		__VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score.Value;
 
 	private CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score_Value() => 
-		new CqlCode("71989-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("71989-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - oblique method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___oblique_method_T_score() => 
 		__VR_36_Physical_component_summary__PCS__score___oblique_method_T_score.Value;
 
 	private CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score_Value() => 
-		new CqlCode("72007-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("72007-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("VR-36 Physical component summary (PCS) score - orthogonal method T-score")]
 	public CqlCode VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score() => 
@@ -426,35 +426,35 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("85609-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("86923-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("86924-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71940-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72195-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("85618-7", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71969-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71971-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71967-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71965-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71963-3", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71961-7", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71959-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71957-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71955-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72189-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72190-2", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72196-9", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72194-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71938-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72191-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72026-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72028-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72025-0", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72027-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71990-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72008-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("71989-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("72007-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("85609-6", "http://loinc.org", default, default),
+			new CqlCode("86923-0", "http://loinc.org", default, default),
+			new CqlCode("86924-8", "http://loinc.org", default, default),
+			new CqlCode("71940-1", "http://loinc.org", default, default),
+			new CqlCode("72195-1", "http://loinc.org", default, default),
+			new CqlCode("85618-7", "http://loinc.org", default, default),
+			new CqlCode("71969-0", "http://loinc.org", default, default),
+			new CqlCode("71971-6", "http://loinc.org", default, default),
+			new CqlCode("71967-4", "http://loinc.org", default, default),
+			new CqlCode("71965-8", "http://loinc.org", default, default),
+			new CqlCode("71963-3", "http://loinc.org", default, default),
+			new CqlCode("71961-7", "http://loinc.org", default, default),
+			new CqlCode("71959-1", "http://loinc.org", default, default),
+			new CqlCode("71957-5", "http://loinc.org", default, default),
+			new CqlCode("71955-9", "http://loinc.org", default, default),
+			new CqlCode("72189-4", "http://loinc.org", default, default),
+			new CqlCode("72190-2", "http://loinc.org", default, default),
+			new CqlCode("72196-9", "http://loinc.org", default, default),
+			new CqlCode("72194-4", "http://loinc.org", default, default),
+			new CqlCode("71938-5", "http://loinc.org", default, default),
+			new CqlCode("72191-0", "http://loinc.org", default, default),
+			new CqlCode("72026-8", "http://loinc.org", default, default),
+			new CqlCode("72028-4", "http://loinc.org", default, default),
+			new CqlCode("72025-0", "http://loinc.org", default, default),
+			new CqlCode("72027-6", "http://loinc.org", default, default),
+			new CqlCode("71990-6", "http://loinc.org", default, default),
+			new CqlCode("72008-6", "http://loinc.org", default, default),
+			new CqlCode("71989-8", "http://loinc.org", default, default),
+			new CqlCode("72007-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -467,7 +467,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("702956004", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("702956004", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -479,8 +479,8 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000", "Measurement Period", c_);
 
@@ -493,7 +493,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -550,12 +550,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Online_Assessments();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
 		IEnumerable<Encounter> i_ = Status_1_6_000.Finished_Encounter(h_);
 		bool? j_(Encounter ValidEncounter)
@@ -628,12 +628,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
 		CqlValueSet j_ = this.Heart_Failure();
-		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default(PropertyInfo));
+		IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default);
 		bool? l_(Condition HeartFailure)
 		{
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HeartFailure);
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
-			bool? u_ = context.Operators.OverlapsBefore(s_, t_, default(string));
+			bool? u_ = context.Operators.OverlapsBefore(s_, t_, default);
 
 			return u_;
 		};
@@ -667,12 +667,12 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 		bool? a_ = Hospice_6_9_000.Has_Hospice_Services();
 		CqlCode b_ = this.Severe_cognitive_impairment__finding_();
 		IEnumerable<CqlCode> c_ = context.Operators.ToList<CqlCode>(b_);
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByCodes<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByCodes<Condition>(c_, default);
 		bool? e_(Condition Dementia)
 		{
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Dementia);
 			CqlInterval<CqlDateTime> j_ = this.Measurement_Period();
-			bool? k_ = context.Operators.Overlaps(i_, j_, default(string));
+			bool? k_ = context.Operators.Overlaps(i_, j_, default);
 
 			return k_;
 		};
@@ -691,11 +691,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.PROMIS_10_Global_Mental_Health__GMH__score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.PROMIS_10_Global_Physical_Health__GPH__score_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation PROMIS10MentalScore, Observation PROMIS10PhysicalScore)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -829,31 +829,31 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.PROMIS_29_Sleep_disturbance_score_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.PROMIS_29_Satisfaction_with_participation_in_social_roles_score_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		CqlCode i_ = this.PROMIS_29_Physical_function_score_T_score();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default);
 		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
 		CqlCode m_ = this.PROMIS_29_Pain_interference_score_T_score();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default);
 		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
 		CqlCode q_ = this.PROMIS_29_Fatigue_score_T_score();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default);
 		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
 		CqlCode u_ = this.PROMIS_29_Depression_score_T_score();
 		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default(PropertyInfo));
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default);
 		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
 		CqlCode y_ = this.PROMIS_29_Anxiety_score_T_score();
 		IEnumerable<CqlCode> z_ = context.Operators.ToList<CqlCode>(y_);
-		IEnumerable<Observation> aa_ = context.Operators.RetrieveByCodes<Observation>(z_, default(PropertyInfo));
+		IEnumerable<Observation> aa_ = context.Operators.RetrieveByCodes<Observation>(z_, default);
 		IEnumerable<Observation> ab_ = Status_1_6_000.Final_Survey_Observation(aa_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation>> ac_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_, ab_);
 		(Observation Promis29Sleep, Observation Promis29SocialRoles, Observation Promis29Physical, Observation Promis29Pain, Observation Promis29Fatigue, Observation Promis29Depression, Observation Promis29Anxiety)? ad_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -1092,11 +1092,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1230,11 +1230,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_12_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_12_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR12MentalAssessment, Observation VR12PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1368,11 +1368,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___oblique_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1506,11 +1506,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.VR_36_Mental_component_summary__MCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.VR_36_Physical_component_summary__PCS__score___orthogonal_method_T_score();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation VR36MentalAssessment, Observation VR36PhysicalAssessment)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1644,11 +1644,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Physical_score__MLHFQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Emotional_score__MLHFQ_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation MLHFQPhysical, Observation MLHFQEmotional)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1782,11 +1782,11 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Kansas_City_Cardiomyopathy_Questionnaire___12_item__KCCQ_12_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Overall_summary_score__KCCQ_12_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		IEnumerable<ValueTuple<Observation, Observation>> i_ = context.Operators.CrossJoin<Observation, Observation>(d_, h_);
 		(Observation KCCQ12Item, Observation KCCQ12Summary)? j_(ValueTuple<Observation, Observation> _valueTuple)
@@ -1920,27 +1920,27 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Quality_of_life_score__KCCQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		CqlCode e_ = this.Symptom_stability_score__KCCQ_();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<Observation> h_ = Status_1_6_000.Final_Survey_Observation(g_);
 		CqlCode i_ = this.Self_efficacy_score__KCCQ_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default);
 		IEnumerable<Observation> l_ = Status_1_6_000.Final_Survey_Observation(k_);
 		CqlCode m_ = this.Total_symptom_score__KCCQ_();
 		IEnumerable<CqlCode> n_ = context.Operators.ToList<CqlCode>(m_);
-		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default(PropertyInfo));
+		IEnumerable<Observation> o_ = context.Operators.RetrieveByCodes<Observation>(n_, default);
 		IEnumerable<Observation> p_ = Status_1_6_000.Final_Survey_Observation(o_);
 		CqlCode q_ = this.Physical_limitation_score__KCCQ_();
 		IEnumerable<CqlCode> r_ = context.Operators.ToList<CqlCode>(q_);
-		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default(PropertyInfo));
+		IEnumerable<Observation> s_ = context.Operators.RetrieveByCodes<Observation>(r_, default);
 		IEnumerable<Observation> t_ = Status_1_6_000.Final_Survey_Observation(s_);
 		CqlCode u_ = this.Social_limitation_score__KCCQ_();
 		IEnumerable<CqlCode> v_ = context.Operators.ToList<CqlCode>(u_);
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default(PropertyInfo));
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByCodes<Observation>(v_, default);
 		IEnumerable<Observation> x_ = Status_1_6_000.Final_Survey_Observation(w_);
 		IEnumerable<ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation>> y_ = context.Operators.CrossJoin<Observation, Observation, Observation, Observation, Observation, Observation>(d_, h_, l_, p_, t_, x_);
 		(Observation KCCQLifeQuality, Observation KCCQSymptomStability, Observation KCCQSelfEfficacy, Observation KCCQSymptoms, Observation KCCQPhysicalLimits, Observation KCCQSocialLimits)? z_(ValueTuple<Observation, Observation, Observation, Observation, Observation, Observation> _valueTuple)
@@ -2158,7 +2158,7 @@ public class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000
 	{
 		CqlCode a_ = this.Overall_summary_score__KCCQ_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.Final_Survey_Observation(c_);
 		bool? e_(Observation KCCQSummaryScore)
 		{

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -130,7 +130,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -138,7 +138,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Ethnicity.Value;
 
 	private CqlValueSet Hospital_Dietitian_Referral_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", default(string));
 
     [CqlDeclaration("Hospital Dietitian Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91")]
@@ -146,7 +146,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Hospital_Dietitian_Referral.Value;
 
 	private CqlValueSet Malnutrition_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", default(string));
 
     [CqlDeclaration("Malnutrition Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55")]
@@ -154,7 +154,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Diagnosis.Value;
 
 	private CqlValueSet Malnutrition_Risk_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", default(string));
 
     [CqlDeclaration("Malnutrition Risk Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92")]
@@ -162,7 +162,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Risk_Screening.Value;
 
 	private CqlValueSet Malnutrition_Screening_At_Risk_Result_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", default(string));
 
     [CqlDeclaration("Malnutrition Screening At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38")]
@@ -170,7 +170,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Screening_At_Risk_Result.Value;
 
 	private CqlValueSet Malnutrition_Screening_Not_At_Risk_Result_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", default(string));
 
     [CqlDeclaration("Malnutrition Screening Not At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34")]
@@ -178,7 +178,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Screening_Not_At_Risk_Result.Value;
 
 	private CqlValueSet Nutrition_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", default(string));
 
     [CqlDeclaration("Nutrition Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21")]
@@ -186,7 +186,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", default(string));
 
     [CqlDeclaration("Nutrition Assessment Status Moderately Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44")]
@@ -194,7 +194,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Moderately_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", default(string));
 
     [CqlDeclaration("Nutrition Assessment Status Not or Mildly Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48")]
@@ -202,7 +202,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Not_or_Mildly_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", default(string));
 
     [CqlDeclaration("Nutrition Assessment Status Severely Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42")]
@@ -210,7 +210,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Severely_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Care_Plan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", default(string));
 
     [CqlDeclaration("Nutrition Care Plan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93")]
@@ -218,7 +218,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Care_Plan.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -226,7 +226,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -234,7 +234,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -242,7 +242,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Race.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -251,7 +251,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -287,8 +287,8 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("GlobalMalnutritionCompositeFHIR-0.1.000", "Measurement Period", c_);
 
@@ -301,7 +301,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -358,7 +358,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Period e_ = EncounterInpatient?.Period;
@@ -426,7 +426,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Hospital_Dietitian_Referral();
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		(Encounter QualifyingEncounter, Procedure HospitalDietitianReferral)? e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
@@ -455,7 +455,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
 			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_blodcpfeecjfnodfofhfzlqfa?.QualifyingEncounter);
-			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default(string));
 			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;
@@ -476,7 +476,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -506,7 +506,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -561,7 +561,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -591,7 +591,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -643,7 +643,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -673,7 +673,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -724,7 +724,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -754,7 +754,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -788,7 +788,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -818,7 +818,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -848,7 +848,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -878,7 +878,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -904,7 +904,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Diagnosis();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		(Encounter QualifyingEncounter, Condition MalnutritionDiagnosis)? e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
@@ -922,7 +922,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_gsigyornrkjgexbhejviwntmn?.MalnutritionDiagnosis);
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_gsigyornrkjgexbhejviwntmn?.QualifyingEncounter);
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default(string));
 			bool? t_ = context.Operators.And(o_, s_);
 
 			return t_;
@@ -943,7 +943,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Care_Plan();
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, null);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		(Encounter QualifyingEncounter, Procedure NutritionCarePlan)? e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
@@ -971,7 +971,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
 			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_igutmwhaufjcwzmijcgjeysm?.QualifyingEncounter);
-			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, null);
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default(string));
 			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("GlobalMalnutritionCompositeFHIR", "0.1.000")]
 public class GlobalMalnutritionCompositeFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.1.000.g.cs
@@ -122,7 +122,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -130,7 +130,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -138,7 +138,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Ethnicity.Value;
 
 	private CqlValueSet Hospital_Dietitian_Referral_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91", default);
 
     [CqlDeclaration("Hospital Dietitian Referral")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.91")]
@@ -146,7 +146,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Hospital_Dietitian_Referral.Value;
 
 	private CqlValueSet Malnutrition_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55", default);
 
     [CqlDeclaration("Malnutrition Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.55")]
@@ -154,7 +154,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Diagnosis.Value;
 
 	private CqlValueSet Malnutrition_Risk_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92", default);
 
     [CqlDeclaration("Malnutrition Risk Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.92")]
@@ -162,7 +162,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Risk_Screening.Value;
 
 	private CqlValueSet Malnutrition_Screening_At_Risk_Result_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38", default);
 
     [CqlDeclaration("Malnutrition Screening At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.38")]
@@ -170,7 +170,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Screening_At_Risk_Result.Value;
 
 	private CqlValueSet Malnutrition_Screening_Not_At_Risk_Result_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34", default);
 
     [CqlDeclaration("Malnutrition Screening Not At Risk Result")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.34")]
@@ -178,7 +178,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Malnutrition_Screening_Not_At_Risk_Result.Value;
 
 	private CqlValueSet Nutrition_Assessment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21", default);
 
     [CqlDeclaration("Nutrition Assessment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.21")]
@@ -186,7 +186,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Moderately_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44", default);
 
     [CqlDeclaration("Nutrition Assessment Status Moderately Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.44")]
@@ -194,7 +194,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Moderately_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Not_or_Mildly_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48", default);
 
     [CqlDeclaration("Nutrition Assessment Status Not or Mildly Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.48")]
@@ -202,7 +202,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Not_or_Mildly_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Assessment_Status_Severely_Malnourished_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42", default);
 
     [CqlDeclaration("Nutrition Assessment Status Severely Malnourished")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.42")]
@@ -210,7 +210,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Assessment_Status_Severely_Malnourished.Value;
 
 	private CqlValueSet Nutrition_Care_Plan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93", default);
 
     [CqlDeclaration("Nutrition Care Plan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1095.93")]
@@ -218,7 +218,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Nutrition_Care_Plan.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -226,7 +226,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -234,7 +234,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -242,7 +242,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 		__Race.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -251,7 +251,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -287,8 +287,8 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("GlobalMalnutritionCompositeFHIR-0.1.000", "Measurement Period", c_);
 
@@ -301,7 +301,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -358,7 +358,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Period e_ = EncounterInpatient?.Period;
@@ -426,7 +426,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Hospital_Dietitian_Referral();
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default(PropertyInfo));
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		(Encounter QualifyingEncounter, Procedure HospitalDietitianReferral)? e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
@@ -455,7 +455,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
 			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_blodcpfeecjfnodfofhfzlqfa?.QualifyingEncounter);
-			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default(string));
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default);
 			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;
@@ -476,7 +476,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -506,7 +506,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -561,7 +561,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -591,7 +591,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -643,7 +643,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Risk_Screening();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation MalnutritionRiskScreening)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -673,7 +673,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -724,7 +724,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -754,7 +754,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -788,7 +788,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -818,7 +818,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -848,7 +848,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Assessment();
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByValueSet<Observation>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
 		(Encounter QualifyingEncounter, Observation NutritionAssessment)? e_(ValueTuple<Encounter, Observation> _valueTuple)
 		{
@@ -878,7 +878,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			DataType x_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
 			object y_ = FHIRHelpers_4_3_000.ToValue(x_);
 			CqlInterval<CqlDateTime> z_ = QICoreCommon_2_0_000.toInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, z_, default);
 			bool? ab_ = context.Operators.And(v_, aa_);
 			DataType ac_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Value;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
@@ -904,7 +904,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Malnutrition_Diagnosis();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Condition>> d_ = context.Operators.CrossJoin<Encounter, Condition>(a_, c_);
 		(Encounter QualifyingEncounter, Condition MalnutritionDiagnosis)? e_(ValueTuple<Encounter, Condition> _valueTuple)
 		{
@@ -922,7 +922,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_gsigyornrkjgexbhejviwntmn?.MalnutritionDiagnosis);
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_gsigyornrkjgexbhejviwntmn?.QualifyingEncounter);
-			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default);
 			bool? t_ = context.Operators.And(o_, s_);
 
 			return t_;
@@ -943,7 +943,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 	{
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter();
 		CqlValueSet b_ = this.Nutrition_Care_Plan();
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default(PropertyInfo));
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByValueSet<Procedure>(b_, default);
 		IEnumerable<ValueTuple<Encounter, Procedure>> d_ = context.Operators.CrossJoin<Encounter, Procedure>(a_, c_);
 		(Encounter QualifyingEncounter, Procedure NutritionCarePlan)? e_(ValueTuple<Encounter, Procedure> _valueTuple)
 		{
@@ -971,7 +971,7 @@ public class GlobalMalnutritionCompositeFHIR_0_1_000
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 			CqlDateTime x_ = QICoreCommon_2_0_000.earliest(w_);
 			CqlInterval<CqlDateTime> y_ = CQMCommon_2_0_000.hospitalizationWithObservation(tuple_igutmwhaufjcwzmijcgjeysm?.QualifyingEncounter);
-			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default(string));
+			bool? z_ = context.Operators.In<CqlDateTime>(x_, y_, default);
 			bool? aa_ = context.Operators.And(u_, z_);
 
 			return aa_;

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -124,7 +124,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
     #endregion
 
 	private CqlValueSet Allergy_to_Beta_Blocker_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", default(string));
 
     [CqlDeclaration("Allergy to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177")]
@@ -132,7 +132,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Allergy_to_Beta_Blocker_Therapy.Value;
 
 	private CqlValueSet Arrhythmia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", default(string));
 
     [CqlDeclaration("Arrhythmia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366")]
@@ -140,7 +140,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Arrhythmia.Value;
 
 	private CqlValueSet Asthma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", default(string));
 
     [CqlDeclaration("Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362")]
@@ -148,7 +148,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Asthma.Value;
 
 	private CqlValueSet Atrioventricular_Block_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", default(string));
 
     [CqlDeclaration("Atrioventricular Block")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367")]
@@ -156,7 +156,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Atrioventricular_Block.Value;
 
 	private CqlValueSet Beta_Blocker_Therapy_for_LVSD_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", default(string));
 
     [CqlDeclaration("Beta Blocker Therapy for LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184")]
@@ -164,7 +164,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Beta_Blocker_Therapy_for_LVSD.Value;
 
 	private CqlValueSet Beta_Blocker_Therapy_Ingredient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", default(string));
 
     [CqlDeclaration("Beta Blocker Therapy Ingredient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493")]
@@ -172,7 +172,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Beta_Blocker_Therapy_Ingredient.Value;
 
 	private CqlValueSet Bradycardia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", default(string));
 
     [CqlDeclaration("Bradycardia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412")]
@@ -180,7 +180,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Bradycardia.Value;
 
 	private CqlValueSet Cardiac_Pacer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", default(string));
 
     [CqlDeclaration("Cardiac Pacer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53")]
@@ -188,7 +188,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Cardiac_Pacer.Value;
 
 	private CqlValueSet Cardiac_Pacer_in_Situ_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", default(string));
 
     [CqlDeclaration("Cardiac Pacer in Situ")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368")]
@@ -196,7 +196,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Cardiac_Pacer_in_Situ.Value;
 
 	private CqlValueSet Hypotension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", default(string));
 
     [CqlDeclaration("Hypotension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370")]
@@ -204,7 +204,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Hypotension.Value;
 
 	private CqlValueSet Intolerance_to_Beta_Blocker_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", default(string));
 
     [CqlDeclaration("Intolerance to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178")]
@@ -212,7 +212,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Intolerance_to_Beta_Blocker_Therapy.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default(string));
 
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
@@ -220,7 +220,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -228,7 +228,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -236,7 +236,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Patient_Reason.Value;
 
 	private CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value() => 
-		new CqlCode("373254001", "http://snomed.info/sct", null, null);
+		new CqlCode("373254001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Substance with beta adrenergic receptor antagonist mechanism of action (substance)")]
 	public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_() => 
@@ -245,7 +245,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("373254001", "http://snomed.info/sct", null, null),
+			new CqlCode("373254001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -257,8 +257,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HFBetaBlockerTherapyforLVSDFHIR-1.3.000", "Measurement Period", c_);
 
@@ -271,7 +271,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -341,8 +341,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest BetaBlockerOrdered)
 		{
@@ -384,8 +384,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ActiveBetaBlocker)
 		{
@@ -418,7 +418,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private bool? Has_Consecutive_Heart_Rates_Less_than_50_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Encounter> b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 		IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
 		(Observation HeartRate, Encounter ModerateOrSevereLVSDHFOutpatientEncounter)? d_(ValueTuple<Observation, Encounter> _valueTuple)
@@ -435,7 +435,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 			DataType n_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
 			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
 			Code<ObservationStatus> r_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.StatusElement;
 			ObservationStatus? s_ = r_?.Value;
 			string t_ = context.Operators.Convert<string>(s_);
@@ -452,7 +452,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 			CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
 			bool? ab_ = context.Operators.Less(z_, aa_);
 			bool? ac_ = context.Operators.And(w_, ab_);
-			IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? ae_(Observation MostRecentPriorHeartRate)
 			{
 				Period ap_ = tuple_fufpmqdratbglhghdwfuubanf?.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
@@ -460,13 +460,13 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				DataType ar_ = MostRecentPriorHeartRate?.Effective;
 				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.toInterval(as_);
-				bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, null);
+				bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, default(string));
 				object aw_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlInterval<CqlDateTime> ax_ = QICoreCommon_2_0_000.toInterval(aw_);
 				DataType ay_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
 				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
 				CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.toInterval(az_);
-				bool? bb_ = context.Operators.Before(ax_, ba_, null);
+				bool? bb_ = context.Operators.Before(ax_, ba_, default(string));
 				bool? bc_ = context.Operators.And(au_, bb_);
 
 				return bc_;
@@ -506,7 +506,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value()
 	{
-		IEnumerable<MedicationRequest> a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(null, null);
+		IEnumerable<MedicationRequest> a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<MedicationRequest> b_(MedicationRequest NoBetaBlockerOrdered)
 		{
 			IEnumerable<Encounter> g_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -516,7 +516,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
 				Period n_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, null);
+				bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, default(string));
 
 				return p_;
 			};
@@ -572,7 +572,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Arrhythmia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Arrhythmia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Arrhythmia)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Arrhythmia);
@@ -600,7 +600,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Hypotension_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hypotension();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Hypotension)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Hypotension);
@@ -628,7 +628,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Asthma_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Asthma();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Asthma)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Asthma);
@@ -656,9 +656,9 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value()
 	{
 		CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
 		{
@@ -687,7 +687,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Bradycardia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Bradycardia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Bradycardia)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Bradycardia);
@@ -715,10 +715,10 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient();
-		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
+		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default(PropertyInfo));
 		CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, null);
+		IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, default(PropertyInfo));
 		IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
 		bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
 		{
@@ -747,7 +747,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Atrioventricular_Block_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Atrioventricular_Block();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition AtrioventricularBlock)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(AtrioventricularBlock);
@@ -775,7 +775,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value()
 	{
 		CqlValueSet a_ = this.Cardiac_Pacer_in_Situ();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition CardiacPacerDiagnosis)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((CardiacPacerDiagnosis as object));
@@ -803,7 +803,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Cardiac_Pacer_Device_Implanted_Value()
 	{
 		CqlValueSet a_ = this.Cardiac_Pacer();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
 		{
 			IEnumerable<Encounter> h_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -816,7 +816,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, null);
+				bool? t_ = context.Operators.Before(p_, s_, default(string));
 
 				return t_;
 			};

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HFBetaBlockerTherapyforLVSDFHIR", "1.3.000")]
 public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 {

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.3.000.g.cs
@@ -124,7 +124,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
     #endregion
 
 	private CqlValueSet Allergy_to_Beta_Blocker_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", default);
 
     [CqlDeclaration("Allergy to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177")]
@@ -132,7 +132,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Allergy_to_Beta_Blocker_Therapy.Value;
 
 	private CqlValueSet Arrhythmia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", default);
 
     [CqlDeclaration("Arrhythmia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366")]
@@ -140,7 +140,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Arrhythmia.Value;
 
 	private CqlValueSet Asthma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", default);
 
     [CqlDeclaration("Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362")]
@@ -148,7 +148,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Asthma.Value;
 
 	private CqlValueSet Atrioventricular_Block_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", default);
 
     [CqlDeclaration("Atrioventricular Block")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367")]
@@ -156,7 +156,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Atrioventricular_Block.Value;
 
 	private CqlValueSet Beta_Blocker_Therapy_for_LVSD_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", default);
 
     [CqlDeclaration("Beta Blocker Therapy for LVSD")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184")]
@@ -164,7 +164,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Beta_Blocker_Therapy_for_LVSD.Value;
 
 	private CqlValueSet Beta_Blocker_Therapy_Ingredient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", default);
 
     [CqlDeclaration("Beta Blocker Therapy Ingredient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493")]
@@ -172,7 +172,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Beta_Blocker_Therapy_Ingredient.Value;
 
 	private CqlValueSet Bradycardia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", default);
 
     [CqlDeclaration("Bradycardia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412")]
@@ -180,7 +180,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Bradycardia.Value;
 
 	private CqlValueSet Cardiac_Pacer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", default);
 
     [CqlDeclaration("Cardiac Pacer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53")]
@@ -188,7 +188,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Cardiac_Pacer.Value;
 
 	private CqlValueSet Cardiac_Pacer_in_Situ_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", default);
 
     [CqlDeclaration("Cardiac Pacer in Situ")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368")]
@@ -196,7 +196,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Cardiac_Pacer_in_Situ.Value;
 
 	private CqlValueSet Hypotension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", default);
 
     [CqlDeclaration("Hypotension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370")]
@@ -204,7 +204,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Hypotension.Value;
 
 	private CqlValueSet Intolerance_to_Beta_Blocker_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", default);
 
     [CqlDeclaration("Intolerance to Beta Blocker Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178")]
@@ -212,7 +212,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Intolerance_to_Beta_Blocker_Therapy.Value;
 
 	private CqlValueSet Left_Ventricular_Assist_Device_Placement_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61", default);
 
     [CqlDeclaration("Left Ventricular Assist Device Placement")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.61")]
@@ -220,7 +220,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Left_Ventricular_Assist_Device_Placement.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -228,7 +228,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default);
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -236,7 +236,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 		__Patient_Reason.Value;
 
 	private CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance__Value() => 
-		new CqlCode("373254001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("373254001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Substance with beta adrenergic receptor antagonist mechanism of action (substance)")]
 	public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_() => 
@@ -245,7 +245,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("373254001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("373254001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -257,8 +257,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HFBetaBlockerTherapyforLVSDFHIR-1.3.000", "Measurement Period", c_);
 
@@ -271,7 +271,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -341,8 +341,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest BetaBlockerOrdered)
 		{
@@ -384,8 +384,8 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ActiveBetaBlocker)
 		{
@@ -418,7 +418,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private bool? Has_Consecutive_Heart_Rates_Less_than_50_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Encounter> b_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
 		IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
 		(Observation HeartRate, Encounter ModerateOrSevereLVSDHFOutpatientEncounter)? d_(ValueTuple<Observation, Encounter> _valueTuple)
@@ -435,7 +435,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 			DataType n_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
 			object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 			CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
+			bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default);
 			Code<ObservationStatus> r_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.StatusElement;
 			ObservationStatus? s_ = r_?.Value;
 			string t_ = context.Operators.Convert<string>(s_);
@@ -452,7 +452,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 			CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
 			bool? ab_ = context.Operators.Less(z_, aa_);
 			bool? ac_ = context.Operators.And(w_, ab_);
-			IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? ae_(Observation MostRecentPriorHeartRate)
 			{
 				Period ap_ = tuple_fufpmqdratbglhghdwfuubanf?.ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
@@ -460,13 +460,13 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				DataType ar_ = MostRecentPriorHeartRate?.Effective;
 				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlInterval<CqlDateTime> at_ = QICoreCommon_2_0_000.toInterval(as_);
-				bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, default(string));
+				bool? au_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aq_, at_, default);
 				object aw_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlInterval<CqlDateTime> ax_ = QICoreCommon_2_0_000.toInterval(aw_);
 				DataType ay_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
 				object az_ = FHIRHelpers_4_3_000.ToValue(ay_);
 				CqlInterval<CqlDateTime> ba_ = QICoreCommon_2_0_000.toInterval(az_);
-				bool? bb_ = context.Operators.Before(ax_, ba_, default(string));
+				bool? bb_ = context.Operators.Before(ax_, ba_, default);
 				bool? bc_ = context.Operators.And(au_, bb_);
 
 				return bc_;
@@ -506,7 +506,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 
 	private bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD_Value()
 	{
-		IEnumerable<MedicationRequest> a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<MedicationRequest> a_ = context.Operators.RetrieveByValueSet<MedicationRequest>(default, default);
 		IEnumerable<MedicationRequest> b_(MedicationRequest NoBetaBlockerOrdered)
 		{
 			IEnumerable<Encounter> g_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -516,7 +516,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
 				Period n_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, default(string));
+				bool? p_ = context.Operators.In<CqlDateTime>(m_, o_, default);
 
 				return p_;
 			};
@@ -572,7 +572,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Arrhythmia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Arrhythmia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Arrhythmia)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Arrhythmia);
@@ -600,7 +600,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Hypotension_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hypotension();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Hypotension)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Hypotension);
@@ -628,7 +628,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Asthma_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Asthma();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Asthma)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Asthma);
@@ -656,9 +656,9 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Value()
 	{
 		CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
 		{
@@ -687,7 +687,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Bradycardia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Bradycardia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Bradycardia)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(Bradycardia);
@@ -715,10 +715,10 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_Value()
 	{
 		CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient();
-		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default(PropertyInfo));
+		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default);
 		CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_();
 		IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
-		IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, default(PropertyInfo));
+		IEnumerable<AllergyIntolerance> e_ = context.Operators.RetrieveByCodes<AllergyIntolerance>(d_, default);
 		IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
 		bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
 		{
@@ -747,7 +747,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Atrioventricular_Block_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Atrioventricular_Block();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition AtrioventricularBlock)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsHeartFailureOutpatientEncounter(AtrioventricularBlock);
@@ -775,7 +775,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_Value()
 	{
 		CqlValueSet a_ = this.Cardiac_Pacer_in_Situ();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition CardiacPacerDiagnosis)
 		{
 			bool? f_ = AHAOverall_2_6_000.overlapsAfterHeartFailureOutpatientEncounter((CardiacPacerDiagnosis as object));
@@ -803,7 +803,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 	private bool? Has_Cardiac_Pacer_Device_Implanted_Value()
 	{
 		CqlValueSet a_ = this.Cardiac_Pacer();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
 		{
 			IEnumerable<Encounter> h_ = AHAOverall_2_6_000.Heart_Failure_Outpatient_Encounter_with_History_of_Moderate_or_Severe_LVSD();
@@ -816,7 +816,7 @@ public class HFBetaBlockerTherapyforLVSDFHIR_1_3_000
 				Period q_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_3_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.End(r_);
-				bool? t_ = context.Operators.Before(p_, s_, default(string));
+				bool? t_ = context.Operators.Before(p_, s_, default);
 
 				return t_;
 			};

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class HIVRetentionFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -110,7 +110,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -118,7 +118,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -126,7 +126,7 @@ public class HIVRetentionFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet HIV_Viral_Load_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default(string));
 
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
@@ -134,7 +134,7 @@ public class HIVRetentionFHIR_0_1_000
 		__HIV_Viral_Load.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -142,7 +142,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -150,7 +150,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -158,7 +158,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -166,7 +166,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -174,7 +174,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -182,7 +182,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -190,7 +190,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -198,7 +198,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", default(string));
 
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150")]
@@ -219,8 +219,8 @@ public class HIVRetentionFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HIVRetentionFHIR-0.1.000", "Measurement Period", c_);
 
@@ -233,7 +233,7 @@ public class HIVRetentionFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -273,7 +273,7 @@ public class HIVRetentionFHIR_0_1_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -303,7 +303,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -328,7 +328,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), y_);
+					: default(List<Extension>)), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -356,7 +356,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), af_);
+					: default(List<Extension>)), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -399,7 +399,7 @@ public class HIVRetentionFHIR_0_1_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -429,7 +429,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -456,7 +456,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), w_);
+					: default(List<Extension>)), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -484,7 +484,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), ad_);
+					: default(List<Extension>)), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -522,7 +522,7 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition HIVDx)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDx);
@@ -533,7 +533,7 @@ public class HIVRetentionFHIR_0_1_000
 			CqlDateTime k_ = context.Operators.Add(i_, j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
-			bool? n_ = context.Operators.SameOrBefore(g_, m_, null);
+			bool? n_ = context.Operators.SameOrBefore(g_, m_, default(string));
 			bool? o_ = QICoreCommon_2_0_000.isActive(HIVDx);
 			bool? p_ = context.Operators.And(n_, o_);
 
@@ -552,36 +552,36 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
@@ -634,47 +634,47 @@ public class HIVRetentionFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		IEnumerable<Encounter> ag_(Encounter ValidEncounter)
 		{
 			CqlValueSet ai_ = this.HIV();
-			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, null);
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default(PropertyInfo));
 			bool? ak_(Condition HIVDiagnosis)
 			{
 				CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 				Period ap_ = ValidEncounter?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
+				bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
 				CqlInterval<CqlDateTime> as_()
 				{
 					bool az_()
@@ -686,7 +686,7 @@ public class HIVRetentionFHIR_0_1_000
 					};
 					if (az_())
 					{
-						return null;
+						return default(CqlInterval<CqlDateTime>);
 					}
 					else
 					{
@@ -725,7 +725,7 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_HIV_Viral_Load_Test_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV_Viral_Load();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation ViralLoadTest)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
@@ -752,14 +752,14 @@ public class HIVRetentionFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
 		{
 			CqlValueSet e_ = this.HIV_Viral_Load();
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(e_, default(PropertyInfo));
 			bool? g_(Observation ViralLoadTest)
 			{
 				CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 				DataType l_ = ViralLoadTest?.Effective;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.ToInterval(m_);
-				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default(string));
 				object q_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.Start(r_);

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class HIVRetentionFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -110,7 +110,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default);
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -118,7 +118,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -126,7 +126,7 @@ public class HIVRetentionFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet HIV_Viral_Load_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default);
 
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
@@ -134,7 +134,7 @@ public class HIVRetentionFHIR_0_1_000
 		__HIV_Viral_Load.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -142,7 +142,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -150,7 +150,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -158,7 +158,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -166,7 +166,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -174,7 +174,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -182,7 +182,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -190,7 +190,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -198,7 +198,7 @@ public class HIVRetentionFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150", default);
 
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1150")]
@@ -219,8 +219,8 @@ public class HIVRetentionFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HIVRetentionFHIR-0.1.000", "Measurement Period", c_);
 
@@ -233,7 +233,7 @@ public class HIVRetentionFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -273,7 +273,7 @@ public class HIVRetentionFHIR_0_1_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -303,7 +303,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -328,7 +328,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), y_);
+					: default), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -356,7 +356,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), af_);
+					: default), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -399,7 +399,7 @@ public class HIVRetentionFHIR_0_1_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -429,7 +429,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -456,7 +456,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), w_);
+					: default), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -484,7 +484,7 @@ public class HIVRetentionFHIR_0_1_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), ad_);
+					: default), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -522,7 +522,7 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_Active_HIV_Diagnosis_Starts_On_or_Before_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition HIVDx)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.prevalenceInterval(HIVDx);
@@ -533,7 +533,7 @@ public class HIVRetentionFHIR_0_1_000
 			CqlDateTime k_ = context.Operators.Add(i_, j_);
 			CqlDate l_ = context.Operators.DateFrom(k_);
 			CqlDateTime m_ = context.Operators.ConvertDateToDateTime(l_);
-			bool? n_ = context.Operators.SameOrBefore(g_, m_, default(string));
+			bool? n_ = context.Operators.SameOrBefore(g_, m_, default);
 			bool? o_ = QICoreCommon_2_0_000.isActive(HIVDx);
 			bool? p_ = context.Operators.And(n_, o_);
 
@@ -552,36 +552,36 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
@@ -634,47 +634,47 @@ public class HIVRetentionFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_During_Measurement_Period_With_HIV_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		IEnumerable<Encounter> ag_(Encounter ValidEncounter)
 		{
 			CqlValueSet ai_ = this.HIV();
-			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default(PropertyInfo));
+			IEnumerable<Condition> aj_ = context.Operators.RetrieveByValueSet<Condition>(ai_, default);
 			bool? ak_(Condition HIVDiagnosis)
 			{
 				CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 				Period ap_ = ValidEncounter?.Period;
 				CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_3_000.ToInterval(ap_);
-				bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
+				bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default);
 				CqlInterval<CqlDateTime> as_()
 				{
 					bool az_()
@@ -686,7 +686,7 @@ public class HIVRetentionFHIR_0_1_000
 					};
 					if (az_())
 					{
-						return default(CqlInterval<CqlDateTime>);
+						return default;
 					}
 					else
 					{
@@ -725,7 +725,7 @@ public class HIVRetentionFHIR_0_1_000
 	private bool? Has_HIV_Viral_Load_Test_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV_Viral_Load();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation ViralLoadTest)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
@@ -752,14 +752,14 @@ public class HIVRetentionFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter EncounterWithHIV)
 		{
 			CqlValueSet e_ = this.HIV_Viral_Load();
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(e_, default);
 			bool? g_(Observation ViralLoadTest)
 			{
 				CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 				DataType l_ = ViralLoadTest?.Effective;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.ToInterval(m_);
-				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default(string));
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default);
 				object q_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> r_ = QICoreCommon_2_0_000.ToInterval(q_);
 				CqlDateTime s_ = context.Operators.Start(r_);

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HIVRetentionFHIR", "0.1.000")]
 public class HIVRetentionFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class HIVViralSuppressionFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -110,7 +110,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -118,7 +118,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -126,7 +126,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet HIV_Viral_Load_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default(string));
 
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
@@ -134,7 +134,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__HIV_Viral_Load.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -142,7 +142,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -150,7 +150,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -158,7 +158,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -166,7 +166,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -174,7 +174,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default(string));
 
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
@@ -182,7 +182,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Other.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -190,7 +190,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -198,7 +198,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telehealth_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default(string));
 
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
@@ -206,7 +206,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Telehealth_Services.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -214,14 +214,14 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Below_threshold_level__qualifier_value__Value() => 
-		new CqlCode("260988000", "http://snomed.info/sct", null, null);
+		new CqlCode("260988000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Below threshold level (qualifier value)")]
 	public CqlCode Below_threshold_level__qualifier_value_() => 
 		__Below_threshold_level__qualifier_value_.Value;
 
 	private CqlCode Not_detected__qualifier_value__Value() => 
-		new CqlCode("260415000", "http://snomed.info/sct", null, null);
+		new CqlCode("260415000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Not detected (qualifier value)")]
 	public CqlCode Not_detected__qualifier_value_() => 
@@ -230,8 +230,8 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("260988000", "http://snomed.info/sct", null, null),
-			new CqlCode("260415000", "http://snomed.info/sct", null, null),
+			new CqlCode("260988000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("260415000", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -255,8 +255,8 @@ public class HIVViralSuppressionFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HIVViralSuppressionFHIR-0.1.000", "Measurement Period", c_);
 
@@ -269,7 +269,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -282,7 +282,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition HIVDx)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIVDx);
@@ -308,36 +308,36 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
@@ -434,7 +434,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private Observation Most_Recent_Viral_Load_Test_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV_Viral_Load();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation ViralLoad)
 		{
 			object h_()

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -102,7 +102,7 @@ public class HIVViralSuppressionFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -110,7 +110,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default);
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -118,7 +118,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -126,7 +126,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__HIV.Value;
 
 	private CqlValueSet HIV_Viral_Load_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002", default);
 
     [CqlDeclaration("HIV Viral Load")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1002")]
@@ -134,7 +134,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__HIV_Viral_Load.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -142,7 +142,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -150,7 +150,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -158,7 +158,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -166,7 +166,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -174,7 +174,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default);
 
     [CqlDeclaration("Preventive Care Services Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
@@ -182,7 +182,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services_Other.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -190,7 +190,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -198,7 +198,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telehealth_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031", default);
 
     [CqlDeclaration("Telehealth Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1031")]
@@ -206,7 +206,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Telehealth_Services.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -214,14 +214,14 @@ public class HIVViralSuppressionFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode Below_threshold_level__qualifier_value__Value() => 
-		new CqlCode("260988000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("260988000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Below threshold level (qualifier value)")]
 	public CqlCode Below_threshold_level__qualifier_value_() => 
 		__Below_threshold_level__qualifier_value_.Value;
 
 	private CqlCode Not_detected__qualifier_value__Value() => 
-		new CqlCode("260415000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("260415000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Not detected (qualifier value)")]
 	public CqlCode Not_detected__qualifier_value_() => 
@@ -230,8 +230,8 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("260988000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("260415000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("260988000", "http://snomed.info/sct", default, default),
+			new CqlCode("260415000", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -255,8 +255,8 @@ public class HIVViralSuppressionFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HIVViralSuppressionFHIR-0.1.000", "Measurement Period", c_);
 
@@ -269,7 +269,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -282,7 +282,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private bool? Has_Active_HIV_Diagnosis_Before_or_in_First_90_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition HIVDx)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(HIVDx);
@@ -308,36 +308,36 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private bool? Has_Qualifying_Encounter_During_First_240_Days_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Face_to_Face_Interaction();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Preventive_Care_Services_Other();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
 		IEnumerable<Encounter> af_ = context.Operators.Union<Encounter>(ac_, ae_);
 		bool? ag_(Encounter QualifyingEncounter)
 		{
@@ -434,7 +434,7 @@ public class HIVViralSuppressionFHIR_0_1_000
 	private Observation Most_Recent_Viral_Load_Test_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.HIV_Viral_Load();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation ViralLoad)
 		{
 			object h_()

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HIVViralSuppressionFHIR", "0.1.000")]
 public class HIVViralSuppressionFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Hospice", "6.9.000")]
 public class Hospice_6_9_000
 {

--- a/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
@@ -66,7 +66,7 @@ public class Hospice_6_9_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -74,7 +74,7 @@ public class Hospice_6_9_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default);
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -82,7 +82,7 @@ public class Hospice_6_9_000
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Hospice_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", default);
 
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003")]
@@ -90,7 +90,7 @@ public class Hospice_6_9_000
 		__Hospice_Encounter.Value;
 
 	private CqlValueSet Hospice_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", default);
 
     [CqlDeclaration("Hospice Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165")]
@@ -98,28 +98,28 @@ public class Hospice_6_9_000
 		__Hospice_Diagnosis.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428361000124107", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("45755-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("373066001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -128,7 +128,7 @@ public class Hospice_6_9_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("45755-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -141,9 +141,9 @@ public class Hospice_6_9_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default, default),
+			new CqlCode("373066001", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -155,8 +155,8 @@ public class Hospice_6_9_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Hospice-6.9.000", "Measurement Period", c_);
 
@@ -169,7 +169,7 @@ public class Hospice_6_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -182,7 +182,7 @@ public class Hospice_6_9_000
 	private bool? Has_Hospice_Services_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
@@ -211,7 +211,7 @@ public class Hospice_6_9_000
 		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 		bool? f_ = context.Operators.Exists<Encounter>(e_);
 		CqlValueSet g_ = this.Hospice_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default);
 		IEnumerable<Encounter> i_ = Status_1_6_000.isEncounterPerformed(h_);
 		bool? j_(Encounter HospiceEncounter)
 		{
@@ -228,7 +228,7 @@ public class Hospice_6_9_000
 		bool? m_ = context.Operators.Or(f_, l_);
 		CqlCode n_ = this.Hospice_care__Minimum_Data_Set_();
 		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
-		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default(PropertyInfo));
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default);
 		IEnumerable<Observation> q_ = Status_1_6_000.isAssessmentPerformed(p_);
 		bool? r_(Observation HospiceAssessment)
 		{
@@ -250,7 +250,7 @@ public class Hospice_6_9_000
 		bool? t_ = context.Operators.Exists<Observation>(s_);
 		bool? u_ = context.Operators.Or(m_, t_);
 		CqlValueSet v_ = this.Hospice_Care_Ambulatory();
-		IEnumerable<ServiceRequest> w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, default);
 		IEnumerable<ServiceRequest> x_ = Status_1_6_000.isInterventionOrder(w_);
 		bool? y_(ServiceRequest HospiceOrder)
 		{
@@ -265,7 +265,7 @@ public class Hospice_6_9_000
 		IEnumerable<ServiceRequest> z_ = context.Operators.Where<ServiceRequest>(x_, y_);
 		bool? aa_ = context.Operators.Exists<ServiceRequest>(z_);
 		bool? ab_ = context.Operators.Or(u_, aa_);
-		IEnumerable<Procedure> ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default(PropertyInfo));
+		IEnumerable<Procedure> ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default);
 		IEnumerable<Procedure> ae_ = Status_1_6_000.isInterventionPerformed(ad_);
 		bool? af_(Procedure HospicePerformed)
 		{
@@ -281,7 +281,7 @@ public class Hospice_6_9_000
 		bool? ah_ = context.Operators.Exists<Procedure>(ag_);
 		bool? ai_ = context.Operators.Or(ab_, ah_);
 		CqlValueSet aj_ = this.Hospice_Diagnosis();
-		IEnumerable<Condition> ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, default(PropertyInfo));
+		IEnumerable<Condition> ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, default);
 		bool? al_(Condition HospiceCareDiagnosis)
 		{
 			CqlInterval<CqlDateTime> cj_ = QICoreCommon_2_0_000.prevalenceInterval(HospiceCareDiagnosis);

--- a/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.9.000.g.cs
@@ -66,7 +66,7 @@ public class Hospice_6_9_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -74,7 +74,7 @@ public class Hospice_6_9_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -82,7 +82,7 @@ public class Hospice_6_9_000
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Hospice_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", default(string));
 
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003")]
@@ -90,7 +90,7 @@ public class Hospice_6_9_000
 		__Hospice_Encounter.Value;
 
 	private CqlValueSet Hospice_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", default(string));
 
     [CqlDeclaration("Hospice Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165")]
@@ -98,28 +98,28 @@ public class Hospice_6_9_000
 		__Hospice_Diagnosis.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode Hospice_care__Minimum_Data_Set__Value() => 
-		new CqlCode("45755-6", "http://loinc.org", null, null);
+		new CqlCode("45755-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Hospice care [Minimum Data Set]")]
 	public CqlCode Hospice_care__Minimum_Data_Set_() => 
 		__Hospice_care__Minimum_Data_Set_.Value;
 
 	private CqlCode Yes__qualifier_value__Value() => 
-		new CqlCode("373066001", "http://snomed.info/sct", null, null);
+		new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Yes (qualifier value)")]
 	public CqlCode Yes__qualifier_value_() => 
@@ -128,7 +128,7 @@ public class Hospice_6_9_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("45755-6", "http://loinc.org", null, null),
+			new CqlCode("45755-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -141,9 +141,9 @@ public class Hospice_6_9_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
-			new CqlCode("373066001", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("373066001", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -155,8 +155,8 @@ public class Hospice_6_9_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Hospice-6.9.000", "Measurement Period", c_);
 
@@ -169,7 +169,7 @@ public class Hospice_6_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -182,7 +182,7 @@ public class Hospice_6_9_000
 	private bool? Has_Hospice_Services_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
@@ -211,7 +211,7 @@ public class Hospice_6_9_000
 		IEnumerable<Encounter> e_ = context.Operators.Where<Encounter>(c_, d_);
 		bool? f_ = context.Operators.Exists<Encounter>(e_);
 		CqlValueSet g_ = this.Hospice_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
 		IEnumerable<Encounter> i_ = Status_1_6_000.isEncounterPerformed(h_);
 		bool? j_(Encounter HospiceEncounter)
 		{
@@ -228,7 +228,7 @@ public class Hospice_6_9_000
 		bool? m_ = context.Operators.Or(f_, l_);
 		CqlCode n_ = this.Hospice_care__Minimum_Data_Set_();
 		IEnumerable<CqlCode> o_ = context.Operators.ToList<CqlCode>(n_);
-		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, null);
+		IEnumerable<Observation> p_ = context.Operators.RetrieveByCodes<Observation>(o_, default(PropertyInfo));
 		IEnumerable<Observation> q_ = Status_1_6_000.isAssessmentPerformed(p_);
 		bool? r_(Observation HospiceAssessment)
 		{
@@ -250,7 +250,7 @@ public class Hospice_6_9_000
 		bool? t_ = context.Operators.Exists<Observation>(s_);
 		bool? u_ = context.Operators.Or(m_, t_);
 		CqlValueSet v_ = this.Hospice_Care_Ambulatory();
-		IEnumerable<ServiceRequest> w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, null);
+		IEnumerable<ServiceRequest> w_ = context.Operators.RetrieveByValueSet<ServiceRequest>(v_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> x_ = Status_1_6_000.isInterventionOrder(w_);
 		bool? y_(ServiceRequest HospiceOrder)
 		{
@@ -265,7 +265,7 @@ public class Hospice_6_9_000
 		IEnumerable<ServiceRequest> z_ = context.Operators.Where<ServiceRequest>(x_, y_);
 		bool? aa_ = context.Operators.Exists<ServiceRequest>(z_);
 		bool? ab_ = context.Operators.Or(u_, aa_);
-		IEnumerable<Procedure> ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, null);
+		IEnumerable<Procedure> ad_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default(PropertyInfo));
 		IEnumerable<Procedure> ae_ = Status_1_6_000.isInterventionPerformed(ad_);
 		bool? af_(Procedure HospicePerformed)
 		{
@@ -281,7 +281,7 @@ public class Hospice_6_9_000
 		bool? ah_ = context.Operators.Exists<Procedure>(ag_);
 		bool? ai_ = context.Operators.Or(ab_, ah_);
 		CqlValueSet aj_ = this.Hospice_Diagnosis();
-		IEnumerable<Condition> ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, null);
+		IEnumerable<Condition> ak_ = context.Operators.RetrieveByValueSet<Condition>(aj_, default(PropertyInfo));
 		bool? al_(Condition HospiceCareDiagnosis)
 		{
 			CqlInterval<CqlDateTime> cj_ = QICoreCommon_2_0_000.prevalenceInterval(HospiceCareDiagnosis);

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospitalHarmOpioidRelatedAdverseEventsFHIR", "0.1.000")]
 public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -90,7 +90,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -98,7 +98,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -106,7 +106,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -114,7 +114,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Operating_Room_Suite_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", default(string));
 
     [CqlDeclaration("Operating Room Suite")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141")]
@@ -122,7 +122,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Operating_Room_Suite.Value;
 
 	private CqlValueSet Opioid_Antagonist_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", default(string));
 
     [CqlDeclaration("Opioid Antagonist")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119")]
@@ -130,7 +130,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Opioid_Antagonist.Value;
 
 	private CqlValueSet Opioids__All_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", default(string));
 
     [CqlDeclaration("Opioids, All")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226")]
@@ -138,7 +138,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Opioids__All.Value;
 
 	private CqlValueSet Routes_of_Administration_for_Opioid_Antagonists_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", default(string));
 
     [CqlDeclaration("Routes of Administration for Opioid Antagonists")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187")]
@@ -146,7 +146,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Routes_of_Administration_for_Opioid_Antagonists.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
@@ -155,7 +155,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -179,8 +179,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -193,7 +193,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -206,7 +206,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -244,8 +244,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Opioid_Administration_Value()
 	{
 		CqlValueSet a_ = this.Opioids__All();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration Opioids)
 		{
@@ -283,7 +283,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientEncounter);
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
 				List<Encounter.LocationComponent> o_ = InpatientEncounter?.Location;
 				bool? p_(Encounter.LocationComponent EncounterLocation)
 				{
@@ -305,7 +305,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 					CqlDateTime ae_ = context.Operators.Start(ad_);
 					Period af_ = EncounterLocation?.Period;
 					CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-					bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, null);
+					bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default(string));
 					bool? ai_ = context.Operators.And(aa_, ah_);
 
 					return ai_;
@@ -358,8 +358,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration_Value()
 	{
 		CqlValueSet a_ = this.Opioid_Antagonist();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration AntagonistGiven)
 		{
@@ -420,7 +420,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 				CqlDateTime br_ = context.Operators.Start(bq_);
 				Period bs_ = EncounterLocation?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
 				bool? bv_ = context.Operators.And(bn_, bu_);
 
 				return bv_;
@@ -433,12 +433,12 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
 			CqlDateTime t_ = context.Operators.Start(s_);
 			CqlInterval<CqlDateTime> u_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dioqpvxlkifmhgtiyeejrusad?.EncounterWithQualifyingAge);
-			bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, null);
+			bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, default(string));
 			DataType w_ = tuple_dioqpvxlkifmhgtiyeejrusad?.OpioidGiven?.Effective;
 			object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval(x_);
 			CqlDateTime z_ = context.Operators.Start(y_);
-			bool? ab_ = context.Operators.In<CqlDateTime>(z_, u_, null);
+			bool? ab_ = context.Operators.In<CqlDateTime>(z_, u_, default(string));
 			bool? ac_ = context.Operators.And(v_, ab_);
 			object ae_ = FHIRHelpers_4_3_000.ToValue(w_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
@@ -452,7 +452,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
 			CqlDateTime aq_ = context.Operators.Start(ap_);
 			CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(am_, aq_, true, false);
-			bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, null);
+			bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, default(string));
 			object au_ = FHIRHelpers_4_3_000.ToValue(q_);
 			CqlInterval<CqlDateTime> av_ = QICoreCommon_2_0_000.ToInterval(au_);
 			CqlDateTime aw_ = context.Operators.Start(av_);

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -90,7 +90,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -98,7 +98,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -106,7 +106,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -114,7 +114,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Operating_Room_Suite_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141", default);
 
     [CqlDeclaration("Operating Room Suite")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.141")]
@@ -122,7 +122,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Operating_Room_Suite.Value;
 
 	private CqlValueSet Opioid_Antagonist_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119", default);
 
     [CqlDeclaration("Opioid Antagonist")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.119")]
@@ -130,7 +130,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Opioid_Antagonist.Value;
 
 	private CqlValueSet Opioids__All_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226", default);
 
     [CqlDeclaration("Opioids, All")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.226")]
@@ -138,7 +138,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Opioids__All.Value;
 
 	private CqlValueSet Routes_of_Administration_for_Opioid_Antagonists_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187", default);
 
     [CqlDeclaration("Routes of Administration for Opioid Antagonists")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.187")]
@@ -146,7 +146,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 		__Routes_of_Administration_for_Opioid_Antagonists.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
@@ -155,7 +155,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -179,8 +179,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -193,7 +193,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -206,7 +206,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -244,8 +244,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Opioid_Administration_Value()
 	{
 		CqlValueSet a_ = this.Opioids__All();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration Opioids)
 		{
@@ -283,7 +283,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientEncounter);
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
 				List<Encounter.LocationComponent> o_ = InpatientEncounter?.Location;
 				bool? p_(Encounter.LocationComponent EncounterLocation)
 				{
@@ -305,7 +305,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 					CqlDateTime ae_ = context.Operators.Start(ad_);
 					Period af_ = EncounterLocation?.Period;
 					CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
-					bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default(string));
+					bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default);
 					bool? ai_ = context.Operators.And(aa_, ah_);
 
 					return ai_;
@@ -358,8 +358,8 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Opioid_Antagonist_Administration_Value()
 	{
 		CqlValueSet a_ = this.Opioid_Antagonist();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration AntagonistGiven)
 		{
@@ -420,7 +420,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 				CqlDateTime br_ = context.Operators.Start(bq_);
 				Period bs_ = EncounterLocation?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default);
 				bool? bv_ = context.Operators.And(bn_, bu_);
 
 				return bv_;
@@ -433,12 +433,12 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 			CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.ToInterval(r_);
 			CqlDateTime t_ = context.Operators.Start(s_);
 			CqlInterval<CqlDateTime> u_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_dioqpvxlkifmhgtiyeejrusad?.EncounterWithQualifyingAge);
-			bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, default(string));
+			bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, default);
 			DataType w_ = tuple_dioqpvxlkifmhgtiyeejrusad?.OpioidGiven?.Effective;
 			object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 			CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.ToInterval(x_);
 			CqlDateTime z_ = context.Operators.Start(y_);
-			bool? ab_ = context.Operators.In<CqlDateTime>(z_, u_, default(string));
+			bool? ab_ = context.Operators.In<CqlDateTime>(z_, u_, default);
 			bool? ac_ = context.Operators.And(v_, ab_);
 			object ae_ = FHIRHelpers_4_3_000.ToValue(w_);
 			CqlInterval<CqlDateTime> af_ = QICoreCommon_2_0_000.ToInterval(ae_);
@@ -452,7 +452,7 @@ public class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000
 			CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.ToInterval(ao_);
 			CqlDateTime aq_ = context.Operators.Start(ap_);
 			CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(am_, aq_, true, false);
-			bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, default(string));
+			bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, default);
 			object au_ = FHIRHelpers_4_3_000.ToValue(q_);
 			CqlInterval<CqlDateTime> av_ = QICoreCommon_2_0_000.ToInterval(au_);
 			CqlDateTime aw_ = context.Operators.Start(av_);

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospitalHarmPressureInjuryFHIR", "0.1.000")]
 public class HospitalHarmPressureInjuryFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -114,7 +114,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
     #endregion
 
 	private CqlValueSet COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", default(string));
 
     [CqlDeclaration("COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140")]
@@ -122,7 +122,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__COVID_19.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -130,7 +130,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -138,7 +138,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", default(string));
 
     [CqlDeclaration("Not Present On Admission or Documentation Insufficient to Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198")]
@@ -146,7 +146,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -154,7 +154,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -162,7 +162,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", default(string));
 
     [CqlDeclaration("Pressure Injury Deep Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112")]
@@ -170,7 +170,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Deep_Tissue.Value;
 
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", default(string));
 
     [CqlDeclaration("Pressure Injury Deep Tissue Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194")]
@@ -178,7 +178,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Deep_Tissue_Diagnoses.Value;
 
 	private CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", default(string));
 
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4 or Unstageable")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113")]
@@ -186,7 +186,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Stage_2__3__4_or_Unstageable.Value;
 
 	private CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", default(string));
 
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4, or Unstageable Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196")]
@@ -194,7 +194,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses.Value;
 
 	private CqlCode Physical_findings_of_Skin_Value() => 
-		new CqlCode("8709-8", "http://loinc.org", null, null);
+		new CqlCode("8709-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Physical findings of Skin")]
 	public CqlCode Physical_findings_of_Skin() => 
@@ -203,7 +203,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8709-8", "http://loinc.org", null, null),
+			new CqlCode("8709-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -215,8 +215,8 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmPressureInjuryFHIR-0.1.000", "Measurement Period", c_);
 
@@ -229,7 +229,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -242,7 +242,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_with_Age_18_and_Older_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -324,7 +324,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
-						: null), n_);
+						: default(List<Extension>)), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -362,7 +362,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -375,7 +375,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlQuantity s_ = context.Operators.Quantity(72m, "hours");
 				CqlDateTime t_ = context.Operators.Add(r_, s_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -449,7 +449,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
-						: null), n_);
+						: default(List<Extension>)), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -487,7 +487,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -500,7 +500,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlQuantity s_ = context.Operators.Quantity(24m, "hours");
 				CqlDateTime t_ = context.Operators.Add(r_, s_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -618,7 +618,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
-						: null), n_);
+						: default(List<Extension>)), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -656,7 +656,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -669,7 +669,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlDateTime r_ = context.Operators.Add(p_, q_);
 				CqlDateTime t_ = context.Operators.End(o_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -763,7 +763,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
-						: null), n_);
+						: default(List<Extension>)), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -801,7 +801,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -814,7 +814,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlDateTime r_ = context.Operators.Add(p_, q_);
 				CqlDateTime t_ = context.Operators.End(o_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -114,7 +114,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
     #endregion
 
 	private CqlValueSet COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140", default);
 
     [CqlDeclaration("COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.140")]
@@ -122,7 +122,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__COVID_19.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -130,7 +130,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -138,7 +138,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198", default);
 
     [CqlDeclaration("Not Present On Admission or Documentation Insufficient to Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.198")]
@@ -146,7 +146,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Not_Present_On_Admission_or_Documentation_Insufficient_to_Determine.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -154,7 +154,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default);
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -162,7 +162,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112", default);
 
     [CqlDeclaration("Pressure Injury Deep Tissue")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.112")]
@@ -170,7 +170,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Deep_Tissue.Value;
 
 	private CqlValueSet Pressure_Injury_Deep_Tissue_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194", default);
 
     [CqlDeclaration("Pressure Injury Deep Tissue Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.194")]
@@ -178,7 +178,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Deep_Tissue_Diagnoses.Value;
 
 	private CqlValueSet Pressure_Injury_Stage_2__3__4_or_Unstageable_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113", default);
 
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4 or Unstageable")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.113")]
@@ -186,7 +186,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Stage_2__3__4_or_Unstageable.Value;
 
 	private CqlValueSet Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196", default);
 
     [CqlDeclaration("Pressure Injury Stage 2, 3, 4, or Unstageable Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.196")]
@@ -194,7 +194,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		__Pressure_Injury_Stage_2__3__4__or_Unstageable_Diagnoses.Value;
 
 	private CqlCode Physical_findings_of_Skin_Value() => 
-		new CqlCode("8709-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("8709-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Physical findings of Skin")]
 	public CqlCode Physical_findings_of_Skin() => 
@@ -203,7 +203,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8709-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8709-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -215,8 +215,8 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmPressureInjuryFHIR-0.1.000", "Measurement Period", c_);
 
@@ -229,7 +229,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -242,7 +242,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 	private IEnumerable<Encounter> Encounter_with_Age_18_and_Older_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -324,7 +324,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
-						: default(List<Extension>)), n_);
+						: default), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -362,7 +362,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -375,7 +375,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlQuantity s_ = context.Operators.Quantity(72m, "hours");
 				CqlDateTime t_ = context.Operators.Add(r_, s_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -449,7 +449,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
-						: default(List<Extension>)), n_);
+						: default), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -487,7 +487,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -500,7 +500,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlQuantity s_ = context.Operators.Quantity(24m, "hours");
 				CqlDateTime t_ = context.Operators.Add(r_, s_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -618,7 +618,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiag is Element)
 						? ((EncounterDiag as Element).Extension)
-						: default(List<Extension>)), n_);
+						: default), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -656,7 +656,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -669,7 +669,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlDateTime r_ = context.Operators.Add(p_, q_);
 				CqlDateTime t_ = context.Operators.End(o_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);
@@ -763,7 +763,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				};
 				IEnumerable<Extension> o_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((Stage234UnstageablePressureInjury is Element)
 						? ((Stage234UnstageablePressureInjury as Element).Extension)
-						: default(List<Extension>)), n_);
+						: default), n_);
 				DataType p_(Extension @this)
 				{
 					DataType ab_ = @this?.Value;
@@ -801,7 +801,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 		{
 			CqlCode d_ = this.Physical_findings_of_Skin();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			bool? g_(Observation SkinExam)
 			{
 				DataType k_ = SkinExam?.Effective;
@@ -814,7 +814,7 @@ public class HospitalHarmPressureInjuryFHIR_0_1_000
 				CqlDateTime r_ = context.Operators.Add(p_, q_);
 				CqlDateTime t_ = context.Operators.End(o_);
 				CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
+				bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
 				Code<ObservationStatus> w_ = SkinExam?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -86,7 +86,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -94,7 +94,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__birth_date.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -102,7 +102,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -110,7 +110,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_Lab_Test_Mass_Per_Volume_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", default);
 
     [CqlDeclaration("Glucose Lab Test Mass Per Volume")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34")]
@@ -118,7 +118,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Glucose_Lab_Test_Mass_Per_Volume.Value;
 
 	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default);
 
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
@@ -126,7 +126,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Hypoglycemics_Severe_Hypoglycemia.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -135,8 +135,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.1.000", "Measurement Period", c_);
 
@@ -149,7 +149,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -162,7 +162,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -200,8 +200,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
 	{
 		CqlValueSet a_ = this.Hypoglycemics_Severe_Hypoglycemia();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration HypoMedication)
 		{
@@ -239,7 +239,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
 
 				return n_;
 			};
@@ -286,7 +286,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<MedicationAdministration> b_ = this.Hypoglycemic_Medication_Administration();
 		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default);
 		IEnumerable<ValueTuple<Encounter, MedicationAdministration, Observation>> e_ = context.Operators.CrossJoin<Encounter, MedicationAdministration, Observation>(a_, b_, d_);
 		(Encounter QualifyingEncounter, MedicationAdministration HypoglycemicMedication, Observation GlucoseTest)? f_(ValueTuple<Encounter, MedicationAdministration, Observation> _valueTuple)
 		{
@@ -351,7 +351,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime n_ = QICoreCommon_2_0_000.Earliest(m_());
 			CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_btymmdgachdragrhofgxbxgho?.QualifyingEncounter);
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
 			Code<ObservationStatus> q_ = tuple_btymmdgachdragrhofgxbxgho?.GlucoseTest?.StatusElement;
 			ObservationStatus? r_ = q_?.Value;
 			Code<ObservationStatus> s_ = context.Operators.Convert<Code<ObservationStatus>>(r_);
@@ -481,7 +481,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime al_ = QICoreCommon_2_0_000.Earliest(ak_());
 			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
-			bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, default(string));
+			bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, default);
 			object ao_()
 			{
 				bool cv_()
@@ -558,7 +558,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Observation> b_ = this.Glucose_Test_with_Result_Less_Than_40();
 		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default);
 		IEnumerable<ValueTuple<Encounter, Observation, Observation>> e_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, b_, d_);
 		(Encounter QualifyingEncounter, Observation LowGlucoseTest, Observation FollowupGlucoseTest)? f_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
 		{
@@ -731,7 +731,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			CqlQuantity s_ = context.Operators.Quantity(5m, "minutes");
 			CqlDateTime t_ = context.Operators.Add(r_, s_);
 			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, false, true);
-			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
 			object w_()
 			{
 				bool df_()
@@ -841,7 +841,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime ab_ = QICoreCommon_2_0_000.Earliest(aa_());
 			CqlInterval<CqlDateTime> ac_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_clljqcgdejtdiiewkzyjpwapd?.QualifyingEncounter);
-			bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default(string));
+			bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
 			bool? ae_ = context.Operators.And(z_, ad_);
 			object af_()
 			{
@@ -896,7 +896,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 				}
 			};
 			CqlDateTime ag_ = QICoreCommon_2_0_000.Earliest(af_());
-			bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, default(string));
+			bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, default);
 			bool? aj_ = context.Operators.And(ae_, ai_);
 			Id ak_ = tuple_clljqcgdejtdiiewkzyjpwapd?.FollowupGlucoseTest?.IdElement;
 			string al_ = ak_?.Value;
@@ -948,7 +948,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			{
 				string m_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
-	: default(Id))?.Value;
+	: default)?.Value;
 				bool? n_ = context.Operators.Not((bool?)(m_ is null));
 
 				return n_;
@@ -958,7 +958,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			{
 				string o_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
-	: default(Id))?.Value;
+	: default)?.Value;
 
 				return o_;
 			};
@@ -1045,7 +1045,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime l_ = QICoreCommon_2_0_000.Earliest(k_());
 			CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_hfnempjqliopfnrmypnydhffr?.QualifyingEncounter);
-			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
+			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
 
 			return n_;
 		};

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.1.000")]
 public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -86,7 +86,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -94,7 +94,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__birth_date.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -102,7 +102,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -110,7 +110,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_Lab_Test_Mass_Per_Volume_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34", default(string));
 
     [CqlDeclaration("Glucose Lab Test Mass Per Volume")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.34")]
@@ -118,7 +118,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Glucose_Lab_Test_Mass_Per_Volume.Value;
 
 	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default(string));
 
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
@@ -126,7 +126,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		__Hypoglycemics_Severe_Hypoglycemia.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -135,8 +135,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.1.000", "Measurement Period", c_);
 
@@ -149,7 +149,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -162,7 +162,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter InpatientEncounter)
 		{
 			Patient e_ = this.Patient();
@@ -200,8 +200,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
 	{
 		CqlValueSet a_ = this.Hypoglycemics_Severe_Hypoglycemia();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration HypoMedication)
 		{
@@ -239,7 +239,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.ToInterval(j_);
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(InpatientHospitalization);
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
 
 				return n_;
 			};
@@ -286,7 +286,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<MedicationAdministration> b_ = this.Hypoglycemic_Medication_Administration();
 		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, MedicationAdministration, Observation>> e_ = context.Operators.CrossJoin<Encounter, MedicationAdministration, Observation>(a_, b_, d_);
 		(Encounter QualifyingEncounter, MedicationAdministration HypoglycemicMedication, Observation GlucoseTest)? f_(ValueTuple<Encounter, MedicationAdministration, Observation> _valueTuple)
 		{
@@ -351,7 +351,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime n_ = QICoreCommon_2_0_000.Earliest(m_());
 			CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_btymmdgachdragrhofgxbxgho?.QualifyingEncounter);
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
 			Code<ObservationStatus> q_ = tuple_btymmdgachdragrhofgxbxgho?.GlucoseTest?.StatusElement;
 			ObservationStatus? r_ = q_?.Value;
 			Code<ObservationStatus> s_ = context.Operators.Convert<Code<ObservationStatus>>(r_);
@@ -481,7 +481,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime al_ = QICoreCommon_2_0_000.Earliest(ak_());
 			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
-			bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, null);
+			bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, default(string));
 			object ao_()
 			{
 				bool cv_()
@@ -558,7 +558,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 		IEnumerable<Encounter> a_ = this.Denominator();
 		IEnumerable<Observation> b_ = this.Glucose_Test_with_Result_Less_Than_40();
 		CqlValueSet c_ = this.Glucose_Lab_Test_Mass_Per_Volume();
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, null);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(c_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Observation, Observation>> e_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, b_, d_);
 		(Encounter QualifyingEncounter, Observation LowGlucoseTest, Observation FollowupGlucoseTest)? f_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
 		{
@@ -731,7 +731,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			CqlQuantity s_ = context.Operators.Quantity(5m, "minutes");
 			CqlDateTime t_ = context.Operators.Add(r_, s_);
 			CqlInterval<CqlDateTime> u_ = context.Operators.Interval(p_, t_, false, true);
-			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, null);
+			bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default(string));
 			object w_()
 			{
 				bool df_()
@@ -841,7 +841,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime ab_ = QICoreCommon_2_0_000.Earliest(aa_());
 			CqlInterval<CqlDateTime> ac_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_clljqcgdejtdiiewkzyjpwapd?.QualifyingEncounter);
-			bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, null);
+			bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default(string));
 			bool? ae_ = context.Operators.And(z_, ad_);
 			object af_()
 			{
@@ -896,7 +896,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 				}
 			};
 			CqlDateTime ag_ = QICoreCommon_2_0_000.Earliest(af_());
-			bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, null);
+			bool? ai_ = context.Operators.In<CqlDateTime>(ag_, ac_, default(string));
 			bool? aj_ = context.Operators.And(ae_, ai_);
 			Id ak_ = tuple_clljqcgdejtdiiewkzyjpwapd?.FollowupGlucoseTest?.IdElement;
 			string al_ = ak_?.Value;
@@ -948,7 +948,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			{
 				string m_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
-	: null)?.Value;
+	: default(Id))?.Value;
 				bool? n_ = context.Operators.Not((bool?)(m_ is null));
 
 				return n_;
@@ -958,7 +958,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			{
 				string o_ = ((@this is Resource)
 	? ((@this as Resource).IdElement)
-	: null)?.Value;
+	: default(Id))?.Value;
 
 				return o_;
 			};
@@ -1045,7 +1045,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_1_000
 			};
 			CqlDateTime l_ = QICoreCommon_2_0_000.Earliest(k_());
 			CqlInterval<CqlDateTime> m_ = CQMCommon_2_0_000.HospitalizationWithObservation(tuple_hfnempjqliopfnrmypnydhffr?.QualifyingEncounter);
-			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
 
 			return n_;
 		};

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -112,7 +112,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -120,7 +120,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -128,7 +128,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -136,7 +136,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -144,7 +144,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default(string));
 
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
@@ -152,7 +152,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Medicare_Advantage_payer.Value;
 
 	private CqlValueSet Medicare_FFS_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
 
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -160,7 +160,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Medicare_FFS_payer.Value;
 
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default(string));
 
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
@@ -168,7 +168,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
 	private CqlValueSet Platelet_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default(string));
 
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
@@ -176,7 +176,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Platelet_count_lab_test.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -184,7 +184,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -192,21 +192,21 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
-		new CqlCode("2708-6", "http://loinc.org", null, null);
+		new CqlCode("2708-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", null, null);
+		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -215,9 +215,9 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("2708-6", "http://loinc.org", null, null),
-			new CqlCode("59408-5", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("2708-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -253,8 +253,8 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHospitalWideMortalityFHIR-0.0.001", "Measurement Period", c_);
 
@@ -267,7 +267,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -280,13 +280,13 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
 			CqlValueSet e_ = this.Medicare_FFS_payer();
-			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default(PropertyInfo));
 			CqlValueSet g_ = this.Medicare_Advantage_payer();
-			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default(PropertyInfo));
 			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
@@ -308,7 +308,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDate ac_ = context.Operators.DateFrom(ab_);
 				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
 				CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
-				bool? af_ = context.Operators.In<int?>(ad_, ae_, null);
+				bool? af_ = context.Operators.In<int?>(ad_, ae_, default(string));
 				bool? ag_ = context.Operators.And(u_, af_);
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime aj_ = context.Operators.End(ai_);
@@ -352,7 +352,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation temperature)
 			{
 				DataType y_ = temperature?.Effective;
@@ -368,7 +368,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				Code<ObservationStatus> an_ = temperature?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -416,7 +416,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
 				Code<ObservationStatus> bq_ = temperature?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -469,7 +469,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -485,7 +485,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -533,7 +533,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
 				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -587,7 +587,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
@@ -653,7 +653,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
 				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
-				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default(string));
 				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
 				ObservationStatus? ag_ = af_?.Value;
 				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
@@ -740,7 +740,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool cc_()
 				{
 					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default(PropertyInfo));
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
@@ -806,7 +806,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
 						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
-						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default(string));
 						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
 						ObservationStatus? de_ = dd_?.Value;
 						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
@@ -895,7 +895,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool cd_()
 				{
 					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default(PropertyInfo));
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
@@ -961,7 +961,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
 						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default(string));
 						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
 						ObservationStatus? fz_ = fy_?.Value;
 						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
@@ -1050,7 +1050,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool ce_()
 				{
 					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default(PropertyInfo));
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
@@ -1116,7 +1116,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
 						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
-						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default(string));
 						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
 						ObservationStatus? iu_ = it_?.Value;
 						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
@@ -1205,7 +1205,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				if (cc_())
 				{
 					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default(PropertyInfo));
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
@@ -1271,7 +1271,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
 						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default(string));
 						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
 						ObservationStatus? lo_ = ln_?.Value;
 						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
@@ -1359,7 +1359,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				else if (cd_())
 				{
 					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default(PropertyInfo));
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
@@ -1425,7 +1425,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
 						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
-						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default(string));
 						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
 						ObservationStatus? oi_ = oh_?.Value;
 						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
@@ -1513,7 +1513,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				else if (ce_())
 				{
 					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default(PropertyInfo));
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
@@ -1579,7 +1579,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
 						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default(string));
 						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
 						ObservationStatus? rc_ = rb_?.Value;
 						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
@@ -1685,7 +1685,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Observation BloodPressure)
 		{
 			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
@@ -1728,7 +1728,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Bicarbonate_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation BicarbonateLab)
 			{
 				Instant z_ = BicarbonateLab?.IssuedElement;
@@ -1744,7 +1744,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = BicarbonateLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1776,7 +1776,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation BicarbonateLab)
 			{
 				Instant bd_ = BicarbonateLab?.IssuedElement;
@@ -1792,7 +1792,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = BicarbonateLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1846,7 +1846,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Creatinine_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation CreatinineLab)
 			{
 				Instant z_ = CreatinineLab?.IssuedElement;
@@ -1862,7 +1862,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1894,7 +1894,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation CreatinineLab)
 			{
 				Instant bd_ = CreatinineLab?.IssuedElement;
@@ -1910,7 +1910,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1964,7 +1964,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation HematocritLab)
 			{
 				Instant z_ = HematocritLab?.IssuedElement;
@@ -1980,7 +1980,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2012,7 +2012,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation HematocritLab)
 			{
 				Instant bd_ = HematocritLab?.IssuedElement;
@@ -2028,7 +2028,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2082,7 +2082,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Platelet_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation PlateletLab)
 			{
 				Instant z_ = PlateletLab?.IssuedElement;
@@ -2098,7 +2098,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = PlateletLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2130,7 +2130,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation PlateletLab)
 			{
 				Instant bd_ = PlateletLab?.IssuedElement;
@@ -2146,7 +2146,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = PlateletLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2200,7 +2200,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Sodium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation SodiumLab)
 			{
 				Instant z_ = SodiumLab?.IssuedElement;
@@ -2216,7 +2216,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2248,7 +2248,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation SodiumLab)
 			{
 				Instant bd_ = SodiumLab?.IssuedElement;
@@ -2264,7 +2264,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2318,7 +2318,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation WhiteBloodCellLab)
 			{
 				Instant z_ = WhiteBloodCellLab?.IssuedElement;
@@ -2334,7 +2334,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2366,7 +2366,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation WhiteBloodCellLab)
 			{
 				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
@@ -2382,7 +2382,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -112,7 +112,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -120,7 +120,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -128,7 +128,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -136,7 +136,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -144,7 +144,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default);
 
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
@@ -152,7 +152,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Medicare_Advantage_payer.Value;
 
 	private CqlValueSet Medicare_FFS_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default);
 
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -160,7 +160,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Medicare_FFS_payer.Value;
 
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default);
 
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
@@ -168,7 +168,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
 	private CqlValueSet Platelet_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default);
 
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
@@ -176,7 +176,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Platelet_count_lab_test.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -184,7 +184,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -192,21 +192,21 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
-		new CqlCode("2708-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("2708-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("59408-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -215,9 +215,9 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("2708-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("2708-6", "http://loinc.org", default, default),
+			new CqlCode("59408-5", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -253,8 +253,8 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHospitalWideMortalityFHIR-0.0.001", "Measurement Period", c_);
 
@@ -267,7 +267,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -280,13 +280,13 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
 			CqlValueSet e_ = this.Medicare_FFS_payer();
-			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default(PropertyInfo));
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default);
 			CqlValueSet g_ = this.Medicare_Advantage_payer();
-			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default(PropertyInfo));
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default);
 			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
@@ -308,7 +308,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDate ac_ = context.Operators.DateFrom(ab_);
 				int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
 				CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
-				bool? af_ = context.Operators.In<int?>(ad_, ae_, default(string));
+				bool? af_ = context.Operators.In<int?>(ad_, ae_, default);
 				bool? ag_ = context.Operators.And(u_, af_);
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_3_000.ToInterval(z_);
 				CqlDateTime aj_ = context.Operators.End(ai_);
@@ -352,7 +352,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation temperature)
 			{
 				DataType y_ = temperature?.Effective;
@@ -368,7 +368,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				Code<ObservationStatus> an_ = temperature?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -416,7 +416,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default);
 				Code<ObservationStatus> bq_ = temperature?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -469,7 +469,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -485,7 +485,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -533,7 +533,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default);
 				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -587,7 +587,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
@@ -653,7 +653,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
 				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
-				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default(string));
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default);
 				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
 				ObservationStatus? ag_ = af_?.Value;
 				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
@@ -740,7 +740,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool cc_()
 				{
 					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default(PropertyInfo));
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default);
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
@@ -806,7 +806,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
 						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
-						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default(string));
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default);
 						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
 						ObservationStatus? de_ = dd_?.Value;
 						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
@@ -895,7 +895,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool cd_()
 				{
 					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default(PropertyInfo));
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default);
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
@@ -961,7 +961,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
 						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default(string));
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default);
 						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
 						ObservationStatus? fz_ = fy_?.Value;
 						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
@@ -1050,7 +1050,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				bool ce_()
 				{
 					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default(PropertyInfo));
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default);
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
@@ -1116,7 +1116,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
 						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
-						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default(string));
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default);
 						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
 						ObservationStatus? iu_ = it_?.Value;
 						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
@@ -1205,7 +1205,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				if (cc_())
 				{
 					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default(PropertyInfo));
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default);
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
@@ -1271,7 +1271,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
 						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default(string));
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default);
 						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
 						ObservationStatus? lo_ = ln_?.Value;
 						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
@@ -1359,7 +1359,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				else if (cd_())
 				{
 					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default(PropertyInfo));
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default);
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
@@ -1425,7 +1425,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
 						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
-						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default(string));
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default);
 						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
 						ObservationStatus? oi_ = oh_?.Value;
 						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
@@ -1513,7 +1513,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				else if (ce_())
 				{
 					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default(PropertyInfo));
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default);
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
@@ -1579,7 +1579,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
 						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default(string));
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default);
 						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
 						ObservationStatus? rc_ = rb_?.Value;
 						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
@@ -1685,7 +1685,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		bool? b_(Observation BloodPressure)
 		{
 			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
@@ -1728,7 +1728,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Bicarbonate_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation BicarbonateLab)
 			{
 				Instant z_ = BicarbonateLab?.IssuedElement;
@@ -1744,7 +1744,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = BicarbonateLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1776,7 +1776,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation BicarbonateLab)
 			{
 				Instant bd_ = BicarbonateLab?.IssuedElement;
@@ -1792,7 +1792,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = BicarbonateLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1846,7 +1846,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Creatinine_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation CreatinineLab)
 			{
 				Instant z_ = CreatinineLab?.IssuedElement;
@@ -1862,7 +1862,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1894,7 +1894,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation CreatinineLab)
 			{
 				Instant bd_ = CreatinineLab?.IssuedElement;
@@ -1910,7 +1910,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1964,7 +1964,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation HematocritLab)
 			{
 				Instant z_ = HematocritLab?.IssuedElement;
@@ -1980,7 +1980,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2012,7 +2012,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation HematocritLab)
 			{
 				Instant bd_ = HematocritLab?.IssuedElement;
@@ -2028,7 +2028,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2082,7 +2082,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Platelet_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation PlateletLab)
 			{
 				Instant z_ = PlateletLab?.IssuedElement;
@@ -2098,7 +2098,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = PlateletLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2130,7 +2130,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation PlateletLab)
 			{
 				Instant bd_ = PlateletLab?.IssuedElement;
@@ -2146,7 +2146,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = PlateletLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2200,7 +2200,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Sodium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation SodiumLab)
 			{
 				Instant z_ = SodiumLab?.IssuedElement;
@@ -2216,7 +2216,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2248,7 +2248,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation SodiumLab)
 			{
 				Instant bd_ = SodiumLab?.IssuedElement;
@@ -2264,7 +2264,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2318,7 +2318,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation WhiteBloodCellLab)
 			{
 				Instant z_ = WhiteBloodCellLab?.IssuedElement;
@@ -2334,7 +2334,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2366,7 +2366,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation WhiteBloodCellLab)
 			{
 				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
@@ -2382,7 +2382,7 @@ public class HybridHospitalWideMortalityFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HybridHospitalWideMortalityFHIR", "0.0.001")]
 public class HybridHospitalWideMortalityFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HybridHospitalWideReadmissionFHIR", "0.0.001")]
 public class HybridHospitalWideReadmissionFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -120,7 +120,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -128,7 +128,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -136,7 +136,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -144,7 +144,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -152,7 +152,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -160,7 +160,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default);
 
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
@@ -168,7 +168,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Medicare_Advantage_payer.Value;
 
 	private CqlValueSet Medicare_FFS_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default);
 
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -176,7 +176,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Medicare_FFS_payer.Value;
 
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default);
 
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
@@ -184,7 +184,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
 	private CqlValueSet Potassium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default);
 
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
@@ -192,7 +192,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Potassium_lab_test.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -200,7 +200,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -208,21 +208,21 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
-		new CqlCode("2708-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("2708-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("59408-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -231,9 +231,9 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("2708-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("2708-6", "http://loinc.org", default, default),
+			new CqlCode("59408-5", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -269,8 +269,8 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHospitalWideReadmissionFHIR-0.0.001", "Measurement Period", c_);
 
@@ -283,7 +283,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -296,13 +296,13 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
 			CqlValueSet e_ = this.Medicare_FFS_payer();
-			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default(PropertyInfo));
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default);
 			CqlValueSet g_ = this.Medicare_Advantage_payer();
-			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default(PropertyInfo));
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default);
 			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
@@ -367,7 +367,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation temperature)
 			{
 				DataType y_ = temperature?.Effective;
@@ -383,7 +383,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				Code<ObservationStatus> an_ = temperature?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -431,7 +431,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default);
 				Code<ObservationStatus> bq_ = temperature?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -484,7 +484,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -500,7 +500,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -548,7 +548,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default);
 				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -602,7 +602,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
@@ -668,7 +668,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
 				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
-				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default(string));
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default);
 				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
 				ObservationStatus? ag_ = af_?.Value;
 				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
@@ -755,7 +755,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool cc_()
 				{
 					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default(PropertyInfo));
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default);
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
@@ -821,7 +821,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
 						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
-						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default(string));
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default);
 						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
 						ObservationStatus? de_ = dd_?.Value;
 						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
@@ -910,7 +910,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool cd_()
 				{
 					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default(PropertyInfo));
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default);
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
@@ -976,7 +976,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
 						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default(string));
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default);
 						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
 						ObservationStatus? fz_ = fy_?.Value;
 						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
@@ -1065,7 +1065,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool ce_()
 				{
 					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default(PropertyInfo));
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default);
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
@@ -1131,7 +1131,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
 						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
-						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default(string));
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default);
 						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
 						ObservationStatus? iu_ = it_?.Value;
 						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
@@ -1220,7 +1220,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				if (cc_())
 				{
 					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default(PropertyInfo));
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default);
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
@@ -1286,7 +1286,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
 						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default(string));
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default);
 						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
 						ObservationStatus? lo_ = ln_?.Value;
 						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
@@ -1374,7 +1374,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				else if (cd_())
 				{
 					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default(PropertyInfo));
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default);
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
@@ -1440,7 +1440,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
 						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
-						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default(string));
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default);
 						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
 						ObservationStatus? oi_ = oh_?.Value;
 						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
@@ -1528,7 +1528,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				else if (ce_())
 				{
 					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default(PropertyInfo));
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default);
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
@@ -1594,7 +1594,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
 						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default(string));
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default);
 						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
 						ObservationStatus? rc_ = rb_?.Value;
 						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
@@ -1705,7 +1705,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation RespRate)
 			{
 				DataType y_ = RespRate?.Effective;
@@ -1721,7 +1721,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				Code<ObservationStatus> an_ = RespRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -1769,7 +1769,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default);
 				Code<ObservationStatus> bq_ = RespRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -1817,7 +1817,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		bool? b_(Observation BloodPressure)
 		{
 			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
@@ -1868,7 +1868,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Bicarbonate_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation bicarbonatelab)
 			{
 				Instant z_ = bicarbonatelab?.IssuedElement;
@@ -1884,7 +1884,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = bicarbonatelab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1916,7 +1916,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation bicarbonatelab)
 			{
 				Instant bd_ = bicarbonatelab?.IssuedElement;
@@ -1932,7 +1932,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = bicarbonatelab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1986,7 +1986,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Creatinine_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation CreatinineLab)
 			{
 				Instant z_ = CreatinineLab?.IssuedElement;
@@ -2002,7 +2002,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2034,7 +2034,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation CreatinineLab)
 			{
 				Instant bd_ = CreatinineLab?.IssuedElement;
@@ -2050,7 +2050,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2104,7 +2104,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Glucose_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation GlucoseLab)
 			{
 				Instant z_ = GlucoseLab?.IssuedElement;
@@ -2120,7 +2120,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = GlucoseLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2152,7 +2152,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation GlucoseLab)
 			{
 				Instant bd_ = GlucoseLab?.IssuedElement;
@@ -2168,7 +2168,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = GlucoseLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2222,7 +2222,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation HematocritLab)
 			{
 				Instant z_ = HematocritLab?.IssuedElement;
@@ -2238,7 +2238,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2270,7 +2270,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation HematocritLab)
 			{
 				Instant bd_ = HematocritLab?.IssuedElement;
@@ -2286,7 +2286,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2340,7 +2340,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Potassium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation PotassiumLab)
 			{
 				Instant z_ = PotassiumLab?.IssuedElement;
@@ -2356,7 +2356,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = PotassiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2388,7 +2388,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation PotassiumLab)
 			{
 				Instant bd_ = PotassiumLab?.IssuedElement;
@@ -2404,7 +2404,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = PotassiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2458,7 +2458,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Sodium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation SodiumLab)
 			{
 				Instant z_ = SodiumLab?.IssuedElement;
@@ -2474,7 +2474,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2506,7 +2506,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation SodiumLab)
 			{
 				Instant bd_ = SodiumLab?.IssuedElement;
@@ -2522,7 +2522,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2576,7 +2576,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation WhiteBloodCellLab)
 			{
 				Instant z_ = WhiteBloodCellLab?.IssuedElement;
@@ -2592,7 +2592,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default);
 				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2624,7 +2624,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation WhiteBloodCellLab)
 			{
 				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
@@ -2640,7 +2640,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
 				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2693,14 +2693,14 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation WeightExam)
 			{
 				DataType y_ = WeightExam?.Effective;
 				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
 				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
 				CqlInterval<CqlDateTime> ab_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default(string));
+				bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
 				Code<ObservationStatus> ad_ = WeightExam?.StatusElement;
 				ObservationStatus? ae_ = ad_?.Value;
 				string af_ = context.Operators.Convert<string>(ae_);
@@ -2739,7 +2739,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlDateTime at_ = QICoreCommon_2_0_000.earliest(as_);
 				CqlInterval<CqlDateTime> au_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, default(string));
+				bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, default);
 				Code<ObservationStatus> aw_ = WeightExam?.StatusElement;
 				ObservationStatus? ax_ = aw_?.Value;
 				string ay_ = context.Operators.Convert<string>(ax_);

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -120,7 +120,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -128,7 +128,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -136,7 +136,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -144,7 +144,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -152,7 +152,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -160,7 +160,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_Advantage_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12", default(string));
 
     [CqlDeclaration("Medicare Advantage payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.12")]
@@ -168,7 +168,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Medicare_Advantage_payer.Value;
 
 	private CqlValueSet Medicare_FFS_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
 
     [CqlDeclaration("Medicare FFS payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -176,7 +176,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Medicare_FFS_payer.Value;
 
 	private CqlValueSet Oxygen_Saturation_by_Pulse_Oximetry_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151", default(string));
 
     [CqlDeclaration("Oxygen Saturation by Pulse Oximetry")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.151")]
@@ -184,7 +184,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Oxygen_Saturation_by_Pulse_Oximetry.Value;
 
 	private CqlValueSet Potassium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default(string));
 
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
@@ -192,7 +192,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Potassium_lab_test.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -200,7 +200,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -208,21 +208,21 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_Value() => 
-		new CqlCode("2708-6", "http://loinc.org", null, null);
+		new CqlCode("2708-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood() => 
 		__Oxygen_saturation_in_Arterial_blood.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", null, null);
+		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -231,9 +231,9 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("2708-6", "http://loinc.org", null, null),
-			new CqlCode("59408-5", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("2708-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -269,8 +269,8 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHospitalWideReadmissionFHIR-0.0.001", "Measurement Period", c_);
 
@@ -283,7 +283,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -296,13 +296,13 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_(Encounter InpatientEncounter)
 		{
 			CqlValueSet e_ = this.Medicare_FFS_payer();
-			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, null);
+			IEnumerable<Coverage> f_ = context.Operators.RetrieveByValueSet<Coverage>(e_, default(PropertyInfo));
 			CqlValueSet g_ = this.Medicare_Advantage_payer();
-			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, null);
+			IEnumerable<Coverage> h_ = context.Operators.RetrieveByValueSet<Coverage>(g_, default(PropertyInfo));
 			IEnumerable<Coverage> i_ = context.Operators.Union<Coverage>(f_, h_);
 			bool? j_(Coverage MedicarePayer)
 			{
@@ -367,7 +367,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation temperature)
 			{
 				DataType y_ = temperature?.Effective;
@@ -383,7 +383,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				Code<ObservationStatus> an_ = temperature?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -431,7 +431,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
 				Code<ObservationStatus> bq_ = temperature?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -484,7 +484,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -500,7 +500,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				Code<ObservationStatus> an_ = HeartRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -548,7 +548,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
 				Code<ObservationStatus> bq_ = HeartRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -602,7 +602,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation O2Saturation)
 			{
 				object r_()
@@ -668,7 +668,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity ab_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ac_ = context.Operators.Add(aa_, ab_);
 				CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(x_, ac_, true, true);
-				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, null);
+				bool? ae_ = context.Operators.In<CqlDateTime>(s_, ad_, default(string));
 				Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
 				ObservationStatus? ag_ = af_?.Value;
 				Code<ObservationStatus> ah_ = context.Operators.Convert<Code<ObservationStatus>>(ag_);
@@ -755,7 +755,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool cc_()
 				{
 					CqlValueSet cf_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, null);
+					IEnumerable<Observation> cg_ = context.Operators.RetrieveByValueSet<Observation>(cf_, default(PropertyInfo));
 					bool? ch_(Observation O2Saturation)
 					{
 						object cp_()
@@ -821,7 +821,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity cz_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime da_ = context.Operators.Add(cy_, cz_);
 						CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cv_, da_, true, true);
-						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, null);
+						bool? dc_ = context.Operators.In<CqlDateTime>(cq_, db_, default(string));
 						Code<ObservationStatus> dd_ = O2Saturation?.StatusElement;
 						ObservationStatus? de_ = dd_?.Value;
 						Code<ObservationStatus> df_ = context.Operators.Convert<Code<ObservationStatus>>(de_);
@@ -910,7 +910,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool cd_()
 				{
 					CqlValueSet fa_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, null);
+					IEnumerable<Observation> fb_ = context.Operators.RetrieveByValueSet<Observation>(fa_, default(PropertyInfo));
 					bool? fc_(Observation O2Saturation)
 					{
 						object fk_()
@@ -976,7 +976,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity fu_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime fv_ = context.Operators.Add(ft_, fu_);
 						CqlInterval<CqlDateTime> fw_ = context.Operators.Interval(fq_, fv_, true, true);
-						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, null);
+						bool? fx_ = context.Operators.In<CqlDateTime>(fl_, fw_, default(string));
 						Code<ObservationStatus> fy_ = O2Saturation?.StatusElement;
 						ObservationStatus? fz_ = fy_?.Value;
 						Code<ObservationStatus> ga_ = context.Operators.Convert<Code<ObservationStatus>>(fz_);
@@ -1065,7 +1065,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				bool ce_()
 				{
 					CqlValueSet hv_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, null);
+					IEnumerable<Observation> hw_ = context.Operators.RetrieveByValueSet<Observation>(hv_, default(PropertyInfo));
 					bool? hx_(Observation O2Saturation)
 					{
 						object if_()
@@ -1131,7 +1131,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity ip_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime iq_ = context.Operators.Add(io_, ip_);
 						CqlInterval<CqlDateTime> ir_ = context.Operators.Interval(il_, iq_, true, true);
-						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, null);
+						bool? is_ = context.Operators.In<CqlDateTime>(ig_, ir_, default(string));
 						Code<ObservationStatus> it_ = O2Saturation?.StatusElement;
 						ObservationStatus? iu_ = it_?.Value;
 						Code<ObservationStatus> iv_ = context.Operators.Convert<Code<ObservationStatus>>(iu_);
@@ -1220,7 +1220,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				if (cc_())
 				{
 					CqlValueSet kq_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, null);
+					IEnumerable<Observation> kr_ = context.Operators.RetrieveByValueSet<Observation>(kq_, default(PropertyInfo));
 					bool? ks_(Observation O2Saturation)
 					{
 						object kz_()
@@ -1286,7 +1286,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity lj_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime lk_ = context.Operators.Add(li_, lj_);
 						CqlInterval<CqlDateTime> ll_ = context.Operators.Interval(lf_, lk_, true, true);
-						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, null);
+						bool? lm_ = context.Operators.In<CqlDateTime>(la_, ll_, default(string));
 						Code<ObservationStatus> ln_ = O2Saturation?.StatusElement;
 						ObservationStatus? lo_ = ln_?.Value;
 						Code<ObservationStatus> lp_ = context.Operators.Convert<Code<ObservationStatus>>(lo_);
@@ -1374,7 +1374,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				else if (cd_())
 				{
 					CqlValueSet nk_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, null);
+					IEnumerable<Observation> nl_ = context.Operators.RetrieveByValueSet<Observation>(nk_, default(PropertyInfo));
 					bool? nm_(Observation O2Saturation)
 					{
 						object nt_()
@@ -1440,7 +1440,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity od_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime oe_ = context.Operators.Add(oc_, od_);
 						CqlInterval<CqlDateTime> of_ = context.Operators.Interval(nz_, oe_, true, true);
-						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, null);
+						bool? og_ = context.Operators.In<CqlDateTime>(nu_, of_, default(string));
 						Code<ObservationStatus> oh_ = O2Saturation?.StatusElement;
 						ObservationStatus? oi_ = oh_?.Value;
 						Code<ObservationStatus> oj_ = context.Operators.Convert<Code<ObservationStatus>>(oi_);
@@ -1528,7 +1528,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				else if (ce_())
 				{
 					CqlValueSet qe_ = this.Oxygen_Saturation_by_Pulse_Oximetry();
-					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, null);
+					IEnumerable<Observation> qf_ = context.Operators.RetrieveByValueSet<Observation>(qe_, default(PropertyInfo));
 					bool? qg_(Observation O2Saturation)
 					{
 						object qn_()
@@ -1594,7 +1594,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 						CqlQuantity qx_ = context.Operators.Quantity(120m, "minutes");
 						CqlDateTime qy_ = context.Operators.Add(qw_, qx_);
 						CqlInterval<CqlDateTime> qz_ = context.Operators.Interval(qt_, qy_, true, true);
-						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, null);
+						bool? ra_ = context.Operators.In<CqlDateTime>(qo_, qz_, default(string));
 						Code<ObservationStatus> rb_ = O2Saturation?.StatusElement;
 						ObservationStatus? rc_ = rb_?.Value;
 						Code<ObservationStatus> rd_ = context.Operators.Convert<Code<ObservationStatus>>(rc_);
@@ -1705,7 +1705,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation RespRate)
 			{
 				DataType y_ = RespRate?.Effective;
@@ -1721,7 +1721,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity aj_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime ak_ = context.Operators.Add(ai_, aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(af_, ak_, true, true);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				Code<ObservationStatus> an_ = RespRate?.StatusElement;
 				ObservationStatus? ao_ = an_?.Value;
 				string ap_ = context.Operators.Convert<string>(ao_);
@@ -1769,7 +1769,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlQuantity bm_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime bn_ = context.Operators.Add(bl_, bm_);
 				CqlInterval<CqlDateTime> bo_ = context.Operators.Interval(bi_, bn_, true, true);
-				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, null);
+				bool? bp_ = context.Operators.In<CqlDateTime>(bd_, bo_, default(string));
 				Code<ObservationStatus> bq_ = RespRate?.StatusElement;
 				ObservationStatus? br_ = bq_?.Value;
 				string bs_ = context.Operators.Convert<string>(br_);
@@ -1817,7 +1817,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 
 	private IEnumerable<Observation> Blood_Pressure_Reading_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Observation BloodPressure)
 		{
 			Code<ObservationStatus> d_ = BloodPressure?.StatusElement;
@@ -1868,7 +1868,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Bicarbonate_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation bicarbonatelab)
 			{
 				Instant z_ = bicarbonatelab?.IssuedElement;
@@ -1884,7 +1884,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = bicarbonatelab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -1916,7 +1916,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation bicarbonatelab)
 			{
 				Instant bd_ = bicarbonatelab?.IssuedElement;
@@ -1932,7 +1932,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = bicarbonatelab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -1986,7 +1986,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Creatinine_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation CreatinineLab)
 			{
 				Instant z_ = CreatinineLab?.IssuedElement;
@@ -2002,7 +2002,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = CreatinineLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2034,7 +2034,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation CreatinineLab)
 			{
 				Instant bd_ = CreatinineLab?.IssuedElement;
@@ -2050,7 +2050,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = CreatinineLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2104,7 +2104,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Glucose_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation GlucoseLab)
 			{
 				Instant z_ = GlucoseLab?.IssuedElement;
@@ -2120,7 +2120,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = GlucoseLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2152,7 +2152,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation GlucoseLab)
 			{
 				Instant bd_ = GlucoseLab?.IssuedElement;
@@ -2168,7 +2168,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = GlucoseLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2222,7 +2222,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation HematocritLab)
 			{
 				Instant z_ = HematocritLab?.IssuedElement;
@@ -2238,7 +2238,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = HematocritLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2270,7 +2270,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation HematocritLab)
 			{
 				Instant bd_ = HematocritLab?.IssuedElement;
@@ -2286,7 +2286,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = HematocritLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2340,7 +2340,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Potassium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation PotassiumLab)
 			{
 				Instant z_ = PotassiumLab?.IssuedElement;
@@ -2356,7 +2356,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = PotassiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2388,7 +2388,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation PotassiumLab)
 			{
 				Instant bd_ = PotassiumLab?.IssuedElement;
@@ -2404,7 +2404,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = PotassiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2458,7 +2458,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Sodium_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation SodiumLab)
 			{
 				Instant z_ = SodiumLab?.IssuedElement;
@@ -2474,7 +2474,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = SodiumLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2506,7 +2506,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation SodiumLab)
 			{
 				Instant bd_ = SodiumLab?.IssuedElement;
@@ -2522,7 +2522,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = SodiumLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2576,7 +2576,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation WhiteBloodCellLab)
 			{
 				Instant z_ = WhiteBloodCellLab?.IssuedElement;
@@ -2592,7 +2592,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlDateTime am_ = context.Operators.Add(ak_, ag_);
 				CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ah_, am_, true, true);
-				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, null);
+				bool? ao_ = context.Operators.In<CqlDateTime>(ac_, an_, default(string));
 				Code<ObservationStatus> ap_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? aq_ = ap_?.Value;
 				string ar_ = context.Operators.Convert<string>(aq_);
@@ -2624,7 +2624,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation WhiteBloodCellLab)
 			{
 				Instant bd_ = WhiteBloodCellLab?.IssuedElement;
@@ -2640,7 +2640,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				CqlDateTime bo_ = context.Operators.Start(bn_);
 				CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
 				CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, null);
+				bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default(string));
 				Code<ObservationStatus> bt_ = WhiteBloodCellLab?.StatusElement;
 				ObservationStatus? bu_ = bt_?.Value;
 				string bv_ = context.Operators.Convert<string>(bu_);
@@ -2693,14 +2693,14 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 		{
 			Id d_ = EncounterInpatient?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation WeightExam)
 			{
 				DataType y_ = WeightExam?.Effective;
 				object z_ = FHIRHelpers_4_3_000.ToValue(y_);
 				CqlDateTime aa_ = QICoreCommon_2_0_000.earliest(z_);
 				CqlInterval<CqlDateTime> ab_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, null);
+				bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default(string));
 				Code<ObservationStatus> ad_ = WeightExam?.StatusElement;
 				ObservationStatus? ae_ = ad_?.Value;
 				string af_ = context.Operators.Convert<string>(ae_);
@@ -2739,7 +2739,7 @@ public class HybridHospitalWideReadmissionFHIR_0_0_001
 				object as_ = FHIRHelpers_4_3_000.ToValue(ar_);
 				CqlDateTime at_ = QICoreCommon_2_0_000.earliest(as_);
 				CqlInterval<CqlDateTime> au_ = CQMCommon_2_0_000.hospitalizationWithObservationAndOutpatientSurgeryService(EncounterInpatient);
-				bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, null);
+				bool? av_ = context.Operators.In<CqlDateTime>(at_, au_, default(string));
 				Code<ObservationStatus> aw_ = WeightExam?.StatusElement;
 				ObservationStatus? ax_ = aw_?.Value;
 				string ay_ = context.Operators.Convert<string>(ax_);

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -142,7 +142,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
     #endregion
 
 	private CqlValueSet Active_Tuberculosis_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", default(string));
 
     [CqlDeclaration("Active Tuberculosis for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56")]
@@ -150,7 +150,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Active_Tuberculosis_for_Urology_Care.Value;
 
 	private CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", default(string));
 
     [CqlDeclaration("BCG Bacillus Calmette Guerin for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52")]
@@ -158,7 +158,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__BCG_Bacillus_Calmette_Guerin_for_Urology_Care.Value;
 
 	private CqlValueSet Bladder_Cancer_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", default(string));
 
     [CqlDeclaration("Bladder Cancer for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45")]
@@ -166,7 +166,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Bladder_Cancer_for_Urology_Care.Value;
 
 	private CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", default(string));
 
     [CqlDeclaration("Chemotherapy Agents for Advanced Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60")]
@@ -174,7 +174,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Chemotherapy_Agents_for_Advanced_Cancer.Value;
 
 	private CqlValueSet Cystectomy_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", default(string));
 
     [CqlDeclaration("Cystectomy for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55")]
@@ -182,7 +182,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Cystectomy_for_Urology_Care.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -190,7 +190,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__HIV.Value;
 
 	private CqlValueSet Immunocompromised_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", default(string));
 
     [CqlDeclaration("Immunocompromised Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940")]
@@ -198,7 +198,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Immunocompromised_Conditions.Value;
 
 	private CqlValueSet Immunosuppressive_Drugs_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", default(string));
 
     [CqlDeclaration("Immunosuppressive Drugs for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32")]
@@ -206,7 +206,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Immunosuppressive_Drugs_for_Urology_Care.Value;
 
 	private CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", default(string));
 
     [CqlDeclaration("Mixed histology urothelial cell carcinoma for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39")]
@@ -214,7 +214,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -222,7 +222,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", default(string));
 
     [CqlDeclaration("Unavailability of Bacillus Calmette Guerin for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44")]
@@ -230,63 +230,63 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care.Value;
 
 	private CqlCode Carcinoma_in_situ_of_bladder_Value() => 
-		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Carcinoma in situ of bladder")]
 	public CqlCode Carcinoma_in_situ_of_bladder() => 
 		__Carcinoma_in_situ_of_bladder.Value;
 
 	private CqlCode Combined_radiotherapy__procedure__Value() => 
-		new CqlCode("169331000", "http://snomed.info/sct", null, null);
+		new CqlCode("169331000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Combined radiotherapy (procedure)")]
 	public CqlCode Combined_radiotherapy__procedure_() => 
 		__Combined_radiotherapy__procedure_.Value;
 
 	private CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value() => 
-		new CqlCode("369935001", "http://snomed.info/sct", null, null);
+		new CqlCode("369935001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("T1: Urinary tract tumor invades subepithelial connective tissue (finding)")]
 	public CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_() => 
 		__T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_.Value;
 
 	private CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value() => 
-		new CqlCode("369949005", "http://snomed.info/sct", null, null);
+		new CqlCode("369949005", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Ta: Noninvasive papillary carcinoma (urinary tract) (finding)")]
 	public CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_() => 
 		__Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_.Value;
 
 	private CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value() => 
-		new CqlCode("369934002", "http://snomed.info/sct", null, null);
+		new CqlCode("369934002", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Tis: Carcinoma in situ (flat tumor of urinary bladder) (finding)")]
 	public CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_() => 
 		__Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_.Value;
 
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
-		new CqlCode("254292007", "http://snomed.info/sct", null, null);
+		new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
 		__Tumor_staging__tumor_staging_.Value;
 
 	private CqlCode Dead__finding__Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode Stage_group_pathology_Cancer_Value() => 
-		new CqlCode("21902-2", "http://loinc.org", null, null);
+		new CqlCode("21902-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Stage group.pathology Cancer")]
 	public CqlCode Stage_group_pathology_Cancer() => 
@@ -295,12 +295,12 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("169331000", "http://snomed.info/sct", null, null),
-			new CqlCode("369935001", "http://snomed.info/sct", null, null),
-			new CqlCode("369949005", "http://snomed.info/sct", null, null),
-			new CqlCode("369934002", "http://snomed.info/sct", null, null),
-			new CqlCode("254292007", "http://snomed.info/sct", null, null),
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("169331000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("369935001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("369949005", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("369934002", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -313,7 +313,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -326,7 +326,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21902-2", "http://loinc.org", null, null),
+			new CqlCode("21902-2", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -339,7 +339,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -351,8 +351,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000", "Measurement Period", c_);
 
@@ -365,7 +365,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -418,14 +418,14 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Condition> Bladder_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Bladder_Cancer_for_Urology_Care();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition BladderCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.Before(f_, h_, null);
+			bool? i_ = context.Operators.Before(f_, h_, default(string));
 			bool? j_ = this.isConfirmedActiveDiagnosis(BladderCancer);
 			bool? k_ = context.Operators.And(i_, j_);
 
@@ -444,7 +444,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlCode a_ = this.Tumor_staging__tumor_staging_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, null);
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default(PropertyInfo));
 		IEnumerable<Procedure> d_(Procedure BladderCancerStaging)
 		{
 			IEnumerable<Condition> k_ = this.Bladder_Cancer_Diagnosis();
@@ -623,7 +623,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlCode a_ = this.Stage_group_pathology_Cancer();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation StagingObservation)
 		{
 			IEnumerable<Procedure> g_ = this.getStagingProcedure(StagingObservation);
@@ -676,13 +676,13 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			Period g_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default(string));
 			Coding j_ = ValidEncounter?.Class;
 			CqlCode k_ = FHIRHelpers_4_3_000.ToCode(j_);
 			CqlCode l_ = this.@virtual();
@@ -737,8 +737,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value()
 	{
 		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCGNotGiven)
 		{
@@ -759,7 +759,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				};
 				IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
-						: null), p_);
+						: default(List<Extension>)), p_);
 				DataType r_(Extension @this)
 				{
 					DataType ba_ = @this?.Value;
@@ -779,7 +779,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlQuantity ad_ = context.Operators.Quantity(6m, "months");
 				CqlDateTime ae_ = context.Operators.Add(ac_, ad_);
 				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(y_, ae_, false, true);
-				bool? ag_ = context.Operators.In<CqlDateTime>(u_, af_, null);
+				bool? ag_ = context.Operators.In<CqlDateTime>(u_, af_, default(string));
 				object ai_ = FHIRHelpers_4_3_000.ToValue(v_);
 				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
 				CqlDateTime ak_ = context.Operators.Start(aj_);
@@ -796,7 +796,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				};
 				IEnumerable<Extension> ao_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
-						: null), an_);
+						: default(List<Extension>)), an_);
 				DataType ap_(Extension @this)
 				{
 					DataType bf_ = @this?.Value;
@@ -807,7 +807,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				DataType ar_ = context.Operators.SingletonFrom<DataType>(aq_);
 				CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
 				CqlInterval<CqlDateTime> at_ = this.Measurement_Period();
-				bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, null);
+				bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default(string));
 				bool? av_ = context.Operators.And(am_, au_);
 
 				return av_;
@@ -859,8 +859,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private MedicationAdministration First_BCG_Administered_Value()
 	{
 		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCG)
 		{
@@ -884,7 +884,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlQuantity ae_ = context.Operators.Quantity(6m, "months");
 				CqlDateTime af_ = context.Operators.Add(ad_, ae_);
 				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(z_, af_, false, true);
-				bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, null);
+				bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, default(string));
 				object aj_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
 				CqlDateTime al_ = context.Operators.Start(ak_);
@@ -894,7 +894,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.toInterval(ap_);
 				CqlDateTime ar_ = context.Operators.Start(aq_);
 				CqlInterval<CqlDateTime> as_ = this.Measurement_Period();
-				bool? at_ = context.Operators.In<CqlDateTime>(ar_, as_, null);
+				bool? at_ = context.Operators.In<CqlDateTime>(ar_, as_, default(string));
 				bool? au_ = context.Operators.And(an_, at_);
 
 				return au_;
@@ -1000,7 +1000,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Condition> Acute_Tuberculosis_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Active_Tuberculosis_for_Urology_Care();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition ActiveTuberculosis)
 		{
 			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1013,7 +1013,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				DataType n_ = FirstBladderCancerStaging?.Performed;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.OverlapsAfter(m_, p_, null);
+				bool? q_ = context.Operators.OverlapsAfter(m_, p_, default(string));
 
 				return q_;
 			};
@@ -1043,8 +1043,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<MedicationRequest> Immunosuppressive_Drugs_Value()
 	{
 		CqlValueSet a_ = this.Immunosuppressive_Drugs_for_Urology_Care();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ImmunosuppressiveDrugs)
 		{
@@ -1061,7 +1061,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.toInterval(r_);
 				CqlDateTime t_ = context.Operators.Start(s_);
-				bool? u_ = context.Operators.SameOrBefore(p_, t_, null);
+				bool? u_ = context.Operators.SameOrBefore(p_, t_, default(string));
 
 				return u_;
 			};
@@ -1084,7 +1084,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Procedure> Cystectomy_Done_Value()
 	{
 		CqlValueSet a_ = this.Cystectomy_for_Urology_Care();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_(Procedure Cystectomy)
 		{
 			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1107,7 +1107,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(v_, z_, true, false);
-				bool? ab_ = context.Operators.In<CqlDateTime>(p_, aa_, null);
+				bool? ab_ = context.Operators.In<CqlDateTime>(p_, aa_, default(string));
 				object ad_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.toInterval(ad_);
 				CqlDateTime af_ = context.Operators.Start(ae_);
@@ -1145,12 +1145,12 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Immunocompromised_Conditions();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		IEnumerable<Condition> i_(Condition ExclusionDiagnosis)
 		{
@@ -1166,7 +1166,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
 				CqlDateTime y_ = context.Operators.Start(x_);
-				bool? z_ = context.Operators.SameOrBefore(u_, y_, null);
+				bool? z_ = context.Operators.SameOrBefore(u_, y_, default(string));
 
 				return z_;
 			};
@@ -1197,8 +1197,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value()
 	{
 		CqlValueSet a_ = this.Chemotherapy_Agents_for_Advanced_Cancer();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ExclusionMed)
 		{
@@ -1221,7 +1221,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ag_, ak_, true, false);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, null);
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
 				object ao_ = FHIRHelpers_4_3_000.ToValue(ab_);
 				CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.toInterval(ao_);
 				CqlDateTime aq_ = context.Operators.Start(ap_);
@@ -1264,7 +1264,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
 		CqlCode j_ = this.Combined_radiotherapy__procedure_();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Procedure> l_ = context.Operators.RetrieveByCodes<Procedure>(k_, null);
+		IEnumerable<Procedure> l_ = context.Operators.RetrieveByCodes<Procedure>(k_, default(PropertyInfo));
 		IEnumerable<Procedure> m_(Procedure ExclusionProcedure)
 		{
 			Procedure bi_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1287,7 +1287,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> ca_ = QICoreCommon_2_0_000.toInterval(bz_);
 				CqlDateTime cb_ = context.Operators.Start(ca_);
 				CqlInterval<CqlDateTime> cc_ = context.Operators.Interval(bx_, cb_, true, false);
-				bool? cd_ = context.Operators.In<CqlDateTime>(br_, cc_, null);
+				bool? cd_ = context.Operators.In<CqlDateTime>(br_, cc_, default(string));
 				object cf_ = FHIRHelpers_4_3_000.ToValue(bs_);
 				CqlInterval<CqlDateTime> cg_ = QICoreCommon_2_0_000.toInterval(cf_);
 				CqlDateTime ch_ = context.Operators.Start(cg_);

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR", "1.3.000")]
 public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 {

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000.g.cs
@@ -142,7 +142,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
     #endregion
 
 	private CqlValueSet Active_Tuberculosis_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56", default);
 
     [CqlDeclaration("Active Tuberculosis for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.56")]
@@ -150,7 +150,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Active_Tuberculosis_for_Urology_Care.Value;
 
 	private CqlValueSet BCG_Bacillus_Calmette_Guerin_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52", default);
 
     [CqlDeclaration("BCG Bacillus Calmette Guerin for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.52")]
@@ -158,7 +158,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__BCG_Bacillus_Calmette_Guerin_for_Urology_Care.Value;
 
 	private CqlValueSet Bladder_Cancer_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45", default);
 
     [CqlDeclaration("Bladder Cancer for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.45")]
@@ -166,7 +166,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Bladder_Cancer_for_Urology_Care.Value;
 
 	private CqlValueSet Chemotherapy_Agents_for_Advanced_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60", default);
 
     [CqlDeclaration("Chemotherapy Agents for Advanced Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.60")]
@@ -174,7 +174,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Chemotherapy_Agents_for_Advanced_Cancer.Value;
 
 	private CqlValueSet Cystectomy_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55", default);
 
     [CqlDeclaration("Cystectomy for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.55")]
@@ -182,7 +182,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Cystectomy_for_Urology_Care.Value;
 
 	private CqlValueSet HIV_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003", default);
 
     [CqlDeclaration("HIV")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.120.12.1003")]
@@ -190,7 +190,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__HIV.Value;
 
 	private CqlValueSet Immunocompromised_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940", default);
 
     [CqlDeclaration("Immunocompromised Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.1940")]
@@ -198,7 +198,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Immunocompromised_Conditions.Value;
 
 	private CqlValueSet Immunosuppressive_Drugs_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32", default);
 
     [CqlDeclaration("Immunosuppressive Drugs for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.32")]
@@ -206,7 +206,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Immunosuppressive_Drugs_for_Urology_Care.Value;
 
 	private CqlValueSet Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39", default);
 
     [CqlDeclaration("Mixed histology urothelial cell carcinoma for Urology Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.39")]
@@ -214,7 +214,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -222,7 +222,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44", default);
 
     [CqlDeclaration("Unavailability of Bacillus Calmette Guerin for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1151.44")]
@@ -230,63 +230,63 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		__Unavailability_of_Bacillus_Calmette_Guerin_for_urology_care.Value;
 
 	private CqlCode Carcinoma_in_situ_of_bladder_Value() => 
-		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Carcinoma in situ of bladder")]
 	public CqlCode Carcinoma_in_situ_of_bladder() => 
 		__Carcinoma_in_situ_of_bladder.Value;
 
 	private CqlCode Combined_radiotherapy__procedure__Value() => 
-		new CqlCode("169331000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("169331000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Combined radiotherapy (procedure)")]
 	public CqlCode Combined_radiotherapy__procedure_() => 
 		__Combined_radiotherapy__procedure_.Value;
 
 	private CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding__Value() => 
-		new CqlCode("369935001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("369935001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("T1: Urinary tract tumor invades subepithelial connective tissue (finding)")]
 	public CqlCode T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_() => 
 		__T1__Urinary_tract_tumor_invades_subepithelial_connective_tissue__finding_.Value;
 
 	private CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding__Value() => 
-		new CqlCode("369949005", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("369949005", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Ta: Noninvasive papillary carcinoma (urinary tract) (finding)")]
 	public CqlCode Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_() => 
 		__Ta__Noninvasive_papillary_carcinoma__urinary_tract___finding_.Value;
 
 	private CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding__Value() => 
-		new CqlCode("369934002", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("369934002", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Tis: Carcinoma in situ (flat tumor of urinary bladder) (finding)")]
 	public CqlCode Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_() => 
 		__Tis__Carcinoma_in_situ__flat_tumor_of_urinary_bladder___finding_.Value;
 
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
-		new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("254292007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
 		__Tumor_staging__tumor_staging_.Value;
 
 	private CqlCode Dead__finding__Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead (finding)")]
 	public CqlCode Dead__finding_() => 
 		__Dead__finding_.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode Stage_group_pathology_Cancer_Value() => 
-		new CqlCode("21902-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("21902-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("Stage group.pathology Cancer")]
 	public CqlCode Stage_group_pathology_Cancer() => 
@@ -295,12 +295,12 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("169331000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("369935001", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("369949005", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("369934002", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("169331000", "http://snomed.info/sct", default, default),
+			new CqlCode("369935001", "http://snomed.info/sct", default, default),
+			new CqlCode("369949005", "http://snomed.info/sct", default, default),
+			new CqlCode("369934002", "http://snomed.info/sct", default, default),
+			new CqlCode("254292007", "http://snomed.info/sct", default, default),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -313,7 +313,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("D09.0", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -326,7 +326,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21902-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21902-2", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -339,7 +339,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -351,8 +351,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.3.000", "Measurement Period", c_);
 
@@ -365,7 +365,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -418,14 +418,14 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Condition> Bladder_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Bladder_Cancer_for_Urology_Care();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition BladderCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(BladderCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.Before(f_, h_, default(string));
+			bool? i_ = context.Operators.Before(f_, h_, default);
 			bool? j_ = this.isConfirmedActiveDiagnosis(BladderCancer);
 			bool? k_ = context.Operators.And(i_, j_);
 
@@ -444,7 +444,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlCode a_ = this.Tumor_staging__tumor_staging_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default(PropertyInfo));
+		IEnumerable<Procedure> c_ = context.Operators.RetrieveByCodes<Procedure>(b_, default);
 		IEnumerable<Procedure> d_(Procedure BladderCancerStaging)
 		{
 			IEnumerable<Condition> k_ = this.Bladder_Cancer_Diagnosis();
@@ -623,7 +623,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	{
 		CqlCode a_ = this.Stage_group_pathology_Cancer();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation StagingObservation)
 		{
 			IEnumerable<Procedure> g_ = this.getStagingProcedure(StagingObservation);
@@ -676,13 +676,13 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			Period g_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> h_ = FHIRHelpers_4_3_000.ToInterval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default(string));
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default);
 			Coding j_ = ValidEncounter?.Class;
 			CqlCode k_ = FHIRHelpers_4_3_000.ToCode(j_);
 			CqlCode l_ = this.@virtual();
@@ -737,8 +737,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<MedicationAdministration> BCG_Not_Available_Within_6_Months_After_Bladder_Cancer_Staging_Value()
 	{
 		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCGNotGiven)
 		{
@@ -759,7 +759,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				};
 				IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
-						: default(List<Extension>)), p_);
+						: default), p_);
 				DataType r_(Extension @this)
 				{
 					DataType ba_ = @this?.Value;
@@ -779,7 +779,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlQuantity ad_ = context.Operators.Quantity(6m, "months");
 				CqlDateTime ae_ = context.Operators.Add(ac_, ad_);
 				CqlInterval<CqlDateTime> af_ = context.Operators.Interval(y_, ae_, false, true);
-				bool? ag_ = context.Operators.In<CqlDateTime>(u_, af_, default(string));
+				bool? ag_ = context.Operators.In<CqlDateTime>(u_, af_, default);
 				object ai_ = FHIRHelpers_4_3_000.ToValue(v_);
 				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
 				CqlDateTime ak_ = context.Operators.Start(aj_);
@@ -796,7 +796,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				};
 				IEnumerable<Extension> ao_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((BCGNotGiven is DomainResource)
 						? ((BCGNotGiven as DomainResource).Extension)
-						: default(List<Extension>)), an_);
+						: default), an_);
 				DataType ap_(Extension @this)
 				{
 					DataType bf_ = @this?.Value;
@@ -807,7 +807,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				DataType ar_ = context.Operators.SingletonFrom<DataType>(aq_);
 				CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
 				CqlInterval<CqlDateTime> at_ = this.Measurement_Period();
-				bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default(string));
+				bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
 				bool? av_ = context.Operators.And(am_, au_);
 
 				return av_;
@@ -859,8 +859,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private MedicationAdministration First_BCG_Administered_Value()
 	{
 		CqlValueSet a_ = this.BCG_Bacillus_Calmette_Guerin_for_Urology_Care();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		IEnumerable<MedicationAdministration> f_(MedicationAdministration BCG)
 		{
@@ -884,7 +884,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlQuantity ae_ = context.Operators.Quantity(6m, "months");
 				CqlDateTime af_ = context.Operators.Add(ad_, ae_);
 				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(z_, af_, false, true);
-				bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, default(string));
+				bool? ah_ = context.Operators.In<CqlDateTime>(v_, ag_, default);
 				object aj_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> ak_ = QICoreCommon_2_0_000.toInterval(aj_);
 				CqlDateTime al_ = context.Operators.Start(ak_);
@@ -894,7 +894,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_0_000.toInterval(ap_);
 				CqlDateTime ar_ = context.Operators.Start(aq_);
 				CqlInterval<CqlDateTime> as_ = this.Measurement_Period();
-				bool? at_ = context.Operators.In<CqlDateTime>(ar_, as_, default(string));
+				bool? at_ = context.Operators.In<CqlDateTime>(ar_, as_, default);
 				bool? au_ = context.Operators.And(an_, at_);
 
 				return au_;
@@ -1000,7 +1000,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Condition> Acute_Tuberculosis_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Active_Tuberculosis_for_Urology_Care();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition ActiveTuberculosis)
 		{
 			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1013,7 +1013,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				DataType n_ = FirstBladderCancerStaging?.Performed;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.OverlapsAfter(m_, p_, default(string));
+				bool? q_ = context.Operators.OverlapsAfter(m_, p_, default);
 
 				return q_;
 			};
@@ -1043,8 +1043,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<MedicationRequest> Immunosuppressive_Drugs_Value()
 	{
 		CqlValueSet a_ = this.Immunosuppressive_Drugs_for_Urology_Care();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ImmunosuppressiveDrugs)
 		{
@@ -1061,7 +1061,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> s_ = QICoreCommon_2_0_000.toInterval(r_);
 				CqlDateTime t_ = context.Operators.Start(s_);
-				bool? u_ = context.Operators.SameOrBefore(p_, t_, default(string));
+				bool? u_ = context.Operators.SameOrBefore(p_, t_, default);
 
 				return u_;
 			};
@@ -1084,7 +1084,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private IEnumerable<Procedure> Cystectomy_Done_Value()
 	{
 		CqlValueSet a_ = this.Cystectomy_for_Urology_Care();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_(Procedure Cystectomy)
 		{
 			Procedure g_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1107,7 +1107,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
 				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(v_, z_, true, false);
-				bool? ab_ = context.Operators.In<CqlDateTime>(p_, aa_, default(string));
+				bool? ab_ = context.Operators.In<CqlDateTime>(p_, aa_, default);
 				object ad_ = FHIRHelpers_4_3_000.ToValue(q_);
 				CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.toInterval(ad_);
 				CqlDateTime af_ = context.Operators.Start(ae_);
@@ -1145,12 +1145,12 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Excluding__HIV__Immunocompromised_Conditions_or_Mixed_Histology_Before_Staging_Value()
 	{
 		CqlValueSet a_ = this.HIV();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Immunocompromised_Conditions();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Mixed_histology_urothelial_cell_carcinoma_for_Urology_Care();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		IEnumerable<Condition> i_(Condition ExclusionDiagnosis)
 		{
@@ -1166,7 +1166,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				object w_ = FHIRHelpers_4_3_000.ToValue(v_);
 				CqlInterval<CqlDateTime> x_ = QICoreCommon_2_0_000.toInterval(w_);
 				CqlDateTime y_ = context.Operators.Start(x_);
-				bool? z_ = context.Operators.SameOrBefore(u_, y_, default(string));
+				bool? z_ = context.Operators.SameOrBefore(u_, y_, default);
 
 				return z_;
 			};
@@ -1197,8 +1197,8 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 	private bool? Has_Excluding_Chemotherapy_or_Radiotherapy_Procedure_Before_Staging_Value()
 	{
 		CqlValueSet a_ = this.Chemotherapy_Agents_for_Advanced_Cancer();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_(MedicationRequest ExclusionMed)
 		{
@@ -1221,7 +1221,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> aj_ = QICoreCommon_2_0_000.toInterval(ai_);
 				CqlDateTime ak_ = context.Operators.Start(aj_);
 				CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ag_, ak_, true, false);
-				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default(string));
+				bool? am_ = context.Operators.In<CqlDateTime>(aa_, al_, default);
 				object ao_ = FHIRHelpers_4_3_000.ToValue(ab_);
 				CqlInterval<CqlDateTime> ap_ = QICoreCommon_2_0_000.toInterval(ao_);
 				CqlDateTime aq_ = context.Operators.Start(ap_);
@@ -1264,7 +1264,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 		IEnumerable<MedicationRequest> i_ = context.Operators.Where<MedicationRequest>(g_, h_);
 		CqlCode j_ = this.Combined_radiotherapy__procedure_();
 		IEnumerable<CqlCode> k_ = context.Operators.ToList<CqlCode>(j_);
-		IEnumerable<Procedure> l_ = context.Operators.RetrieveByCodes<Procedure>(k_, default(PropertyInfo));
+		IEnumerable<Procedure> l_ = context.Operators.RetrieveByCodes<Procedure>(k_, default);
 		IEnumerable<Procedure> m_(Procedure ExclusionProcedure)
 		{
 			Procedure bi_ = this.First_Bladder_Cancer_Staging_Procedure();
@@ -1287,7 +1287,7 @@ public class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_3_000
 				CqlInterval<CqlDateTime> ca_ = QICoreCommon_2_0_000.toInterval(bz_);
 				CqlDateTime cb_ = context.Operators.Start(ca_);
 				CqlInterval<CqlDateTime> cc_ = context.Operators.Interval(bx_, cb_, true, false);
-				bool? cd_ = context.Operators.In<CqlDateTime>(br_, cc_, default(string));
+				bool? cd_ = context.Operators.In<CqlDateTime>(br_, cc_, default);
 				object cf_ = FHIRHelpers_4_3_000.ToValue(bs_);
 				CqlInterval<CqlDateTime> cg_ = QICoreCommon_2_0_000.toInterval(cf_);
 				CqlDateTime ch_ = context.Operators.Start(cg_);

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -120,7 +120,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -128,7 +128,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -136,7 +136,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Chronic_Kidney_Disease__Stage_5_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", default);
 
     [CqlDeclaration("Chronic Kidney Disease, Stage 5")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002")]
@@ -144,7 +144,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Chronic_Kidney_Disease__Stage_5.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -152,7 +152,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Diabetes.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -160,7 +160,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default);
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -168,7 +168,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Estimated_Glomerular_Filtration_Rate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", default);
 
     [CqlDeclaration("Estimated Glomerular Filtration Rate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000")]
@@ -176,7 +176,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Estimated_Glomerular_Filtration_Rate.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -184,7 +184,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default);
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -192,7 +192,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -200,7 +200,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -208,7 +208,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default);
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -216,7 +216,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -224,7 +224,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -232,7 +232,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -240,7 +240,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Urine_Albumin_Creatinine_Ratio_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", default);
 
     [CqlDeclaration("Urine Albumin Creatinine Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007")]
@@ -248,28 +248,28 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Urine_Albumin_Creatinine_Ratio.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428361000124107", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -278,8 +278,8 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -292,7 +292,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -305,7 +305,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -317,8 +317,8 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("KidneyHealthEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
@@ -331,7 +331,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -344,12 +344,12 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Active_Diabetes_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Diabetes();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 			CodeableConcept i_ = Diabetes?.ClinicalStatus;
 			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
 			CqlCode k_ = this.active();
@@ -372,31 +372,31 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Outpatient_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Office_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		bool? u_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
 			Period y_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, default(string));
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, default);
 			Code<Encounter.EncounterStatus> ab_ = ValidEncounter?.StatusElement;
 			Encounter.EncounterStatus? ac_ = ab_?.Value;
 			Code<Encounter.EncounterStatus> ad_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ac_);
@@ -426,7 +426,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		bool? k_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Has_Outpatient_Visit_During_Measurement_Period();
@@ -453,15 +453,15 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Chronic_Kidney_Disease__Stage_5();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition CKDOrESRD)
 		{
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(CKDOrESRD);
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
-			bool? j_ = context.Operators.Overlaps(h_, i_, default(string));
+			bool? j_ = context.Operators.Overlaps(h_, i_, default);
 			CodeableConcept k_ = CKDOrESRD?.ClinicalStatus;
 			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
 			CqlCode m_ = this.active();
@@ -499,14 +499,14 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Kidney_Panel_Performed_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Estimated_Glomerular_Filtration_Rate();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation eGFRTest)
 		{
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 			DataType m_ = eGFRTest?.Effective;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default);
 			DataType q_ = eGFRTest?.Value;
 			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
@@ -528,14 +528,14 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Urine_Albumin_Creatinine_Ratio();
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 		bool? h_(Observation uACRTest)
 		{
 			CqlInterval<CqlDateTime> ab_ = this.Measurement_Period();
 			DataType ac_ = uACRTest?.Effective;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-			bool? af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, default(string));
+			bool? af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, default);
 			DataType ag_ = uACRTest?.Value;
 			object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
 			bool? ai_ = context.Operators.Not((bool?)(ah_ is null));

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -120,7 +120,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -128,7 +128,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -136,7 +136,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Chronic_Kidney_Disease__Stage_5_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002", default(string));
 
     [CqlDeclaration("Chronic Kidney Disease, Stage 5")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1002")]
@@ -144,7 +144,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Chronic_Kidney_Disease__Stage_5.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -152,7 +152,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Diabetes.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -160,7 +160,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -168,7 +168,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Estimated_Glomerular_Filtration_Rate_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000", default(string));
 
     [CqlDeclaration("Estimated Glomerular Filtration Rate")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1000")]
@@ -176,7 +176,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Estimated_Glomerular_Filtration_Rate.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -184,7 +184,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -192,7 +192,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -200,7 +200,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -208,7 +208,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -216,7 +216,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -224,7 +224,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -232,7 +232,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -240,7 +240,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Urine_Albumin_Creatinine_Ratio_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007", default(string));
 
     [CqlDeclaration("Urine Albumin Creatinine Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.6929.3.1007")]
@@ -248,28 +248,28 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		__Urine_Albumin_Creatinine_Ratio.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
 		__Discharge_to_home_for_hospice_care__procedure_.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
 		__AMB.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -278,8 +278,8 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -292,7 +292,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -305,7 +305,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -317,8 +317,8 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("KidneyHealthEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
@@ -331,7 +331,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -344,12 +344,12 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Active_Diabetes_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Diabetes();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Diabetes);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 			CodeableConcept i_ = Diabetes?.ClinicalStatus;
 			CqlConcept j_ = FHIRHelpers_4_3_000.ToConcept(i_);
 			CqlCode k_ = this.active();
@@ -372,31 +372,31 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Outpatient_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Office_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		bool? u_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> x_ = this.Measurement_Period();
 			Period y_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
-			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, null);
+			bool? aa_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, z_, default(string));
 			Code<Encounter.EncounterStatus> ab_ = ValidEncounter?.StatusElement;
 			Encounter.EncounterStatus? ac_ = ab_?.Value;
 			Code<Encounter.EncounterStatus> ad_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(ac_);
@@ -426,7 +426,7 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		bool? k_ = this.Has_Active_Diabetes_Overlaps_Measurement_Period();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Has_Outpatient_Visit_During_Measurement_Period();
@@ -453,15 +453,15 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private IEnumerable<Condition> Has_CKD_Stage_5_or_ESRD_Diagnosis_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Chronic_Kidney_Disease__Stage_5();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		bool? f_(Condition CKDOrESRD)
 		{
 			CqlInterval<CqlDateTime> h_ = QICoreCommon_2_0_000.ToPrevalenceInterval(CKDOrESRD);
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
-			bool? j_ = context.Operators.Overlaps(h_, i_, null);
+			bool? j_ = context.Operators.Overlaps(h_, i_, default(string));
 			CodeableConcept k_ = CKDOrESRD?.ClinicalStatus;
 			CqlConcept l_ = FHIRHelpers_4_3_000.ToConcept(k_);
 			CqlCode m_ = this.active();
@@ -499,14 +499,14 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 	private bool? Has_Kidney_Panel_Performed_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Estimated_Glomerular_Filtration_Rate();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation eGFRTest)
 		{
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 			DataType m_ = eGFRTest?.Effective;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.ToInterval(n_);
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
 			DataType q_ = eGFRTest?.Value;
 			object r_ = FHIRHelpers_4_3_000.ToValue(q_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
@@ -528,14 +528,14 @@ public class KidneyHealthEvaluationFHIR_0_1_000
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Urine_Albumin_Creatinine_Ratio();
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 		bool? h_(Observation uACRTest)
 		{
 			CqlInterval<CqlDateTime> ab_ = this.Measurement_Period();
 			DataType ac_ = uACRTest?.Effective;
 			object ad_ = FHIRHelpers_4_3_000.ToValue(ac_);
 			CqlInterval<CqlDateTime> ae_ = QICoreCommon_2_0_000.ToInterval(ad_);
-			bool? af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, null);
+			bool? af_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ab_, ae_, default(string));
 			DataType ag_ = uACRTest?.Value;
 			object ah_ = FHIRHelpers_4_3_000.ToValue(ag_);
 			bool? ai_ = context.Operators.Not((bool?)(ah_ is null));

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("KidneyHealthEvaluationFHIR", "0.1.000")]
 public class KidneyHealthEvaluationFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -88,7 +88,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", default(string));
 
     [CqlDeclaration("Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010")]
@@ -96,7 +96,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Cancer.Value;
 
 	private CqlValueSet Chemotherapy_Administration_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", default(string));
 
     [CqlDeclaration("Chemotherapy Administration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027")]
@@ -104,7 +104,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Chemotherapy_Administration.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -112,7 +112,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Radiation_Treatment_Management_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", default(string));
 
     [CqlDeclaration("Radiation Treatment Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026")]
@@ -120,7 +120,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Radiation_Treatment_Management.Value;
 
 	private CqlValueSet Standardized_Pain_Assessment_Tool_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", default(string));
 
     [CqlDeclaration("Standardized Pain Assessment Tool")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028")]
@@ -128,7 +128,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Standardized_Pain_Assessment_Tool.Value;
 
 	private CqlCode Radiation_treatment_management__5_treatments_Value() => 
-		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Radiation treatment management, 5 treatments")]
 	public CqlCode Radiation_treatment_management__5_treatments() => 
@@ -137,7 +137,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -149,8 +149,8 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("OncologyPainIntensityQuantifiedFHIR-0.1.000", "Measurement Period", c_);
 
@@ -163,7 +163,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -176,7 +176,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Chemotherapy_Administration();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ChemoAdministration)
 		{
@@ -189,7 +189,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			DataType m_ = ChemoAdministration?.Performed;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, null);
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
 
 			return p_;
 		};
@@ -205,11 +205,11 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
 		IEnumerable<Procedure> d_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
 		CqlValueSet f_ = this.Cancer();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Procedure, Procedure, Condition>> h_ = context.Operators.CrossJoin<Encounter, Procedure, Procedure, Condition>(c_, d_, d_, g_);
 		(Encounter FaceToFaceOrTelehealthEncounter, Procedure ChemoBeforeEncounter, Procedure ChemoAfterEncounter, Condition Cancer)? i_(ValueTuple<Encounter, Procedure, Procedure, Condition> _valueTuple)
 		{
@@ -224,7 +224,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_cibligzrihjljqmithporoase?.Cancer);
 			Period r_ = tuple_cibligzrihjljqmithporoase?.FaceToFaceOrTelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.Overlaps(q_, s_, null);
+			bool? t_ = context.Operators.Overlaps(q_, s_, default(string));
 			bool? u_ = context.Operators.And(p_, t_);
 			DataType v_ = tuple_cibligzrihjljqmithporoase?.ChemoBeforeEncounter?.Performed;
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
@@ -268,7 +268,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			bool? br_ = context.Operators.And(bi_, bq_);
 			CqlInterval<CqlDateTime> bs_ = this.Measurement_Period();
 			CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, null);
+			bool? bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, default(string));
 			bool? bw_ = context.Operators.And(br_, bv_);
 
 			return bw_;
@@ -310,23 +310,23 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Radiation_Treatment_Management();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
 		IEnumerable<Encounter> d_(Encounter RadiationTreatmentManagement)
 		{
 			CqlValueSet f_ = this.Cancer();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			bool? h_(Condition Cancer)
 			{
 				bool? l_ = QICoreCommon_2_0_000.isActive(Cancer);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(Cancer);
 				Period n_ = RadiationTreatmentManagement?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? p_ = context.Operators.Overlaps(m_, o_, null);
+				bool? p_ = context.Operators.Overlaps(m_, o_, default(string));
 				bool? q_ = context.Operators.And(l_, p_);
 				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, null);
+				bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default(string));
 				bool? v_ = context.Operators.And(q_, u_);
 
 				return v_;
@@ -375,7 +375,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo)
 		{
 			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
 			bool? f_(Observation PainAssessed)
 			{
 				Period j_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
@@ -383,7 +383,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 				DataType l_ = PainAssessed?.Effective;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, null);
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default(string));
 				DataType p_ = PainAssessed?.Value;
 				object q_ = FHIRHelpers_4_3_000.ToValue(p_);
 				bool? r_ = context.Operators.Not((bool?)(q_ is null));
@@ -418,7 +418,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter RadiationManagementEncounter)
 		{
 			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
 			bool? f_(Observation PainAssessed)
 			{
 				bool? j_()

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("OncologyPainIntensityQuantifiedFHIR", "0.1.000")]
 public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -88,7 +88,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010", default);
 
     [CqlDeclaration("Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1010")]
@@ -96,7 +96,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Cancer.Value;
 
 	private CqlValueSet Chemotherapy_Administration_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027", default);
 
     [CqlDeclaration("Chemotherapy Administration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1027")]
@@ -104,7 +104,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Chemotherapy_Administration.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -112,7 +112,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Radiation_Treatment_Management_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026", default);
 
     [CqlDeclaration("Radiation Treatment Management")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1026")]
@@ -120,7 +120,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Radiation_Treatment_Management.Value;
 
 	private CqlValueSet Standardized_Pain_Assessment_Tool_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028", default);
 
     [CqlDeclaration("Standardized Pain Assessment Tool")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1028")]
@@ -128,7 +128,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		__Standardized_Pain_Assessment_Tool.Value;
 
 	private CqlCode Radiation_treatment_management__5_treatments_Value() => 
-		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Radiation treatment management, 5 treatments")]
 	public CqlCode Radiation_treatment_management__5_treatments() => 
@@ -137,7 +137,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("77427", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -149,8 +149,8 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("OncologyPainIntensityQuantifiedFHIR-0.1.000", "Measurement Period", c_);
 
@@ -163,7 +163,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -176,7 +176,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Procedure> Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Chemotherapy_Administration();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ChemoAdministration)
 		{
@@ -189,7 +189,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			DataType m_ = ChemoAdministration?.Performed;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
 			CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.toInterval(n_);
-			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default(string));
+			bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, o_, default);
 
 			return p_;
 		};
@@ -205,11 +205,11 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Encounter> Face_to_Face_or_Telehealth_Encounter_with_Ongoing_Chemotherapy_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
 		IEnumerable<Procedure> d_ = this.Chemotherapy_Within_31_Days_Prior_and_During_Measurement_Period();
 		CqlValueSet f_ = this.Cancer();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<ValueTuple<Encounter, Procedure, Procedure, Condition>> h_ = context.Operators.CrossJoin<Encounter, Procedure, Procedure, Condition>(c_, d_, d_, g_);
 		(Encounter FaceToFaceOrTelehealthEncounter, Procedure ChemoBeforeEncounter, Procedure ChemoAfterEncounter, Condition Cancer)? i_(ValueTuple<Encounter, Procedure, Procedure, Condition> _valueTuple)
 		{
@@ -224,7 +224,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			CqlInterval<CqlDateTime> q_ = QICoreCommon_2_0_000.prevalenceInterval(tuple_cibligzrihjljqmithporoase?.Cancer);
 			Period r_ = tuple_cibligzrihjljqmithporoase?.FaceToFaceOrTelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.Overlaps(q_, s_, default(string));
+			bool? t_ = context.Operators.Overlaps(q_, s_, default);
 			bool? u_ = context.Operators.And(p_, t_);
 			DataType v_ = tuple_cibligzrihjljqmithporoase?.ChemoBeforeEncounter?.Performed;
 			object w_ = FHIRHelpers_4_3_000.ToValue(v_);
@@ -268,7 +268,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 			bool? br_ = context.Operators.And(bi_, bq_);
 			CqlInterval<CqlDateTime> bs_ = this.Measurement_Period();
 			CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, default(string));
+			bool? bv_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(bs_, bu_, default);
 			bool? bw_ = context.Operators.And(br_, bv_);
 
 			return bw_;
@@ -310,23 +310,23 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 	private IEnumerable<Encounter> Radiation_Treatment_Management_During_Measurement_Period_with_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Radiation_Treatment_Management();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.Finished_Encounter(b_);
 		IEnumerable<Encounter> d_(Encounter RadiationTreatmentManagement)
 		{
 			CqlValueSet f_ = this.Cancer();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			bool? h_(Condition Cancer)
 			{
 				bool? l_ = QICoreCommon_2_0_000.isActive(Cancer);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(Cancer);
 				Period n_ = RadiationTreatmentManagement?.Period;
 				CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? p_ = context.Operators.Overlaps(m_, o_, default(string));
+				bool? p_ = context.Operators.Overlaps(m_, o_, default);
 				bool? q_ = context.Operators.And(l_, p_);
 				CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 				CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_3_000.ToInterval(n_);
-				bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default(string));
+				bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default);
 				bool? v_ = context.Operators.And(q_, u_);
 
 				return v_;
@@ -375,7 +375,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter FaceToFaceOrTelehealthEncounterWithChemo)
 		{
 			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default);
 			bool? f_(Observation PainAssessed)
 			{
 				Period j_ = FaceToFaceOrTelehealthEncounterWithChemo?.Period;
@@ -383,7 +383,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 				DataType l_ = PainAssessed?.Effective;
 				object m_ = FHIRHelpers_4_3_000.ToValue(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.toInterval(m_);
-				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default(string));
+				bool? o_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, n_, default);
 				DataType p_ = PainAssessed?.Value;
 				object q_ = FHIRHelpers_4_3_000.ToValue(p_);
 				bool? r_ = context.Operators.Not((bool?)(q_ is null));
@@ -418,7 +418,7 @@ public class OncologyPainIntensityQuantifiedFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter RadiationManagementEncounter)
 		{
 			CqlValueSet d_ = this.Standardized_Pain_Assessment_Tool();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default);
 			bool? f_(Observation PainAssessed)
 			{
 				bool? j_()

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
@@ -66,7 +66,7 @@ public class PCMaternal_5_16_000
     #endregion
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default);
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -74,7 +74,7 @@ public class PCMaternal_5_16_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default);
 
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
@@ -82,7 +82,7 @@ public class PCMaternal_5_16_000
 		__ED_Visit_and_OB_Triage.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -90,7 +90,7 @@ public class PCMaternal_5_16_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Estimated_Gestational_Age_at_Delivery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", default);
 
     [CqlDeclaration("Estimated Gestational Age at Delivery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26")]
@@ -98,7 +98,7 @@ public class PCMaternal_5_16_000
 		__Estimated_Gestational_Age_at_Delivery.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -106,14 +106,14 @@ public class PCMaternal_5_16_000
 		__Observation_Services.Value;
 
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
-		new CqlCode("93857-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("93857-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
 		__Date_and_time_of_obstetric_delivery.Value;
 
 	private CqlCode Delivery_date_Estimated_Value() => 
-		new CqlCode("11778-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("11778-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Delivery date Estimated")]
 	public CqlCode Delivery_date_Estimated() => 
@@ -122,8 +122,8 @@ public class PCMaternal_5_16_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("93857-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("11778-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("93857-1", "http://loinc.org", default, default),
+			new CqlCode("11778-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -135,8 +135,8 @@ public class PCMaternal_5_16_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PCMaternal-5.16.000", "Measurement Period", c_);
 
@@ -149,7 +149,7 @@ public class PCMaternal_5_16_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -174,7 +174,7 @@ public class PCMaternal_5_16_000
 			CqlDate k_ = context.Operators.DateFrom(j_);
 			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
 			CqlInterval<int?> m_ = context.Operators.Interval(8, 65, true, false);
-			bool? n_ = context.Operators.In<int?>(l_, m_, default(string));
+			bool? n_ = context.Operators.In<int?>(l_, m_, default);
 
 			return n_;
 		};
@@ -196,14 +196,14 @@ public class PCMaternal_5_16_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.ED_Visit_and_OB_Triage();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastEDOBTriage)
 			{
 				Period af_ = LastEDOBTriage?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? ak_(Encounter LastObs)
 				{
 					Period cg_ = LastObs?.Period;
@@ -217,7 +217,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_3_000.ToInterval(cj_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					CqlInterval<CqlDateTime> cr_ = context.Operators.Interval(cn_, cq_, true, true);
-					bool? cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, default(string));
+					bool? cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, default);
 					CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_3_000.ToInterval(cj_);
 					CqlDateTime cv_ = context.Operators.Start(cu_);
 					bool? cw_ = context.Operators.Not((bool?)(cv_ is null));
@@ -249,7 +249,7 @@ public class PCMaternal_5_16_000
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? az_(Encounter LastObs)
 				{
 					Period dg_ = LastObs?.Period;
@@ -263,7 +263,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(dj_);
 					CqlDateTime dq_ = context.Operators.Start(dp_);
 					CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dn_, dq_, true, true);
-					bool? ds_ = context.Operators.In<CqlDateTime>(di_, dr_, default(string));
+					bool? ds_ = context.Operators.In<CqlDateTime>(di_, dr_, default);
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dj_);
 					CqlDateTime dv_ = context.Operators.Start(du_);
 					bool? dw_ = context.Operators.Not((bool?)(dv_ is null));
@@ -293,8 +293,8 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default);
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? bo_(Encounter LastObs)
 				{
 					Period eg_ = LastObs?.Period;
@@ -308,7 +308,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> ep_ = FHIRHelpers_4_3_000.ToInterval(ej_);
 					CqlDateTime eq_ = context.Operators.Start(ep_);
 					CqlInterval<CqlDateTime> er_ = context.Operators.Interval(en_, eq_, true, true);
-					bool? es_ = context.Operators.In<CqlDateTime>(ei_, er_, default(string));
+					bool? es_ = context.Operators.In<CqlDateTime>(ei_, er_, default);
 					CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_3_000.ToInterval(ej_);
 					CqlDateTime ev_ = context.Operators.Start(eu_);
 					bool? ew_ = context.Operators.Not((bool?)(ev_ is null));
@@ -362,7 +362,7 @@ public class PCMaternal_5_16_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Period fj_ = LastObs?.Period;
@@ -376,7 +376,7 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
 				CqlDateTime ft_ = context.Operators.Start(fs_);
 				CqlInterval<CqlDateTime> fu_ = context.Operators.Interval(fq_, ft_, true, true);
-				bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, default(string));
+				bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, default);
 				CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_3_000.ToInterval(fm_);
 				CqlDateTime fy_ = context.Operators.Start(fx_);
 				bool? fz_ = context.Operators.Not((bool?)(fy_ is null));
@@ -424,7 +424,7 @@ public class PCMaternal_5_16_000
 		IEnumerable<Encounter> b_(Encounter EncounterWithAge)
 		{
 			CqlValueSet d_ = this.Delivery_Procedures();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure DeliveryProcedure)
 			{
 				Code<EventStatus> j_ = DeliveryProcedure?.StatusElement;
@@ -436,7 +436,7 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
 				CqlInterval<CqlDateTime> r_ = this.hospitalizationWithEDOBTriageObservation(EncounterWithAge);
-				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default(string));
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default);
 				bool? t_ = context.Operators.And(m_, s_);
 
 				return t_;
@@ -462,7 +462,7 @@ public class PCMaternal_5_16_000
 	{
 		CqlCode a_ = this.Date_and_time_of_obstetric_delivery();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation TimeOfDelivery)
 		{
 			DataType k_ = TimeOfDelivery?.Value;
@@ -533,10 +533,10 @@ public class PCMaternal_5_16_000
 			};
 			CqlDateTime v_ = QICoreCommon_2_0_000.earliest(u_());
 			CqlInterval<CqlDateTime> w_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, default(string));
+			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, default);
 			bool? y_ = context.Operators.And(t_, x_);
 			object aa_ = FHIRHelpers_4_3_000.ToValue(k_);
-			bool? ac_ = context.Operators.In<CqlDateTime>((aa_ as CqlDateTime), w_, default(string));
+			bool? ac_ = context.Operators.In<CqlDateTime>((aa_ as CqlDateTime), w_, default);
 			bool? ad_ = context.Operators.And(y_, ac_);
 
 			return ad_;
@@ -613,7 +613,7 @@ public class PCMaternal_5_16_000
 	{
 		CqlCode a_ = this.Delivery_date_Estimated();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation EstimatedDateOfDelivery)
 		{
 			DataType k_ = EstimatedDateOfDelivery?.Value;
@@ -687,7 +687,7 @@ public class PCMaternal_5_16_000
 			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, true);
-			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default(string));
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default);
 			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
 			bool? ae_ = context.Operators.And(ab_, ad_);
 			bool? af_ = context.Operators.And(t_, ae_);
@@ -798,7 +798,7 @@ public class PCMaternal_5_16_000
 	public CqlQuantity lastEstimatedGestationalAge(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Estimated_Gestational_Age_at_Delivery();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation EstimatedGestationalAge)
 		{
 			object j_()
@@ -858,7 +858,7 @@ public class PCMaternal_5_16_000
 			CqlQuantity m_ = context.Operators.Quantity(24m, "hours");
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(n_, l_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, default);
 			bool? s_ = context.Operators.Not((bool?)(l_ is null));
 			bool? t_ = context.Operators.And(q_, s_);
 			DataType u_ = EstimatedGestationalAge?.Value;
@@ -984,7 +984,7 @@ public class PCMaternal_5_16_000
 			};
 			CqlDateTime ak_ = QICoreCommon_2_0_000.earliest(aj_());
 			CqlInterval<CqlDateTime> al_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default(string));
+			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default);
 			bool? an_ = context.Operators.And(ai_, am_);
 			object ap_ = FHIRHelpers_4_3_000.ToValue(u_);
 			bool? aq_ = context.Operators.Not((bool?)(ap_ is null));

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PCMaternal", "5.16.000")]
 public class PCMaternal_5_16_000
 {

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.16.000.g.cs
@@ -66,7 +66,7 @@ public class PCMaternal_5_16_000
     #endregion
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -74,7 +74,7 @@ public class PCMaternal_5_16_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default(string));
 
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
@@ -82,7 +82,7 @@ public class PCMaternal_5_16_000
 		__ED_Visit_and_OB_Triage.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -90,7 +90,7 @@ public class PCMaternal_5_16_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Estimated_Gestational_Age_at_Delivery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26", default(string));
 
     [CqlDeclaration("Estimated Gestational Age at Delivery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.26")]
@@ -98,7 +98,7 @@ public class PCMaternal_5_16_000
 		__Estimated_Gestational_Age_at_Delivery.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -106,14 +106,14 @@ public class PCMaternal_5_16_000
 		__Observation_Services.Value;
 
 	private CqlCode Date_and_time_of_obstetric_delivery_Value() => 
-		new CqlCode("93857-1", "http://loinc.org", null, null);
+		new CqlCode("93857-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Date and time of obstetric delivery")]
 	public CqlCode Date_and_time_of_obstetric_delivery() => 
 		__Date_and_time_of_obstetric_delivery.Value;
 
 	private CqlCode Delivery_date_Estimated_Value() => 
-		new CqlCode("11778-8", "http://loinc.org", null, null);
+		new CqlCode("11778-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Delivery date Estimated")]
 	public CqlCode Delivery_date_Estimated() => 
@@ -122,8 +122,8 @@ public class PCMaternal_5_16_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("93857-1", "http://loinc.org", null, null),
-			new CqlCode("11778-8", "http://loinc.org", null, null),
+			new CqlCode("93857-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11778-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -135,8 +135,8 @@ public class PCMaternal_5_16_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PCMaternal-5.16.000", "Measurement Period", c_);
 
@@ -149,7 +149,7 @@ public class PCMaternal_5_16_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -174,7 +174,7 @@ public class PCMaternal_5_16_000
 			CqlDate k_ = context.Operators.DateFrom(j_);
 			int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
 			CqlInterval<int?> m_ = context.Operators.Interval(8, 65, true, false);
-			bool? n_ = context.Operators.In<int?>(l_, m_, null);
+			bool? n_ = context.Operators.In<int?>(l_, m_, default(string));
 
 			return n_;
 		};
@@ -196,14 +196,14 @@ public class PCMaternal_5_16_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.ED_Visit_and_OB_Triage();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastEDOBTriage)
 			{
 				Period af_ = LastEDOBTriage?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_3_000.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? ak_(Encounter LastObs)
 				{
 					Period cg_ = LastObs?.Period;
@@ -217,7 +217,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_3_000.ToInterval(cj_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					CqlInterval<CqlDateTime> cr_ = context.Operators.Interval(cn_, cq_, true, true);
-					bool? cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, null);
+					bool? cs_ = context.Operators.In<CqlDateTime>(ci_, cr_, default(string));
 					CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_3_000.ToInterval(cj_);
 					CqlDateTime cv_ = context.Operators.Start(cu_);
 					bool? cw_ = context.Operators.Not((bool?)(cv_ is null));
@@ -249,7 +249,7 @@ public class PCMaternal_5_16_000
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? az_(Encounter LastObs)
 				{
 					Period dg_ = LastObs?.Period;
@@ -263,7 +263,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(dj_);
 					CqlDateTime dq_ = context.Operators.Start(dp_);
 					CqlInterval<CqlDateTime> dr_ = context.Operators.Interval(dn_, dq_, true, true);
-					bool? ds_ = context.Operators.In<CqlDateTime>(di_, dr_, null);
+					bool? ds_ = context.Operators.In<CqlDateTime>(di_, dr_, default(string));
 					CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_3_000.ToInterval(dj_);
 					CqlDateTime dv_ = context.Operators.Start(du_);
 					bool? dw_ = context.Operators.Not((bool?)(dv_ is null));
@@ -293,8 +293,8 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_3_000.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? bo_(Encounter LastObs)
 				{
 					Period eg_ = LastObs?.Period;
@@ -308,7 +308,7 @@ public class PCMaternal_5_16_000
 					CqlInterval<CqlDateTime> ep_ = FHIRHelpers_4_3_000.ToInterval(ej_);
 					CqlDateTime eq_ = context.Operators.Start(ep_);
 					CqlInterval<CqlDateTime> er_ = context.Operators.Interval(en_, eq_, true, true);
-					bool? es_ = context.Operators.In<CqlDateTime>(ei_, er_, null);
+					bool? es_ = context.Operators.In<CqlDateTime>(ei_, er_, default(string));
 					CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_3_000.ToInterval(ej_);
 					CqlDateTime ev_ = context.Operators.Start(eu_);
 					bool? ew_ = context.Operators.Not((bool?)(ev_ is null));
@@ -362,7 +362,7 @@ public class PCMaternal_5_16_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_3_000.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Period fj_ = LastObs?.Period;
@@ -376,7 +376,7 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_3_000.ToInterval(fm_);
 				CqlDateTime ft_ = context.Operators.Start(fs_);
 				CqlInterval<CqlDateTime> fu_ = context.Operators.Interval(fq_, ft_, true, true);
-				bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, null);
+				bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, default(string));
 				CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_3_000.ToInterval(fm_);
 				CqlDateTime fy_ = context.Operators.Start(fx_);
 				bool? fz_ = context.Operators.Not((bool?)(fy_ is null));
@@ -424,7 +424,7 @@ public class PCMaternal_5_16_000
 		IEnumerable<Encounter> b_(Encounter EncounterWithAge)
 		{
 			CqlValueSet d_ = this.Delivery_Procedures();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure DeliveryProcedure)
 			{
 				Code<EventStatus> j_ = DeliveryProcedure?.StatusElement;
@@ -436,7 +436,7 @@ public class PCMaternal_5_16_000
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
 				CqlInterval<CqlDateTime> r_ = this.hospitalizationWithEDOBTriageObservation(EncounterWithAge);
-				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, null);
+				bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default(string));
 				bool? t_ = context.Operators.And(m_, s_);
 
 				return t_;
@@ -462,7 +462,7 @@ public class PCMaternal_5_16_000
 	{
 		CqlCode a_ = this.Date_and_time_of_obstetric_delivery();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation TimeOfDelivery)
 		{
 			DataType k_ = TimeOfDelivery?.Value;
@@ -533,10 +533,10 @@ public class PCMaternal_5_16_000
 			};
 			CqlDateTime v_ = QICoreCommon_2_0_000.earliest(u_());
 			CqlInterval<CqlDateTime> w_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, null);
+			bool? x_ = context.Operators.In<CqlDateTime>(v_, w_, default(string));
 			bool? y_ = context.Operators.And(t_, x_);
 			object aa_ = FHIRHelpers_4_3_000.ToValue(k_);
-			bool? ac_ = context.Operators.In<CqlDateTime>((aa_ as CqlDateTime), w_, null);
+			bool? ac_ = context.Operators.In<CqlDateTime>((aa_ as CqlDateTime), w_, default(string));
 			bool? ad_ = context.Operators.And(y_, ac_);
 
 			return ad_;
@@ -613,7 +613,7 @@ public class PCMaternal_5_16_000
 	{
 		CqlCode a_ = this.Delivery_date_Estimated();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation EstimatedDateOfDelivery)
 		{
 			DataType k_ = EstimatedDateOfDelivery?.Value;
@@ -687,7 +687,7 @@ public class PCMaternal_5_16_000
 			CqlQuantity x_ = context.Operators.Quantity(42m, "weeks");
 			CqlDateTime y_ = context.Operators.Subtract(w_, x_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(y_, w_, true, true);
-			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, null);
+			bool? ab_ = context.Operators.In<CqlDateTime>(v_, aa_, default(string));
 			bool? ad_ = context.Operators.Not((bool?)(w_ is null));
 			bool? ae_ = context.Operators.And(ab_, ad_);
 			bool? af_ = context.Operators.And(t_, ae_);
@@ -798,7 +798,7 @@ public class PCMaternal_5_16_000
 	public CqlQuantity lastEstimatedGestationalAge(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Estimated_Gestational_Age_at_Delivery();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation EstimatedGestationalAge)
 		{
 			object j_()
@@ -858,7 +858,7 @@ public class PCMaternal_5_16_000
 			CqlQuantity m_ = context.Operators.Quantity(24m, "hours");
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(n_, l_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, default(string));
 			bool? s_ = context.Operators.Not((bool?)(l_ is null));
 			bool? t_ = context.Operators.And(q_, s_);
 			DataType u_ = EstimatedGestationalAge?.Value;
@@ -984,7 +984,7 @@ public class PCMaternal_5_16_000
 			};
 			CqlDateTime ak_ = QICoreCommon_2_0_000.earliest(aj_());
 			CqlInterval<CqlDateTime> al_ = this.hospitalizationWithEDOBTriageObservation(TheEncounter);
-			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, null);
+			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default(string));
 			bool? an_ = context.Operators.And(ai_, am_);
 			object ap_ = FHIRHelpers_4_3_000.ToValue(u_);
 			bool? aq_ = context.Operators.Not((bool?)(ap_ is null));

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -160,7 +160,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Diagnosis_of_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", default(string));
 
     [CqlDeclaration("Diagnosis of Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263")]
@@ -168,7 +168,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Diagnosis_of_Hypertension.Value;
 
 	private CqlValueSet Dietary_Recommendations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", default(string));
 
     [CqlDeclaration("Dietary Recommendations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515")]
@@ -176,7 +176,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Dietary_Recommendations.Value;
 
 	private CqlValueSet Encounter_to_Screen_for_Blood_Pressure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", default(string));
 
     [CqlDeclaration("Encounter to Screen for Blood Pressure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920")]
@@ -184,7 +184,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Encounter_to_Screen_for_Blood_Pressure.Value;
 
 	private CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", default(string));
 
     [CqlDeclaration("Finding of Elevated Blood Pressure or Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514")]
@@ -192,7 +192,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Finding_of_Elevated_Blood_Pressure_or_Hypertension.Value;
 
 	private CqlValueSet Follow_Up_Within_4_Weeks_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", default(string));
 
     [CqlDeclaration("Follow Up Within 4 Weeks")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578")]
@@ -200,7 +200,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Follow_Up_Within_4_Weeks.Value;
 
 	private CqlValueSet Laboratory_Tests_for_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", default(string));
 
     [CqlDeclaration("Laboratory Tests for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482")]
@@ -208,7 +208,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Laboratory_Tests_for_Hypertension.Value;
 
 	private CqlValueSet Lifestyle_Recommendation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", default(string));
 
     [CqlDeclaration("Lifestyle Recommendation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581")]
@@ -216,7 +216,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Lifestyle_Recommendation.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -224,7 +224,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Patient_Declined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", default(string));
 
     [CqlDeclaration("Patient Declined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582")]
@@ -232,7 +232,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Patient_Declined.Value;
 
 	private CqlValueSet Pharmacologic_Therapy_for_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", default(string));
 
     [CqlDeclaration("Pharmacologic Therapy for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577")]
@@ -240,7 +240,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Pharmacologic_Therapy_for_Hypertension.Value;
 
 	private CqlValueSet Recommendation_to_Increase_Physical_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", default(string));
 
     [CqlDeclaration("Recommendation to Increase Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518")]
@@ -248,7 +248,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Recommendation_to_Increase_Physical_Activity.Value;
 
 	private CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", default(string));
 
     [CqlDeclaration("Referral or Counseling for Alcohol Consumption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583")]
@@ -256,7 +256,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Referral_or_Counseling_for_Alcohol_Consumption.Value;
 
 	private CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", default(string));
 
     [CqlDeclaration("Referral to Primary Care or Alternate Provider")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580")]
@@ -264,7 +264,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Referral_to_Primary_Care_or_Alternate_Provider.Value;
 
 	private CqlValueSet Weight_Reduction_Recommended_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", default(string));
 
     [CqlDeclaration("Weight Reduction Recommended")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510")]
@@ -272,49 +272,49 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Weight_Reduction_Recommended.Value;
 
 	private CqlCode Diastolic_blood_pressure_Value() => 
-		new CqlCode("8462-4", "http://loinc.org", null, null);
+		new CqlCode("8462-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Diastolic blood pressure")]
 	public CqlCode Diastolic_blood_pressure() => 
 		__Diastolic_blood_pressure.Value;
 
 	private CqlCode _12_lead_EKG_panel_Value() => 
-		new CqlCode("34534-8", "http://loinc.org", null, null);
+		new CqlCode("34534-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("12 lead EKG panel")]
 	public CqlCode _12_lead_EKG_panel() => 
 		___12_lead_EKG_panel.Value;
 
 	private CqlCode EKG_study_Value() => 
-		new CqlCode("11524-6", "http://loinc.org", null, null);
+		new CqlCode("11524-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("EKG study")]
 	public CqlCode EKG_study() => 
 		__EKG_study.Value;
 
 	private CqlCode Follow_up_2_3_months__finding__Value() => 
-		new CqlCode("183624006", "http://snomed.info/sct", null, null);
+		new CqlCode("183624006", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Follow-up 2-3 months (finding)")]
 	public CqlCode Follow_up_2_3_months__finding_() => 
 		__Follow_up_2_3_months__finding_.Value;
 
 	private CqlCode Follow_up_4_6_months__finding__Value() => 
-		new CqlCode("183625007", "http://snomed.info/sct", null, null);
+		new CqlCode("183625007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Follow-up 4-6 months (finding)")]
 	public CqlCode Follow_up_4_6_months__finding_() => 
 		__Follow_up_4_6_months__finding_.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
@@ -323,7 +323,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -336,10 +336,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8462-4", "http://loinc.org", null, null),
-			new CqlCode("34534-8", "http://loinc.org", null, null),
-			new CqlCode("11524-6", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("8462-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("34534-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("11524-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -352,8 +352,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("183624006", "http://snomed.info/sct", null, null),
-			new CqlCode("183625007", "http://snomed.info/sct", null, null),
+			new CqlCode("183624006", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("183625007", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -365,8 +365,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PCSBPScreeningFollowUpFHIR-0.2.000", "Measurement Period", c_);
 
@@ -379,7 +379,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -392,7 +392,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_to_Screen_for_Blood_Pressure();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
@@ -464,7 +464,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diagnosis_of_Hypertension();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			bool? f_(Condition Hypertension)
 			{
 				bool? j_ = QICoreCommon_2_0_000.isProblemListItem(Hypertension);
@@ -483,7 +483,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 					};
 					if (t_())
 					{
-						return null;
+						return default(CqlInterval<CqlDateTime>);
 					}
 					else
 					{
@@ -523,7 +523,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Observation BloodPressure)
 			{
 				DataType ak_ = BloodPressure?.Effective;
@@ -532,7 +532,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime an_ = context.Operators.End(am_);
 				Period ao_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default(string));
 				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
 				ObservationStatus? as_ = ar_?.Value;
 				string at_ = context.Operators.Convert<string>(as_);
@@ -583,7 +583,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(1m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(120m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, false);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
 			bool? u_(Observation BloodPressure)
 			{
 				DataType bo_ = BloodPressure?.Effective;
@@ -592,7 +592,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime br_ = context.Operators.End(bq_);
 				Period bs_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
 				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
 				ObservationStatus? bw_ = bv_?.Value;
 				string bx_ = context.Operators.Convert<string>(bw_);
@@ -642,7 +642,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(p_, ag_, true, false);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
 			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
@@ -661,7 +661,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Observation BloodPressure)
 			{
 				DataType ak_ = BloodPressure?.Effective;
@@ -670,7 +670,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime an_ = context.Operators.End(am_);
 				Period ao_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, null);
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default(string));
 				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
 				ObservationStatus? as_ = ar_?.Value;
 				string at_ = context.Operators.Convert<string>(as_);
@@ -721,7 +721,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(120m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(129m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
 			bool? u_(Observation BloodPressure)
 			{
 				DataType bo_ = BloodPressure?.Effective;
@@ -730,7 +730,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime br_ = context.Operators.End(bq_);
 				Period bs_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, null);
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
 				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
 				ObservationStatus? bw_ = bv_?.Value;
 				string bx_ = context.Operators.Convert<string>(bw_);
@@ -781,7 +781,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity af_ = context.Operators.Quantity(1m, "mm[Hg]");
 			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, false);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
 			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
@@ -799,10 +799,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this.Follow_up_2_3_months__finding_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
 		CqlCode d_ = this.Follow_up_4_6_months__finding_();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		bool? h_(ServiceRequest FollowUp)
 		{
@@ -825,18 +825,18 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> NonPharmacological_Interventions_Value()
 	{
 		CqlValueSet a_ = this.Lifestyle_Recommendation();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Weight_Reduction_Recommended();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Dietary_Recommendations();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Recommendation_to_Increase_Physical_Activity();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		CqlValueSet l_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> n_ = context.Operators.Union<ServiceRequest>(k_, m_);
 		bool? o_(ServiceRequest NonPharmaInterventions)
 		{
@@ -859,7 +859,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		bool? c_(ServiceRequest Referral)
 		{
 			List<CodeableConcept> e_ = Referral?.ReasonCode;
@@ -969,7 +969,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bk_ = BloodPressure?.Effective;
@@ -984,7 +984,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(bo_);
 				CqlDateTime bv_ = context.Operators.Start(bu_);
 				CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bs_, bv_, true, true);
-				bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, null);
+				bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, default(string));
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(bo_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
 				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
@@ -1052,7 +1052,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_3_000.ToInterval(de_);
 				CqlDateTime dl_ = context.Operators.Start(dk_);
 				CqlInterval<CqlDateTime> dm_ = context.Operators.Interval(di_, dl_, true, true);
-				bool? dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, null);
+				bool? dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, default(string));
 				CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(de_);
 				CqlDateTime dq_ = context.Operators.Start(dp_);
 				bool? dr_ = context.Operators.Not((bool?)(dq_ is null));
@@ -1120,7 +1120,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> fa_ = FHIRHelpers_4_3_000.ToInterval(eu_);
 				CqlDateTime fb_ = context.Operators.Start(fa_);
 				CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(ey_, fb_, true, true);
-				bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, null);
+				bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, default(string));
 				CqlInterval<CqlDateTime> ff_ = FHIRHelpers_4_3_000.ToInterval(eu_);
 				CqlDateTime fg_ = context.Operators.Start(ff_);
 				bool? fh_ = context.Operators.Not((bool?)(fg_ is null));
@@ -1188,7 +1188,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> gq_ = FHIRHelpers_4_3_000.ToInterval(gk_);
 				CqlDateTime gr_ = context.Operators.Start(gq_);
 				CqlInterval<CqlDateTime> gs_ = context.Operators.Interval(go_, gr_, true, true);
-				bool? gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, null);
+				bool? gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, default(string));
 				CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gk_);
 				CqlDateTime gw_ = context.Operators.Start(gv_);
 				bool? gx_ = context.Operators.Not((bool?)(gw_ is null));
@@ -1261,7 +1261,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation BloodPressure)
 			{
 				DataType bm_ = BloodPressure?.Effective;
@@ -1473,7 +1473,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value()
 	{
 		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_(ServiceRequest FourWeekRescreen)
 		{
 			IEnumerable<ServiceRequest> g_ = this.NonPharmacological_Interventions();
@@ -1550,7 +1550,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bs_ = BloodPressure?.Effective;
@@ -1610,7 +1610,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(130m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(139m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, null);
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
 			bool? u_(Observation BloodPressure)
 			{
 				DataType cw_ = BloodPressure?.Effective;
@@ -1670,7 +1670,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity af_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlQuantity ag_ = context.Operators.Quantity(89m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, true);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, null);
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
 			bool? aj_ = context.Operators.Or(s_, ai_);
 			bool? al_(Observation BloodPressure)
 			{
@@ -1810,13 +1810,13 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this._12_lead_EKG_panel();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
 		CqlCode d_ = this.EKG_study();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		bool? k_(ServiceRequest EKGLab)
 		{
@@ -1950,7 +1950,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bn_ = BloodPressure?.Effective;
@@ -1959,7 +1959,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime bq_ = context.Operators.End(bp_);
 				Period br_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bs_ = FHIRHelpers_4_3_000.ToInterval(br_);
-				bool? bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, null);
+				bool? bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, default(string));
 				Code<ObservationStatus> bu_ = BloodPressure?.StatusElement;
 				ObservationStatus? bv_ = bu_?.Value;
 				string bw_ = context.Operators.Convert<string>(bv_);
@@ -2017,7 +2017,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime cu_ = context.Operators.End(ct_);
 				Period cv_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_3_000.ToInterval(cv_);
-				bool? cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, null);
+				bool? cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, default(string));
 				Code<ObservationStatus> cy_ = BloodPressure?.StatusElement;
 				ObservationStatus? cz_ = cy_?.Value;
 				string da_ = context.Operators.Convert<string>(cz_);
@@ -2075,7 +2075,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime dy_ = context.Operators.End(dx_);
 				Period dz_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_3_000.ToInterval(dz_);
-				bool? eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, null);
+				bool? eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, default(string));
 				Code<ObservationStatus> ec_ = BloodPressure?.StatusElement;
 				ObservationStatus? ed_ = ec_?.Value;
 				string ee_ = context.Operators.Convert<string>(ed_);
@@ -2133,7 +2133,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime fc_ = context.Operators.End(fb_);
 				Period fd_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-				bool? ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, null);
+				bool? ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, default(string));
 				Code<ObservationStatus> fg_ = BloodPressure?.StatusElement;
 				ObservationStatus? fh_ = fg_?.Value;
 				string fi_ = context.Operators.Convert<string>(fh_);
@@ -2203,7 +2203,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value()
 	{
 		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> c_(ServiceRequest WeeksRescreen)
 		{
 			IEnumerable<ServiceRequest> i_ = this.Laboratory_Test_or_ECG_for_Hypertension();
@@ -2261,8 +2261,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<ServiceRequest> g_(ServiceRequest WeeksRescreen)
 		{
 			CqlValueSet ap_ = this.Pharmacologic_Therapy_for_Hypertension();
-			IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-			IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+			IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
 			bool? au_(MedicationRequest Medications)
 			{
@@ -2374,10 +2374,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		{
 			CqlCode d_ = this.Systolic_blood_pressure();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
 			CqlCode g_ = this.Diastolic_blood_pressure();
 			IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
-			IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, null);
+			IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default(PropertyInfo));
 			IEnumerable<Observation> j_ = context.Operators.Union<Observation>(f_, i_);
 			bool? k_(Observation NoBPScreen)
 			{
@@ -2398,7 +2398,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
-						: null), u_);
+						: default(List<Extension>)), u_);
 				DataType w_(Extension @this)
 				{
 					DataType ax_ = @this?.Value;
@@ -2422,7 +2422,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
-						: null), ad_);
+						: default(List<Extension>)), ad_);
 				DataType af_(Extension @this)
 				{
 					DataType bc_ = @this?.Value;
@@ -2464,27 +2464,27 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Lifestyle_Recommendation();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Weight_Reduction_Recommended();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		CqlValueSet l_ = this.Dietary_Recommendations();
-		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
-		IEnumerable<ServiceRequest> o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, null);
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> p_ = context.Operators.Union<ServiceRequest>(m_, o_);
 		IEnumerable<ServiceRequest> q_ = context.Operators.Union<ServiceRequest>(k_, p_);
 		CqlValueSet r_ = this.Recommendation_to_Increase_Physical_Activity();
-		IEnumerable<ServiceRequest> s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
-		IEnumerable<ServiceRequest> u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, null);
+		IEnumerable<ServiceRequest> s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> v_ = context.Operators.Union<ServiceRequest>(s_, u_);
 		IEnumerable<ServiceRequest> w_ = context.Operators.Union<ServiceRequest>(q_, v_);
 		CqlValueSet x_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-		IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+		IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
 		IEnumerable<ServiceRequest> ac_ = context.Operators.Union<ServiceRequest>(w_, ab_);
 		bool? ad_(ServiceRequest NonPharmIntervention)
@@ -2500,7 +2500,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NonPharmIntervention is DomainResource)
 					? ((NonPharmIntervention as DomainResource).Extension)
-					: null), af_);
+					: default(List<Extension>)), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType ax_ = @this?.Value;
@@ -2534,14 +2534,14 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this._12_lead_EKG_panel();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, null);
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
 		CqlCode d_ = this.EKG_study();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, null);
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
-		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, null);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(i_, k_);
 		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(g_, l_);
 		bool? n_(ServiceRequest LabECGNotDone)
@@ -2557,7 +2557,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LabECGNotDone is DomainResource)
 					? ((LabECGNotDone as DomainResource).Extension)
-					: null), p_);
+					: default(List<Extension>)), p_);
 			DataType r_(Extension @this)
 			{
 				DataType ac_ = @this?.Value;
@@ -2585,15 +2585,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlCode f_ = this.Follow_up_2_3_months__finding_();
 		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
-		IEnumerable<ServiceRequest> h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, null);
+		IEnumerable<ServiceRequest> h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, default(PropertyInfo));
 		CqlCode i_ = this.Follow_up_4_6_months__finding_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, null);
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(h_, k_);
 		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(e_, l_);
 		bool? n_(ServiceRequest SecondHTNDeclinedReferralAndFollowUp)
@@ -2609,7 +2609,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTNDeclinedReferralAndFollowUp is DomainResource)
 					? ((SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension)
-					: null), t_);
+					: default(List<Extension>)), t_);
 			DataType v_(Extension @this)
 			{
 				DataType al_ = @this?.Value;
@@ -2646,12 +2646,12 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		bool? l_(ServiceRequest SecondHTN140Over90ReferralFollowUpNotDone)
@@ -2667,7 +2667,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> aa_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTN140Over90ReferralFollowUpNotDone is DomainResource)
 					? ((SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension)
-					: null), z_);
+					: default(List<Extension>)), z_);
 			DataType ab_(Extension @this)
 			{
 				DataType ar_ = @this?.Value;
@@ -2690,8 +2690,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		};
 		IEnumerable<ServiceRequest> m_ = context.Operators.Where<ServiceRequest>(k_, l_);
 		CqlValueSet n_ = this.Pharmacologic_Therapy_for_Hypertension();
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
 		bool? s_(MedicationRequest MedicationRequestNotOrdered)
 		{
@@ -2722,15 +2722,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter ElevatedBPEncounter)
 		{
 			CqlValueSet x_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
-			IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, null);
+			IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
 			IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
 			CqlCode ac_ = this.Follow_up_2_3_months__finding_();
 			IEnumerable<CqlCode> ad_ = context.Operators.ToList<CqlCode>(ac_);
-			IEnumerable<ServiceRequest> ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, null);
+			IEnumerable<ServiceRequest> ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, default(PropertyInfo));
 			CqlCode af_ = this.Follow_up_4_6_months__finding_();
 			IEnumerable<CqlCode> ag_ = context.Operators.ToList<CqlCode>(af_);
-			IEnumerable<ServiceRequest> ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, null);
+			IEnumerable<ServiceRequest> ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, default(PropertyInfo));
 			IEnumerable<ServiceRequest> ai_ = context.Operators.Union<ServiceRequest>(ae_, ah_);
 			IEnumerable<ServiceRequest> aj_ = context.Operators.Union<ServiceRequest>(ab_, ai_);
 			bool? ak_(ServiceRequest ElevatedBPDeclinedInterventions)
@@ -2746,7 +2746,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> ap_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((ElevatedBPDeclinedInterventions is DomainResource)
 						? ((ElevatedBPDeclinedInterventions as DomainResource).Extension)
-						: null), ao_);
+						: default(List<Extension>)), ao_);
 				DataType aq_(Extension @this)
 				{
 					DataType bm_ = @this?.Value;
@@ -2807,12 +2807,12 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> i_(Encounter FirstHTNEncounter)
 		{
 			CqlValueSet bx_ = this.Follow_Up_Within_4_Weeks();
-			IEnumerable<ServiceRequest> by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
-			IEnumerable<ServiceRequest> ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, null);
+			IEnumerable<ServiceRequest> by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default(PropertyInfo));
 			IEnumerable<ServiceRequest> cb_ = context.Operators.Union<ServiceRequest>(by_, ca_);
 			CqlValueSet cc_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			IEnumerable<ServiceRequest> cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
-			IEnumerable<ServiceRequest> cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, null);
+			IEnumerable<ServiceRequest> cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default(PropertyInfo));
 			IEnumerable<ServiceRequest> cg_ = context.Operators.Union<ServiceRequest>(cd_, cf_);
 			IEnumerable<ServiceRequest> ch_ = context.Operators.Union<ServiceRequest>(cb_, cg_);
 			bool? ci_(ServiceRequest FirstHTNDeclinedInterventions)
@@ -2828,7 +2828,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> cn_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((FirstHTNDeclinedInterventions is DomainResource)
 						? ((FirstHTNDeclinedInterventions as DomainResource).Extension)
-						: null), cm_);
+						: default(List<Extension>)), cm_);
 				DataType co_(Extension @this)
 				{
 					DataType dk_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PCSBPScreeningFollowUpFHIR", "0.2.000")]
 public class PCSBPScreeningFollowUpFHIR_0_2_000
 {

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -160,7 +160,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Diagnosis_of_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263", default);
 
     [CqlDeclaration("Diagnosis of Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.263")]
@@ -168,7 +168,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Diagnosis_of_Hypertension.Value;
 
 	private CqlValueSet Dietary_Recommendations_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515", default);
 
     [CqlDeclaration("Dietary Recommendations")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1515")]
@@ -176,7 +176,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Dietary_Recommendations.Value;
 
 	private CqlValueSet Encounter_to_Screen_for_Blood_Pressure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920", default);
 
     [CqlDeclaration("Encounter to Screen for Blood Pressure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1920")]
@@ -184,7 +184,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Encounter_to_Screen_for_Blood_Pressure.Value;
 
 	private CqlValueSet Finding_of_Elevated_Blood_Pressure_or_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514", default);
 
     [CqlDeclaration("Finding of Elevated Blood Pressure or Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.514")]
@@ -192,7 +192,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Finding_of_Elevated_Blood_Pressure_or_Hypertension.Value;
 
 	private CqlValueSet Follow_Up_Within_4_Weeks_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578", default);
 
     [CqlDeclaration("Follow Up Within 4 Weeks")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1578")]
@@ -200,7 +200,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Follow_Up_Within_4_Weeks.Value;
 
 	private CqlValueSet Laboratory_Tests_for_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482", default);
 
     [CqlDeclaration("Laboratory Tests for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1482")]
@@ -208,7 +208,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Laboratory_Tests_for_Hypertension.Value;
 
 	private CqlValueSet Lifestyle_Recommendation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581", default);
 
     [CqlDeclaration("Lifestyle Recommendation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1581")]
@@ -216,7 +216,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Lifestyle_Recommendation.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -224,7 +224,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Patient_Declined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582", default);
 
     [CqlDeclaration("Patient Declined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1582")]
@@ -232,7 +232,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Patient_Declined.Value;
 
 	private CqlValueSet Pharmacologic_Therapy_for_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577", default);
 
     [CqlDeclaration("Pharmacologic Therapy for Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.1577")]
@@ -240,7 +240,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Pharmacologic_Therapy_for_Hypertension.Value;
 
 	private CqlValueSet Recommendation_to_Increase_Physical_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518", default);
 
     [CqlDeclaration("Recommendation to Increase Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1518")]
@@ -248,7 +248,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Recommendation_to_Increase_Physical_Activity.Value;
 
 	private CqlValueSet Referral_or_Counseling_for_Alcohol_Consumption_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583", default);
 
     [CqlDeclaration("Referral or Counseling for Alcohol Consumption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1583")]
@@ -256,7 +256,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Referral_or_Counseling_for_Alcohol_Consumption.Value;
 
 	private CqlValueSet Referral_to_Primary_Care_or_Alternate_Provider_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580", default);
 
     [CqlDeclaration("Referral to Primary Care or Alternate Provider")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1580")]
@@ -264,7 +264,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Referral_to_Primary_Care_or_Alternate_Provider.Value;
 
 	private CqlValueSet Weight_Reduction_Recommended_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510", default);
 
     [CqlDeclaration("Weight Reduction Recommended")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1510")]
@@ -272,49 +272,49 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		__Weight_Reduction_Recommended.Value;
 
 	private CqlCode Diastolic_blood_pressure_Value() => 
-		new CqlCode("8462-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("8462-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Diastolic blood pressure")]
 	public CqlCode Diastolic_blood_pressure() => 
 		__Diastolic_blood_pressure.Value;
 
 	private CqlCode _12_lead_EKG_panel_Value() => 
-		new CqlCode("34534-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("34534-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("12 lead EKG panel")]
 	public CqlCode _12_lead_EKG_panel() => 
 		___12_lead_EKG_panel.Value;
 
 	private CqlCode EKG_study_Value() => 
-		new CqlCode("11524-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("11524-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("EKG study")]
 	public CqlCode EKG_study() => 
 		__EKG_study.Value;
 
 	private CqlCode Follow_up_2_3_months__finding__Value() => 
-		new CqlCode("183624006", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("183624006", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Follow-up 2-3 months (finding)")]
 	public CqlCode Follow_up_2_3_months__finding_() => 
 		__Follow_up_2_3_months__finding_.Value;
 
 	private CqlCode Follow_up_4_6_months__finding__Value() => 
-		new CqlCode("183625007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("183625007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Follow-up 4-6 months (finding)")]
 	public CqlCode Follow_up_4_6_months__finding_() => 
 		__Follow_up_4_6_months__finding_.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
 		__Systolic_blood_pressure.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
@@ -323,7 +323,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -336,10 +336,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8462-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("34534-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("11524-6", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8462-4", "http://loinc.org", default, default),
+			new CqlCode("34534-8", "http://loinc.org", default, default),
+			new CqlCode("11524-6", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -352,8 +352,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("183624006", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("183625007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("183624006", "http://snomed.info/sct", default, default),
+			new CqlCode("183625007", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -365,8 +365,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PCSBPScreeningFollowUpFHIR-0.2.000", "Measurement Period", c_);
 
@@ -379,7 +379,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -392,7 +392,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_to_Screen_for_Blood_Pressure();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> e_ = this.Measurement_Period();
@@ -464,7 +464,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diagnosis_of_Hypertension();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			bool? f_(Condition Hypertension)
 			{
 				bool? j_ = QICoreCommon_2_0_000.isProblemListItem(Hypertension);
@@ -483,7 +483,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 					};
 					if (t_())
 					{
-						return default(CqlInterval<CqlDateTime>);
+						return default;
 					}
 					else
 					{
@@ -523,7 +523,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? e_(Observation BloodPressure)
 			{
 				DataType ak_ = BloodPressure?.Effective;
@@ -532,7 +532,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime an_ = context.Operators.End(am_);
 				Period ao_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default(string));
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default);
 				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
 				ObservationStatus? as_ = ar_?.Value;
 				string at_ = context.Operators.Convert<string>(as_);
@@ -583,7 +583,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(1m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(120m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, false);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default);
 			bool? u_(Observation BloodPressure)
 			{
 				DataType bo_ = BloodPressure?.Effective;
@@ -592,7 +592,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime br_ = context.Operators.End(bq_);
 				Period bs_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default);
 				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
 				ObservationStatus? bw_ = bv_?.Value;
 				string bx_ = context.Operators.Convert<string>(bw_);
@@ -642,7 +642,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			object ae_ = FHIRHelpers_4_3_000.ToValue(ad_);
 			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(p_, ag_, true, false);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default);
 			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
@@ -661,7 +661,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? e_(Observation BloodPressure)
 			{
 				DataType ak_ = BloodPressure?.Effective;
@@ -670,7 +670,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime an_ = context.Operators.End(am_);
 				Period ao_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_3_000.ToInterval(ao_);
-				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default(string));
+				bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default);
 				Code<ObservationStatus> ar_ = BloodPressure?.StatusElement;
 				ObservationStatus? as_ = ar_?.Value;
 				string at_ = context.Operators.Convert<string>(as_);
@@ -721,7 +721,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(120m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(129m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default);
 			bool? u_(Observation BloodPressure)
 			{
 				DataType bo_ = BloodPressure?.Effective;
@@ -730,7 +730,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime br_ = context.Operators.End(bq_);
 				Period bs_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_3_000.ToInterval(bs_);
-				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default(string));
+				bool? bu_ = context.Operators.In<CqlDateTime>(br_, bt_, default);
 				Code<ObservationStatus> bv_ = BloodPressure?.StatusElement;
 				ObservationStatus? bw_ = bv_?.Value;
 				string bx_ = context.Operators.Convert<string>(bw_);
@@ -781,7 +781,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity af_ = context.Operators.Quantity(1m, "mm[Hg]");
 			CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, false);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default);
 			bool? aj_ = context.Operators.And(s_, ai_);
 
 			return aj_;
@@ -799,10 +799,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this.Follow_up_2_3_months__finding_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default);
 		CqlCode d_ = this.Follow_up_4_6_months__finding_();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default);
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		bool? h_(ServiceRequest FollowUp)
 		{
@@ -825,18 +825,18 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> NonPharmacological_Interventions_Value()
 	{
 		CqlValueSet a_ = this.Lifestyle_Recommendation();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		CqlValueSet c_ = this.Weight_Reduction_Recommended();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Dietary_Recommendations();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
 		CqlValueSet h_ = this.Recommendation_to_Increase_Physical_Activity();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default);
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		CqlValueSet l_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default);
 		IEnumerable<ServiceRequest> n_ = context.Operators.Union<ServiceRequest>(k_, m_);
 		bool? o_(ServiceRequest NonPharmaInterventions)
 		{
@@ -859,7 +859,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Referral_to_Alternate_or_Primary_Healthcare_Professional_for_Hypertensive_Reading_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		bool? c_(ServiceRequest Referral)
 		{
 			List<CodeableConcept> e_ = Referral?.ReasonCode;
@@ -969,7 +969,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bk_ = BloodPressure?.Effective;
@@ -984,7 +984,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_3_000.ToInterval(bo_);
 				CqlDateTime bv_ = context.Operators.Start(bu_);
 				CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bs_, bv_, true, true);
-				bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, default(string));
+				bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, default);
 				CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_3_000.ToInterval(bo_);
 				CqlDateTime ca_ = context.Operators.Start(bz_);
 				bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
@@ -1052,7 +1052,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_3_000.ToInterval(de_);
 				CqlDateTime dl_ = context.Operators.Start(dk_);
 				CqlInterval<CqlDateTime> dm_ = context.Operators.Interval(di_, dl_, true, true);
-				bool? dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, default(string));
+				bool? dn_ = context.Operators.In<CqlDateTime>(dd_, dm_, default);
 				CqlInterval<CqlDateTime> dp_ = FHIRHelpers_4_3_000.ToInterval(de_);
 				CqlDateTime dq_ = context.Operators.Start(dp_);
 				bool? dr_ = context.Operators.Not((bool?)(dq_ is null));
@@ -1120,7 +1120,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> fa_ = FHIRHelpers_4_3_000.ToInterval(eu_);
 				CqlDateTime fb_ = context.Operators.Start(fa_);
 				CqlInterval<CqlDateTime> fc_ = context.Operators.Interval(ey_, fb_, true, true);
-				bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, default(string));
+				bool? fd_ = context.Operators.In<CqlDateTime>(et_, fc_, default);
 				CqlInterval<CqlDateTime> ff_ = FHIRHelpers_4_3_000.ToInterval(eu_);
 				CqlDateTime fg_ = context.Operators.Start(ff_);
 				bool? fh_ = context.Operators.Not((bool?)(fg_ is null));
@@ -1188,7 +1188,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlInterval<CqlDateTime> gq_ = FHIRHelpers_4_3_000.ToInterval(gk_);
 				CqlDateTime gr_ = context.Operators.Start(gq_);
 				CqlInterval<CqlDateTime> gs_ = context.Operators.Interval(go_, gr_, true, true);
-				bool? gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, default(string));
+				bool? gt_ = context.Operators.In<CqlDateTime>(gj_, gs_, default);
 				CqlInterval<CqlDateTime> gv_ = FHIRHelpers_4_3_000.ToInterval(gk_);
 				CqlDateTime gw_ = context.Operators.Start(gv_);
 				bool? gx_ = context.Operators.Not((bool?)(gw_ is null));
@@ -1261,7 +1261,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation BloodPressure)
 			{
 				DataType bm_ = BloodPressure?.Effective;
@@ -1473,7 +1473,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> First_Hypertensive_Reading_Interventions_or_Referral_to_Alternate_Professional_Value()
 	{
 		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_(ServiceRequest FourWeekRescreen)
 		{
 			IEnumerable<ServiceRequest> g_ = this.NonPharmacological_Interventions();
@@ -1550,7 +1550,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bs_ = BloodPressure?.Effective;
@@ -1610,7 +1610,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity p_ = context.Operators.Quantity(130m, "mm[Hg]");
 			CqlQuantity q_ = context.Operators.Quantity(139m, "mm[Hg]");
 			CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default(string));
+			bool? s_ = context.Operators.In<CqlQuantity>((o_ as CqlQuantity), r_, default);
 			bool? u_(Observation BloodPressure)
 			{
 				DataType cw_ = BloodPressure?.Effective;
@@ -1670,7 +1670,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			CqlQuantity af_ = context.Operators.Quantity(80m, "mm[Hg]");
 			CqlQuantity ag_ = context.Operators.Quantity(89m, "mm[Hg]");
 			CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, true);
-			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default(string));
+			bool? ai_ = context.Operators.In<CqlQuantity>((ae_ as CqlQuantity), ah_, default);
 			bool? aj_ = context.Operators.Or(s_, ai_);
 			bool? al_(Observation BloodPressure)
 			{
@@ -1810,13 +1810,13 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this._12_lead_EKG_panel();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default);
 		CqlCode d_ = this.EKG_study();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default);
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default);
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		bool? k_(ServiceRequest EKGLab)
 		{
@@ -1950,7 +1950,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> a_ = this.Qualifying_Encounter_during_Measurement_Period();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? e_(Observation BloodPressure)
 			{
 				DataType bn_ = BloodPressure?.Effective;
@@ -1959,7 +1959,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime bq_ = context.Operators.End(bp_);
 				Period br_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> bs_ = FHIRHelpers_4_3_000.ToInterval(br_);
-				bool? bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, default(string));
+				bool? bt_ = context.Operators.In<CqlDateTime>(bq_, bs_, default);
 				Code<ObservationStatus> bu_ = BloodPressure?.StatusElement;
 				ObservationStatus? bv_ = bu_?.Value;
 				string bw_ = context.Operators.Convert<string>(bv_);
@@ -2017,7 +2017,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime cu_ = context.Operators.End(ct_);
 				Period cv_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> cw_ = FHIRHelpers_4_3_000.ToInterval(cv_);
-				bool? cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, default(string));
+				bool? cx_ = context.Operators.In<CqlDateTime>(cu_, cw_, default);
 				Code<ObservationStatus> cy_ = BloodPressure?.StatusElement;
 				ObservationStatus? cz_ = cy_?.Value;
 				string da_ = context.Operators.Convert<string>(cz_);
@@ -2075,7 +2075,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime dy_ = context.Operators.End(dx_);
 				Period dz_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_3_000.ToInterval(dz_);
-				bool? eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, default(string));
+				bool? eb_ = context.Operators.In<CqlDateTime>(dy_, ea_, default);
 				Code<ObservationStatus> ec_ = BloodPressure?.StatusElement;
 				ObservationStatus? ed_ = ec_?.Value;
 				string ee_ = context.Operators.Convert<string>(ed_);
@@ -2133,7 +2133,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				CqlDateTime fc_ = context.Operators.End(fb_);
 				Period fd_ = QualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_3_000.ToInterval(fd_);
-				bool? ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, default(string));
+				bool? ff_ = context.Operators.In<CqlDateTime>(fc_, fe_, default);
 				Code<ObservationStatus> fg_ = BloodPressure?.StatusElement;
 				ObservationStatus? fh_ = fg_?.Value;
 				string fi_ = context.Operators.Convert<string>(fh_);
@@ -2203,7 +2203,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Value()
 	{
 		CqlValueSet a_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> c_(ServiceRequest WeeksRescreen)
 		{
 			IEnumerable<ServiceRequest> i_ = this.Laboratory_Test_or_ECG_for_Hypertension();
@@ -2261,8 +2261,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<ServiceRequest> g_(ServiceRequest WeeksRescreen)
 		{
 			CqlValueSet ap_ = this.Pharmacologic_Therapy_for_Hypertension();
-			IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default);
+			IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default);
 			IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
 			bool? au_(MedicationRequest Medications)
 			{
@@ -2374,10 +2374,10 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		{
 			CqlCode d_ = this.Systolic_blood_pressure();
 			IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByCodes<Observation>(e_, default);
 			CqlCode g_ = this.Diastolic_blood_pressure();
 			IEnumerable<CqlCode> h_ = context.Operators.ToList<CqlCode>(g_);
-			IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default(PropertyInfo));
+			IEnumerable<Observation> i_ = context.Operators.RetrieveByCodes<Observation>(h_, default);
 			IEnumerable<Observation> j_ = context.Operators.Union<Observation>(f_, i_);
 			bool? k_(Observation NoBPScreen)
 			{
@@ -2398,7 +2398,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
-						: default(List<Extension>)), u_);
+						: default), u_);
 				DataType w_(Extension @this)
 				{
 					DataType ax_ = @this?.Value;
@@ -2422,7 +2422,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NoBPScreen is DomainResource)
 						? ((NoBPScreen as DomainResource).Extension)
-						: default(List<Extension>)), ad_);
+						: default), ad_);
 				DataType af_(Extension @this)
 				{
 					DataType bc_ = @this?.Value;
@@ -2464,27 +2464,27 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> NonPharmacological_Intervention_Not_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Lifestyle_Recommendation();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Weight_Reduction_Recommended();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		CqlValueSet l_ = this.Dietary_Recommendations();
-		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> m_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default);
+		IEnumerable<ServiceRequest> o_ = context.Operators.RetrieveByValueSet<ServiceRequest>(l_, default);
 		IEnumerable<ServiceRequest> p_ = context.Operators.Union<ServiceRequest>(m_, o_);
 		IEnumerable<ServiceRequest> q_ = context.Operators.Union<ServiceRequest>(k_, p_);
 		CqlValueSet r_ = this.Recommendation_to_Increase_Physical_Activity();
-		IEnumerable<ServiceRequest> s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> s_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default);
+		IEnumerable<ServiceRequest> u_ = context.Operators.RetrieveByValueSet<ServiceRequest>(r_, default);
 		IEnumerable<ServiceRequest> v_ = context.Operators.Union<ServiceRequest>(s_, u_);
 		IEnumerable<ServiceRequest> w_ = context.Operators.Union<ServiceRequest>(q_, v_);
 		CqlValueSet x_ = this.Referral_or_Counseling_for_Alcohol_Consumption();
-		IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default);
+		IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default);
 		IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
 		IEnumerable<ServiceRequest> ac_ = context.Operators.Union<ServiceRequest>(w_, ab_);
 		bool? ad_(ServiceRequest NonPharmIntervention)
@@ -2500,7 +2500,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((NonPharmIntervention is DomainResource)
 					? ((NonPharmIntervention as DomainResource).Extension)
-					: default(List<Extension>)), af_);
+					: default), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType ax_ = @this?.Value;
@@ -2534,14 +2534,14 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	{
 		CqlCode a_ = this._12_lead_EKG_panel();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> c_ = context.Operators.RetrieveByCodes<ServiceRequest>(b_, default);
 		CqlCode d_ = this.EKG_study();
 		IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
-		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> f_ = context.Operators.RetrieveByCodes<ServiceRequest>(e_, default);
 		IEnumerable<ServiceRequest> g_ = context.Operators.Union<ServiceRequest>(c_, f_);
 		CqlValueSet h_ = this.Laboratory_Tests_for_Hypertension();
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default);
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByValueSet<ServiceRequest>(h_, default);
 		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(i_, k_);
 		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(g_, l_);
 		bool? n_(ServiceRequest LabECGNotDone)
@@ -2557,7 +2557,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> q_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((LabECGNotDone is DomainResource)
 					? ((LabECGNotDone as DomainResource).Extension)
-					: default(List<Extension>)), p_);
+					: default), p_);
 			DataType r_(Extension @this)
 			{
 				DataType ac_ = @this?.Value;
@@ -2585,15 +2585,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<ServiceRequest> Second_Hypertensive_Reading_SBP_130_to_139_OR_DBP_80_to_89_Interventions_Declined_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlCode f_ = this.Follow_up_2_3_months__finding_();
 		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
-		IEnumerable<ServiceRequest> h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> h_ = context.Operators.RetrieveByCodes<ServiceRequest>(g_, default);
 		CqlCode i_ = this.Follow_up_4_6_months__finding_();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> k_ = context.Operators.RetrieveByCodes<ServiceRequest>(j_, default);
 		IEnumerable<ServiceRequest> l_ = context.Operators.Union<ServiceRequest>(h_, k_);
 		IEnumerable<ServiceRequest> m_ = context.Operators.Union<ServiceRequest>(e_, l_);
 		bool? n_(ServiceRequest SecondHTNDeclinedReferralAndFollowUp)
@@ -2609,7 +2609,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTNDeclinedReferralAndFollowUp is DomainResource)
 					? ((SecondHTNDeclinedReferralAndFollowUp as DomainResource).Extension)
-					: default(List<Extension>)), t_);
+					: default), t_);
 			DataType v_(Extension @this)
 			{
 				DataType al_ = @this?.Value;
@@ -2646,12 +2646,12 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 	private IEnumerable<object> Second_Hypertensive_Reading_SBP_Greater_than_or_Equal_to_140_OR_DBP_Greater_than_or_Equal_to_90_Interventions_Declined_Value()
 	{
 		CqlValueSet a_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		CqlValueSet f_ = this.Follow_Up_Within_4_Weeks();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
-		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
+		IEnumerable<ServiceRequest> i_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
 		IEnumerable<ServiceRequest> j_ = context.Operators.Union<ServiceRequest>(g_, i_);
 		IEnumerable<ServiceRequest> k_ = context.Operators.Union<ServiceRequest>(e_, j_);
 		bool? l_(ServiceRequest SecondHTN140Over90ReferralFollowUpNotDone)
@@ -2667,7 +2667,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 			};
 			IEnumerable<Extension> aa_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((SecondHTN140Over90ReferralFollowUpNotDone is DomainResource)
 					? ((SecondHTN140Over90ReferralFollowUpNotDone as DomainResource).Extension)
-					: default(List<Extension>)), z_);
+					: default), z_);
 			DataType ab_(Extension @this)
 			{
 				DataType ar_ = @this?.Value;
@@ -2690,8 +2690,8 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		};
 		IEnumerable<ServiceRequest> m_ = context.Operators.Where<ServiceRequest>(k_, l_);
 		CqlValueSet n_ = this.Pharmacologic_Therapy_for_Hypertension();
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default);
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default);
 		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
 		bool? s_(MedicationRequest MedicationRequestNotOrdered)
 		{
@@ -2722,15 +2722,15 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> b_(Encounter ElevatedBPEncounter)
 		{
 			CqlValueSet x_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
-			IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> y_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default);
+			IEnumerable<ServiceRequest> aa_ = context.Operators.RetrieveByValueSet<ServiceRequest>(x_, default);
 			IEnumerable<ServiceRequest> ab_ = context.Operators.Union<ServiceRequest>(y_, aa_);
 			CqlCode ac_ = this.Follow_up_2_3_months__finding_();
 			IEnumerable<CqlCode> ad_ = context.Operators.ToList<CqlCode>(ac_);
-			IEnumerable<ServiceRequest> ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> ae_ = context.Operators.RetrieveByCodes<ServiceRequest>(ad_, default);
 			CqlCode af_ = this.Follow_up_4_6_months__finding_();
 			IEnumerable<CqlCode> ag_ = context.Operators.ToList<CqlCode>(af_);
-			IEnumerable<ServiceRequest> ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> ah_ = context.Operators.RetrieveByCodes<ServiceRequest>(ag_, default);
 			IEnumerable<ServiceRequest> ai_ = context.Operators.Union<ServiceRequest>(ae_, ah_);
 			IEnumerable<ServiceRequest> aj_ = context.Operators.Union<ServiceRequest>(ab_, ai_);
 			bool? ak_(ServiceRequest ElevatedBPDeclinedInterventions)
@@ -2746,7 +2746,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> ap_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((ElevatedBPDeclinedInterventions is DomainResource)
 						? ((ElevatedBPDeclinedInterventions as DomainResource).Extension)
-						: default(List<Extension>)), ao_);
+						: default), ao_);
 				DataType aq_(Extension @this)
 				{
 					DataType bm_ = @this?.Value;
@@ -2807,12 +2807,12 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 		IEnumerable<Encounter> i_(Encounter FirstHTNEncounter)
 		{
 			CqlValueSet bx_ = this.Follow_Up_Within_4_Weeks();
-			IEnumerable<ServiceRequest> by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default(PropertyInfo));
-			IEnumerable<ServiceRequest> ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> by_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default);
+			IEnumerable<ServiceRequest> ca_ = context.Operators.RetrieveByValueSet<ServiceRequest>(bx_, default);
 			IEnumerable<ServiceRequest> cb_ = context.Operators.Union<ServiceRequest>(by_, ca_);
 			CqlValueSet cc_ = this.Referral_to_Primary_Care_or_Alternate_Provider();
-			IEnumerable<ServiceRequest> cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default(PropertyInfo));
-			IEnumerable<ServiceRequest> cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> cd_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default);
+			IEnumerable<ServiceRequest> cf_ = context.Operators.RetrieveByValueSet<ServiceRequest>(cc_, default);
 			IEnumerable<ServiceRequest> cg_ = context.Operators.Union<ServiceRequest>(cd_, cf_);
 			IEnumerable<ServiceRequest> ch_ = context.Operators.Union<ServiceRequest>(cb_, cg_);
 			bool? ci_(ServiceRequest FirstHTNDeclinedInterventions)
@@ -2828,7 +2828,7 @@ public class PCSBPScreeningFollowUpFHIR_0_2_000
 				};
 				IEnumerable<Extension> cn_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((FirstHTNDeclinedInterventions is DomainResource)
 						? ((FirstHTNDeclinedInterventions as DomainResource).Extension)
-						: default(List<Extension>)), cm_);
+						: default), cm_);
 				DataType co_(Extension @this)
 				{
 					DataType dk_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("POAGOpticNerveEvaluationFHIR", "0.1.000")]
 public class POAGOpticNerveEvaluationFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -98,7 +98,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -106,7 +106,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Cup_to_Disc_Ratio_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", default(string));
 
     [CqlDeclaration("Cup to Disc Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333")]
@@ -114,7 +114,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Cup_to_Disc_Ratio.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -122,7 +122,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -130,7 +130,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -138,7 +138,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -146,7 +146,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -154,7 +154,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", default(string));
 
     [CqlDeclaration("Optic Disc Exam for Structural Abnormalities")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334")]
@@ -162,7 +162,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Optic_Disc_Exam_for_Structural_Abnormalities.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -170,7 +170,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Primary_Open_Angle_Glaucoma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", default(string));
 
     [CqlDeclaration("Primary Open-Angle Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326")]
@@ -178,14 +178,14 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Primary_Open_Angle_Glaucoma.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -194,8 +194,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -207,8 +207,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("POAGOpticNerveEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
@@ -221,7 +221,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -278,25 +278,25 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;
 			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
@@ -326,13 +326,13 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Primary_Open_Angle_Glaucoma();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			bool? f_(Condition PrimaryOpenAngleGlaucoma)
 			{
 				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(PrimaryOpenAngleGlaucoma);
 				Period k_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.Overlaps(j_, l_, null);
+				bool? m_ = context.Operators.Overlaps(j_, l_, default(string));
 				bool? n_ = QICoreCommon_2_0_000.isActive(PrimaryOpenAngleGlaucoma);
 				bool? o_ = context.Operators.And(m_, n_);
 				CodeableConcept p_ = PrimaryOpenAngleGlaucoma?.VerificationStatus;
@@ -407,8 +407,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value()
 	{
 		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CupToDiscExamNotPerformed)
 		{
@@ -420,7 +420,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterWithPOAG?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
 
 				return t_;
 			};
@@ -445,7 +445,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((CupToDiscExamNotPerformed is DomainResource)
 					? ((CupToDiscExamNotPerformed as DomainResource).Extension)
-					: null), u_);
+					: default(List<Extension>)), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;
@@ -473,8 +473,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value()
 	{
 		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation OpticDiscExamNotPerformed)
 		{
@@ -486,7 +486,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterWithPOAG?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, null);
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
 
 				return t_;
 			};
@@ -511,7 +511,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((OpticDiscExamNotPerformed is DomainResource)
 					? ((OpticDiscExamNotPerformed as DomainResource).Extension)
-					: null), u_);
+					: default(List<Extension>)), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;
@@ -554,7 +554,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result_Value()
 	{
 		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation CupToDiscExamPerformed)
 		{
 			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
@@ -565,7 +565,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				DataType n_ = CupToDiscExamPerformed?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
 
 				return q_;
 			};
@@ -608,7 +608,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result_Value()
 	{
 		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation OpticDiscExamPerformed)
 		{
 			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
@@ -619,7 +619,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				DataType n_ = OpticDiscExamPerformed?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, null);
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
 
 				return q_;
 			};

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -98,7 +98,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -106,7 +106,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Cup_to_Disc_Ratio_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333", default);
 
     [CqlDeclaration("Cup to Disc Ratio")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1333")]
@@ -114,7 +114,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Cup_to_Disc_Ratio.Value;
 
 	private CqlValueSet Face_to_Face_Interaction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", default);
 
     [CqlDeclaration("Face-to-Face Interaction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048")]
@@ -122,7 +122,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Face_to_Face_Interaction.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -130,7 +130,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -138,7 +138,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -146,7 +146,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -154,7 +154,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Optic_Disc_Exam_for_Structural_Abnormalities_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334", default);
 
     [CqlDeclaration("Optic Disc Exam for Structural Abnormalities")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1334")]
@@ -162,7 +162,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Optic_Disc_Exam_for_Structural_Abnormalities.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -170,7 +170,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Primary_Open_Angle_Glaucoma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326", default);
 
     [CqlDeclaration("Primary Open-Angle Glaucoma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.326")]
@@ -178,14 +178,14 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		__Primary_Open_Angle_Glaucoma.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode AMB_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("AMB")]
 	public CqlCode AMB() => 
@@ -194,8 +194,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -207,8 +207,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("POAGOpticNerveEvaluationFHIR-0.1.000", "Measurement Period", c_);
 
@@ -221,7 +221,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -278,25 +278,25 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default);
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			Encounter.EncounterStatus? v_ = u_?.Value;
 			Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
@@ -326,13 +326,13 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Primary_Open_Angle_Glaucoma();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			bool? f_(Condition PrimaryOpenAngleGlaucoma)
 			{
 				CqlInterval<CqlDateTime> j_ = QICoreCommon_2_0_000.prevalenceInterval(PrimaryOpenAngleGlaucoma);
 				Period k_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_3_000.ToInterval(k_);
-				bool? m_ = context.Operators.Overlaps(j_, l_, default(string));
+				bool? m_ = context.Operators.Overlaps(j_, l_, default);
 				bool? n_ = QICoreCommon_2_0_000.isActive(PrimaryOpenAngleGlaucoma);
 				bool? o_ = context.Operators.And(m_, n_);
 				CodeableConcept p_ = PrimaryOpenAngleGlaucoma?.VerificationStatus;
@@ -407,8 +407,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Cup_to_Disc_Ratio_Value()
 	{
 		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation CupToDiscExamNotPerformed)
 		{
@@ -420,7 +420,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterWithPOAG?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
 
 				return t_;
 			};
@@ -445,7 +445,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((CupToDiscExamNotPerformed is DomainResource)
 					? ((CupToDiscExamNotPerformed as DomainResource).Extension)
-					: default(List<Extension>)), u_);
+					: default), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;
@@ -473,8 +473,8 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Medical_Reason_for_Not_Performing_Optic_Disc_Exam_Value()
 	{
 		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
-		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
+		IEnumerable<Observation> d_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> e_ = context.Operators.Union<Observation>(b_, d_);
 		IEnumerable<Observation> f_(Observation OpticDiscExamNotPerformed)
 		{
@@ -486,7 +486,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
 				Period r_ = EncounterWithPOAG?.Period;
 				CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.ToInterval(r_);
-				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default(string));
+				bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
 
 				return t_;
 			};
@@ -511,7 +511,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 			};
 			IEnumerable<Extension> v_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((OpticDiscExamNotPerformed is DomainResource)
 					? ((OpticDiscExamNotPerformed as DomainResource).Extension)
-					: default(List<Extension>)), u_);
+					: default), u_);
 			DataType w_(Extension @this)
 			{
 				DataType ah_ = @this?.Value;
@@ -554,7 +554,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Cup_to_Disc_Ratio_Performed_with_Result_Value()
 	{
 		CqlValueSet a_ = this.Cup_to_Disc_Ratio();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation CupToDiscExamPerformed)
 		{
 			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
@@ -565,7 +565,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				DataType n_ = CupToDiscExamPerformed?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default);
 
 				return q_;
 			};
@@ -608,7 +608,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 	private IEnumerable<Observation> Optic_Disc_Exam_Performed_with_Result_Value()
 	{
 		CqlValueSet a_ = this.Optic_Disc_Exam_for_Structural_Abnormalities();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation OpticDiscExamPerformed)
 		{
 			IEnumerable<Encounter> g_ = this.Primary_Open_Angle_Glaucoma_Encounter();
@@ -619,7 +619,7 @@ public class POAGOpticNerveEvaluationFHIR_0_1_000
 				DataType n_ = OpticDiscExamPerformed?.Effective;
 				object o_ = FHIRHelpers_4_3_000.ToValue(n_);
 				CqlInterval<CqlDateTime> p_ = QICoreCommon_2_0_000.toInterval(o_);
-				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default(string));
+				bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default);
 
 				return q_;
 			};

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
@@ -56,7 +56,7 @@ public class PalliativeCare_1_9_000
     #endregion
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
@@ -64,7 +64,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
@@ -72,7 +72,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Intervention.Value;
 
 	private CqlValueSet Palliative_Care_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", default);
 
     [CqlDeclaration("Palliative Care Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167")]
@@ -80,7 +80,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Diagnosis.Value;
 
 	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
-		new CqlCode("71007-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("71007-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
 	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
@@ -89,7 +89,7 @@ public class PalliativeCare_1_9_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71007-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71007-9", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -112,7 +112,7 @@ public class PalliativeCare_1_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -126,7 +126,7 @@ public class PalliativeCare_1_9_000
 	{
 		CqlCode a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
 		bool? e_(Observation PalliativeAssessment)
 		{
@@ -141,7 +141,7 @@ public class PalliativeCare_1_9_000
 		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		bool? g_ = context.Operators.Exists<Observation>(f_);
 		CqlValueSet h_ = this.Palliative_Care_Diagnosis();
-		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
+		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default);
 		bool? j_(Condition PalliativeDiagnosis)
 		{
 			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
@@ -154,7 +154,7 @@ public class PalliativeCare_1_9_000
 		bool? l_ = context.Operators.Exists<Condition>(k_);
 		bool? m_ = context.Operators.Or(g_, l_);
 		CqlValueSet n_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter PalliativeEncounter)
 		{
@@ -170,7 +170,7 @@ public class PalliativeCare_1_9_000
 		bool? s_ = context.Operators.Exists<Encounter>(r_);
 		bool? t_ = context.Operators.Or(m_, s_);
 		CqlValueSet u_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, default(PropertyInfo));
+		IEnumerable<Procedure> v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, default);
 		IEnumerable<Procedure> w_ = Status_1_6_000.isInterventionPerformed(v_);
 		bool? x_(Procedure PalliativeIntervention)
 		{

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PalliativeCare", "1.9.000")]
 public class PalliativeCare_1_9_000
 {

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.9.000.g.cs
@@ -56,7 +56,7 @@ public class PalliativeCare_1_9_000
     #endregion
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default(string));
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
@@ -64,7 +64,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default(string));
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
@@ -72,7 +72,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Intervention.Value;
 
 	private CqlValueSet Palliative_Care_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", default(string));
 
     [CqlDeclaration("Palliative Care Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167")]
@@ -80,7 +80,7 @@ public class PalliativeCare_1_9_000
 		__Palliative_Care_Diagnosis.Value;
 
 	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
-		new CqlCode("71007-9", "http://loinc.org", null, null);
+		new CqlCode("71007-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
 	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
@@ -89,7 +89,7 @@ public class PalliativeCare_1_9_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71007-9", "http://loinc.org", null, null),
+			new CqlCode("71007-9", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -112,7 +112,7 @@ public class PalliativeCare_1_9_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -126,7 +126,7 @@ public class PalliativeCare_1_9_000
 	{
 		CqlCode a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_ = Status_1_6_000.isAssessmentPerformed(c_);
 		bool? e_(Observation PalliativeAssessment)
 		{
@@ -141,7 +141,7 @@ public class PalliativeCare_1_9_000
 		IEnumerable<Observation> f_ = context.Operators.Where<Observation>(d_, e_);
 		bool? g_ = context.Operators.Exists<Observation>(f_);
 		CqlValueSet h_ = this.Palliative_Care_Diagnosis();
-		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
 		bool? j_(Condition PalliativeDiagnosis)
 		{
 			CqlInterval<CqlDateTime> ag_ = QICoreCommon_2_0_000.prevalenceInterval(PalliativeDiagnosis);
@@ -154,7 +154,7 @@ public class PalliativeCare_1_9_000
 		bool? l_ = context.Operators.Exists<Condition>(k_);
 		bool? m_ = context.Operators.Or(g_, l_);
 		CqlValueSet n_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = Status_1_6_000.isEncounterPerformed(o_);
 		bool? q_(Encounter PalliativeEncounter)
 		{
@@ -170,7 +170,7 @@ public class PalliativeCare_1_9_000
 		bool? s_ = context.Operators.Exists<Encounter>(r_);
 		bool? t_ = context.Operators.Or(m_, s_);
 		CqlValueSet u_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, null);
+		IEnumerable<Procedure> v_ = context.Operators.RetrieveByValueSet<Procedure>(u_, default(PropertyInfo));
 		IEnumerable<Procedure> w_ = Status_1_6_000.isInterventionPerformed(v_);
 		bool? x_(Procedure PalliativeIntervention)
 		{

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR", "0.0.001")]
 public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR_0_0_001
 {

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -152,7 +152,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -160,7 +160,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -168,7 +168,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Limited_Life_Expectancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", default(string));
 
     [CqlDeclaration("Limited Life Expectancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259")]
@@ -176,7 +176,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Limited_Life_Expectancy.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -184,7 +184,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nutrition_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", default(string));
 
     [CqlDeclaration("Nutrition Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006")]
@@ -192,7 +192,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Nutrition_Services.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -200,7 +200,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -208,7 +208,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -216,7 +216,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -224,7 +224,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default(string));
 
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
@@ -232,7 +232,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Physical_Therapy_Evaluation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -240,7 +240,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -248,7 +248,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -256,7 +256,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -264,7 +264,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -272,7 +272,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -280,7 +280,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychoanalysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default(string));
 
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
@@ -288,7 +288,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psychoanalysis.Value;
 
 	private CqlValueSet Speech_and_Hearing_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", default(string));
 
     [CqlDeclaration("Speech and Hearing Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530")]
@@ -296,7 +296,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Speech_and_Hearing_Evaluation.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -304,7 +304,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Tobacco_Non_User_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", default(string));
 
     [CqlDeclaration("Tobacco Non User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189")]
@@ -312,7 +312,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Non_User.Value;
 
 	private CqlValueSet Tobacco_Use_Cessation_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", default(string));
 
     [CqlDeclaration("Tobacco Use Cessation Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509")]
@@ -320,7 +320,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Cessation_Counseling.Value;
 
 	private CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", default(string));
 
     [CqlDeclaration("Tobacco Use Cessation Pharmacotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190")]
@@ -328,7 +328,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Cessation_Pharmacotherapy.Value;
 
 	private CqlValueSet Tobacco_Use_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", default(string));
 
     [CqlDeclaration("Tobacco Use Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278")]
@@ -336,7 +336,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Screening.Value;
 
 	private CqlValueSet Tobacco_User_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", default(string));
 
     [CqlDeclaration("Tobacco User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170")]
@@ -344,35 +344,35 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_User.Value;
 
 	private CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value() => 
-		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Health behavior assessment, or re-assessment (ie, health-focused clinical interview, behavioral observations, clinical decision making)")]
 	public CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_() => 
 		__Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_.Value;
 
 	private CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value() => 
-		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Health behavior intervention, individual, face-to-face; initial 30 minutes")]
 	public CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes() => 
 		__Health_behavior_intervention__individual__face_to_face__initial_30_minutes.Value;
 
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
-		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
 	private CqlCode Tobacco_abuse_counseling_Value() => 
-		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Tobacco abuse counseling")]
 	public CqlCode Tobacco_abuse_counseling() => 
 		__Tobacco_abuse_counseling.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -381,10 +381,10 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", null, null),
-			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", null, null),
-			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", null, null),
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -397,7 +397,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -409,8 +409,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001", "Measurement Period", c_);
 
@@ -423,7 +423,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -436,8 +436,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? d_(Encounter E)
 		{
 			List<CodeableConcept> ar_ = E?.Type;
@@ -488,35 +488,35 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		};
 		IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(c_, h_);
 		CqlValueSet j_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, null);
+		IEnumerable<Encounter> k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, default(PropertyInfo));
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(i_, k_);
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(f_, l_);
 		CqlValueSet n_ = this.Office_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		CqlValueSet p_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, null);
+		IEnumerable<Encounter> q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, default(PropertyInfo));
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(o_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(m_, r_);
 		CqlValueSet t_ = this.Physical_Therapy_Evaluation();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		CqlValueSet v_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		CqlValueSet z_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		CqlValueSet ab_ = this.Psychoanalysis();
-		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, null);
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default(PropertyInfo));
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
 		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
 		CqlValueSet af_ = this.Speech_and_Hearing_Evaluation();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, null);
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
 		CqlValueSet ah_ = this.Telephone_Visits();
-		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, null);
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default(PropertyInfo));
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
 		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
 		CqlValueSet al_ = this.Online_Assessments();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, null);
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = Status_1_6_000.isEncounterPerformed(an_);
 		bool? ap_(Encounter OfficeBasedEncounter)
@@ -541,13 +541,13 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? i_(Encounter E)
 		{
 			List<CodeableConcept> ac_ = E?.Type;
@@ -575,7 +575,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
 		bool? p_(Encounter E)
 		{
 			List<CodeableConcept> am_ = E?.Type;
@@ -603,9 +603,9 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(n_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(l_, r_);
 		CqlValueSet t_ = this.Nutrition_Services();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		CqlValueSet v_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, null);
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
@@ -668,7 +668,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
@@ -742,7 +742,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
@@ -806,7 +806,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<object> Tobacco_Cessation_Counseling_Given_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Counseling();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.isInterventionPerformed(b_);
 		bool? d_(Procedure TobaccoCessationCounseling)
 		{
@@ -826,7 +826,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlCode f_ = this.Tobacco_abuse_counseling();
 		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
-		IEnumerable<Condition> h_ = context.Operators.RetrieveByCodes<Condition>(g_, null);
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByCodes<Condition>(g_, default(PropertyInfo));
 		bool? i_(Condition TobaccoCounseling)
 		{
 			CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.prevalenceInterval(TobaccoCounseling);
@@ -854,8 +854,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationOrder(e_);
 		bool? g_(MedicationRequest CessationPharmacotherapyOrdered)
@@ -884,8 +884,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest TakingCessationPharmacotherapy)

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -152,7 +152,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -160,7 +160,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -168,7 +168,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Limited_Life_Expectancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259", default);
 
     [CqlDeclaration("Limited Life Expectancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1259")]
@@ -176,7 +176,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Limited_Life_Expectancy.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -184,7 +184,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nutrition_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006", default);
 
     [CqlDeclaration("Nutrition Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1006")]
@@ -192,7 +192,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Nutrition_Services.Value;
 
 	private CqlValueSet Occupational_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011", default);
 
     [CqlDeclaration("Occupational Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1011")]
@@ -200,7 +200,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Occupational_Therapy_Evaluation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -208,7 +208,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -216,7 +216,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -224,7 +224,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Physical_Therapy_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", default);
 
     [CqlDeclaration("Physical Therapy Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022")]
@@ -232,7 +232,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Physical_Therapy_Evaluation.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -240,7 +240,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default);
 
     [CqlDeclaration("Preventive Care Services Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -248,7 +248,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -256,7 +256,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -264,7 +264,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Psych_Visit_Diagnostic_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492", default);
 
     [CqlDeclaration("Psych Visit Diagnostic Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1492")]
@@ -272,7 +272,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psych_Visit_Diagnostic_Evaluation.Value;
 
 	private CqlValueSet Psych_Visit_Psychotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496", default);
 
     [CqlDeclaration("Psych Visit Psychotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1496")]
@@ -280,7 +280,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psych_Visit_Psychotherapy.Value;
 
 	private CqlValueSet Psychoanalysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141", default);
 
     [CqlDeclaration("Psychoanalysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1141")]
@@ -288,7 +288,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Psychoanalysis.Value;
 
 	private CqlValueSet Speech_and_Hearing_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530", default);
 
     [CqlDeclaration("Speech and Hearing Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1530")]
@@ -296,7 +296,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Speech_and_Hearing_Evaluation.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -304,7 +304,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Tobacco_Non_User_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189", default);
 
     [CqlDeclaration("Tobacco Non User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1189")]
@@ -312,7 +312,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Non_User.Value;
 
 	private CqlValueSet Tobacco_Use_Cessation_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509", default);
 
     [CqlDeclaration("Tobacco Use Cessation Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.509")]
@@ -320,7 +320,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Cessation_Counseling.Value;
 
 	private CqlValueSet Tobacco_Use_Cessation_Pharmacotherapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190", default);
 
     [CqlDeclaration("Tobacco Use Cessation Pharmacotherapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1190")]
@@ -328,7 +328,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Cessation_Pharmacotherapy.Value;
 
 	private CqlValueSet Tobacco_Use_Screening_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278", default);
 
     [CqlDeclaration("Tobacco Use Screening")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1278")]
@@ -336,7 +336,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_Use_Screening.Value;
 
 	private CqlValueSet Tobacco_User_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170", default);
 
     [CqlDeclaration("Tobacco User")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1170")]
@@ -344,35 +344,35 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		__Tobacco_User.Value;
 
 	private CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making__Value() => 
-		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Health behavior assessment, or re-assessment (ie, health-focused clinical interview, behavioral observations, clinical decision making)")]
 	public CqlCode Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_() => 
 		__Health_behavior_assessment__or_re_assessment__ie__health_focused_clinical_interview__behavioral_observations__clinical_decision_making_.Value;
 
 	private CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes_Value() => 
-		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Health behavior intervention, individual, face-to-face; initial 30 minutes")]
 	public CqlCode Health_behavior_intervention__individual__face_to_face__initial_30_minutes() => 
 		__Health_behavior_intervention__individual__face_to_face__initial_30_minutes.Value;
 
 	private CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure_Value() => 
-		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Postoperative follow-up visit, normally included in the surgical package, to indicate that an evaluation and management service was performed during a postoperative period for a reason(s) related to the original procedure")]
 	public CqlCode Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure() => 
 		__Postoperative_follow_up_visit__normally_included_in_the_surgical_package__to_indicate_that_an_evaluation_and_management_service_was_performed_during_a_postoperative_period_for_a_reason_s__related_to_the_original_procedure.Value;
 
 	private CqlCode Tobacco_abuse_counseling_Value() => 
-		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Tobacco abuse counseling")]
 	public CqlCode Tobacco_abuse_counseling() => 
 		__Tobacco_abuse_counseling.Value;
 
 	private CqlCode Unlisted_preventive_medicine_service_Value() => 
-		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Unlisted preventive medicine service")]
 	public CqlCode Unlisted_preventive_medicine_service() => 
@@ -381,10 +381,10 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
-			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
-			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
-			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("96156", "http://www.ama-assn.org/go/cpt", default, default),
+			new CqlCode("96158", "http://www.ama-assn.org/go/cpt", default, default),
+			new CqlCode("99024", "http://www.ama-assn.org/go/cpt", default, default),
+			new CqlCode("99429", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -397,7 +397,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("Z71.6", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -409,8 +409,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001", "Measurement Period", c_);
 
@@ -423,7 +423,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -436,8 +436,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<Encounter> Qualifying_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
-		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
+		IEnumerable<Encounter> c_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? d_(Encounter E)
 		{
 			List<CodeableConcept> ar_ = E?.Type;
@@ -488,35 +488,35 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		};
 		IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(c_, h_);
 		CqlValueSet j_ = this.Occupational_Therapy_Evaluation();
-		IEnumerable<Encounter> k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, default(PropertyInfo));
+		IEnumerable<Encounter> k_ = context.Operators.RetrieveByValueSet<Encounter>(j_, default);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(i_, k_);
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(f_, l_);
 		CqlValueSet n_ = this.Office_Visit();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		CqlValueSet p_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, default(PropertyInfo));
+		IEnumerable<Encounter> q_ = context.Operators.RetrieveByValueSet<Encounter>(p_, default);
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(o_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(m_, r_);
 		CqlValueSet t_ = this.Physical_Therapy_Evaluation();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		CqlValueSet v_ = this.Psych_Visit_Diagnostic_Evaluation();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default);
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		CqlValueSet z_ = this.Psych_Visit_Psychotherapy();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		CqlValueSet ab_ = this.Psychoanalysis();
-		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default(PropertyInfo));
+		IEnumerable<Encounter> ac_ = context.Operators.RetrieveByValueSet<Encounter>(ab_, default);
 		IEnumerable<Encounter> ad_ = context.Operators.Union<Encounter>(aa_, ac_);
 		IEnumerable<Encounter> ae_ = context.Operators.Union<Encounter>(y_, ad_);
 		CqlValueSet af_ = this.Speech_and_Hearing_Evaluation();
-		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default(PropertyInfo));
+		IEnumerable<Encounter> ag_ = context.Operators.RetrieveByValueSet<Encounter>(af_, default);
 		CqlValueSet ah_ = this.Telephone_Visits();
-		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default(PropertyInfo));
+		IEnumerable<Encounter> ai_ = context.Operators.RetrieveByValueSet<Encounter>(ah_, default);
 		IEnumerable<Encounter> aj_ = context.Operators.Union<Encounter>(ag_, ai_);
 		IEnumerable<Encounter> ak_ = context.Operators.Union<Encounter>(ae_, aj_);
 		CqlValueSet al_ = this.Online_Assessments();
-		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default(PropertyInfo));
+		IEnumerable<Encounter> am_ = context.Operators.RetrieveByValueSet<Encounter>(al_, default);
 		IEnumerable<Encounter> an_ = context.Operators.Union<Encounter>(ak_, am_);
 		IEnumerable<Encounter> ao_ = Status_1_6_000.isEncounterPerformed(an_);
 		bool? ap_(Encounter OfficeBasedEncounter)
@@ -541,13 +541,13 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<Encounter> Preventive_Visit_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Group_Counseling();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? i_(Encounter E)
 		{
 			List<CodeableConcept> ac_ = E?.Type;
@@ -575,7 +575,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
 		IEnumerable<Encounter> l_ = context.Operators.Union<Encounter>(e_, k_);
 		CqlValueSet m_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default);
 		bool? p_(Encounter E)
 		{
 			List<CodeableConcept> am_ = E?.Type;
@@ -603,9 +603,9 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Encounter> r_ = context.Operators.Union<Encounter>(n_, q_);
 		IEnumerable<Encounter> s_ = context.Operators.Union<Encounter>(l_, r_);
 		CqlValueSet t_ = this.Nutrition_Services();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		CqlValueSet v_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default(PropertyInfo));
+		IEnumerable<Encounter> w_ = context.Operators.RetrieveByValueSet<Encounter>(v_, default);
 		IEnumerable<Encounter> x_ = context.Operators.Union<Encounter>(u_, w_);
 		IEnumerable<Encounter> y_ = context.Operators.Union<Encounter>(s_, x_);
 		IEnumerable<Encounter> z_ = Status_1_6_000.isEncounterPerformed(y_);
@@ -668,7 +668,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_User_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
@@ -742,7 +742,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private Observation Most_Recent_Tobacco_Use_Screening_Indicates_Tobacco_Non_User_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Screening();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_ = Status_1_6_000.isAssessmentPerformed(b_);
 		bool? d_(Observation TobaccoUseScreening)
 		{
@@ -806,7 +806,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<object> Tobacco_Cessation_Counseling_Given_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Counseling();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.isInterventionPerformed(b_);
 		bool? d_(Procedure TobaccoCessationCounseling)
 		{
@@ -826,7 +826,7 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		CqlCode f_ = this.Tobacco_abuse_counseling();
 		IEnumerable<CqlCode> g_ = context.Operators.ToList<CqlCode>(f_);
-		IEnumerable<Condition> h_ = context.Operators.RetrieveByCodes<Condition>(g_, default(PropertyInfo));
+		IEnumerable<Condition> h_ = context.Operators.RetrieveByCodes<Condition>(g_, default);
 		bool? i_(Condition TobaccoCounseling)
 		{
 			CqlInterval<CqlDateTime> w_ = QICoreCommon_2_0_000.prevalenceInterval(TobaccoCounseling);
@@ -854,8 +854,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<MedicationRequest> Tobacco_Cessation_Pharmacotherapy_Ordered_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationOrder(e_);
 		bool? g_(MedicationRequest CessationPharmacotherapyOrdered)
@@ -884,8 +884,8 @@ public class PreventiveCareAndScreeningTobaccoUseScreeningAndCessationInterventi
 	private IEnumerable<MedicationRequest> Active_Pharmacotherapy_for_Tobacco_Cessation_Value()
 	{
 		CqlValueSet a_ = this.Tobacco_Use_Cessation_Pharmacotherapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.isMedicationActive(e_);
 		bool? g_(MedicationRequest TakingCessationPharmacotherapy)

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -84,7 +84,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -92,7 +92,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -100,7 +100,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hosice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hosice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -108,7 +108,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Discharged_to_Home_for_Hosice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -116,7 +116,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default(string));
 
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
@@ -124,7 +124,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Fluoride_Varnish_Application_for_Children.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -133,8 +133,8 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002", "Measurement Period", c_);
 
@@ -147,7 +147,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -160,7 +160,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
@@ -191,7 +191,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -228,7 +228,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Fluoride_Varnish_Application_for_Children();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure FluorideApplication)
 		{
@@ -274,7 +274,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 5, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -294,7 +294,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(6, 12, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -314,7 +314,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(13, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PrimaryCariesPreventionasOfferedbyDentistsFHIR", "0.0.002")]
 public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 {

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -84,7 +84,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default);
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -92,7 +92,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -100,7 +100,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hosice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hosice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -108,7 +108,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Discharged_to_Home_for_Hosice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -116,7 +116,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default);
 
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
@@ -124,7 +124,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		__Fluoride_Varnish_Application_for_Children.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -133,8 +133,8 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002", "Measurement Period", c_);
 
@@ -147,7 +147,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -160,7 +160,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = Status_1_6_000.isEncounterPerformed(b_);
 		bool? d_(Encounter ValidEncounter)
 		{
@@ -191,7 +191,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounters();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -228,7 +228,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Fluoride_Varnish_Application_for_Children();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.isProcedurePerformed(b_);
 		bool? d_(Procedure FluorideApplication)
 		{
@@ -274,7 +274,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(1, 5, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -294,7 +294,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(6, 12, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -314,7 +314,7 @@ public class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(13, 20, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -108,7 +108,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Bone_Scan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", default(string));
 
     [CqlDeclaration("Bone Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320")]
@@ -116,7 +116,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Bone_Scan.Value;
 
 	private CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", default(string));
 
     [CqlDeclaration("Pain Warranting Further Investigation for Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451")]
@@ -124,7 +124,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Pain_Warranting_Further_Investigation_for_Prostate_Cancer.Value;
 
 	private CqlValueSet Prostate_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", default(string));
 
     [CqlDeclaration("Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319")]
@@ -132,7 +132,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Cancer.Value;
 
 	private CqlValueSet Prostate_Cancer_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", default(string));
 
     [CqlDeclaration("Prostate Cancer Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398")]
@@ -140,7 +140,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Cancer_Treatment.Value;
 
 	private CqlValueSet Prostate_Specific_Antigen_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", default(string));
 
     [CqlDeclaration("Prostate Specific Antigen Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401")]
@@ -148,7 +148,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Specific_Antigen_Test.Value;
 
 	private CqlValueSet Salvage_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", default(string));
 
     [CqlDeclaration("Salvage Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399")]
@@ -156,49 +156,49 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Salvage_Therapy.Value;
 
 	private CqlCode Gleason_score_in_Specimen_Qualitative_Value() => 
-		new CqlCode("35266-6", "http://loinc.org", null, null);
+		new CqlCode("35266-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Gleason score in Specimen Qualitative")]
 	public CqlCode Gleason_score_in_Specimen_Qualitative() => 
 		__Gleason_score_in_Specimen_Qualitative.Value;
 
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value() => 
-		new CqlCode("433351000124101", "http://snomed.info/sct", null, null);
+		new CqlCode("433351000124101", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T1c: Tumor identified by needle biopsy (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_.Value;
 
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value() => 
-		new CqlCode("433361000124104", "http://snomed.info/sct", null, null);
+		new CqlCode("433361000124104", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T2a: Involves one-half of one lobe or less (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_.Value;
 
 	private CqlCode Procedure_reason_record__record_artifact__Value() => 
-		new CqlCode("433611000124109", "http://snomed.info/sct", null, null);
+		new CqlCode("433611000124109", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Procedure reason record (record artifact)")]
 	public CqlCode Procedure_reason_record__record_artifact_() => 
 		__Procedure_reason_record__record_artifact_.Value;
 
 	private CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value() => 
-		new CqlCode("369833007", "http://snomed.info/sct", null, null);
+		new CqlCode("369833007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("T1a: Prostate tumor incidental histologic finding in 5 percent or less of tissue resected (finding)")]
 	public CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_() => 
 		__T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_.Value;
 
 	private CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value() => 
-		new CqlCode("369834001", "http://snomed.info/sct", null, null);
+		new CqlCode("369834001", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("T1b: Prostate tumor incidental histologic finding in greater than 5 percent of tissue resected (finding)")]
 	public CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_() => 
 		__T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_.Value;
 
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
-		new CqlCode("254292007", "http://snomed.info/sct", null, null);
+		new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
@@ -207,7 +207,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("35266-6", "http://loinc.org", null, null),
+			new CqlCode("35266-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -220,12 +220,12 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("433351000124101", "http://snomed.info/sct", null, null),
-			new CqlCode("433361000124104", "http://snomed.info/sct", null, null),
-			new CqlCode("433611000124109", "http://snomed.info/sct", null, null),
-			new CqlCode("369833007", "http://snomed.info/sct", null, null),
-			new CqlCode("369834001", "http://snomed.info/sct", null, null),
-			new CqlCode("254292007", "http://snomed.info/sct", null, null),
+			new CqlCode("433351000124101", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("433361000124104", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("433611000124109", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("369833007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("369834001", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -237,8 +237,8 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000", "Measurement Period", c_);
 
@@ -251,7 +251,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -308,7 +308,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private IEnumerable<Condition> Prostate_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ProstateCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
@@ -335,7 +335,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value()
 	{
 		CqlValueSet a_ = this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition ProstateCancerPain)
 		{
 			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
@@ -345,7 +345,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime n_ = context.Operators.Start(m_);
-				bool? o_ = context.Operators.After(l_, n_, null);
+				bool? o_ = context.Operators.After(l_, n_, default(string));
 				bool? p_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancerPain);
 				bool? q_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancerPain);
 				bool? r_ = context.Operators.Or(p_, q_);
@@ -375,7 +375,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Salvage_Therapy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_(Procedure SalvageTherapy)
 		{
 			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
@@ -387,7 +387,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.Start(m_);
 				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime p_ = context.Operators.Start(o_);
-				bool? q_ = context.Operators.After(n_, p_, null);
+				bool? q_ = context.Operators.After(n_, p_, default(string));
 				Code<EventStatus> r_ = SalvageTherapy?.StatusElement;
 				EventStatus? s_ = r_?.Value;
 				string t_ = context.Operators.Convert<string>(s_);
@@ -416,7 +416,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private IEnumerable<Observation> Bone_Scan_Study_Performed_Value()
 	{
 		CqlValueSet a_ = this.Bone_Scan();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation BoneScan)
 		{
 			IEnumerable<Condition> e_ = this.Prostate_Cancer_Diagnosis();
@@ -428,7 +428,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime m_ = context.Operators.Start(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime o_ = context.Operators.Start(n_);
-				bool? p_ = context.Operators.After(m_, o_, null);
+				bool? p_ = context.Operators.After(m_, o_, default(string));
 
 				return p_;
 			};
@@ -489,7 +489,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Cancer_Treatment();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure ProstateCancerTreatment)
 		{
 			DataType h_ = ProstateCancerTreatment?.Performed;
@@ -542,7 +542,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	{
 		CqlCode a_ = this.Gleason_score_in_Specimen_Qualitative();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_(Observation GleasonScore)
 		{
 			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
@@ -559,7 +559,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.Before(v_, z_, null);
+				bool? aa_ = context.Operators.Before(v_, z_, default(string));
 				Code<ObservationStatus> ab_ = GleasonScore?.StatusElement;
 				ObservationStatus? ac_ = ab_?.Value;
 				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
@@ -618,7 +618,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	{
 		CqlCode a_ = this.Tumor_staging__tumor_staging_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<Observation> d_(Observation ProstateCancerStaging)
 		{
 			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
@@ -635,7 +635,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.Before(v_, z_, null);
+				bool? aa_ = context.Operators.Before(v_, z_, default(string));
 				Code<ObservationStatus> ab_ = ProstateCancerStaging?.StatusElement;
 				ObservationStatus? ac_ = ab_?.Value;
 				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
@@ -723,7 +723,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Most_Recent_PSA_Test_Result_is_Low_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Specific_Antigen_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation PSATest)
 		{
 			Observation l_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
@@ -745,7 +745,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 					};
 					if (ad_())
 					{
-						return null;
+						return default(CqlInterval<CqlDateTime>);
 					}
 					else
 					{
@@ -764,7 +764,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				DataType s_ = MostRecentProstateCancerStaging?.Effective;
 				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
-				bool? v_ = context.Operators.Before(r_(), u_, null);
+				bool? v_ = context.Operators.Before(r_(), u_, default(string));
 				Code<ObservationStatus> w_ = PSATest?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -108,7 +108,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
     #endregion
 
 	private CqlValueSet Bone_Scan_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320", default);
 
     [CqlDeclaration("Bone Scan")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.320")]
@@ -116,7 +116,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Bone_Scan.Value;
 
 	private CqlValueSet Pain_Warranting_Further_Investigation_for_Prostate_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451", default);
 
     [CqlDeclaration("Pain Warranting Further Investigation for Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.451")]
@@ -124,7 +124,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Pain_Warranting_Further_Investigation_for_Prostate_Cancer.Value;
 
 	private CqlValueSet Prostate_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319", default);
 
     [CqlDeclaration("Prostate Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.319")]
@@ -132,7 +132,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Cancer.Value;
 
 	private CqlValueSet Prostate_Cancer_Treatment_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398", default);
 
     [CqlDeclaration("Prostate Cancer Treatment")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.398")]
@@ -140,7 +140,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Cancer_Treatment.Value;
 
 	private CqlValueSet Prostate_Specific_Antigen_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401", default);
 
     [CqlDeclaration("Prostate Specific Antigen Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.401")]
@@ -148,7 +148,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Prostate_Specific_Antigen_Test.Value;
 
 	private CqlValueSet Salvage_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399", default);
 
     [CqlDeclaration("Salvage Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.399")]
@@ -156,49 +156,49 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 		__Salvage_Therapy.Value;
 
 	private CqlCode Gleason_score_in_Specimen_Qualitative_Value() => 
-		new CqlCode("35266-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("35266-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Gleason score in Specimen Qualitative")]
 	public CqlCode Gleason_score_in_Specimen_Qualitative() => 
 		__Gleason_score_in_Specimen_Qualitative.Value;
 
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding__Value() => 
-		new CqlCode("433351000124101", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("433351000124101", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T1c: Tumor identified by needle biopsy (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T1c__Tumor_identified_by_needle_biopsy__finding_.Value;
 
 	private CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding__Value() => 
-		new CqlCode("433361000124104", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("433361000124104", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Neoplasm of prostate primary tumor staging category T2a: Involves one-half of one lobe or less (finding)")]
 	public CqlCode Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_() => 
 		__Neoplasm_of_prostate_primary_tumor_staging_category_T2a__Involves_one_half_of_one_lobe_or_less__finding_.Value;
 
 	private CqlCode Procedure_reason_record__record_artifact__Value() => 
-		new CqlCode("433611000124109", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("433611000124109", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Procedure reason record (record artifact)")]
 	public CqlCode Procedure_reason_record__record_artifact_() => 
 		__Procedure_reason_record__record_artifact_.Value;
 
 	private CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding__Value() => 
-		new CqlCode("369833007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("369833007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("T1a: Prostate tumor incidental histologic finding in 5 percent or less of tissue resected (finding)")]
 	public CqlCode T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_() => 
 		__T1a__Prostate_tumor_incidental_histologic_finding_in_5_percent_or_less_of_tissue_resected__finding_.Value;
 
 	private CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding__Value() => 
-		new CqlCode("369834001", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("369834001", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("T1b: Prostate tumor incidental histologic finding in greater than 5 percent of tissue resected (finding)")]
 	public CqlCode T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_() => 
 		__T1b__Prostate_tumor_incidental_histologic_finding_in_greater_than_5_percent_of_tissue_resected__finding_.Value;
 
 	private CqlCode Tumor_staging__tumor_staging__Value() => 
-		new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("254292007", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Tumor staging (tumor staging)")]
 	public CqlCode Tumor_staging__tumor_staging_() => 
@@ -207,7 +207,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("35266-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("35266-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -220,12 +220,12 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("433351000124101", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("433361000124104", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("433611000124109", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("369833007", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("369834001", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("254292007", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("433351000124101", "http://snomed.info/sct", default, default),
+			new CqlCode("433361000124104", "http://snomed.info/sct", default, default),
+			new CqlCode("433611000124109", "http://snomed.info/sct", default, default),
+			new CqlCode("369833007", "http://snomed.info/sct", default, default),
+			new CqlCode("369834001", "http://snomed.info/sct", default, default),
+			new CqlCode("254292007", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -237,8 +237,8 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000", "Measurement Period", c_);
 
@@ -251,7 +251,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -308,7 +308,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private IEnumerable<Condition> Prostate_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ProstateCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = QICoreCommon_2_0_000.prevalenceInterval(ProstateCancer);
@@ -335,7 +335,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Has_Diagnosis_of_Pain_related_to_Prostate_Cancer_Value()
 	{
 		CqlValueSet a_ = this.Pain_Warranting_Further_Investigation_for_Prostate_Cancer();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition ProstateCancerPain)
 		{
 			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
@@ -345,7 +345,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime l_ = context.Operators.Start(k_);
 				CqlInterval<CqlDateTime> m_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime n_ = context.Operators.Start(m_);
-				bool? o_ = context.Operators.After(l_, n_, default(string));
+				bool? o_ = context.Operators.After(l_, n_, default);
 				bool? p_ = QICoreCommon_2_0_000.isProblemListItem(ProstateCancerPain);
 				bool? q_ = QICoreCommon_2_0_000.isHealthConcern(ProstateCancerPain);
 				bool? r_ = context.Operators.Or(p_, q_);
@@ -375,7 +375,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Has_Salvage_Therapy_Performed_after_Prostate_Cancer_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Salvage_Therapy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_(Procedure SalvageTherapy)
 		{
 			IEnumerable<Condition> f_ = this.Prostate_Cancer_Diagnosis();
@@ -387,7 +387,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime n_ = context.Operators.Start(m_);
 				CqlInterval<CqlDateTime> o_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime p_ = context.Operators.Start(o_);
-				bool? q_ = context.Operators.After(n_, p_, default(string));
+				bool? q_ = context.Operators.After(n_, p_, default);
 				Code<EventStatus> r_ = SalvageTherapy?.StatusElement;
 				EventStatus? s_ = r_?.Value;
 				string t_ = context.Operators.Convert<string>(s_);
@@ -416,7 +416,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private IEnumerable<Observation> Bone_Scan_Study_Performed_Value()
 	{
 		CqlValueSet a_ = this.Bone_Scan();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation BoneScan)
 		{
 			IEnumerable<Condition> e_ = this.Prostate_Cancer_Diagnosis();
@@ -428,7 +428,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				CqlDateTime m_ = context.Operators.Start(l_);
 				CqlInterval<CqlDateTime> n_ = QICoreCommon_2_0_000.prevalenceInterval(ActiveProstateCancer);
 				CqlDateTime o_ = context.Operators.Start(n_);
-				bool? p_ = context.Operators.After(m_, o_, default(string));
+				bool? p_ = context.Operators.After(m_, o_, default);
 
 				return p_;
 			};
@@ -489,7 +489,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private Procedure First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Cancer_Treatment();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure ProstateCancerTreatment)
 		{
 			DataType h_ = ProstateCancerTreatment?.Performed;
@@ -542,7 +542,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	{
 		CqlCode a_ = this.Gleason_score_in_Specimen_Qualitative();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_(Observation GleasonScore)
 		{
 			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
@@ -559,7 +559,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.Before(v_, z_, default(string));
+				bool? aa_ = context.Operators.Before(v_, z_, default);
 				Code<ObservationStatus> ab_ = GleasonScore?.StatusElement;
 				ObservationStatus? ac_ = ab_?.Value;
 				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
@@ -618,7 +618,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	{
 		CqlCode a_ = this.Tumor_staging__tumor_staging_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<Observation> d_(Observation ProstateCancerStaging)
 		{
 			Procedure m_ = this.First_Prostate_Cancer_Treatment_during_day_of_Measurement_Period();
@@ -635,7 +635,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				object x_ = FHIRHelpers_4_3_000.ToValue(w_);
 				CqlInterval<CqlDateTime> y_ = QICoreCommon_2_0_000.toInterval(x_);
 				CqlDateTime z_ = context.Operators.Start(y_);
-				bool? aa_ = context.Operators.Before(v_, z_, default(string));
+				bool? aa_ = context.Operators.Before(v_, z_, default);
 				Code<ObservationStatus> ab_ = ProstateCancerStaging?.StatusElement;
 				ObservationStatus? ac_ = ab_?.Value;
 				Code<ObservationStatus> ad_ = context.Operators.Convert<Code<ObservationStatus>>(ac_);
@@ -723,7 +723,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 	private bool? Most_Recent_PSA_Test_Result_is_Low_Value()
 	{
 		CqlValueSet a_ = this.Prostate_Specific_Antigen_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation PSATest)
 		{
 			Observation l_ = this.Most_Recent_Prostate_Cancer_Staging_Tumor_Size_T1a_to_T2a();
@@ -745,7 +745,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 					};
 					if (ad_())
 					{
-						return default(CqlInterval<CqlDateTime>);
+						return default;
 					}
 					else
 					{
@@ -764,7 +764,7 @@ public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 				DataType s_ = MostRecentProstateCancerStaging?.Effective;
 				object t_ = FHIRHelpers_4_3_000.ToValue(s_);
 				CqlInterval<CqlDateTime> u_ = QICoreCommon_2_0_000.toInterval(t_);
-				bool? v_ = context.Operators.Before(r_(), u_, default(string));
+				bool? v_ = context.Operators.Before(r_(), u_, default);
 				Code<ObservationStatus> w_ = PSATest?.StatusElement;
 				ObservationStatus? x_ = w_?.Value;
 				Code<ObservationStatus> y_ = context.Operators.Convert<Code<ObservationStatus>>(x_);

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ProstateCaAvoidanceBoneScanOveruseFHIR", "0.2.000")]
 public class ProstateCaAvoidanceBoneScanOveruseFHIR_0_2_000
 {

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("QICoreCommon", "2.0.000")]
 public class QICoreCommon_2_0_000
 {

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
@@ -184,406 +184,406 @@ public class QICoreCommon_2_0_000
     #endregion
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode field_Value() => 
-		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("field")]
 	public CqlCode field() => 
 		__field.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_encounter_Value() => 
-		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient encounter")]
 	public CqlCode inpatient_encounter() => 
 		__inpatient_encounter.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode observation_encounter_Value() => 
-		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("observation encounter")]
 	public CqlCode observation_encounter() => 
 		__observation_encounter.Value;
 
 	private CqlCode pre_admission_Value() => 
-		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("pre-admission")]
 	public CqlCode pre_admission() => 
 		__pre_admission.Value;
 
 	private CqlCode short_stay_Value() => 
-		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("short stay")]
 	public CqlCode short_stay() => 
 		__short_stay.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode health_concern_Value() => 
-		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null);
+		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("health-concern")]
 	public CqlCode health_concern() => 
 		__health_concern.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode AD_Value() => 
-		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("AD")]
 	public CqlCode AD() => 
 		__AD.Value;
 
 	private CqlCode DD_Value() => 
-		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("DD")]
 	public CqlCode DD() => 
 		__DD.Value;
 
 	private CqlCode CC_Value() => 
-		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("CC")]
 	public CqlCode CC() => 
 		__CC.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode pre_op_Value() => 
-		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("pre-op")]
 	public CqlCode pre_op() => 
 		__pre_op.Value;
 
 	private CqlCode post_op_Value() => 
-		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("post-op")]
 	public CqlCode post_op() => 
 		__post_op.Value;
 
 	private CqlCode billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("billing")]
 	public CqlCode billing() => 
 		__billing.Value;
 
 	private CqlCode social_history_Value() => 
-		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("social-history")]
 	public CqlCode social_history() => 
 		__social_history.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode imaging_Value() => 
-		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("imaging")]
 	public CqlCode imaging() => 
 		__imaging.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode procedure_Value() => 
-		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("procedure")]
 	public CqlCode procedure() => 
 		__procedure.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode therapy_Value() => 
-		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("therapy")]
 	public CqlCode therapy() => 
 		__therapy.Value;
 
 	private CqlCode activity_Value() => 
-		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("activity")]
 	public CqlCode activity() => 
 		__activity.Value;
 
 	private CqlCode clinical_test_Value() => 
-		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null);
+		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string));
 
     [CqlDeclaration("clinical-test")]
 	public CqlCode clinical_test() => 
@@ -592,7 +592,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -605,7 +605,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -618,17 +618,17 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -641,8 +641,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -655,14 +655,14 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
 		];
 
 		return a_;
@@ -687,10 +687,10 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -703,12 +703,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -721,12 +721,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
 		];
 
 		return a_;
@@ -739,9 +739,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -754,9 +754,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -769,15 +769,15 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -790,7 +790,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", null, null),
+			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -803,8 +803,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -817,7 +817,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", null, null),
+			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -829,7 +829,7 @@ public class QICoreCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1316,7 +1316,7 @@ public class QICoreCommon_2_0_000
 		};
 		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
-				: null), a_);
+				: default(IEnumerable<Extension>)), a_);
 		bool? c_(Extension E)
 		{
 			DataType i_ = E?.Value;
@@ -2416,7 +2416,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);
@@ -2439,7 +2439,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.0.000.g.cs
@@ -184,406 +184,406 @@ public class QICoreCommon_2_0_000
     #endregion
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode field_Value() => 
-		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("field")]
 	public CqlCode field() => 
 		__field.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_encounter_Value() => 
-		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient encounter")]
 	public CqlCode inpatient_encounter() => 
 		__inpatient_encounter.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode observation_encounter_Value() => 
-		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("observation encounter")]
 	public CqlCode observation_encounter() => 
 		__observation_encounter.Value;
 
 	private CqlCode pre_admission_Value() => 
-		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("pre-admission")]
 	public CqlCode pre_admission() => 
 		__pre_admission.Value;
 
 	private CqlCode short_stay_Value() => 
-		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("short stay")]
 	public CqlCode short_stay() => 
 		__short_stay.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode health_concern_Value() => 
-		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("health-concern")]
 	public CqlCode health_concern() => 
 		__health_concern.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode AD_Value() => 
-		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("AD")]
 	public CqlCode AD() => 
 		__AD.Value;
 
 	private CqlCode DD_Value() => 
-		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("DD")]
 	public CqlCode DD() => 
 		__DD.Value;
 
 	private CqlCode CC_Value() => 
-		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("CC")]
 	public CqlCode CC() => 
 		__CC.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode pre_op_Value() => 
-		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("pre-op")]
 	public CqlCode pre_op() => 
 		__pre_op.Value;
 
 	private CqlCode post_op_Value() => 
-		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("post-op")]
 	public CqlCode post_op() => 
 		__post_op.Value;
 
 	private CqlCode billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("billing")]
 	public CqlCode billing() => 
 		__billing.Value;
 
 	private CqlCode social_history_Value() => 
-		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("social-history")]
 	public CqlCode social_history() => 
 		__social_history.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode imaging_Value() => 
-		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("imaging")]
 	public CqlCode imaging() => 
 		__imaging.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode procedure_Value() => 
-		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("procedure")]
 	public CqlCode procedure() => 
 		__procedure.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode therapy_Value() => 
-		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("therapy")]
 	public CqlCode therapy() => 
 		__therapy.Value;
 
 	private CqlCode activity_Value() => 
-		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("activity")]
 	public CqlCode activity() => 
 		__activity.Value;
 
 	private CqlCode clinical_test_Value() => 
-		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string));
+		new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default, default);
 
     [CqlDeclaration("clinical-test")]
 	public CqlCode clinical_test() => 
@@ -592,7 +592,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -605,7 +605,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -618,17 +618,17 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("EMER", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("FLD", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("HH", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("IMP", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("NONAC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("OBSENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("PRENC", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("SS", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -641,8 +641,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
 		];
 
 		return a_;
@@ -655,14 +655,14 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("AD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("DD", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("CC", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("pre-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("post-op", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
 		];
 
 		return a_;
@@ -687,10 +687,10 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
 		];
 
 		return a_;
@@ -703,12 +703,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -721,12 +721,12 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
 		];
 
 		return a_;
@@ -739,9 +739,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
 		];
 
 		return a_;
@@ -754,9 +754,9 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
 		];
 
 		return a_;
@@ -769,15 +769,15 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("social-history", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("imaging", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("procedure", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("therapy", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("activity", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -790,7 +790,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreObservationCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default(string), default(string)),
+			new CqlCode("clinical-test", "http://hl7.org/fhir/us/core/CodeSystem/us-core-observation-category", default, default),
 		];
 
 		return a_;
@@ -803,8 +803,8 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] ConditionCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
 		];
 
 		return a_;
@@ -817,7 +817,7 @@ public class QICoreCommon_2_0_000
 	private CqlCode[] USCoreConditionCategoryExtensionCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("health-concern", "http://hl7.org/fhir/us/core/CodeSystem/condition-category", default, default),
 		];
 
 		return a_;
@@ -829,7 +829,7 @@ public class QICoreCommon_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -1316,7 +1316,7 @@ public class QICoreCommon_2_0_000
 		};
 		IEnumerable<Extension> b_ = context.Operators.Where<Extension>(((deviceRequest is DomainResource)
 				? ((IEnumerable<Extension>)(deviceRequest as DomainResource).ModifierExtension)
-				: default(IEnumerable<Extension>)), a_);
+				: default), a_);
 		bool? c_(Extension E)
 		{
 			DataType i_ = E?.Value;
@@ -2416,7 +2416,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);
@@ -2439,7 +2439,7 @@ public class QICoreCommon_2_0_000
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default);
 		int? g_(CqlInterval<int?> DayNumber)
 		{
 			int? i_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -254,7 +254,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
     #endregion
 
 	private CqlValueSet _20_to_42_Plus_Weeks_Gestation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", default);
 
     [CqlDeclaration("20 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67")]
@@ -262,7 +262,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		___20_to_42_Plus_Weeks_Gestation.Value;
 
 	private CqlValueSet Acute_or_Persistent_Asthma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", default);
 
     [CqlDeclaration("Acute or Persistent Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271")]
@@ -270,7 +270,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Acute_or_Persistent_Asthma.Value;
 
 	private CqlValueSet Anemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", default);
 
     [CqlDeclaration("Anemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323")]
@@ -278,7 +278,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Anemia.Value;
 
 	private CqlValueSet Autoimmune_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", default);
 
     [CqlDeclaration("Autoimmune Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311")]
@@ -286,7 +286,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Autoimmune_Disease.Value;
 
 	private CqlValueSet Bariatric_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", default);
 
     [CqlDeclaration("Bariatric Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317")]
@@ -294,7 +294,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Bariatric_Surgery.Value;
 
 	private CqlValueSet Bleeding_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", default);
 
     [CqlDeclaration("Bleeding Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287")]
@@ -302,7 +302,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Bleeding_Disorder.Value;
 
 	private CqlValueSet Blood_Transfusion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", default);
 
     [CqlDeclaration("Blood Transfusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213")]
@@ -310,7 +310,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Blood_Transfusion.Value;
 
 	private CqlValueSet Cardiac_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", default);
 
     [CqlDeclaration("Cardiac Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341")]
@@ -318,7 +318,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Cardiac_Disease.Value;
 
 	private CqlValueSet COVID_19_Confirmed_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", default);
 
     [CqlDeclaration("COVID 19 Confirmed")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373")]
@@ -326,7 +326,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__COVID_19_Confirmed.Value;
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default);
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -334,7 +334,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet Economic_Housing_Instability_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", default);
 
     [CqlDeclaration("Economic Housing Instability")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292")]
@@ -342,7 +342,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Economic_Housing_Instability.Value;
 
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default);
 
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
@@ -350,7 +350,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__ED_Visit_and_OB_Triage.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -358,7 +358,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Gastrointestinal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", default);
 
     [CqlDeclaration("Gastrointestinal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338")]
@@ -366,7 +366,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Gastrointestinal_Disease.Value;
 
 	private CqlValueSet Gestational_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", default);
 
     [CqlDeclaration("Gestational Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269")]
@@ -374,7 +374,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Gestational_Diabetes.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -382,7 +382,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", default);
 
     [CqlDeclaration("HIV in Pregnancy Childbirth and Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272")]
@@ -390,7 +390,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__HIV_in_Pregnancy_Childbirth_and_Puerperium.Value;
 
 	private CqlValueSet Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", default);
 
     [CqlDeclaration("Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332")]
@@ -398,7 +398,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Hypertension.Value;
 
 	private CqlValueSet Long_Term_Anticoagulant_Use_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", default);
 
     [CqlDeclaration("Long Term Anticoagulant Use")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366")]
@@ -406,7 +406,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Long_Term_Anticoagulant_Use.Value;
 
 	private CqlValueSet Mental_Health_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", default);
 
     [CqlDeclaration("Mental Health Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314")]
@@ -414,7 +414,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Mental_Health_Disorder.Value;
 
 	private CqlValueSet Mild_or_Moderate_Preeclampsia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", default);
 
     [CqlDeclaration("Mild or Moderate Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329")]
@@ -422,7 +422,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Mild_or_Moderate_Preeclampsia.Value;
 
 	private CqlValueSet Morbid_or_Severe_Obesity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", default);
 
     [CqlDeclaration("Morbid or Severe Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290")]
@@ -430,7 +430,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Morbid_or_Severe_Obesity.Value;
 
 	private CqlValueSet Multiple_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", default);
 
     [CqlDeclaration("Multiple Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284")]
@@ -438,7 +438,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Multiple_Pregnancy.Value;
 
 	private CqlValueSet Neuromuscular_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", default);
 
     [CqlDeclaration("Neuromuscular Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308")]
@@ -446,7 +446,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Neuromuscular_Disease.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -454,7 +454,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -462,7 +462,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Placenta_Previa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", default);
 
     [CqlDeclaration("Placenta Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35")]
@@ -470,7 +470,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placenta_Previa.Value;
 
 	private CqlValueSet Placental_Abruption_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", default);
 
     [CqlDeclaration("Placental Abruption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305")]
@@ -478,7 +478,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placental_Abruption.Value;
 
 	private CqlValueSet Placental_Accreta_Spectrum_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", default);
 
     [CqlDeclaration("Placental Accreta Spectrum")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302")]
@@ -486,7 +486,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placental_Accreta_Spectrum.Value;
 
 	private CqlValueSet Preexisting_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", default);
 
     [CqlDeclaration("Preexisting Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275")]
@@ -494,7 +494,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Preexisting_Diabetes.Value;
 
 	private CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", default);
 
     [CqlDeclaration("Present on Admission is No or Unable To Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370")]
@@ -502,7 +502,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Present_on_Admission_is_No_or_Unable_To_Determine.Value;
 
 	private CqlValueSet Present_On_Admission_is_Yes_or_Exempt_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", default);
 
     [CqlDeclaration("Present On Admission is Yes or Exempt")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63")]
@@ -510,7 +510,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Present_On_Admission_is_Yes_or_Exempt.Value;
 
 	private CqlValueSet Preterm_Birth_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", default);
 
     [CqlDeclaration("Preterm Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299")]
@@ -518,7 +518,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Preterm_Birth.Value;
 
 	private CqlValueSet Previous_Cesarean_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", default);
 
     [CqlDeclaration("Previous Cesarean")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278")]
@@ -526,7 +526,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Previous_Cesarean.Value;
 
 	private CqlValueSet Pulmonary_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", default);
 
     [CqlDeclaration("Pulmonary Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281")]
@@ -534,7 +534,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Pulmonary_Hypertension.Value;
 
 	private CqlValueSet Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", default);
 
     [CqlDeclaration("Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335")]
@@ -542,7 +542,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Renal_Disease.Value;
 
 	private CqlValueSet Respiratory_Conditions_Related_to_COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", default);
 
     [CqlDeclaration("Respiratory Conditions Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376")]
@@ -550,7 +550,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Respiratory_Conditions_Related_to_COVID_19.Value;
 
 	private CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", default);
 
     [CqlDeclaration("Respiratory Support Procedures Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379")]
@@ -558,7 +558,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Respiratory_Support_Procedures_Related_to_COVID_19.Value;
 
 	private CqlValueSet Severe_Maternal_Morbidity_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", default);
 
     [CqlDeclaration("Severe Maternal Morbidity Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255")]
@@ -566,7 +566,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Maternal_Morbidity_Diagnoses.Value;
 
 	private CqlValueSet Severe_Maternal_Morbidity_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", default);
 
     [CqlDeclaration("Severe Maternal Morbidity Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256")]
@@ -574,7 +574,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Maternal_Morbidity_Procedures.Value;
 
 	private CqlValueSet Severe_Preeclampsia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", default);
 
     [CqlDeclaration("Severe Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327")]
@@ -582,7 +582,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Preeclampsia.Value;
 
 	private CqlValueSet Substance_Abuse_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", default);
 
     [CqlDeclaration("Substance Abuse")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320")]
@@ -590,7 +590,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Substance_Abuse.Value;
 
 	private CqlValueSet Thyrotoxicosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", default);
 
     [CqlDeclaration("Thyrotoxicosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296")]
@@ -598,7 +598,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Thyrotoxicosis.Value;
 
 	private CqlValueSet Venous_Thromboembolism_in_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", default);
 
     [CqlDeclaration("Venous Thromboembolism in Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363")]
@@ -606,7 +606,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Venous_Thromboembolism_in_Pregnancy.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -614,14 +614,14 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("8867-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -630,8 +630,8 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8867-4", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -655,8 +655,8 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("SevereObstetricComplicationsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -669,7 +669,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -848,7 +848,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				};
 				IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 						? ((EncounterDiagnoses as Element).Extension)
-						: default(List<Extension>)), t_);
+						: default), t_);
 				DataType v_(Extension @this)
 				{
 					DataType ah_ = @this?.Value;
@@ -868,7 +868,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
 			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 			CqlValueSet h_ = this.Severe_Maternal_Morbidity_Procedures();
-			IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
+			IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default);
 			bool? j_(Procedure EncounterSMMProcedures)
 			{
 				Code<EventStatus> ai_ = EncounterSMMProcedures?.StatusElement;
@@ -928,7 +928,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter)
 		{
 			CqlValueSet d_ = this.Blood_Transfusion();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 			bool? f_(Procedure BloodTransfusion)
 			{
 				Code<EventStatus> j_ = BloodTransfusion?.StatusElement;
@@ -1016,7 +1016,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			IEnumerable<Condition> j_ = context.Operators.Where<Condition>(d_, i_);
 			bool? k_ = context.Operators.Exists<Condition>(j_);
 			CqlValueSet l_ = this.Respiratory_Support_Procedures_Related_to_COVID_19();
-			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default(PropertyInfo));
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default);
 			bool? n_(Procedure COVIDRespiratoryProcedure)
 			{
 				Code<EventStatus> aa_ = COVIDRespiratoryProcedure?.StatusElement;
@@ -1138,7 +1138,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			};
 			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 					? ((EncounterDiagnoses as Element).Extension)
-					: default(List<Extension>)), f_);
+					: default), f_);
 			DataType h_(Extension @this)
 			{
 				DataType s_ = @this?.Value;
@@ -1736,7 +1736,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			int? h_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
 			CqlInterval<int?> i_ = context.Operators.Interval(20, 36, true, true);
-			bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+			bool? j_ = context.Operators.In<int?>(h_, i_, default);
 			CqlQuantity l_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
 			CqlQuantity m_ = context.Operators.Quantity(20m, "weeks");
 			bool? n_ = context.Operators.GreaterOrEqual(l_, m_);
@@ -1779,7 +1779,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation Hematocrit)
 			{
 				Instant z_ = Hematocrit?.IssuedElement;
@@ -1791,7 +1791,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
 				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
-				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default(string));
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default);
 				Code<ObservationStatus> aj_ = Hematocrit?.StatusElement;
 				ObservationStatus? ak_ = aj_?.Value;
 				string al_ = context.Operators.Convert<string>(ak_);
@@ -1823,7 +1823,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation Hematocrit)
 			{
 				Instant ax_ = Hematocrit?.IssuedElement;
@@ -1835,7 +1835,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
 				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
-				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default(string));
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default);
 				Code<ObservationStatus> bh_ = Hematocrit?.StatusElement;
 				ObservationStatus? bi_ = bh_?.Value;
 				string bj_ = context.Operators.Convert<string>(bi_);
@@ -1889,7 +1889,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation WBC)
 			{
 				Instant z_ = WBC?.IssuedElement;
@@ -1901,7 +1901,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
 				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
-				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default(string));
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default);
 				Code<ObservationStatus> aj_ = WBC?.StatusElement;
 				ObservationStatus? ak_ = aj_?.Value;
 				string al_ = context.Operators.Convert<string>(ak_);
@@ -1933,7 +1933,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? q_(Observation WBC)
 			{
 				Instant ax_ = WBC?.IssuedElement;
@@ -1945,7 +1945,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
 				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
-				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default(string));
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default);
 				Code<ObservationStatus> bh_ = WBC?.StatusElement;
 				ObservationStatus? bi_ = bh_?.Value;
 				string bj_ = context.Operators.Convert<string>(bi_);
@@ -1998,7 +1998,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -2010,7 +2010,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
 				CqlDateTime af_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ae_, af_, true, false);
-				bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, default(string));
+				bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, default);
 				Code<ObservationStatus> ai_ = HeartRate?.StatusElement;
 				ObservationStatus? aj_ = ai_?.Value;
 				string ak_ = context.Operators.Convert<string>(aj_);
@@ -2049,7 +2049,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
 				CqlDateTime ay_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> az_ = context.Operators.Interval(ax_, ay_, true, false);
-				bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, default(string));
+				bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, default);
 				Code<ObservationStatus> bb_ = HeartRate?.StatusElement;
 				ObservationStatus? bc_ = bb_?.Value;
 				string bd_ = context.Operators.Convert<string>(bc_);
@@ -2097,7 +2097,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 			bool? g_(Observation BP)
 			{
 				DataType aa_ = BP?.Effective;
@@ -2109,7 +2109,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
 				CqlDateTime ah_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, false);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, default(string));
+				bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, default);
 				Code<ObservationStatus> ak_ = BP?.StatusElement;
 				ObservationStatus? al_ = ak_?.Value;
 				string am_ = context.Operators.Convert<string>(al_);
@@ -2165,7 +2165,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bg_ = context.Operators.Subtract(be_, bf_);
 				CqlDateTime bh_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(bg_, bh_, true, false);
-				bool? bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, default(string));
+				bool? bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, default);
 				Code<ObservationStatus> bk_ = BP?.StatusElement;
 				ObservationStatus? bl_ = bk_?.Value;
 				string bm_ = context.Operators.Convert<string>(bl_);
@@ -2223,7 +2223,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			};
 			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 					? ((EncounterDiagnoses as Element).Extension)
-					: default(List<Extension>)), f_);
+					: default), f_);
 			DataType h_(Extension @this)
 			{
 				DataType s_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("SevereObstetricComplicationsFHIR", "0.1.000")]
 public class SevereObstetricComplicationsFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -254,7 +254,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
     #endregion
 
 	private CqlValueSet _20_to_42_Plus_Weeks_Gestation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67", default(string));
 
     [CqlDeclaration("20 to 42 Plus Weeks Gestation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.67")]
@@ -262,7 +262,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		___20_to_42_Plus_Weeks_Gestation.Value;
 
 	private CqlValueSet Acute_or_Persistent_Asthma_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271", default(string));
 
     [CqlDeclaration("Acute or Persistent Asthma")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.271")]
@@ -270,7 +270,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Acute_or_Persistent_Asthma.Value;
 
 	private CqlValueSet Anemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323", default(string));
 
     [CqlDeclaration("Anemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.323")]
@@ -278,7 +278,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Anemia.Value;
 
 	private CqlValueSet Autoimmune_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311", default(string));
 
     [CqlDeclaration("Autoimmune Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.311")]
@@ -286,7 +286,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Autoimmune_Disease.Value;
 
 	private CqlValueSet Bariatric_Surgery_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317", default(string));
 
     [CqlDeclaration("Bariatric Surgery")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.317")]
@@ -294,7 +294,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Bariatric_Surgery.Value;
 
 	private CqlValueSet Bleeding_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287", default(string));
 
     [CqlDeclaration("Bleeding Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.287")]
@@ -302,7 +302,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Bleeding_Disorder.Value;
 
 	private CqlValueSet Blood_Transfusion_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213", default(string));
 
     [CqlDeclaration("Blood Transfusion")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.213")]
@@ -310,7 +310,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Blood_Transfusion.Value;
 
 	private CqlValueSet Cardiac_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341", default(string));
 
     [CqlDeclaration("Cardiac Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.341")]
@@ -318,7 +318,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Cardiac_Disease.Value;
 
 	private CqlValueSet COVID_19_Confirmed_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373", default(string));
 
     [CqlDeclaration("COVID 19 Confirmed")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.373")]
@@ -326,7 +326,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__COVID_19_Confirmed.Value;
 
 	private CqlValueSet Delivery_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59", default(string));
 
     [CqlDeclaration("Delivery Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.59")]
@@ -334,7 +334,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Delivery_Procedures.Value;
 
 	private CqlValueSet Economic_Housing_Instability_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292", default(string));
 
     [CqlDeclaration("Economic Housing Instability")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.292")]
@@ -342,7 +342,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Economic_Housing_Instability.Value;
 
 	private CqlValueSet ED_Visit_and_OB_Triage_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369", default(string));
 
     [CqlDeclaration("ED Visit and OB Triage")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.369")]
@@ -350,7 +350,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__ED_Visit_and_OB_Triage.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -358,7 +358,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Gastrointestinal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338", default(string));
 
     [CqlDeclaration("Gastrointestinal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.338")]
@@ -366,7 +366,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Gastrointestinal_Disease.Value;
 
 	private CqlValueSet Gestational_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269", default(string));
 
     [CqlDeclaration("Gestational Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.269")]
@@ -374,7 +374,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Gestational_Diabetes.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -382,7 +382,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet HIV_in_Pregnancy_Childbirth_and_Puerperium_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272", default(string));
 
     [CqlDeclaration("HIV in Pregnancy Childbirth and Puerperium")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.272")]
@@ -390,7 +390,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__HIV_in_Pregnancy_Childbirth_and_Puerperium.Value;
 
 	private CqlValueSet Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332", default(string));
 
     [CqlDeclaration("Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.332")]
@@ -398,7 +398,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Hypertension.Value;
 
 	private CqlValueSet Long_Term_Anticoagulant_Use_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366", default(string));
 
     [CqlDeclaration("Long Term Anticoagulant Use")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.366")]
@@ -406,7 +406,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Long_Term_Anticoagulant_Use.Value;
 
 	private CqlValueSet Mental_Health_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314", default(string));
 
     [CqlDeclaration("Mental Health Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.314")]
@@ -414,7 +414,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Mental_Health_Disorder.Value;
 
 	private CqlValueSet Mild_or_Moderate_Preeclampsia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329", default(string));
 
     [CqlDeclaration("Mild or Moderate Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.329")]
@@ -422,7 +422,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Mild_or_Moderate_Preeclampsia.Value;
 
 	private CqlValueSet Morbid_or_Severe_Obesity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290", default(string));
 
     [CqlDeclaration("Morbid or Severe Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.290")]
@@ -430,7 +430,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Morbid_or_Severe_Obesity.Value;
 
 	private CqlValueSet Multiple_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284", default(string));
 
     [CqlDeclaration("Multiple Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.284")]
@@ -438,7 +438,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Multiple_Pregnancy.Value;
 
 	private CqlValueSet Neuromuscular_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308", default(string));
 
     [CqlDeclaration("Neuromuscular Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.308")]
@@ -446,7 +446,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Neuromuscular_Disease.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -454,7 +454,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -462,7 +462,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Placenta_Previa_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35", default(string));
 
     [CqlDeclaration("Placenta Previa")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.35")]
@@ -470,7 +470,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placenta_Previa.Value;
 
 	private CqlValueSet Placental_Abruption_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305", default(string));
 
     [CqlDeclaration("Placental Abruption")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.305")]
@@ -478,7 +478,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placental_Abruption.Value;
 
 	private CqlValueSet Placental_Accreta_Spectrum_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302", default(string));
 
     [CqlDeclaration("Placental Accreta Spectrum")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.302")]
@@ -486,7 +486,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Placental_Accreta_Spectrum.Value;
 
 	private CqlValueSet Preexisting_Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275", default(string));
 
     [CqlDeclaration("Preexisting Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.275")]
@@ -494,7 +494,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Preexisting_Diabetes.Value;
 
 	private CqlValueSet Present_on_Admission_is_No_or_Unable_To_Determine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370", default(string));
 
     [CqlDeclaration("Present on Admission is No or Unable To Determine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.370")]
@@ -502,7 +502,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Present_on_Admission_is_No_or_Unable_To_Determine.Value;
 
 	private CqlValueSet Present_On_Admission_is_Yes_or_Exempt_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63", default(string));
 
     [CqlDeclaration("Present On Admission is Yes or Exempt")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.63")]
@@ -510,7 +510,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Present_On_Admission_is_Yes_or_Exempt.Value;
 
 	private CqlValueSet Preterm_Birth_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299", default(string));
 
     [CqlDeclaration("Preterm Birth")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.299")]
@@ -518,7 +518,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Preterm_Birth.Value;
 
 	private CqlValueSet Previous_Cesarean_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278", default(string));
 
     [CqlDeclaration("Previous Cesarean")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.278")]
@@ -526,7 +526,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Previous_Cesarean.Value;
 
 	private CqlValueSet Pulmonary_Hypertension_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281", default(string));
 
     [CqlDeclaration("Pulmonary Hypertension")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.281")]
@@ -534,7 +534,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Pulmonary_Hypertension.Value;
 
 	private CqlValueSet Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335", default(string));
 
     [CqlDeclaration("Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.335")]
@@ -542,7 +542,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Renal_Disease.Value;
 
 	private CqlValueSet Respiratory_Conditions_Related_to_COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376", default(string));
 
     [CqlDeclaration("Respiratory Conditions Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.376")]
@@ -550,7 +550,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Respiratory_Conditions_Related_to_COVID_19.Value;
 
 	private CqlValueSet Respiratory_Support_Procedures_Related_to_COVID_19_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379", default(string));
 
     [CqlDeclaration("Respiratory Support Procedures Related to COVID 19")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.379")]
@@ -558,7 +558,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Respiratory_Support_Procedures_Related_to_COVID_19.Value;
 
 	private CqlValueSet Severe_Maternal_Morbidity_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255", default(string));
 
     [CqlDeclaration("Severe Maternal Morbidity Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.255")]
@@ -566,7 +566,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Maternal_Morbidity_Diagnoses.Value;
 
 	private CqlValueSet Severe_Maternal_Morbidity_Procedures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256", default(string));
 
     [CqlDeclaration("Severe Maternal Morbidity Procedures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.256")]
@@ -574,7 +574,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Maternal_Morbidity_Procedures.Value;
 
 	private CqlValueSet Severe_Preeclampsia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327", default(string));
 
     [CqlDeclaration("Severe Preeclampsia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.327")]
@@ -582,7 +582,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Severe_Preeclampsia.Value;
 
 	private CqlValueSet Substance_Abuse_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320", default(string));
 
     [CqlDeclaration("Substance Abuse")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.320")]
@@ -590,7 +590,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Substance_Abuse.Value;
 
 	private CqlValueSet Thyrotoxicosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296", default(string));
 
     [CqlDeclaration("Thyrotoxicosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.296")]
@@ -598,7 +598,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Thyrotoxicosis.Value;
 
 	private CqlValueSet Venous_Thromboembolism_in_Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363", default(string));
 
     [CqlDeclaration("Venous Thromboembolism in Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.363")]
@@ -606,7 +606,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__Venous_Thromboembolism_in_Pregnancy.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -614,14 +614,14 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", null, null);
+		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -630,8 +630,8 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("8867-4", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -655,8 +655,8 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("SevereObstetricComplicationsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -669,7 +669,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -848,7 +848,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				};
 				IEnumerable<Extension> u_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 						? ((EncounterDiagnoses as Element).Extension)
-						: null), t_);
+						: default(List<Extension>)), t_);
 				DataType v_(Extension @this)
 				{
 					DataType ah_ = @this?.Value;
@@ -868,7 +868,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			IEnumerable<Encounter.DiagnosisComponent> f_ = context.Operators.Where<Encounter.DiagnosisComponent>((IEnumerable<Encounter.DiagnosisComponent>)d_, e_);
 			bool? g_ = context.Operators.Exists<Encounter.DiagnosisComponent>(f_);
 			CqlValueSet h_ = this.Severe_Maternal_Morbidity_Procedures();
-			IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, null);
+			IEnumerable<Procedure> i_ = context.Operators.RetrieveByValueSet<Procedure>(h_, default(PropertyInfo));
 			bool? j_(Procedure EncounterSMMProcedures)
 			{
 				Code<EventStatus> ai_ = EncounterSMMProcedures?.StatusElement;
@@ -928,7 +928,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		IEnumerable<Encounter> b_(Encounter TwentyWeeksPlusEncounter)
 		{
 			CqlValueSet d_ = this.Blood_Transfusion();
-			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+			IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 			bool? f_(Procedure BloodTransfusion)
 			{
 				Code<EventStatus> j_ = BloodTransfusion?.StatusElement;
@@ -1016,7 +1016,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			IEnumerable<Condition> j_ = context.Operators.Where<Condition>(d_, i_);
 			bool? k_ = context.Operators.Exists<Condition>(j_);
 			CqlValueSet l_ = this.Respiratory_Support_Procedures_Related_to_COVID_19();
-			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, null);
+			IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(l_, default(PropertyInfo));
 			bool? n_(Procedure COVIDRespiratoryProcedure)
 			{
 				Code<EventStatus> aa_ = COVIDRespiratoryProcedure?.StatusElement;
@@ -1138,7 +1138,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			};
 			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 					? ((EncounterDiagnoses as Element).Extension)
-					: null), f_);
+					: default(List<Extension>)), f_);
 			DataType h_(Extension @this)
 			{
 				DataType s_ = @this?.Value;
@@ -1736,7 +1736,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			int? h_ = PCMaternal_5_16_000.calculatedGestationalAge(DeliveryEncounter);
 			CqlInterval<int?> i_ = context.Operators.Interval(20, 36, true, true);
-			bool? j_ = context.Operators.In<int?>(h_, i_, null);
+			bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 			CqlQuantity l_ = PCMaternal_5_16_000.lastEstimatedGestationalAge(DeliveryEncounter);
 			CqlQuantity m_ = context.Operators.Quantity(20m, "weeks");
 			bool? n_ = context.Operators.GreaterOrEqual(l_, m_);
@@ -1779,7 +1779,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.Hematocrit_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation Hematocrit)
 			{
 				Instant z_ = Hematocrit?.IssuedElement;
@@ -1791,7 +1791,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
 				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
-				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default(string));
 				Code<ObservationStatus> aj_ = Hematocrit?.StatusElement;
 				ObservationStatus? ak_ = aj_?.Value;
 				string al_ = context.Operators.Convert<string>(ak_);
@@ -1823,7 +1823,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation Hematocrit)
 			{
 				Instant ax_ = Hematocrit?.IssuedElement;
@@ -1835,7 +1835,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
 				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
-				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default(string));
 				Code<ObservationStatus> bh_ = Hematocrit?.StatusElement;
 				ObservationStatus? bi_ = bh_?.Value;
 				string bj_ = context.Operators.Convert<string>(bi_);
@@ -1889,7 +1889,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
 			CqlValueSet f_ = this.White_blood_cells_count_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation WBC)
 			{
 				Instant z_ = WBC?.IssuedElement;
@@ -1901,7 +1901,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime af_ = context.Operators.Subtract(ad_, ae_);
 				CqlDateTime ag_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(af_, ag_, true, false);
-				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, null);
+				bool? ai_ = context.Operators.In<CqlDateTime>(ab_, ah_, default(string));
 				Code<ObservationStatus> aj_ = WBC?.StatusElement;
 				ObservationStatus? ak_ = aj_?.Value;
 				string al_ = context.Operators.Convert<string>(ak_);
@@ -1933,7 +1933,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			Observation l_ = context.Operators.First<Observation>(k_);
 			DataType m_ = l_?.Value;
 			object n_ = FHIRHelpers_4_3_000.ToValue(m_);
-			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> p_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? q_(Observation WBC)
 			{
 				Instant ax_ = WBC?.IssuedElement;
@@ -1945,7 +1945,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bd_ = context.Operators.Subtract(bb_, bc_);
 				CqlDateTime be_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bd_, be_, true, false);
-				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, null);
+				bool? bg_ = context.Operators.In<CqlDateTime>(az_, bf_, default(string));
 				Code<ObservationStatus> bh_ = WBC?.StatusElement;
 				ObservationStatus? bi_ = bh_?.Value;
 				string bj_ = context.Operators.Convert<string>(bi_);
@@ -1998,7 +1998,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation HeartRate)
 			{
 				DataType y_ = HeartRate?.Effective;
@@ -2010,7 +2010,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
 				CqlDateTime af_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ae_, af_, true, false);
-				bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, null);
+				bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, default(string));
 				Code<ObservationStatus> ai_ = HeartRate?.StatusElement;
 				ObservationStatus? aj_ = ai_?.Value;
 				string ak_ = context.Operators.Convert<string>(aj_);
@@ -2049,7 +2049,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
 				CqlDateTime ay_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> az_ = context.Operators.Interval(ax_, ay_, true, false);
-				bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, null);
+				bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, default(string));
 				Code<ObservationStatus> bb_ = HeartRate?.StatusElement;
 				ObservationStatus? bc_ = bb_?.Value;
 				string bd_ = context.Operators.Convert<string>(bc_);
@@ -2097,7 +2097,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 		{
 			Id d_ = TwentyWeeksPlusEncounter?.IdElement;
 			string e_ = d_?.Value;
-			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+			IEnumerable<Observation> f_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 			bool? g_(Observation BP)
 			{
 				DataType aa_ = BP?.Effective;
@@ -2109,7 +2109,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
 				CqlDateTime ah_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, false);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, null);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, default(string));
 				Code<ObservationStatus> ak_ = BP?.StatusElement;
 				ObservationStatus? al_ = ak_?.Value;
 				string am_ = context.Operators.Convert<string>(al_);
@@ -2165,7 +2165,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 				CqlDateTime bg_ = context.Operators.Subtract(be_, bf_);
 				CqlDateTime bh_ = PCMaternal_5_16_000.lastTimeOfDelivery(TwentyWeeksPlusEncounter);
 				CqlInterval<CqlDateTime> bi_ = context.Operators.Interval(bg_, bh_, true, false);
-				bool? bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, null);
+				bool? bj_ = context.Operators.In<CqlDateTime>(bc_, bi_, default(string));
 				Code<ObservationStatus> bk_ = BP?.StatusElement;
 				ObservationStatus? bl_ = bk_?.Value;
 				string bm_ = context.Operators.Convert<string>(bl_);
@@ -2223,7 +2223,7 @@ public class SevereObstetricComplicationsFHIR_0_1_000
 			};
 			IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((EncounterDiagnoses is Element)
 					? ((EncounterDiagnoses as Element).Extension)
-					: null), f_);
+					: default(List<Extension>)), f_);
 			DataType h_(Extension @this)
 			{
 				DataType s_ = @this?.Value;

--- a/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
@@ -52,35 +52,35 @@ public class Status_1_6_000
     #endregion
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -89,10 +89,10 @@ public class Status_1_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -105,7 +105,7 @@ public class Status_1_6_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -117,7 +117,7 @@ public class Status_1_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
@@ -52,35 +52,35 @@ public class Status_1_6_000
     #endregion
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
 		__laboratory.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
 		__vital_signs.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
@@ -89,10 +89,10 @@ public class Status_1_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -105,7 +105,7 @@ public class Status_1_6_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -117,7 +117,7 @@ public class Status_1_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.6.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Status", "1.6.000")]
 public class Status_1_6_000
 {

--- a/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElements_3_4_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElements_3_4_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElements_3_4_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElements_3_4_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElements_3_4_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -146,7 +146,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -171,7 +171,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), y_);
+					: default), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -199,7 +199,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: default(List<Extension>)), af_);
+					: default), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -226,7 +226,7 @@ public class SupplementalDataElements_3_4_000
 	private IEnumerable<(CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer_Type();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default);
 		(CqlConcept code, CqlInterval<CqlDateTime> period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -265,7 +265,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(List<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension @this)
@@ -295,7 +295,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), q_);
+					: default), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -322,7 +322,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), w_);
+					: default), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -350,7 +350,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: default(List<Extension>)), ad_);
+					: default), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -408,7 +408,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return default(CqlCode);
+				return default;
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("SupplementalDataElements", "3.4.000")]
 public class SupplementalDataElements_3_4_000
 {

--- a/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElements_3_4_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElements_3_4_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElements_3_4_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Type_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer Type")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElements_3_4_000
 		__Payer_Type.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElements_3_4_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -146,7 +146,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType aq_ = @this?.Value;
@@ -171,7 +171,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> z_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), y_);
+					: default(List<Extension>)), y_);
 			DataType aa_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -199,7 +199,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ag_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((E is Element)
 					? ((E as Element).Extension)
-					: null), af_);
+					: default(List<Extension>)), af_);
 			DataType ah_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -226,7 +226,7 @@ public class SupplementalDataElements_3_4_000
 	private IEnumerable<(CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer_Type();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
 		(CqlConcept code, CqlInterval<CqlDateTime> period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -265,7 +265,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(List<Extension>);
 			}
 		};
 		bool? b_(Extension @this)
@@ -295,7 +295,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> r_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), q_);
+					: default(List<Extension>)), q_);
 			DataType s_(Extension @this)
 			{
 				DataType ao_ = @this?.Value;
@@ -322,7 +322,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> x_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), w_);
+					: default(List<Extension>)), w_);
 			DataType y_(Extension @this)
 			{
 				DataType av_ = @this?.Value;
@@ -350,7 +350,7 @@ public class SupplementalDataElements_3_4_000
 			};
 			IEnumerable<Extension> ae_ = context.Operators.Where<Extension>((IEnumerable<Extension>)((R is Element)
 					? ((R as Element).Extension)
-					: null), ad_);
+					: default(List<Extension>)), ad_);
 			DataType af_(Extension @this)
 			{
 				DataType bc_ = @this?.Value;
@@ -408,7 +408,7 @@ public class SupplementalDataElements_3_4_000
 			}
 			else
 			{
-				return null;
+				return default(CqlCode);
 			}
 		};
 

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
@@ -78,7 +78,7 @@ public class TJCOverall_8_11_000
     #endregion
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -86,7 +86,7 @@ public class TJCOverall_8_11_000
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -94,7 +94,7 @@ public class TJCOverall_8_11_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -102,7 +102,7 @@ public class TJCOverall_8_11_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -110,7 +110,7 @@ public class TJCOverall_8_11_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -118,7 +118,7 @@ public class TJCOverall_8_11_000
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -126,7 +126,7 @@ public class TJCOverall_8_11_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -134,7 +134,7 @@ public class TJCOverall_8_11_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Nonelective_Inpatient_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
 
     [CqlDeclaration("Nonelective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -142,7 +142,7 @@ public class TJCOverall_8_11_000
 		__Nonelective_Inpatient_Encounter.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -162,7 +162,7 @@ public class TJCOverall_8_11_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -175,7 +175,7 @@ public class TJCOverall_8_11_000
 	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Nonelective_Inpatient_Encounter();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter NonElectiveEncounter)
 		{
 			Period e_ = NonElectiveEncounter?.Period;
@@ -316,7 +316,7 @@ public class TJCOverall_8_11_000
 	private IEnumerable<object> Intervention_Comfort_Measures_Value()
 	{
 		CqlValueSet a_ = this.Comfort_Measures();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		bool? c_(ServiceRequest SR)
 		{
 			Code<RequestStatus> j_ = SR?.StatusElement;
@@ -351,7 +351,7 @@ public class TJCOverall_8_11_000
 			return aa_;
 		};
 		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? g_(Procedure InterventionPerformed)
 		{
 			Code<EventStatus> ab_ = InterventionPerformed?.StatusElement;
@@ -390,7 +390,7 @@ public class TJCOverall_8_11_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
 
 				return p_;
 			};
@@ -425,7 +425,7 @@ public class TJCOverall_8_11_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, null);
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
 
 				return p_;
 			};

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("TJCOverall", "8.11.000")]
 public class TJCOverall_8_11_000
 {

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.11.000.g.cs
@@ -78,7 +78,7 @@ public class TJCOverall_8_11_000
     #endregion
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default);
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -86,7 +86,7 @@ public class TJCOverall_8_11_000
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -94,7 +94,7 @@ public class TJCOverall_8_11_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -102,7 +102,7 @@ public class TJCOverall_8_11_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -110,7 +110,7 @@ public class TJCOverall_8_11_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default);
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -118,7 +118,7 @@ public class TJCOverall_8_11_000
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -126,7 +126,7 @@ public class TJCOverall_8_11_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -134,7 +134,7 @@ public class TJCOverall_8_11_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Nonelective_Inpatient_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default);
 
     [CqlDeclaration("Nonelective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -142,7 +142,7 @@ public class TJCOverall_8_11_000
 		__Nonelective_Inpatient_Encounter.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -162,7 +162,7 @@ public class TJCOverall_8_11_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -175,7 +175,7 @@ public class TJCOverall_8_11_000
 	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Nonelective_Inpatient_Encounter();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter NonElectiveEncounter)
 		{
 			Period e_ = NonElectiveEncounter?.Period;
@@ -316,7 +316,7 @@ public class TJCOverall_8_11_000
 	private IEnumerable<object> Intervention_Comfort_Measures_Value()
 	{
 		CqlValueSet a_ = this.Comfort_Measures();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		bool? c_(ServiceRequest SR)
 		{
 			Code<RequestStatus> j_ = SR?.StatusElement;
@@ -351,7 +351,7 @@ public class TJCOverall_8_11_000
 			return aa_;
 		};
 		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? g_(Procedure InterventionPerformed)
 		{
 			Code<EventStatus> ab_ = InterventionPerformed?.StatusElement;
@@ -390,7 +390,7 @@ public class TJCOverall_8_11_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default);
 
 				return p_;
 			};
@@ -425,7 +425,7 @@ public class TJCOverall_8_11_000
 				object m_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
 				CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
 				CqlInterval<CqlDateTime> o_ = CQMCommon_2_0_000.hospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default(string));
+				bool? p_ = context.Operators.In<CqlDateTime>((l_ ?? n_), o_, default);
 
 				return p_;
 			};

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
@@ -120,7 +120,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
     #endregion
 
 	private CqlValueSet Hospital_Services_for_urology_care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64", default);
 
     [CqlDeclaration("Hospital Services for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64")]
@@ -128,7 +128,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Hospital_Services_for_urology_care.Value;
 
 	private CqlValueSet Morbid_Obesity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67", default);
 
     [CqlDeclaration("Morbid Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67")]
@@ -136,7 +136,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Morbid_Obesity.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -144,7 +144,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Office_Visit.Value;
 
 	private CqlValueSet Urinary_retention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52", default);
 
     [CqlDeclaration("Urinary retention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52")]
@@ -152,42 +152,42 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Urinary_retention.Value;
 
 	private CqlCode American_Urological_Association_Symptom_Index__AUASI__Value() => 
-		new CqlCode("80883-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("80883-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("American Urological Association Symptom Index [AUASI]")]
 	public CqlCode American_Urological_Association_Symptom_Index__AUASI_() => 
 		__American_Urological_Association_Symptom_Index__AUASI_.Value;
 
 	private CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms_Value() => 
-		new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Benign prostatic hyperplasia with lower urinary tract symptoms")]
 	public CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms() => 
 		__Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms.Value;
 
 	private CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS__Value() => 
-		new CqlCode("81090-3", "http://loinc.org", default(string), default(string));
+		new CqlCode("81090-3", "http://loinc.org", default, default);
 
     [CqlDeclaration("If you were to spend the rest of your life with your urinary condition just the way it is now, how would you feel about that [IPSS]")]
 	public CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_() => 
 		__If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_.Value;
 
 	private CqlCode International_Prostate_Symptom_Score__IPSS__Value() => 
-		new CqlCode("80976-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("80976-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("International Prostate Symptom Score [IPSS]")]
 	public CqlCode International_Prostate_Symptom_Score__IPSS_() => 
 		__International_Prostate_Symptom_Score__IPSS_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
@@ -196,9 +196,9 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("80883-2", "http://loinc.org", default(string), default(string)),
-			new CqlCode("81090-3", "http://loinc.org", default(string), default(string)),
-			new CqlCode("80976-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("80883-2", "http://loinc.org", default, default),
+			new CqlCode("81090-3", "http://loinc.org", default, default),
+			new CqlCode("80976-4", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -211,7 +211,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -224,7 +224,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -237,7 +237,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default, default),
 		];
 
 		return a_;
@@ -249,8 +249,8 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000", "Measurement Period", c_);
 
@@ -263,7 +263,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -291,7 +291,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
@@ -366,7 +366,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default);
 		bool? d_(Condition NewBPHDiagnosis)
 		{
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.prevalenceInterval(NewBPHDiagnosis);
@@ -419,7 +419,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.International_Prostate_Symptom_Score__IPSS_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation IPSSAssessment)
 		{
 			Code<ObservationStatus> h_ = IPSSAssessment?.StatusElement;
@@ -514,7 +514,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.American_Urological_Association_Symptom_Index__AUASI_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation AUASIAssessment)
 		{
 			List<CodeableConcept> h_ = AUASIAssessment?.Category;
@@ -613,7 +613,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
 			CqlCode ag_ = this.If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_();
 			IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ag_);
-			IEnumerable<Observation> ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, default(PropertyInfo));
+			IEnumerable<Observation> ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, default);
 			bool? aj_(Observation QOLAssessment)
 			{
 				object bk_()
@@ -915,7 +915,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlDateTime o_ = USSAssessment?.effectiveDatetime;
 				int? p_ = context.Operators.DurationBetween(n_, o_, "month");
 				CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
-				bool? r_ = context.Operators.In<int?>(p_, q_, default(string));
+				bool? r_ = context.Operators.In<int?>(p_, q_, default);
 
 				return r_;
 			};
@@ -978,7 +978,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private IEnumerable<Condition> Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Urinary_retention();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition UrinaryRetention)
 		{
 			Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
@@ -1034,7 +1034,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		IEnumerable<Condition> c_(Condition InitialBPHDiagnosis)
 		{
 			CqlValueSet f_ = this.Hospital_Services_for_urology_care();
-			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 			bool? h_(Encounter InHospitalServices)
 			{
 				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
@@ -1047,7 +1047,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlQuantity t_ = context.Operators.Quantity(31m, "days");
 				CqlDateTime u_ = context.Operators.Add(s_, t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
 				Code<Encounter.EncounterStatus> x_ = InHospitalServices?.StatusElement;
 				Encounter.EncounterStatus? y_ = x_?.Value;
 				Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
@@ -1076,7 +1076,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private IEnumerable<Condition> Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
 		CqlValueSet a_ = this.Morbid_Obesity();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_(Condition MorbidObesity)
 		{
 			(CqlDateTime effectiveDatetime, int? valueInteger)? e_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
@@ -1087,10 +1087,10 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			{
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(MorbidObesity);
 				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
-				bool? m_ = context.Operators.Overlaps(k_, l_, default(string));
+				bool? m_ = context.Operators.Overlaps(k_, l_, default);
 				CqlDateTime o_ = context.Operators.Start(k_);
 				CqlDateTime p_ = FollowUpUSSAssessment?.effectiveDatetime;
-				bool? q_ = context.Operators.SameOrBefore(o_, p_, default(string));
+				bool? q_ = context.Operators.SameOrBefore(o_, p_, default);
 				bool? r_ = context.Operators.And(m_, q_);
 				bool? s_ = this.isConfirmedActiveDiagnosis(MorbidObesity);
 				bool? t_ = context.Operators.And(r_, s_);
@@ -1115,7 +1115,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private bool? Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Observation> b_(Observation BMIExam)
 		{
 			(CqlDateTime effectiveDatetime, int? valueInteger)? g_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
@@ -1148,7 +1148,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				object ae_ = FHIRHelpers_4_3_000.ToValue(x_);
 				CqlDateTime af_ = QICoreCommon_2_0_000.earliest(ae_);
 				CqlDateTime ag_ = FollowUpUSSAssessment?.effectiveDatetime;
-				bool? ah_ = context.Operators.SameOrBefore(af_, ag_, default(string));
+				bool? ah_ = context.Operators.SameOrBefore(af_, ag_, default);
 				bool? ai_ = context.Operators.And(ac_, ah_);
 
 				return ai_;

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
@@ -120,7 +120,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
     #endregion
 
 	private CqlValueSet Hospital_Services_for_urology_care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64", default(string));
 
     [CqlDeclaration("Hospital Services for urology care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.64")]
@@ -128,7 +128,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Hospital_Services_for_urology_care.Value;
 
 	private CqlValueSet Morbid_Obesity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67", default(string));
 
     [CqlDeclaration("Morbid Obesity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.67")]
@@ -136,7 +136,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Morbid_Obesity.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -144,7 +144,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Office_Visit.Value;
 
 	private CqlValueSet Urinary_retention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52", default(string));
 
     [CqlDeclaration("Urinary retention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1164.52")]
@@ -152,42 +152,42 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		__Urinary_retention.Value;
 
 	private CqlCode American_Urological_Association_Symptom_Index__AUASI__Value() => 
-		new CqlCode("80883-2", "http://loinc.org", null, null);
+		new CqlCode("80883-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("American Urological Association Symptom Index [AUASI]")]
 	public CqlCode American_Urological_Association_Symptom_Index__AUASI_() => 
 		__American_Urological_Association_Symptom_Index__AUASI_.Value;
 
 	private CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms_Value() => 
-		new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Benign prostatic hyperplasia with lower urinary tract symptoms")]
 	public CqlCode Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms() => 
 		__Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms.Value;
 
 	private CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS__Value() => 
-		new CqlCode("81090-3", "http://loinc.org", null, null);
+		new CqlCode("81090-3", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("If you were to spend the rest of your life with your urinary condition just the way it is now, how would you feel about that [IPSS]")]
 	public CqlCode If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_() => 
 		__If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_.Value;
 
 	private CqlCode International_Prostate_Symptom_Score__IPSS__Value() => 
-		new CqlCode("80976-4", "http://loinc.org", null, null);
+		new CqlCode("80976-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("International Prostate Symptom Score [IPSS]")]
 	public CqlCode International_Prostate_Symptom_Score__IPSS_() => 
 		__International_Prostate_Symptom_Score__IPSS_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
 		__survey.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
@@ -196,9 +196,9 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("80883-2", "http://loinc.org", null, null),
-			new CqlCode("81090-3", "http://loinc.org", null, null),
-			new CqlCode("80976-4", "http://loinc.org", null, null),
+			new CqlCode("80883-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("81090-3", "http://loinc.org", default(string), default(string)),
+			new CqlCode("80976-4", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -211,7 +211,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("N40.1", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -224,7 +224,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -237,7 +237,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private CqlCode[] ActCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/CodeSystem/v3-ActCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -249,8 +249,8 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000", "Measurement Period", c_);
 
@@ -263,7 +263,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -291,7 +291,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private bool? Has_Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter ValidEncounter)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
@@ -366,7 +366,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.Benign_prostatic_hyperplasia_with_lower_urinary_tract_symptoms();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByCodes<Condition>(b_, default(PropertyInfo));
 		bool? d_(Condition NewBPHDiagnosis)
 		{
 			CqlInterval<CqlDateTime> i_ = QICoreCommon_2_0_000.prevalenceInterval(NewBPHDiagnosis);
@@ -419,7 +419,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.International_Prostate_Symptom_Score__IPSS_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation IPSSAssessment)
 		{
 			Code<ObservationStatus> h_ = IPSSAssessment?.StatusElement;
@@ -514,7 +514,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	{
 		CqlCode a_ = this.American_Urological_Association_Symptom_Index__AUASI_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation AUASIAssessment)
 		{
 			List<CodeableConcept> h_ = AUASIAssessment?.Category;
@@ -613,7 +613,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			object af_ = FHIRHelpers_4_3_000.ToValue(ae_);
 			CqlCode ag_ = this.If_you_were_to_spend_the_rest_of_your_life_with_your_urinary_condition_just_the_way_it_is_now__how_would_you_feel_about_that__IPSS_();
 			IEnumerable<CqlCode> ah_ = context.Operators.ToList<CqlCode>(ag_);
-			IEnumerable<Observation> ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, null);
+			IEnumerable<Observation> ai_ = context.Operators.RetrieveByCodes<Observation>(ah_, default(PropertyInfo));
 			bool? aj_(Observation QOLAssessment)
 			{
 				object bk_()
@@ -915,7 +915,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlDateTime o_ = USSAssessment?.effectiveDatetime;
 				int? p_ = context.Operators.DurationBetween(n_, o_, "month");
 				CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
-				bool? r_ = context.Operators.In<int?>(p_, q_, null);
+				bool? r_ = context.Operators.In<int?>(p_, q_, default(string));
 
 				return r_;
 			};
@@ -978,7 +978,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private IEnumerable<Condition> Urinary_Retention_Diagnosis_Starts_Within_1_Year_After_Initial_BPH_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Urinary_retention();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition UrinaryRetention)
 		{
 			Condition g_ = this.Initial_BPH_Diagnosis_Starts_Within_6_Months_Before_or_After_Start_of_Measurement_Period();
@@ -1034,7 +1034,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 		IEnumerable<Condition> c_(Condition InitialBPHDiagnosis)
 		{
 			CqlValueSet f_ = this.Hospital_Services_for_urology_care();
-			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+			IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 			bool? h_(Encounter InHospitalServices)
 			{
 				CqlInterval<CqlDateTime> l_ = QICoreCommon_2_0_000.prevalenceInterval(InitialBPHDiagnosis);
@@ -1047,7 +1047,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				CqlQuantity t_ = context.Operators.Quantity(31m, "days");
 				CqlDateTime u_ = context.Operators.Add(s_, t_);
 				CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
-				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+				bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
 				Code<Encounter.EncounterStatus> x_ = InHospitalServices?.StatusElement;
 				Encounter.EncounterStatus? y_ = x_?.Value;
 				Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
@@ -1076,7 +1076,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 	private IEnumerable<Condition> Morbid_Obesity_Diagnosis_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
 		CqlValueSet a_ = this.Morbid_Obesity();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_(Condition MorbidObesity)
 		{
 			(CqlDateTime effectiveDatetime, int? valueInteger)? e_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
@@ -1087,10 +1087,10 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 			{
 				CqlInterval<CqlDateTime> k_ = QICoreCommon_2_0_000.prevalenceInterval(MorbidObesity);
 				CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
-				bool? m_ = context.Operators.Overlaps(k_, l_, null);
+				bool? m_ = context.Operators.Overlaps(k_, l_, default(string));
 				CqlDateTime o_ = context.Operators.Start(k_);
 				CqlDateTime p_ = FollowUpUSSAssessment?.effectiveDatetime;
-				bool? q_ = context.Operators.SameOrBefore(o_, p_, null);
+				bool? q_ = context.Operators.SameOrBefore(o_, p_, default(string));
 				bool? r_ = context.Operators.And(m_, q_);
 				bool? s_ = this.isConfirmedActiveDiagnosis(MorbidObesity);
 				bool? t_ = context.Operators.And(r_, s_);
@@ -1115,7 +1115,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 
 	private bool? Has_BMI_Exam_Result_Greater_Than_or_Equal_To_40_During_Measurement_Period_and_On_or_Before_Follow_Up_USS_Assessment_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Observation> b_(Observation BMIExam)
 		{
 			(CqlDateTime effectiveDatetime, int? valueInteger)? g_ = this.Urinary_Symptom_Score_6_to_12_Months_After_Initial_BPH_Diagnosis();
@@ -1148,7 +1148,7 @@ public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_00
 				object ae_ = FHIRHelpers_4_3_000.ToValue(x_);
 				CqlDateTime af_ = QICoreCommon_2_0_000.earliest(ae_);
 				CqlDateTime ag_ = FollowUpUSSAssessment?.effectiveDatetime;
-				bool? ah_ = context.Operators.SameOrBefore(af_, ag_, null);
+				bool? ah_ = context.Operators.SameOrBefore(af_, ag_, default(string));
 				bool? ai_ = context.Operators.And(ac_, ah_);
 
 				return ai_;

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR", "1.3.000")]
 public class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_3_000
 {

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -212,7 +212,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Alcohol_Withdrawal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", default(string));
 
     [CqlDeclaration("Alcohol Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209")]
@@ -220,7 +220,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Alcohol_Withdrawal.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -228,7 +228,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Anti_Infectives__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", default(string));
 
     [CqlDeclaration("Anti Infectives, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481")]
@@ -236,7 +236,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anti_Infectives__other.Value;
 
 	private CqlValueSet Anticholinergics__anti_Parkinson_agents_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", default(string));
 
     [CqlDeclaration("Anticholinergics, anti Parkinson agents")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049")]
@@ -244,7 +244,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anticholinergics__anti_Parkinson_agents.Value;
 
 	private CqlValueSet Anticholinergics__first_generation_antihistamines_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", default(string));
 
     [CqlDeclaration("Anticholinergics, first generation antihistamines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043")]
@@ -252,7 +252,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anticholinergics__first_generation_antihistamines.Value;
 
 	private CqlValueSet Antipsychotic_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", default(string));
 
     [CqlDeclaration("Antipsychotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523")]
@@ -260,7 +260,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antipsychotic.Value;
 
 	private CqlValueSet Antispasmodics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", default(string));
 
     [CqlDeclaration("Antispasmodics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050")]
@@ -268,7 +268,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antispasmodics.Value;
 
 	private CqlValueSet Antithrombotic_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", default(string));
 
     [CqlDeclaration("Antithrombotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051")]
@@ -276,7 +276,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antithrombotic.Value;
 
 	private CqlValueSet Benzodiazepine_Withdrawal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", default(string));
 
     [CqlDeclaration("Benzodiazepine Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208")]
@@ -284,7 +284,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Benzodiazepine_Withdrawal.Value;
 
 	private CqlValueSet Benzodiazepine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", default(string));
 
     [CqlDeclaration("Benzodiazepine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522")]
@@ -292,7 +292,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Benzodiazepine.Value;
 
 	private CqlValueSet Bipolar_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", default(string));
 
     [CqlDeclaration("Bipolar Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157")]
@@ -300,7 +300,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Bipolar_Disorder.Value;
 
 	private CqlValueSet Cardiovascular__alpha_agonists__central_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", default(string));
 
     [CqlDeclaration("Cardiovascular, alpha agonists, central")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052")]
@@ -308,7 +308,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Cardiovascular__alpha_agonists__central.Value;
 
 	private CqlValueSet Cardiovascular__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", default(string));
 
     [CqlDeclaration("Cardiovascular, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053")]
@@ -316,7 +316,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Cardiovascular__other.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -324,7 +324,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Central_nervous_system__antidepressants_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", default(string));
 
     [CqlDeclaration("Central nervous system, antidepressants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054")]
@@ -332,7 +332,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__antidepressants.Value;
 
 	private CqlValueSet Central_nervous_system__barbiturates_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", default(string));
 
     [CqlDeclaration("Central nervous system, barbiturates")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055")]
@@ -340,7 +340,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__barbiturates.Value;
 
 	private CqlValueSet Central_nervous_system__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", default(string));
 
     [CqlDeclaration("Central nervous system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057")]
@@ -348,7 +348,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__other.Value;
 
 	private CqlValueSet Central_nervous_system__vasodilators_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", default(string));
 
     [CqlDeclaration("Central nervous system, vasodilators")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056")]
@@ -356,7 +356,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__vasodilators.Value;
 
 	private CqlValueSet Digoxin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", default(string));
 
     [CqlDeclaration("Digoxin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065")]
@@ -364,7 +364,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Digoxin.Value;
 
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default(string));
 
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
@@ -372,7 +372,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Discharge_Services_Nursing_Facility.Value;
 
 	private CqlValueSet Doxepin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", default(string));
 
     [CqlDeclaration("Doxepin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067")]
@@ -380,7 +380,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Doxepin.Value;
 
 	private CqlValueSet Endocrine_system__estrogens_with_or_without_progestins_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", default(string));
 
     [CqlDeclaration("Endocrine system, estrogens with or without progestins")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058")]
@@ -388,7 +388,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__estrogens_with_or_without_progestins.Value;
 
 	private CqlValueSet Endocrine_system__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", default(string));
 
     [CqlDeclaration("Endocrine system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060")]
@@ -396,7 +396,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__other.Value;
 
 	private CqlValueSet Endocrine_system__sulfonylureas__long_duration_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", default(string));
 
     [CqlDeclaration("Endocrine system, sulfonylureas, long duration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059")]
@@ -404,7 +404,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__sulfonylureas__long_duration.Value;
 
 	private CqlValueSet Generalized_Anxiety_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", default(string));
 
     [CqlDeclaration("Generalized Anxiety Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210")]
@@ -412,7 +412,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Generalized_Anxiety_Disorder.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -420,7 +420,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nonbenzodiazepine_hypnotics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", default(string));
 
     [CqlDeclaration("Nonbenzodiazepine hypnotics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480")]
@@ -428,7 +428,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Nonbenzodiazepine_hypnotics.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -436,7 +436,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -444,7 +444,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -452,7 +452,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmologic_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", default(string));
 
     [CqlDeclaration("Ophthalmologic Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206")]
@@ -460,7 +460,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Ophthalmologic_Services.Value;
 
 	private CqlValueSet Pain_medications__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", default(string));
 
     [CqlDeclaration("Pain medications, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063")]
@@ -468,7 +468,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Pain_medications__other.Value;
 
 	private CqlValueSet Pain_medications__skeletal_muscle_relaxants_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", default(string));
 
     [CqlDeclaration("Pain medications, skeletal muscle relaxants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062")]
@@ -476,7 +476,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Pain_medications__skeletal_muscle_relaxants.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -484,7 +484,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -492,7 +492,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet REM_Sleep_Behavior_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", default(string));
 
     [CqlDeclaration("REM Sleep Behavior Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207")]
@@ -500,7 +500,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__REM_Sleep_Behavior_Disorder.Value;
 
 	private CqlValueSet Reserpine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", default(string));
 
     [CqlDeclaration("Reserpine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044")]
@@ -508,7 +508,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Reserpine.Value;
 
 	private CqlValueSet Schizophrenia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", default(string));
 
     [CqlDeclaration("Schizophrenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205")]
@@ -516,7 +516,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Schizophrenia.Value;
 
 	private CqlValueSet Seizure_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", default(string));
 
     [CqlDeclaration("Seizure Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206")]
@@ -524,7 +524,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Seizure_Disorder.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -532,133 +532,133 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode _1_ML_digoxin_0_1_MG_ML_Injection_Value() => 
-		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("1 ML digoxin 0.1 MG/ML Injection")]
 	public CqlCode _1_ML_digoxin_0_1_MG_ML_Injection() => 
 		___1_ML_digoxin_0_1_MG_ML_Injection.Value;
 
 	private CqlCode _2_ML_digoxin_0_25_MG_ML_Injection_Value() => 
-		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("2 ML digoxin 0.25 MG/ML Injection")]
 	public CqlCode _2_ML_digoxin_0_25_MG_ML_Injection() => 
 		___2_ML_digoxin_0_25_MG_ML_Injection.Value;
 
 	private CqlCode digoxin_0_05_MG_ML_Oral_Solution_Value() => 
-		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("digoxin 0.05 MG/ML Oral Solution")]
 	public CqlCode digoxin_0_05_MG_ML_Oral_Solution() => 
 		__digoxin_0_05_MG_ML_Oral_Solution.Value;
 
 	private CqlCode digoxin_0_0625_MG_Oral_Tablet_Value() => 
-		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("digoxin 0.0625 MG Oral Tablet")]
 	public CqlCode digoxin_0_0625_MG_Oral_Tablet() => 
 		__digoxin_0_0625_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_125_MG_Oral_Tablet_Value() => 
-		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("digoxin 0.125 MG Oral Tablet")]
 	public CqlCode digoxin_0_125_MG_Oral_Tablet() => 
 		__digoxin_0_125_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_1875_MG_Oral_Tablet_Value() => 
-		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("digoxin 0.1875 MG Oral Tablet")]
 	public CqlCode digoxin_0_1875_MG_Oral_Tablet() => 
 		__digoxin_0_1875_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_25_MG_Oral_Tablet_Value() => 
-		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("digoxin 0.25 MG Oral Tablet")]
 	public CqlCode digoxin_0_25_MG_Oral_Tablet() => 
 		__digoxin_0_25_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_3_MG_Oral_Tablet_Value() => 
-		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin 3 MG Oral Tablet")]
 	public CqlCode doxepin_3_MG_Oral_Tablet() => 
 		__doxepin_3_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_6_MG_Oral_Tablet_Value() => 
-		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin 6 MG Oral Tablet")]
 	public CqlCode doxepin_6_MG_Oral_Tablet() => 
 		__doxepin_6_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 10 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_10_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value() => 
-		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 10 MG/ML Oral Solution")]
 	public CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution() => 
 		__doxepin_hydrochloride_10_MG_ML_Oral_Solution.Value;
 
 	private CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 100 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_100_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 150 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_150_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 25 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_25_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 50 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_50_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("doxepin hydrochloride 75 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_75_MG_Oral_Capsule.Value;
 
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value() => 
-		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null);
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string));
 
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_.Value;
 
 	private CqlCode reserpine_0_1_MG_Oral_Tablet_Value() => 
-		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("reserpine 0.1 MG Oral Tablet")]
 	public CqlCode reserpine_0_1_MG_Oral_Tablet() => 
 		__reserpine_0_1_MG_Oral_Tablet.Value;
 
 	private CqlCode reserpine_0_25_MG_Oral_Tablet_Value() => 
-		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null);
+		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
 
     [CqlDeclaration("reserpine 0.25 MG Oral Tablet")]
 	public CqlCode reserpine_0_25_MG_Oral_Tablet() => 
@@ -667,24 +667,24 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlCode[] RXNORM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
-			new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", null, null),
+			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
 		];
 
 		return a_;
@@ -697,7 +697,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", null, null),
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
 		];
 
 		return a_;
@@ -709,8 +709,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("UseofHighRiskMedicationsintheElderlyFHIR-0.1.000", "Measurement Period", c_);
 
@@ -723,7 +723,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -736,37 +736,37 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Ophthalmologic_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Discharge_Services_Nursing_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, null);
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, null);
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Online_Assessments();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
-		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(null, null);
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
 		bool? ag_(Encounter E)
 		{
 			List<CodeableConcept> am_ = E?.Type;
@@ -798,7 +798,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
 			Period ax_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
-			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, null);
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default(string));
 
 			return az_;
 		};
@@ -869,7 +869,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				FhirDateTime k_ = OrderMedication1?.AuthoredOnElement;
 				CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
 				CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
 				MedicationRequest.DispenseRequestComponent o_ = OrderMedication1?.DispenseRequest;
 				UnsignedInt p_ = o_?.NumberOfRepeatsAllowedElement;
 				int? q_ = p_?.Value;
@@ -883,10 +883,10 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				bool? z_ = context.Operators.Equivalent(v_, y_);
 				bool? aa_ = context.Operators.Not(z_);
 				CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(k_);
-				bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, null);
+				bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, default(string));
 				bool? af_ = context.Operators.And(aa_, ae_);
 				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(w_);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, null);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, default(string));
 				bool? ak_ = context.Operators.And(af_, aj_);
 				bool? al_ = context.Operators.Or(s_, ak_);
 				CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(k_);
@@ -895,7 +895,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				CqlDate ar_ = context.Operators.DateFrom(aq_);
 				bool? as_ = context.Operators.Equivalent(ao_, ar_);
 				CqlDateTime au_ = context.Operators.Convert<CqlDateTime>(k_);
-				bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, null);
+				bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, default(string));
 				bool? ax_ = context.Operators.And(as_, aw_);
 				CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication1);
 				CqlDate az_ = context.Operators.Start(ay_);
@@ -910,11 +910,11 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				bool? bi_ = context.Operators.And(ax_, bh_);
 				CqlDate bk_ = context.Operators.Start(ay_);
 				CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
-				bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, null);
+				bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, default(string));
 				bool? bo_ = context.Operators.And(bi_, bn_);
 				CqlDate bq_ = context.Operators.Start(bc_);
 				CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
-				bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, null);
+				bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, default(string));
 				bool? bu_ = context.Operators.And(bo_, bt_);
 				bool? bv_ = context.Operators.Or(al_, bu_);
 
@@ -938,96 +938,96 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days_Value()
 	{
 		CqlValueSet a_ = this.Anticholinergics__first_generation_antihistamines();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		CqlValueSet g_ = this.Anticholinergics__anti_Parkinson_agents();
-		IEnumerable<MedicationRequest> h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
-		IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, null);
+		IEnumerable<MedicationRequest> h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(h_, j_);
 		IEnumerable<MedicationRequest> l_ = this.More_Than_One_Order(k_);
 		IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
 		CqlValueSet n_ = this.Antispasmodics();
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
-		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, null);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
 		IEnumerable<MedicationRequest> s_ = this.More_Than_One_Order(r_);
 		CqlValueSet t_ = this.Antithrombotic();
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
 		IEnumerable<MedicationRequest> y_ = this.More_Than_One_Order(x_);
 		IEnumerable<MedicationRequest> z_ = context.Operators.Union<MedicationRequest>(s_, y_);
 		IEnumerable<MedicationRequest> aa_ = context.Operators.Union<MedicationRequest>(m_, z_);
 		CqlValueSet ab_ = this.Cardiovascular__alpha_agonists__central();
-		IEnumerable<MedicationRequest> ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
-		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, null);
+		IEnumerable<MedicationRequest> ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> af_ = context.Operators.Union<MedicationRequest>(ac_, ae_);
 		IEnumerable<MedicationRequest> ag_ = this.More_Than_One_Order(af_);
 		CqlValueSet ah_ = this.Cardiovascular__other();
-		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
-		IEnumerable<MedicationRequest> ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, null);
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> al_ = context.Operators.Union<MedicationRequest>(ai_, ak_);
 		IEnumerable<MedicationRequest> am_ = this.More_Than_One_Order(al_);
 		IEnumerable<MedicationRequest> an_ = context.Operators.Union<MedicationRequest>(ag_, am_);
 		IEnumerable<MedicationRequest> ao_ = context.Operators.Union<MedicationRequest>(aa_, an_);
 		CqlValueSet ap_ = this.Central_nervous_system__antidepressants();
-		IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, null);
+		IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
 		IEnumerable<MedicationRequest> au_ = this.More_Than_One_Order(at_);
 		CqlValueSet av_ = this.Central_nervous_system__barbiturates();
-		IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
-		IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, null);
+		IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
 		IEnumerable<MedicationRequest> ba_ = this.More_Than_One_Order(az_);
 		IEnumerable<MedicationRequest> bb_ = context.Operators.Union<MedicationRequest>(au_, ba_);
 		IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ao_, bb_);
 		CqlValueSet bd_ = this.Central_nervous_system__vasodilators();
-		IEnumerable<MedicationRequest> be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
-		IEnumerable<MedicationRequest> bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, null);
+		IEnumerable<MedicationRequest> be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bh_ = context.Operators.Union<MedicationRequest>(be_, bg_);
 		IEnumerable<MedicationRequest> bi_ = this.More_Than_One_Order(bh_);
 		CqlValueSet bj_ = this.Central_nervous_system__other();
-		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
-		IEnumerable<MedicationRequest> bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, null);
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bn_ = context.Operators.Union<MedicationRequest>(bk_, bm_);
 		IEnumerable<MedicationRequest> bo_ = this.More_Than_One_Order(bn_);
 		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bi_, bo_);
 		IEnumerable<MedicationRequest> bq_ = context.Operators.Union<MedicationRequest>(bc_, bp_);
 		CqlValueSet br_ = this.Endocrine_system__estrogens_with_or_without_progestins();
-		IEnumerable<MedicationRequest> bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
-		IEnumerable<MedicationRequest> bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, null);
+		IEnumerable<MedicationRequest> bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bs_, bu_);
 		IEnumerable<MedicationRequest> bw_ = this.More_Than_One_Order(bv_);
 		CqlValueSet bx_ = this.Endocrine_system__sulfonylureas__long_duration();
-		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
-		IEnumerable<MedicationRequest> ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, null);
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(by_, ca_);
 		IEnumerable<MedicationRequest> cc_ = this.More_Than_One_Order(cb_);
 		IEnumerable<MedicationRequest> cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
 		IEnumerable<MedicationRequest> ce_ = context.Operators.Union<MedicationRequest>(bq_, cd_);
 		CqlValueSet cf_ = this.Endocrine_system__other();
-		IEnumerable<MedicationRequest> cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
-		IEnumerable<MedicationRequest> ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, null);
+		IEnumerable<MedicationRequest> cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cg_, ci_);
 		IEnumerable<MedicationRequest> ck_ = this.More_Than_One_Order(cj_);
 		CqlValueSet cl_ = this.Nonbenzodiazepine_hypnotics();
-		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
-		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, null);
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
 		IEnumerable<MedicationRequest> cq_ = this.More_Than_One_Order(cp_);
 		IEnumerable<MedicationRequest> cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
 		IEnumerable<MedicationRequest> cs_ = context.Operators.Union<MedicationRequest>(ce_, cr_);
 		CqlValueSet ct_ = this.Pain_medications__skeletal_muscle_relaxants();
-		IEnumerable<MedicationRequest> cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
-		IEnumerable<MedicationRequest> cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, null);
+		IEnumerable<MedicationRequest> cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(cu_, cw_);
 		IEnumerable<MedicationRequest> cy_ = this.More_Than_One_Order(cx_);
 		CqlValueSet cz_ = this.Pain_medications__other();
-		IEnumerable<MedicationRequest> da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
-		IEnumerable<MedicationRequest> dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, null);
+		IEnumerable<MedicationRequest> da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> dd_ = context.Operators.Union<MedicationRequest>(da_, dc_);
 		IEnumerable<MedicationRequest> de_ = this.More_Than_One_Order(dd_);
 		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(cy_, de_);
@@ -1119,8 +1119,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? Two_High_Risk_Medications_with_Prolonged_Duration_Value()
 	{
 		CqlValueSet a_ = this.Anti_Infectives__other();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		decimal? g_(MedicationRequest AntiInfectives)
@@ -1400,7 +1400,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			}
 			else
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 		};
 
@@ -1454,7 +1454,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				}
 				else
 				{
-					return null;
+					return default(CqlQuantity);
 				}
 			};
 
@@ -1469,8 +1469,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value()
 	{
 		CqlValueSet a_ = this.Reserpine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ReserpineOrdered)
 		{
@@ -1484,8 +1484,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		IEnumerable<MedicationRequest> h_ = this.More_Than_One_Order(g_);
 		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
 		CqlValueSet j_ = this.Digoxin();
-		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> n_ = context.Operators.Union<MedicationRequest>(k_, m_);
 		bool? o_(MedicationRequest DigoxinOrdered)
 		{
@@ -1500,8 +1500,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		bool? r_ = context.Operators.Exists<MedicationRequest>(q_);
 		bool? s_ = context.Operators.Or(i_, r_);
 		CqlValueSet t_ = this.Doxepin();
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
-		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, null);
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
 		bool? y_(MedicationRequest DoxepinOrdered)
 		{
@@ -1542,8 +1542,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? More_than_One_Antipsychotic_Order_Value()
 	{
 		CqlValueSet a_ = this.Antipsychotic();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
@@ -1558,8 +1558,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlDateTime Antipsychotic_Index_Prescription_Start_Date_Value()
 	{
 		CqlValueSet a_ = this.Antipsychotic();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest AntipsychoticMedication)
@@ -1567,7 +1567,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			FhirDateTime m_ = AntipsychoticMedication?.AuthoredOnElement;
 			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
 
 			return p_;
 		};
@@ -1593,8 +1593,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? More_than_One_Benzodiazepine_Order_Value()
 	{
 		CqlValueSet a_ = this.Benzodiazepine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
@@ -1609,8 +1609,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlDateTime Benzodiazepine_Index_Prescription_Start_Date_Value()
 	{
 		CqlValueSet a_ = this.Benzodiazepine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest BenzodiazepineMedication)
@@ -1618,7 +1618,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			FhirDateTime m_ = BenzodiazepineMedication?.AuthoredOnElement;
 			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
 
 			return p_;
 		};
@@ -1645,9 +1645,9 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	{
 		bool? a_ = this.More_than_One_Antipsychotic_Order();
 		CqlValueSet b_ = this.Schizophrenia();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, null);
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
 		CqlValueSet d_ = this.Bipolar_Disorder();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		bool? g_(Condition AntipsychoticTreatedDiagnoses)
 		{
@@ -1658,7 +1658,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
 			CqlDateTime al_ = this.Antipsychotic_Index_Prescription_Start_Date();
 			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ak_, al_, true, true);
-			bool? an_ = context.Operators.Overlaps(ag_, am_, null);
+			bool? an_ = context.Operators.Overlaps(ag_, am_, default(string));
 
 			return an_;
 		};
@@ -1668,18 +1668,18 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		bool? k_ = context.Operators.And(a_, j_);
 		bool? l_ = this.More_than_One_Benzodiazepine_Order();
 		CqlValueSet m_ = this.Seizure_Disorder();
-		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, null);
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default(PropertyInfo));
 		CqlValueSet o_ = this.REM_Sleep_Behavior_Disorder();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
 		CqlValueSet r_ = this.Benzodiazepine_Withdrawal();
-		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Alcohol_Withdrawal();
-		IEnumerable<Condition> u_ = context.Operators.RetrieveByValueSet<Condition>(t_, null);
+		IEnumerable<Condition> u_ = context.Operators.RetrieveByValueSet<Condition>(t_, default(PropertyInfo));
 		IEnumerable<Condition> v_ = context.Operators.Union<Condition>(s_, u_);
 		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(q_, v_);
 		CqlValueSet x_ = this.Generalized_Anxiety_Disorder();
-		IEnumerable<Condition> y_ = context.Operators.RetrieveByValueSet<Condition>(x_, null);
+		IEnumerable<Condition> y_ = context.Operators.RetrieveByValueSet<Condition>(x_, default(PropertyInfo));
 		IEnumerable<Condition> z_ = context.Operators.Union<Condition>(w_, y_);
 		bool? aa_(Condition BenzodiazepineTreatedDiagnoses)
 		{
@@ -1690,7 +1690,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlDateTime as_ = context.Operators.Subtract(aq_, ar_);
 			CqlDateTime at_ = this.Benzodiazepine_Index_Prescription_Start_Date();
 			CqlInterval<CqlDateTime> au_ = context.Operators.Interval(as_, at_, true, true);
-			bool? av_ = context.Operators.Overlaps(ao_, au_, null);
+			bool? av_ = context.Operators.Overlaps(ao_, au_, default(string));
 
 			return av_;
 		};

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -212,7 +212,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
     #endregion
 
 	private CqlValueSet Alcohol_Withdrawal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209", default);
 
     [CqlDeclaration("Alcohol Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1209")]
@@ -220,7 +220,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Alcohol_Withdrawal.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -228,7 +228,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Anti_Infectives__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481", default);
 
     [CqlDeclaration("Anti Infectives, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1481")]
@@ -236,7 +236,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anti_Infectives__other.Value;
 
 	private CqlValueSet Anticholinergics__anti_Parkinson_agents_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049", default);
 
     [CqlDeclaration("Anticholinergics, anti Parkinson agents")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1049")]
@@ -244,7 +244,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anticholinergics__anti_Parkinson_agents.Value;
 
 	private CqlValueSet Anticholinergics__first_generation_antihistamines_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043", default);
 
     [CqlDeclaration("Anticholinergics, first generation antihistamines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1043")]
@@ -252,7 +252,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Anticholinergics__first_generation_antihistamines.Value;
 
 	private CqlValueSet Antipsychotic_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523", default);
 
     [CqlDeclaration("Antipsychotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1523")]
@@ -260,7 +260,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antipsychotic.Value;
 
 	private CqlValueSet Antispasmodics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050", default);
 
     [CqlDeclaration("Antispasmodics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1050")]
@@ -268,7 +268,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antispasmodics.Value;
 
 	private CqlValueSet Antithrombotic_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051", default);
 
     [CqlDeclaration("Antithrombotic")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1051")]
@@ -276,7 +276,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Antithrombotic.Value;
 
 	private CqlValueSet Benzodiazepine_Withdrawal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208", default);
 
     [CqlDeclaration("Benzodiazepine Withdrawal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1208")]
@@ -284,7 +284,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Benzodiazepine_Withdrawal.Value;
 
 	private CqlValueSet Benzodiazepine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522", default);
 
     [CqlDeclaration("Benzodiazepine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1522")]
@@ -292,7 +292,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Benzodiazepine.Value;
 
 	private CqlValueSet Bipolar_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157", default);
 
     [CqlDeclaration("Bipolar Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1157")]
@@ -300,7 +300,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Bipolar_Disorder.Value;
 
 	private CqlValueSet Cardiovascular__alpha_agonists__central_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052", default);
 
     [CqlDeclaration("Cardiovascular, alpha agonists, central")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1052")]
@@ -308,7 +308,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Cardiovascular__alpha_agonists__central.Value;
 
 	private CqlValueSet Cardiovascular__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053", default);
 
     [CqlDeclaration("Cardiovascular, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1053")]
@@ -316,7 +316,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Cardiovascular__other.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -324,7 +324,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Central_nervous_system__antidepressants_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054", default);
 
     [CqlDeclaration("Central nervous system, antidepressants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1054")]
@@ -332,7 +332,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__antidepressants.Value;
 
 	private CqlValueSet Central_nervous_system__barbiturates_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055", default);
 
     [CqlDeclaration("Central nervous system, barbiturates")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1055")]
@@ -340,7 +340,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__barbiturates.Value;
 
 	private CqlValueSet Central_nervous_system__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057", default);
 
     [CqlDeclaration("Central nervous system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1057")]
@@ -348,7 +348,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__other.Value;
 
 	private CqlValueSet Central_nervous_system__vasodilators_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056", default);
 
     [CqlDeclaration("Central nervous system, vasodilators")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1056")]
@@ -356,7 +356,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Central_nervous_system__vasodilators.Value;
 
 	private CqlValueSet Digoxin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065", default);
 
     [CqlDeclaration("Digoxin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1065")]
@@ -364,7 +364,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Digoxin.Value;
 
 	private CqlValueSet Discharge_Services_Nursing_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013", default);
 
     [CqlDeclaration("Discharge Services Nursing Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1013")]
@@ -372,7 +372,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Discharge_Services_Nursing_Facility.Value;
 
 	private CqlValueSet Doxepin_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067", default);
 
     [CqlDeclaration("Doxepin")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1067")]
@@ -380,7 +380,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Doxepin.Value;
 
 	private CqlValueSet Endocrine_system__estrogens_with_or_without_progestins_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058", default);
 
     [CqlDeclaration("Endocrine system, estrogens with or without progestins")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1058")]
@@ -388,7 +388,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__estrogens_with_or_without_progestins.Value;
 
 	private CqlValueSet Endocrine_system__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060", default);
 
     [CqlDeclaration("Endocrine system, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1060")]
@@ -396,7 +396,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__other.Value;
 
 	private CqlValueSet Endocrine_system__sulfonylureas__long_duration_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059", default);
 
     [CqlDeclaration("Endocrine system, sulfonylureas, long duration")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1059")]
@@ -404,7 +404,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Endocrine_system__sulfonylureas__long_duration.Value;
 
 	private CqlValueSet Generalized_Anxiety_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210", default);
 
     [CqlDeclaration("Generalized Anxiety Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1210")]
@@ -412,7 +412,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Generalized_Anxiety_Disorder.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -420,7 +420,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Nonbenzodiazepine_hypnotics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480", default);
 
     [CqlDeclaration("Nonbenzodiazepine hypnotics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1480")]
@@ -428,7 +428,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Nonbenzodiazepine_hypnotics.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -436,7 +436,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -444,7 +444,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -452,7 +452,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Online_Assessments.Value;
 
 	private CqlValueSet Ophthalmologic_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206", default);
 
     [CqlDeclaration("Ophthalmologic Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.11.1206")]
@@ -460,7 +460,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Ophthalmologic_Services.Value;
 
 	private CqlValueSet Pain_medications__other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063", default);
 
     [CqlDeclaration("Pain medications, other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1063")]
@@ -468,7 +468,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Pain_medications__other.Value;
 
 	private CqlValueSet Pain_medications__skeletal_muscle_relaxants_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062", default);
 
     [CqlDeclaration("Pain medications, skeletal muscle relaxants")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1062")]
@@ -476,7 +476,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Pain_medications__skeletal_muscle_relaxants.Value;
 
 	private CqlValueSet Preventive_Care_Services_Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -484,7 +484,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Preventive_Care_Services_Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -492,7 +492,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet REM_Sleep_Behavior_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207", default);
 
     [CqlDeclaration("REM Sleep Behavior Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1207")]
@@ -500,7 +500,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__REM_Sleep_Behavior_Disorder.Value;
 
 	private CqlValueSet Reserpine_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044", default);
 
     [CqlDeclaration("Reserpine")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1044")]
@@ -508,7 +508,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Reserpine.Value;
 
 	private CqlValueSet Schizophrenia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205", default);
 
     [CqlDeclaration("Schizophrenia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1205")]
@@ -516,7 +516,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Schizophrenia.Value;
 
 	private CqlValueSet Seizure_Disorder_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206", default);
 
     [CqlDeclaration("Seizure Disorder")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.105.12.1206")]
@@ -524,7 +524,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Seizure_Disorder.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -532,133 +532,133 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		__Telephone_Visits.Value;
 
 	private CqlCode _1_ML_digoxin_0_1_MG_ML_Injection_Value() => 
-		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("1 ML digoxin 0.1 MG/ML Injection")]
 	public CqlCode _1_ML_digoxin_0_1_MG_ML_Injection() => 
 		___1_ML_digoxin_0_1_MG_ML_Injection.Value;
 
 	private CqlCode _2_ML_digoxin_0_25_MG_ML_Injection_Value() => 
-		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("2 ML digoxin 0.25 MG/ML Injection")]
 	public CqlCode _2_ML_digoxin_0_25_MG_ML_Injection() => 
 		___2_ML_digoxin_0_25_MG_ML_Injection.Value;
 
 	private CqlCode digoxin_0_05_MG_ML_Oral_Solution_Value() => 
-		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("digoxin 0.05 MG/ML Oral Solution")]
 	public CqlCode digoxin_0_05_MG_ML_Oral_Solution() => 
 		__digoxin_0_05_MG_ML_Oral_Solution.Value;
 
 	private CqlCode digoxin_0_0625_MG_Oral_Tablet_Value() => 
-		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("digoxin 0.0625 MG Oral Tablet")]
 	public CqlCode digoxin_0_0625_MG_Oral_Tablet() => 
 		__digoxin_0_0625_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_125_MG_Oral_Tablet_Value() => 
-		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("digoxin 0.125 MG Oral Tablet")]
 	public CqlCode digoxin_0_125_MG_Oral_Tablet() => 
 		__digoxin_0_125_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_1875_MG_Oral_Tablet_Value() => 
-		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("digoxin 0.1875 MG Oral Tablet")]
 	public CqlCode digoxin_0_1875_MG_Oral_Tablet() => 
 		__digoxin_0_1875_MG_Oral_Tablet.Value;
 
 	private CqlCode digoxin_0_25_MG_Oral_Tablet_Value() => 
-		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("digoxin 0.25 MG Oral Tablet")]
 	public CqlCode digoxin_0_25_MG_Oral_Tablet() => 
 		__digoxin_0_25_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_3_MG_Oral_Tablet_Value() => 
-		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin 3 MG Oral Tablet")]
 	public CqlCode doxepin_3_MG_Oral_Tablet() => 
 		__doxepin_3_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_6_MG_Oral_Tablet_Value() => 
-		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin 6 MG Oral Tablet")]
 	public CqlCode doxepin_6_MG_Oral_Tablet() => 
 		__doxepin_6_MG_Oral_Tablet.Value;
 
 	private CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 10 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_10_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_10_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution_Value() => 
-		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 10 MG/ML Oral Solution")]
 	public CqlCode doxepin_hydrochloride_10_MG_ML_Oral_Solution() => 
 		__doxepin_hydrochloride_10_MG_ML_Oral_Solution.Value;
 
 	private CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 100 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_100_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_100_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 150 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_150_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_150_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 25 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_25_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_25_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 50 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_50_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_50_MG_Oral_Capsule.Value;
 
 	private CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule_Value() => 
-		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("doxepin hydrochloride 75 MG Oral Capsule")]
 	public CqlCode doxepin_hydrochloride_75_MG_Oral_Capsule() => 
 		__doxepin_hydrochloride_75_MG_Oral_Capsule.Value;
 
 	private CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal__Value() => 
-		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string));
+		new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default, default);
 
     [CqlDeclaration("Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.")]
 	public CqlCode Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_() => 
 		__Office_or_other_outpatient_visit_for_the_evaluation_and_management_of_an_established_patient__that_may_not_require_the_presence_of_a_physician_or_other_qualified_health_care_professional__Usually__the_presenting_problem_s__are_minimal_.Value;
 
 	private CqlCode reserpine_0_1_MG_Oral_Tablet_Value() => 
-		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("reserpine 0.1 MG Oral Tablet")]
 	public CqlCode reserpine_0_1_MG_Oral_Tablet() => 
 		__reserpine_0_1_MG_Oral_Tablet.Value;
 
 	private CqlCode reserpine_0_25_MG_Oral_Tablet_Value() => 
-		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string));
+		new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default);
 
     [CqlDeclaration("reserpine 0.25 MG Oral Tablet")]
 	public CqlCode reserpine_0_25_MG_Oral_Tablet() => 
@@ -667,24 +667,24 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlCode[] RXNORM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
-			new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default(string), default(string)),
+			new CqlCode("204504", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("104208", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("393245", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("245273", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("197604", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1441565", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("197606", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("966787", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("966793", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000048", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000054", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000058", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000064", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000070", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000076", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("1000097", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("198196", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
+			new CqlCode("198197", "http://www.nlm.nih.gov/research/umls/rxnorm", default, default),
 		];
 
 		return a_;
@@ -697,7 +697,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlCode[] CPT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default(string), default(string)),
+			new CqlCode("99211", "http://www.ama-assn.org/go/cpt", default, default),
 		];
 
 		return a_;
@@ -709,8 +709,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("UseofHighRiskMedicationsintheElderlyFHIR-0.1.000", "Measurement Period", c_);
 
@@ -723,7 +723,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -736,37 +736,37 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Ophthalmologic_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Discharge_Services_Nursing_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		CqlValueSet x_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default(PropertyInfo));
+		IEnumerable<Encounter> y_ = context.Operators.RetrieveByValueSet<Encounter>(x_, default);
 		CqlValueSet z_ = this.Telephone_Visits();
-		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default(PropertyInfo));
+		IEnumerable<Encounter> aa_ = context.Operators.RetrieveByValueSet<Encounter>(z_, default);
 		IEnumerable<Encounter> ab_ = context.Operators.Union<Encounter>(y_, aa_);
 		IEnumerable<Encounter> ac_ = context.Operators.Union<Encounter>(w_, ab_);
 		CqlValueSet ad_ = this.Online_Assessments();
-		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default(PropertyInfo));
-		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Encounter> ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, default);
+		IEnumerable<Encounter> af_ = context.Operators.RetrieveByValueSet<Encounter>(default, default);
 		bool? ag_(Encounter E)
 		{
 			List<CodeableConcept> am_ = E?.Type;
@@ -798,7 +798,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
 			Period ax_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_3_000.ToInterval(ax_);
-			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default(string));
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default);
 
 			return az_;
 		};
@@ -869,7 +869,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				FhirDateTime k_ = OrderMedication1?.AuthoredOnElement;
 				CqlDateTime l_ = context.Operators.Convert<CqlDateTime>(k_);
 				CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
+				bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
 				MedicationRequest.DispenseRequestComponent o_ = OrderMedication1?.DispenseRequest;
 				UnsignedInt p_ = o_?.NumberOfRepeatsAllowedElement;
 				int? q_ = p_?.Value;
@@ -883,10 +883,10 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				bool? z_ = context.Operators.Equivalent(v_, y_);
 				bool? aa_ = context.Operators.Not(z_);
 				CqlDateTime ac_ = context.Operators.Convert<CqlDateTime>(k_);
-				bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, default(string));
+				bool? ae_ = context.Operators.In<CqlDateTime>(ac_, m_, default);
 				bool? af_ = context.Operators.And(aa_, ae_);
 				CqlDateTime ah_ = context.Operators.Convert<CqlDateTime>(w_);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, default(string));
+				bool? aj_ = context.Operators.In<CqlDateTime>(ah_, m_, default);
 				bool? ak_ = context.Operators.And(af_, aj_);
 				bool? al_ = context.Operators.Or(s_, ak_);
 				CqlDateTime an_ = context.Operators.Convert<CqlDateTime>(k_);
@@ -895,7 +895,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				CqlDate ar_ = context.Operators.DateFrom(aq_);
 				bool? as_ = context.Operators.Equivalent(ao_, ar_);
 				CqlDateTime au_ = context.Operators.Convert<CqlDateTime>(k_);
-				bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, default(string));
+				bool? aw_ = context.Operators.In<CqlDateTime>(au_, m_, default);
 				bool? ax_ = context.Operators.And(as_, aw_);
 				CqlInterval<CqlDate> ay_ = CumulativeMedicationDuration_4_0_000.MedicationRequestPeriod(OrderMedication1);
 				CqlDate az_ = context.Operators.Start(ay_);
@@ -910,11 +910,11 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				bool? bi_ = context.Operators.And(ax_, bh_);
 				CqlDate bk_ = context.Operators.Start(ay_);
 				CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
-				bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, default(string));
+				bool? bn_ = context.Operators.In<CqlDateTime>(bl_, m_, default);
 				bool? bo_ = context.Operators.And(bi_, bn_);
 				CqlDate bq_ = context.Operators.Start(bc_);
 				CqlDateTime br_ = context.Operators.ConvertDateToDateTime(bq_);
-				bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, default(string));
+				bool? bt_ = context.Operators.In<CqlDateTime>(br_, m_, default);
 				bool? bu_ = context.Operators.And(bo_, bt_);
 				bool? bv_ = context.Operators.Or(al_, bu_);
 
@@ -938,96 +938,96 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private IEnumerable<MedicationRequest> Same_High_Risk_Medications_Ordered_on_Different_Days_Value()
 	{
 		CqlValueSet a_ = this.Anticholinergics__first_generation_antihistamines();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		CqlValueSet g_ = this.Anticholinergics__anti_Parkinson_agents();
-		IEnumerable<MedicationRequest> h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> h_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default);
+		IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(g_, default);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(h_, j_);
 		IEnumerable<MedicationRequest> l_ = this.More_Than_One_Order(k_);
 		IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(f_, l_);
 		CqlValueSet n_ = this.Antispasmodics();
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default);
+		IEnumerable<MedicationRequest> q_ = context.Operators.RetrieveByValueSet<MedicationRequest>(n_, default);
 		IEnumerable<MedicationRequest> r_ = context.Operators.Union<MedicationRequest>(o_, q_);
 		IEnumerable<MedicationRequest> s_ = this.More_Than_One_Order(r_);
 		CqlValueSet t_ = this.Antithrombotic();
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default);
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default);
 		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
 		IEnumerable<MedicationRequest> y_ = this.More_Than_One_Order(x_);
 		IEnumerable<MedicationRequest> z_ = context.Operators.Union<MedicationRequest>(s_, y_);
 		IEnumerable<MedicationRequest> aa_ = context.Operators.Union<MedicationRequest>(m_, z_);
 		CqlValueSet ab_ = this.Cardiovascular__alpha_agonists__central();
-		IEnumerable<MedicationRequest> ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ac_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default);
+		IEnumerable<MedicationRequest> ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ab_, default);
 		IEnumerable<MedicationRequest> af_ = context.Operators.Union<MedicationRequest>(ac_, ae_);
 		IEnumerable<MedicationRequest> ag_ = this.More_Than_One_Order(af_);
 		CqlValueSet ah_ = this.Cardiovascular__other();
-		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> ai_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default);
+		IEnumerable<MedicationRequest> ak_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ah_, default);
 		IEnumerable<MedicationRequest> al_ = context.Operators.Union<MedicationRequest>(ai_, ak_);
 		IEnumerable<MedicationRequest> am_ = this.More_Than_One_Order(al_);
 		IEnumerable<MedicationRequest> an_ = context.Operators.Union<MedicationRequest>(ag_, am_);
 		IEnumerable<MedicationRequest> ao_ = context.Operators.Union<MedicationRequest>(aa_, an_);
 		CqlValueSet ap_ = this.Central_nervous_system__antidepressants();
-		IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> aq_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default);
+		IEnumerable<MedicationRequest> as_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ap_, default);
 		IEnumerable<MedicationRequest> at_ = context.Operators.Union<MedicationRequest>(aq_, as_);
 		IEnumerable<MedicationRequest> au_ = this.More_Than_One_Order(at_);
 		CqlValueSet av_ = this.Central_nervous_system__barbiturates();
-		IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> aw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default);
+		IEnumerable<MedicationRequest> ay_ = context.Operators.RetrieveByValueSet<MedicationRequest>(av_, default);
 		IEnumerable<MedicationRequest> az_ = context.Operators.Union<MedicationRequest>(aw_, ay_);
 		IEnumerable<MedicationRequest> ba_ = this.More_Than_One_Order(az_);
 		IEnumerable<MedicationRequest> bb_ = context.Operators.Union<MedicationRequest>(au_, ba_);
 		IEnumerable<MedicationRequest> bc_ = context.Operators.Union<MedicationRequest>(ao_, bb_);
 		CqlValueSet bd_ = this.Central_nervous_system__vasodilators();
-		IEnumerable<MedicationRequest> be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> be_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default);
+		IEnumerable<MedicationRequest> bg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bd_, default);
 		IEnumerable<MedicationRequest> bh_ = context.Operators.Union<MedicationRequest>(be_, bg_);
 		IEnumerable<MedicationRequest> bi_ = this.More_Than_One_Order(bh_);
 		CqlValueSet bj_ = this.Central_nervous_system__other();
-		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bk_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default);
+		IEnumerable<MedicationRequest> bm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bj_, default);
 		IEnumerable<MedicationRequest> bn_ = context.Operators.Union<MedicationRequest>(bk_, bm_);
 		IEnumerable<MedicationRequest> bo_ = this.More_Than_One_Order(bn_);
 		IEnumerable<MedicationRequest> bp_ = context.Operators.Union<MedicationRequest>(bi_, bo_);
 		IEnumerable<MedicationRequest> bq_ = context.Operators.Union<MedicationRequest>(bc_, bp_);
 		CqlValueSet br_ = this.Endocrine_system__estrogens_with_or_without_progestins();
-		IEnumerable<MedicationRequest> bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> bs_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default);
+		IEnumerable<MedicationRequest> bu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(br_, default);
 		IEnumerable<MedicationRequest> bv_ = context.Operators.Union<MedicationRequest>(bs_, bu_);
 		IEnumerable<MedicationRequest> bw_ = this.More_Than_One_Order(bv_);
 		CqlValueSet bx_ = this.Endocrine_system__sulfonylureas__long_duration();
-		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> by_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default);
+		IEnumerable<MedicationRequest> ca_ = context.Operators.RetrieveByValueSet<MedicationRequest>(bx_, default);
 		IEnumerable<MedicationRequest> cb_ = context.Operators.Union<MedicationRequest>(by_, ca_);
 		IEnumerable<MedicationRequest> cc_ = this.More_Than_One_Order(cb_);
 		IEnumerable<MedicationRequest> cd_ = context.Operators.Union<MedicationRequest>(bw_, cc_);
 		IEnumerable<MedicationRequest> ce_ = context.Operators.Union<MedicationRequest>(bq_, cd_);
 		CqlValueSet cf_ = this.Endocrine_system__other();
-		IEnumerable<MedicationRequest> cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cg_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default);
+		IEnumerable<MedicationRequest> ci_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cf_, default);
 		IEnumerable<MedicationRequest> cj_ = context.Operators.Union<MedicationRequest>(cg_, ci_);
 		IEnumerable<MedicationRequest> ck_ = this.More_Than_One_Order(cj_);
 		CqlValueSet cl_ = this.Nonbenzodiazepine_hypnotics();
-		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cm_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default);
+		IEnumerable<MedicationRequest> co_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cl_, default);
 		IEnumerable<MedicationRequest> cp_ = context.Operators.Union<MedicationRequest>(cm_, co_);
 		IEnumerable<MedicationRequest> cq_ = this.More_Than_One_Order(cp_);
 		IEnumerable<MedicationRequest> cr_ = context.Operators.Union<MedicationRequest>(ck_, cq_);
 		IEnumerable<MedicationRequest> cs_ = context.Operators.Union<MedicationRequest>(ce_, cr_);
 		CqlValueSet ct_ = this.Pain_medications__skeletal_muscle_relaxants();
-		IEnumerable<MedicationRequest> cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> cu_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default);
+		IEnumerable<MedicationRequest> cw_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ct_, default);
 		IEnumerable<MedicationRequest> cx_ = context.Operators.Union<MedicationRequest>(cu_, cw_);
 		IEnumerable<MedicationRequest> cy_ = this.More_Than_One_Order(cx_);
 		CqlValueSet cz_ = this.Pain_medications__other();
-		IEnumerable<MedicationRequest> da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> da_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default);
+		IEnumerable<MedicationRequest> dc_ = context.Operators.RetrieveByValueSet<MedicationRequest>(cz_, default);
 		IEnumerable<MedicationRequest> dd_ = context.Operators.Union<MedicationRequest>(da_, dc_);
 		IEnumerable<MedicationRequest> de_ = this.More_Than_One_Order(dd_);
 		IEnumerable<MedicationRequest> df_ = context.Operators.Union<MedicationRequest>(cy_, de_);
@@ -1119,8 +1119,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? Two_High_Risk_Medications_with_Prolonged_Duration_Value()
 	{
 		CqlValueSet a_ = this.Anti_Infectives__other();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		decimal? g_(MedicationRequest AntiInfectives)
@@ -1400,7 +1400,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			}
 			else
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 		};
 
@@ -1454,7 +1454,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 				}
 				else
 				{
-					return default(CqlQuantity);
+					return default;
 				}
 			};
 
@@ -1469,8 +1469,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? High_Risk_Medications_with_Average_Daily_Dose_Criteria_Value()
 	{
 		CqlValueSet a_ = this.Reserpine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest ReserpineOrdered)
 		{
@@ -1484,8 +1484,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		IEnumerable<MedicationRequest> h_ = this.More_Than_One_Order(g_);
 		bool? i_ = context.Operators.Exists<MedicationRequest>(h_);
 		CqlValueSet j_ = this.Digoxin();
-		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default);
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default);
 		IEnumerable<MedicationRequest> n_ = context.Operators.Union<MedicationRequest>(k_, m_);
 		bool? o_(MedicationRequest DigoxinOrdered)
 		{
@@ -1500,8 +1500,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		bool? r_ = context.Operators.Exists<MedicationRequest>(q_);
 		bool? s_ = context.Operators.Or(i_, r_);
 		CqlValueSet t_ = this.Doxepin();
-		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> u_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default);
+		IEnumerable<MedicationRequest> w_ = context.Operators.RetrieveByValueSet<MedicationRequest>(t_, default);
 		IEnumerable<MedicationRequest> x_ = context.Operators.Union<MedicationRequest>(u_, w_);
 		bool? y_(MedicationRequest DoxepinOrdered)
 		{
@@ -1542,8 +1542,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? More_than_One_Antipsychotic_Order_Value()
 	{
 		CqlValueSet a_ = this.Antipsychotic();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
@@ -1558,8 +1558,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlDateTime Antipsychotic_Index_Prescription_Start_Date_Value()
 	{
 		CqlValueSet a_ = this.Antipsychotic();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest AntipsychoticMedication)
@@ -1567,7 +1567,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			FhirDateTime m_ = AntipsychoticMedication?.AuthoredOnElement;
 			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
 
 			return p_;
 		};
@@ -1593,8 +1593,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private bool? More_than_One_Benzodiazepine_Order_Value()
 	{
 		CqlValueSet a_ = this.Benzodiazepine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = this.More_Than_One_Order(e_);
 		bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
@@ -1609,8 +1609,8 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	private CqlDateTime Benzodiazepine_Index_Prescription_Start_Date_Value()
 	{
 		CqlValueSet a_ = this.Benzodiazepine();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		IEnumerable<MedicationRequest> f_ = Status_1_6_000.Active_or_Completed_Medication_Request(e_);
 		bool? g_(MedicationRequest BenzodiazepineMedication)
@@ -1618,7 +1618,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			FhirDateTime m_ = BenzodiazepineMedication?.AuthoredOnElement;
 			CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
 
 			return p_;
 		};
@@ -1645,9 +1645,9 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 	{
 		bool? a_ = this.More_than_One_Antipsychotic_Order();
 		CqlValueSet b_ = this.Schizophrenia();
-		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default(PropertyInfo));
+		IEnumerable<Condition> c_ = context.Operators.RetrieveByValueSet<Condition>(b_, default);
 		CqlValueSet d_ = this.Bipolar_Disorder();
-		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+		IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 		IEnumerable<Condition> f_ = context.Operators.Union<Condition>(c_, e_);
 		bool? g_(Condition AntipsychoticTreatedDiagnoses)
 		{
@@ -1658,7 +1658,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
 			CqlDateTime al_ = this.Antipsychotic_Index_Prescription_Start_Date();
 			CqlInterval<CqlDateTime> am_ = context.Operators.Interval(ak_, al_, true, true);
-			bool? an_ = context.Operators.Overlaps(ag_, am_, default(string));
+			bool? an_ = context.Operators.Overlaps(ag_, am_, default);
 
 			return an_;
 		};
@@ -1668,18 +1668,18 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 		bool? k_ = context.Operators.And(a_, j_);
 		bool? l_ = this.More_than_One_Benzodiazepine_Order();
 		CqlValueSet m_ = this.Seizure_Disorder();
-		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default(PropertyInfo));
+		IEnumerable<Condition> n_ = context.Operators.RetrieveByValueSet<Condition>(m_, default);
 		CqlValueSet o_ = this.REM_Sleep_Behavior_Disorder();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 		IEnumerable<Condition> q_ = context.Operators.Union<Condition>(n_, p_);
 		CqlValueSet r_ = this.Benzodiazepine_Withdrawal();
-		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default(PropertyInfo));
+		IEnumerable<Condition> s_ = context.Operators.RetrieveByValueSet<Condition>(r_, default);
 		CqlValueSet t_ = this.Alcohol_Withdrawal();
-		IEnumerable<Condition> u_ = context.Operators.RetrieveByValueSet<Condition>(t_, default(PropertyInfo));
+		IEnumerable<Condition> u_ = context.Operators.RetrieveByValueSet<Condition>(t_, default);
 		IEnumerable<Condition> v_ = context.Operators.Union<Condition>(s_, u_);
 		IEnumerable<Condition> w_ = context.Operators.Union<Condition>(q_, v_);
 		CqlValueSet x_ = this.Generalized_Anxiety_Disorder();
-		IEnumerable<Condition> y_ = context.Operators.RetrieveByValueSet<Condition>(x_, default(PropertyInfo));
+		IEnumerable<Condition> y_ = context.Operators.RetrieveByValueSet<Condition>(x_, default);
 		IEnumerable<Condition> z_ = context.Operators.Union<Condition>(w_, y_);
 		bool? aa_(Condition BenzodiazepineTreatedDiagnoses)
 		{
@@ -1690,7 +1690,7 @@ public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 			CqlDateTime as_ = context.Operators.Subtract(aq_, ar_);
 			CqlDateTime at_ = this.Benzodiazepine_Index_Prescription_Start_Date();
 			CqlInterval<CqlDateTime> au_ = context.Operators.Interval(as_, at_, true, true);
-			bool? av_ = context.Operators.Overlaps(ao_, au_, default(string));
+			bool? av_ = context.Operators.Overlaps(ao_, au_, default);
 
 			return av_;
 		};

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("UseofHighRiskMedicationsintheElderlyFHIR", "0.1.000")]
 public class UseofHighRiskMedicationsintheElderlyFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
@@ -54,7 +54,7 @@ public class VTE_8_6_000
     #endregion
 
 	private CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", default(string));
 
     [CqlDeclaration("Obstetrical or Pregnancy Related Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263")]
@@ -62,7 +62,7 @@ public class VTE_8_6_000
 		__Obstetrical_or_Pregnancy_Related_Conditions.Value;
 
 	private CqlValueSet Obstetrics_VTE_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", default(string));
 
     [CqlDeclaration("Obstetrics VTE")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264")]
@@ -70,7 +70,7 @@ public class VTE_8_6_000
 		__Obstetrics_VTE.Value;
 
 	private CqlValueSet Venous_Thromboembolism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", default(string));
 
     [CqlDeclaration("Venous Thromboembolism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279")]
@@ -90,7 +90,7 @@ public class VTE_8_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
@@ -54,7 +54,7 @@ public class VTE_8_6_000
     #endregion
 
 	private CqlValueSet Obstetrical_or_Pregnancy_Related_Conditions_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263", default);
 
     [CqlDeclaration("Obstetrical or Pregnancy Related Conditions")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.263")]
@@ -62,7 +62,7 @@ public class VTE_8_6_000
 		__Obstetrical_or_Pregnancy_Related_Conditions.Value;
 
 	private CqlValueSet Obstetrics_VTE_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264", default);
 
     [CqlDeclaration("Obstetrics VTE")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.264")]
@@ -70,7 +70,7 @@ public class VTE_8_6_000
 		__Obstetrics_VTE.Value;
 
 	private CqlValueSet Venous_Thromboembolism_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279", default);
 
     [CqlDeclaration("Venous Thromboembolism")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.279")]
@@ -90,7 +90,7 @@ public class VTE_8_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.6.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("VTE", "8.6.000")]
 public class VTE_8_6_000
 {

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR", "0.1.000")]
 public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR_0_1_000
 {

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -144,7 +144,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
     #endregion
 
 	private CqlValueSet BMI_percentile_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", default);
 
     [CqlDeclaration("BMI percentile")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012")]
@@ -152,7 +152,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__BMI_percentile.Value;
 
 	private CqlValueSet Counseling_for_Nutrition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", default);
 
     [CqlDeclaration("Counseling for Nutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003")]
@@ -160,7 +160,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Counseling_for_Nutrition.Value;
 
 	private CqlValueSet Counseling_for_Physical_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", default);
 
     [CqlDeclaration("Counseling for Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035")]
@@ -168,7 +168,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Counseling_for_Physical_Activity.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -176,7 +176,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -184,7 +184,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -192,7 +192,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Height_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", default);
 
     [CqlDeclaration("Height")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014")]
@@ -200,7 +200,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Height.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -208,7 +208,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -216,7 +216,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -224,7 +224,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Office_Visit.Value;
 
 	private CqlValueSet Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", default);
 
     [CqlDeclaration("Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378")]
@@ -232,7 +232,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Pregnancy.Value;
 
 	private CqlValueSet Preventive_Care_Services___Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default);
 
     [CqlDeclaration("Preventive Care Services - Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -240,7 +240,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services___Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -248,7 +248,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -256,7 +256,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -264,7 +264,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -272,7 +272,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Weight_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", default);
 
     [CqlDeclaration("Weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015")]
@@ -280,77 +280,77 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Weight.Value;
 
 	private CqlCode _in_i__Value() => 
-		new CqlCode("[in_i]", "http://unitsofmeasure.org", default(string), default(string));
+		new CqlCode("[in_i]", "http://unitsofmeasure.org", default, default);
 
     [CqlDeclaration("[in_i]")]
 	public CqlCode _in_i_() => 
 		___in_i_.Value;
 
 	private CqlCode _lb_av__Value() => 
-		new CqlCode("[lb_av]", "http://unitsofmeasure.org", default(string), default(string));
+		new CqlCode("[lb_av]", "http://unitsofmeasure.org", default, default);
 
     [CqlDeclaration("[lb_av]")]
 	public CqlCode _lb_av_() => 
 		___lb_av_.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Body_height_Value() => 
-		new CqlCode("8302-2", "http://loinc.org", default(string), default(string));
+		new CqlCode("8302-2", "http://loinc.org", default, default);
 
     [CqlDeclaration("Body height")]
 	public CqlCode Body_height() => 
 		__Body_height.Value;
 
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
-		new CqlCode("39156-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("39156-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
 	private CqlCode Body_weight_Value() => 
-		new CqlCode("29463-7", "http://loinc.org", default(string), default(string));
+		new CqlCode("29463-7", "http://loinc.org", default, default);
 
     [CqlDeclaration("Body weight")]
 	public CqlCode Body_weight() => 
 		__Body_weight.Value;
 
 	private CqlCode cm_Value() => 
-		new CqlCode("cm", "http://unitsofmeasure.org", default(string), default(string));
+		new CqlCode("cm", "http://unitsofmeasure.org", default, default);
 
     [CqlDeclaration("cm")]
 	public CqlCode cm() => 
 		__cm.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode g_Value() => 
-		new CqlCode("g", "http://unitsofmeasure.org", default(string), default(string));
+		new CqlCode("g", "http://unitsofmeasure.org", default, default);
 
     [CqlDeclaration("g")]
 	public CqlCode g() => 
 		__g.Value;
 
 	private CqlCode kg_Value() => 
-		new CqlCode("kg", "http://unitsofmeasure.org", default(string), default(string));
+		new CqlCode("kg", "http://unitsofmeasure.org", default, default);
 
     [CqlDeclaration("kg")]
 	public CqlCode kg() => 
 		__kg.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
@@ -359,11 +359,11 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] UCUM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("[in_i]", "http://unitsofmeasure.org", default(string), default(string)),
-			new CqlCode("[lb_av]", "http://unitsofmeasure.org", default(string), default(string)),
-			new CqlCode("cm", "http://unitsofmeasure.org", default(string), default(string)),
-			new CqlCode("g", "http://unitsofmeasure.org", default(string), default(string)),
-			new CqlCode("kg", "http://unitsofmeasure.org", default(string), default(string)),
+			new CqlCode("[in_i]", "http://unitsofmeasure.org", default, default),
+			new CqlCode("[lb_av]", "http://unitsofmeasure.org", default, default),
+			new CqlCode("cm", "http://unitsofmeasure.org", default, default),
+			new CqlCode("g", "http://unitsofmeasure.org", default, default),
+			new CqlCode("kg", "http://unitsofmeasure.org", default, default),
 		];
 
 		return a_;
@@ -376,10 +376,10 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8302-2", "http://loinc.org", default(string), default(string)),
-			new CqlCode("39156-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("29463-7", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
+			new CqlCode("8302-2", "http://loinc.org", default, default),
+			new CqlCode("39156-5", "http://loinc.org", default, default),
+			new CqlCode("29463-7", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -392,8 +392,8 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -405,8 +405,8 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -419,7 +419,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -476,24 +476,24 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services___Group_Counseling();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.Finished_Encounter(t_);
 		bool? v_(Encounter ValidEncounters)
@@ -502,7 +502,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			Period y_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
 			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.ToInterval((z_ as object));
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, default(string));
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, default);
 
 			return ab_;
 		};
@@ -526,7 +526,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounter();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -552,13 +552,13 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition Pregnancy)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Pregnancy);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 
 			return h_;
 		};
@@ -587,7 +587,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> BMI_Percentile_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIPercentile)
 		{
@@ -615,7 +615,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> Height_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Observation> b_ = Status_1_6_000.BodyHeight(a_);
 		bool? c_(Observation Height)
 		{
@@ -643,7 +643,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> Weight_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default, default);
 		IEnumerable<Observation> b_ = Status_1_6_000.BodyWeight(a_);
 		bool? c_(Observation Weight)
 		{
@@ -690,7 +690,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private bool? Numerator_2_Value()
 	{
 		CqlValueSet a_ = this.Counseling_for_Nutrition();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure NutritionCounseling)
 		{
@@ -715,7 +715,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private bool? Numerator_3_Value()
 	{
 		CqlValueSet a_ = this.Counseling_for_Physical_Activity();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ActivityCounseling)
 		{
@@ -748,7 +748,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 11, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -768,7 +768,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 17, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000.g.cs
@@ -144,7 +144,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
     #endregion
 
 	private CqlValueSet BMI_percentile_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012", default(string));
 
     [CqlDeclaration("BMI percentile")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1012")]
@@ -152,7 +152,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__BMI_percentile.Value;
 
 	private CqlValueSet Counseling_for_Nutrition_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003", default(string));
 
     [CqlDeclaration("Counseling for Nutrition")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.195.12.1003")]
@@ -160,7 +160,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Counseling_for_Nutrition.Value;
 
 	private CqlValueSet Counseling_for_Physical_Activity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035", default(string));
 
     [CqlDeclaration("Counseling for Physical Activity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1035")]
@@ -168,7 +168,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Counseling_for_Physical_Activity.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -176,7 +176,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -184,7 +184,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -192,7 +192,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Height_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014", default(string));
 
     [CqlDeclaration("Height")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1014")]
@@ -200,7 +200,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Height.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -208,7 +208,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -216,7 +216,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -224,7 +224,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Office_Visit.Value;
 
 	private CqlValueSet Pregnancy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378", default(string));
 
     [CqlDeclaration("Pregnancy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.378")]
@@ -232,7 +232,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Pregnancy.Value;
 
 	private CqlValueSet Preventive_Care_Services___Group_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027", default(string));
 
     [CqlDeclaration("Preventive Care Services - Group Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1027")]
@@ -240,7 +240,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services___Group_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care Services, Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -248,7 +248,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -256,7 +256,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care__Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care, Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -264,7 +264,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Preventive_Care__Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -272,7 +272,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Weight_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015", default(string));
 
     [CqlDeclaration("Weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.121.12.1015")]
@@ -280,77 +280,77 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		__Weight.Value;
 
 	private CqlCode _in_i__Value() => 
-		new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null);
+		new CqlCode("[in_i]", "http://unitsofmeasure.org", default(string), default(string));
 
     [CqlDeclaration("[in_i]")]
 	public CqlCode _in_i_() => 
 		___in_i_.Value;
 
 	private CqlCode _lb_av__Value() => 
-		new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null);
+		new CqlCode("[lb_av]", "http://unitsofmeasure.org", default(string), default(string));
 
     [CqlDeclaration("[lb_av]")]
 	public CqlCode _lb_av_() => 
 		___lb_av_.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Body_height_Value() => 
-		new CqlCode("8302-2", "http://loinc.org", null, null);
+		new CqlCode("8302-2", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Body height")]
 	public CqlCode Body_height() => 
 		__Body_height.Value;
 
 	private CqlCode Body_mass_index__BMI___Ratio__Value() => 
-		new CqlCode("39156-5", "http://loinc.org", null, null);
+		new CqlCode("39156-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Body mass index (BMI) [Ratio]")]
 	public CqlCode Body_mass_index__BMI___Ratio_() => 
 		__Body_mass_index__BMI___Ratio_.Value;
 
 	private CqlCode Body_weight_Value() => 
-		new CqlCode("29463-7", "http://loinc.org", null, null);
+		new CqlCode("29463-7", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Body weight")]
 	public CqlCode Body_weight() => 
 		__Body_weight.Value;
 
 	private CqlCode cm_Value() => 
-		new CqlCode("cm", "http://unitsofmeasure.org", null, null);
+		new CqlCode("cm", "http://unitsofmeasure.org", default(string), default(string));
 
     [CqlDeclaration("cm")]
 	public CqlCode cm() => 
 		__cm.Value;
 
 	private CqlCode exam_Value() => 
-		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("exam")]
 	public CqlCode exam() => 
 		__exam.Value;
 
 	private CqlCode g_Value() => 
-		new CqlCode("g", "http://unitsofmeasure.org", null, null);
+		new CqlCode("g", "http://unitsofmeasure.org", default(string), default(string));
 
     [CqlDeclaration("g")]
 	public CqlCode g() => 
 		__g.Value;
 
 	private CqlCode kg_Value() => 
-		new CqlCode("kg", "http://unitsofmeasure.org", null, null);
+		new CqlCode("kg", "http://unitsofmeasure.org", default(string), default(string));
 
     [CqlDeclaration("kg")]
 	public CqlCode kg() => 
 		__kg.Value;
 
 	private CqlCode vital_signs_Value() => 
-		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("vital-signs")]
 	public CqlCode vital_signs() => 
@@ -359,11 +359,11 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] UCUM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("[in_i]", "http://unitsofmeasure.org", null, null),
-			new CqlCode("[lb_av]", "http://unitsofmeasure.org", null, null),
-			new CqlCode("cm", "http://unitsofmeasure.org", null, null),
-			new CqlCode("g", "http://unitsofmeasure.org", null, null),
-			new CqlCode("kg", "http://unitsofmeasure.org", null, null),
+			new CqlCode("[in_i]", "http://unitsofmeasure.org", default(string), default(string)),
+			new CqlCode("[lb_av]", "http://unitsofmeasure.org", default(string), default(string)),
+			new CqlCode("cm", "http://unitsofmeasure.org", default(string), default(string)),
+			new CqlCode("g", "http://unitsofmeasure.org", default(string), default(string)),
+			new CqlCode("kg", "http://unitsofmeasure.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -376,10 +376,10 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
-			new CqlCode("8302-2", "http://loinc.org", null, null),
-			new CqlCode("39156-5", "http://loinc.org", null, null),
-			new CqlCode("29463-7", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8302-2", "http://loinc.org", default(string), default(string)),
+			new CqlCode("39156-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("29463-7", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -392,8 +392,8 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
-			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("exam", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("vital-signs", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -405,8 +405,8 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.000", "Measurement Period", c_);
 
@@ -419,7 +419,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -476,24 +476,24 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private IEnumerable<Encounter> Qualifying_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care__Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services___Group_Counseling();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		IEnumerable<Encounter> t_ = context.Operators.Union<Encounter>(q_, s_);
 		IEnumerable<Encounter> u_ = Status_1_6_000.Finished_Encounter(t_);
 		bool? v_(Encounter ValidEncounters)
@@ -502,7 +502,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 			Period y_ = ValidEncounters?.Period;
 			CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_3_000.ToInterval(y_);
 			CqlInterval<CqlDateTime> aa_ = QICoreCommon_2_0_000.ToInterval((z_ as object));
-			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, null);
+			bool? ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(x_, aa_, default(string));
 
 			return ab_;
 		};
@@ -526,7 +526,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = this.Qualifying_Encounter();
 		bool? l_ = context.Operators.Exists<Encounter>(k_);
 		bool? m_ = context.Operators.And(j_, l_);
@@ -552,13 +552,13 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private IEnumerable<Condition> Pregnancy_Diagnosis_Which_Overlaps_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = Status_1_6_000.Active_Condition(b_);
 		bool? d_(Condition Pregnancy)
 		{
 			CqlInterval<CqlDateTime> f_ = QICoreCommon_2_0_000.ToPrevalenceInterval(Pregnancy);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 
 			return h_;
 		};
@@ -587,7 +587,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> BMI_Percentile_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Observation> b_ = Status_1_6_000.BMI(a_);
 		bool? c_(Observation BMIPercentile)
 		{
@@ -615,7 +615,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> Height_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Observation> b_ = Status_1_6_000.BodyHeight(a_);
 		bool? c_(Observation Height)
 		{
@@ -643,7 +643,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 
 	private IEnumerable<Observation> Weight_in_Measurement_Period_Value()
 	{
-		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(null, null);
+		IEnumerable<Observation> a_ = context.Operators.RetrieveByValueSet<Observation>(default(CqlValueSet), default(PropertyInfo));
 		IEnumerable<Observation> b_ = Status_1_6_000.BodyWeight(a_);
 		bool? c_(Observation Weight)
 		{
@@ -690,7 +690,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private bool? Numerator_2_Value()
 	{
 		CqlValueSet a_ = this.Counseling_for_Nutrition();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure NutritionCounseling)
 		{
@@ -715,7 +715,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 	private bool? Numerator_3_Value()
 	{
 		CqlValueSet a_ = this.Counseling_for_Physical_Activity();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = Status_1_6_000.Completed_Procedure(b_);
 		bool? d_(Procedure ActivityCounseling)
 		{
@@ -748,7 +748,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(3, 11, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -768,7 +768,7 @@ public class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChil
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 17, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -54,7 +54,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -62,7 +62,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -70,7 +70,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -78,7 +78,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -86,7 +86,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -106,7 +106,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -119,18 +119,18 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter ValidEncounter)
 		{
@@ -140,7 +140,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			Period u_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((u_ as object));
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default(string));
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default);
 			bool? x_ = context.Operators.And(s_, w_);
 
 			return x_;

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AdultOutpatientEncountersFHIR4", "2.2.000")]
 public class AdultOutpatientEncountersFHIR4_2_2_000
 {

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -54,7 +54,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -62,7 +62,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -70,7 +70,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -78,7 +78,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Office_Visit.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -86,7 +86,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -106,7 +106,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -119,18 +119,18 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter ValidEncounter)
 		{
@@ -140,7 +140,7 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
 			Period u_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((u_ as object));
-			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, null);
+			bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default(string));
 			bool? x_ = context.Operators.And(s_, w_);
 
 			return x_;

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -94,7 +94,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -102,7 +102,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -110,7 +110,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -118,7 +118,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -126,7 +126,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -134,7 +134,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -142,7 +142,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -150,7 +150,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -158,7 +158,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -166,7 +166,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -174,7 +174,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -182,7 +182,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -190,7 +190,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Observation.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -210,7 +210,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,8 +223,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<MedicationRequest> Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest DementiaMed)
 		{
@@ -242,7 +242,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
 			CqlDateTime u_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
-			bool? w_ = context.Operators.Overlaps(o_, v_, null);
+			bool? w_ = context.Operators.Overlaps(o_, v_, default(string));
 			bool? x_ = context.Operators.And(n_, w_);
 
 			return x_;
@@ -259,9 +259,9 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Periods_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter LongTermFacilityEncounter)
 		{
@@ -271,7 +271,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			Period m_ = LongTermFacilityEncounter?.Period;
 			CqlInterval<CqlDateTime> n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((m_ as object));
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.Overlaps(n_, o_, null);
+			bool? p_ = context.Operators.Overlaps(n_, o_, default(string));
 			bool? q_ = context.Operators.And(l_, p_);
 
 			return q_;
@@ -298,14 +298,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		bool? l_(Encounter Outpatient)
@@ -320,7 +320,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<Encounter> n_(Encounter OutpatientEncounter)
 		{
 			CqlValueSet s_ = this.Advanced_Illness();
-			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, null);
+			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
 			bool? u_(Condition AdvancedIllnessDiagnosis)
 			{
 				IEnumerable<Condition> y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(OutpatientEncounter);
@@ -334,7 +334,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
 				CqlDateTime ai_ = context.Operators.End(ad_);
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, true, true);
-				bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, null);
+				bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, default(string));
 				CqlDateTime am_ = context.Operators.End(ad_);
 				bool? an_ = context.Operators.Not((bool?)(am_ is null));
 				bool? ao_ = context.Operators.And(ak_, an_);
@@ -398,7 +398,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods_Value()
 	{
 		IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Periods_During_Measurement_Period();
-		IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, null);
+		IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, default(string));
 
 		return b_;
 	}
@@ -426,7 +426,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime q_ = context.Operators.Add(l_, m_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			bool? u_ = context.Operators.Not((bool?)(l_ is null));
 			bool? v_ = context.Operators.And(s_, u_);
 
@@ -455,7 +455,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Overlapping_Periods();
 		IEnumerable<CqlInterval<CqlDateTime>> b_ = this.Long_Term_Care_Adjacent_Periods();
 		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Union<CqlInterval<CqlDateTime>>(a_, b_);
-		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, null);
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, default(string));
 		int? e_(CqlInterval<CqlDateTime> LTCPeriods)
 		{
 			CqlDateTime h_ = context.Operators.Start(LTCPeriods);
@@ -477,7 +477,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<Encounter> Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter AcuteInpatient)
 		{
 			Code<Encounter.EncounterStatus> g_ = AcuteInpatient?.StatusElement;
@@ -490,7 +490,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
 			CqlValueSet j_ = this.Advanced_Illness();
-			IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, null);
+			IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default(PropertyInfo));
 			bool? l_(Condition AdvancedIllnessDiagnosis)
 			{
 				IEnumerable<Condition> p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(InpatientEncounter);
@@ -504,7 +504,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 				CqlDateTime z_ = context.Operators.End(u_);
 				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-				bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, null);
+				bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default(string));
 				CqlDateTime ad_ = context.Operators.End(u_);
 				bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
 				bool? af_ = context.Operators.And(ab_, ae_);
@@ -531,8 +531,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
-		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
+		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
+		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
 		IEnumerable<DeviceRequest> e_ = context.Operators.Union<DeviceRequest>(b_, d_);
 		bool? f_(DeviceRequest FrailtyDeviceOrder)
 		{
@@ -551,14 +551,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 			FhirDateTime ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
 			CqlInterval<CqlDateTime> aq_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ap_ as object));
-			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, null);
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
 			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
 		};
 		IEnumerable<DeviceRequest> g_ = context.Operators.Where<DeviceRequest>(e_, f_);
 		bool? h_ = context.Operators.Exists<DeviceRequest>(g_);
-		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? k_(Observation FrailtyDeviceApplied)
 		{
 			Code<ObservationStatus> at_ = FrailtyDeviceApplied?.StatusElement;
@@ -572,7 +572,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			DataType ax_ = FrailtyDeviceApplied?.Effective;
 			CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ax_);
 			CqlInterval<CqlDateTime> az_ = this.Measurement_Period();
-			bool? ba_ = context.Operators.Overlaps(ay_, az_, null);
+			bool? ba_ = context.Operators.Overlaps(ay_, az_, default(string));
 			bool? bb_ = context.Operators.And(aw_, ba_);
 
 			return bb_;
@@ -581,12 +581,12 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? m_ = context.Operators.Exists<Observation>(l_);
 		bool? n_ = context.Operators.Or(h_, m_);
 		CqlValueSet o_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
 		bool? q_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> bc_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(FrailtyDiagnosis);
 			CqlInterval<CqlDateTime> bd_ = this.Measurement_Period();
-			bool? be_ = context.Operators.Overlaps(bc_, bd_, null);
+			bool? be_ = context.Operators.Overlaps(bc_, bd_, default(string));
 
 			return be_;
 		};
@@ -594,7 +594,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? s_ = context.Operators.Exists<Condition>(r_);
 		bool? t_ = context.Operators.Or(n_, s_);
 		CqlValueSet u_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
+		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default(PropertyInfo));
 		bool? w_(Encounter FrailtyEncounter)
 		{
 			Code<Encounter.EncounterStatus> bf_ = FrailtyEncounter?.StatusElement;
@@ -603,7 +603,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			Period bi_ = FrailtyEncounter?.Period;
 			CqlInterval<CqlDateTime> bj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((bi_ as object));
 			CqlInterval<CqlDateTime> bk_ = this.Measurement_Period();
-			bool? bl_ = context.Operators.Overlaps(bj_, bk_, null);
+			bool? bl_ = context.Operators.Overlaps(bj_, bk_, default(string));
 			bool? bm_ = context.Operators.And(bh_, bl_);
 
 			return bm_;
@@ -612,7 +612,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? y_ = context.Operators.Exists<Encounter>(x_);
 		bool? z_ = context.Operators.Or(t_, y_);
 		CqlValueSet aa_ = this.Frailty_Symptom();
-		IEnumerable<Observation> ab_ = context.Operators.RetrieveByValueSet<Observation>(aa_, null);
+		IEnumerable<Observation> ab_ = context.Operators.RetrieveByValueSet<Observation>(aa_, default(PropertyInfo));
 		bool? ac_(Observation FrailtySymptom)
 		{
 			Code<ObservationStatus> bn_ = FrailtySymptom?.StatusElement;
@@ -627,7 +627,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			DataType br_ = FrailtySymptom?.Effective;
 			CqlInterval<CqlDateTime> bs_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(br_);
 			CqlInterval<CqlDateTime> bt_ = this.Measurement_Period();
-			bool? bu_ = context.Operators.Overlaps(bs_, bt_, null);
+			bool? bu_ = context.Operators.Overlaps(bs_, bt_, default(string));
 			bool? bv_ = context.Operators.And(bq_, bu_);
 
 			return bv_;
@@ -654,7 +654,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(65, 79, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		IEnumerable<Encounter> m_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("AdvancedIllnessandFrailtyExclusionECQMFHIR4", "5.17.000")]
 public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 {

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -94,7 +94,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -102,7 +102,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -110,7 +110,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -118,7 +118,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -126,7 +126,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
@@ -134,7 +134,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -142,7 +142,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -150,7 +150,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -158,7 +158,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -166,7 +166,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -174,7 +174,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -182,7 +182,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -190,7 +190,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		__Observation.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -210,7 +210,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,8 +223,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<MedicationRequest> Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		bool? f_(MedicationRequest DementiaMed)
 		{
@@ -242,7 +242,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
 			CqlDateTime u_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
-			bool? w_ = context.Operators.Overlaps(o_, v_, default(string));
+			bool? w_ = context.Operators.Overlaps(o_, v_, default);
 			bool? x_ = context.Operators.And(n_, w_);
 
 			return x_;
@@ -259,9 +259,9 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Periods_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter LongTermFacilityEncounter)
 		{
@@ -271,7 +271,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			Period m_ = LongTermFacilityEncounter?.Period;
 			CqlInterval<CqlDateTime> n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((m_ as object));
 			CqlInterval<CqlDateTime> o_ = this.Measurement_Period();
-			bool? p_ = context.Operators.Overlaps(n_, o_, default(string));
+			bool? p_ = context.Operators.Overlaps(n_, o_, default);
 			bool? q_ = context.Operators.And(l_, p_);
 
 			return q_;
@@ -298,14 +298,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		bool? l_(Encounter Outpatient)
@@ -320,7 +320,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<Encounter> n_(Encounter OutpatientEncounter)
 		{
 			CqlValueSet s_ = this.Advanced_Illness();
-			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default(PropertyInfo));
+			IEnumerable<Condition> t_ = context.Operators.RetrieveByValueSet<Condition>(s_, default);
 			bool? u_(Condition AdvancedIllnessDiagnosis)
 			{
 				IEnumerable<Condition> y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(OutpatientEncounter);
@@ -334,7 +334,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
 				CqlDateTime ai_ = context.Operators.End(ad_);
 				CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, true, true);
-				bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, default(string));
+				bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, default);
 				CqlDateTime am_ = context.Operators.End(ad_);
 				bool? an_ = context.Operators.Not((bool?)(am_ is null));
 				bool? ao_ = context.Operators.And(ak_, an_);
@@ -398,7 +398,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods_Value()
 	{
 		IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Periods_During_Measurement_Period();
-		IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, default(string));
+		IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, default);
 
 		return b_;
 	}
@@ -426,7 +426,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime q_ = context.Operators.Add(l_, m_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			bool? u_ = context.Operators.Not((bool?)(l_ is null));
 			bool? v_ = context.Operators.And(s_, u_);
 
@@ -455,7 +455,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Overlapping_Periods();
 		IEnumerable<CqlInterval<CqlDateTime>> b_ = this.Long_Term_Care_Adjacent_Periods();
 		IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Union<CqlInterval<CqlDateTime>>(a_, b_);
-		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, default(string));
+		IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, default);
 		int? e_(CqlInterval<CqlDateTime> LTCPeriods)
 		{
 			CqlDateTime h_ = context.Operators.Start(LTCPeriods);
@@ -477,7 +477,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private IEnumerable<Encounter> Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter AcuteInpatient)
 		{
 			Code<Encounter.EncounterStatus> g_ = AcuteInpatient?.StatusElement;
@@ -490,7 +490,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
 			CqlValueSet j_ = this.Advanced_Illness();
-			IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default(PropertyInfo));
+			IEnumerable<Condition> k_ = context.Operators.RetrieveByValueSet<Condition>(j_, default);
 			bool? l_(Condition AdvancedIllnessDiagnosis)
 			{
 				IEnumerable<Condition> p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(InpatientEncounter);
@@ -504,7 +504,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 				CqlDateTime z_ = context.Operators.End(u_);
 				CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-				bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default(string));
+				bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default);
 				CqlDateTime ad_ = context.Operators.End(u_);
 				bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
 				bool? af_ = context.Operators.And(ab_, ae_);
@@ -531,8 +531,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
-		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default(PropertyInfo));
+		IEnumerable<DeviceRequest> b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default);
+		IEnumerable<DeviceRequest> d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, default);
 		IEnumerable<DeviceRequest> e_ = context.Operators.Union<DeviceRequest>(b_, d_);
 		bool? f_(DeviceRequest FrailtyDeviceOrder)
 		{
@@ -551,14 +551,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			CqlInterval<CqlDateTime> ao_ = this.Measurement_Period();
 			FhirDateTime ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
 			CqlInterval<CqlDateTime> aq_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ap_ as object));
-			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default(string));
+			bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default);
 			bool? as_ = context.Operators.And(an_, ar_);
 
 			return as_;
 		};
 		IEnumerable<DeviceRequest> g_ = context.Operators.Where<DeviceRequest>(e_, f_);
 		bool? h_ = context.Operators.Exists<DeviceRequest>(g_);
-		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? k_(Observation FrailtyDeviceApplied)
 		{
 			Code<ObservationStatus> at_ = FrailtyDeviceApplied?.StatusElement;
@@ -572,7 +572,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			DataType ax_ = FrailtyDeviceApplied?.Effective;
 			CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ax_);
 			CqlInterval<CqlDateTime> az_ = this.Measurement_Period();
-			bool? ba_ = context.Operators.Overlaps(ay_, az_, default(string));
+			bool? ba_ = context.Operators.Overlaps(ay_, az_, default);
 			bool? bb_ = context.Operators.And(aw_, ba_);
 
 			return bb_;
@@ -581,12 +581,12 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? m_ = context.Operators.Exists<Observation>(l_);
 		bool? n_ = context.Operators.Or(h_, m_);
 		CqlValueSet o_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default(PropertyInfo));
+		IEnumerable<Condition> p_ = context.Operators.RetrieveByValueSet<Condition>(o_, default);
 		bool? q_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> bc_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(FrailtyDiagnosis);
 			CqlInterval<CqlDateTime> bd_ = this.Measurement_Period();
-			bool? be_ = context.Operators.Overlaps(bc_, bd_, default(string));
+			bool? be_ = context.Operators.Overlaps(bc_, bd_, default);
 
 			return be_;
 		};
@@ -594,7 +594,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? s_ = context.Operators.Exists<Condition>(r_);
 		bool? t_ = context.Operators.Or(n_, s_);
 		CqlValueSet u_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default(PropertyInfo));
+		IEnumerable<Encounter> v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, default);
 		bool? w_(Encounter FrailtyEncounter)
 		{
 			Code<Encounter.EncounterStatus> bf_ = FrailtyEncounter?.StatusElement;
@@ -603,7 +603,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			Period bi_ = FrailtyEncounter?.Period;
 			CqlInterval<CqlDateTime> bj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((bi_ as object));
 			CqlInterval<CqlDateTime> bk_ = this.Measurement_Period();
-			bool? bl_ = context.Operators.Overlaps(bj_, bk_, default(string));
+			bool? bl_ = context.Operators.Overlaps(bj_, bk_, default);
 			bool? bm_ = context.Operators.And(bh_, bl_);
 
 			return bm_;
@@ -612,7 +612,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		bool? y_ = context.Operators.Exists<Encounter>(x_);
 		bool? z_ = context.Operators.Or(t_, y_);
 		CqlValueSet aa_ = this.Frailty_Symptom();
-		IEnumerable<Observation> ab_ = context.Operators.RetrieveByValueSet<Observation>(aa_, default(PropertyInfo));
+		IEnumerable<Observation> ab_ = context.Operators.RetrieveByValueSet<Observation>(aa_, default);
 		bool? ac_(Observation FrailtySymptom)
 		{
 			Code<ObservationStatus> bn_ = FrailtySymptom?.StatusElement;
@@ -627,7 +627,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			DataType br_ = FrailtySymptom?.Effective;
 			CqlInterval<CqlDateTime> bs_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(br_);
 			CqlInterval<CqlDateTime> bt_ = this.Measurement_Period();
-			bool? bu_ = context.Operators.Overlaps(bs_, bt_, default(string));
+			bool? bu_ = context.Operators.Overlaps(bs_, bt_, default);
 			bool? bv_ = context.Operators.And(bq_, bu_);
 
 			return bv_;
@@ -654,7 +654,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(65, 79, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		IEnumerable<Encounter> m_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -112,7 +112,7 @@ public class BCSEHEDISMY2022_1_0_0
     #endregion
 
 	private CqlValueSet Absence_of_Left_Breast_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", default);
 
     [CqlDeclaration("Absence of Left Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329")]
@@ -120,7 +120,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Absence_of_Left_Breast.Value;
 
 	private CqlValueSet Absence_of_Right_Breast_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", default);
 
     [CqlDeclaration("Absence of Right Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330")]
@@ -128,7 +128,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Absence_of_Right_Breast.Value;
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", default);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042")]
@@ -136,7 +136,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet Bilateral_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", default);
 
     [CqlDeclaration("Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043")]
@@ -144,7 +144,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Bilateral_Modifier.Value;
 
 	private CqlValueSet Clinical_Bilateral_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", default);
 
     [CqlDeclaration("Clinical Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951")]
@@ -152,7 +152,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Bilateral_Modifier.Value;
 
 	private CqlValueSet Clinical_Left_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", default);
 
     [CqlDeclaration("Clinical Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949")]
@@ -160,7 +160,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Left_Modifier.Value;
 
 	private CqlValueSet Clinical_Right_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", default);
 
     [CqlDeclaration("Clinical Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950")]
@@ -168,7 +168,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Right_Modifier.Value;
 
 	private CqlValueSet Clinical_Unilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", default);
 
     [CqlDeclaration("Clinical Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948")]
@@ -176,7 +176,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Unilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", default);
 
     [CqlDeclaration("History of Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331")]
@@ -184,7 +184,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__History_of_Bilateral_Mastectomy.Value;
 
 	private CqlValueSet Left_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", default);
 
     [CqlDeclaration("Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148")]
@@ -192,7 +192,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Left_Modifier.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", default);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168")]
@@ -200,7 +200,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Mammography.Value;
 
 	private CqlValueSet Right_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", default);
 
     [CqlDeclaration("Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230")]
@@ -208,7 +208,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Right_Modifier.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", default);
 
     [CqlDeclaration("Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256")]
@@ -216,7 +216,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Unilateral_Mastectomy.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", default);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334")]
@@ -224,7 +224,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", default);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335")]
@@ -244,7 +244,7 @@ public class BCSEHEDISMY2022_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -286,13 +286,13 @@ public class BCSEHEDISMY2022_1_0_0
 
 	private IEnumerable<Coverage> Member_Coverage_Value()
 	{
-		IEnumerable<Coverage> a_ = context.Operators.RetrieveByValueSet<Coverage>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Coverage> a_ = context.Operators.RetrieveByValueSet<Coverage>(default, default);
 		bool? b_(Coverage C)
 		{
 			Period d_ = C?.Period;
 			CqlInterval<CqlDateTime> e_ = NCQAFHIRBase_1_0_0.Normalize_Interval((d_ as object));
 			CqlInterval<CqlDateTime> f_ = this.Participation_Period();
-			bool? g_ = context.Operators.Overlaps(e_, f_, default(string));
+			bool? g_ = context.Operators.Overlaps(e_, f_, default);
 
 			return g_;
 		};
@@ -359,7 +359,7 @@ public class BCSEHEDISMY2022_1_0_0
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(52, 74, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -389,7 +389,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Absence_of_Right_Breast();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition RightMastectomyDiagnosis)
 		{
@@ -397,7 +397,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
 
 			return j_;
 		};
@@ -413,10 +413,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -436,7 +436,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default);
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -462,7 +462,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
 
 			return ai_;
 		};
@@ -478,7 +478,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Absence_of_Left_Breast();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition LeftMastectomyDiagnosis)
 		{
@@ -486,7 +486,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
 
 			return j_;
 		};
@@ -502,10 +502,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -525,7 +525,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default);
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -551,7 +551,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
 
 			return ai_;
 		};
@@ -567,7 +567,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_Bilateral_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition BilateralMastectomyHistory)
 		{
@@ -575,7 +575,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
 
 			return j_;
 		};
@@ -591,10 +591,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default);
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -614,7 +614,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default);
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -640,7 +640,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
 
 			return ai_;
 		};
@@ -701,14 +701,14 @@ public class BCSEHEDISMY2022_1_0_0
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Mammogram)
 		{
 			DataType f_ = Mammogram?.Effective;
 			CqlInterval<CqlDateTime> g_ = NCQAFHIRBase_1_0_0.Normalize_Interval(f_);
 			CqlDateTime h_ = context.Operators.End(g_);
 			CqlInterval<CqlDateTime> i_ = this.Participation_Period();
-			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, default(string));
+			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, default);
 
 			return j_;
 		};

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -112,7 +112,7 @@ public class BCSEHEDISMY2022_1_0_0
     #endregion
 
 	private CqlValueSet Absence_of_Left_Breast_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", default(string));
 
     [CqlDeclaration("Absence of Left Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329")]
@@ -120,7 +120,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Absence_of_Left_Breast.Value;
 
 	private CqlValueSet Absence_of_Right_Breast_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", default(string));
 
     [CqlDeclaration("Absence of Right Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330")]
@@ -128,7 +128,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Absence_of_Right_Breast.Value;
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", default(string));
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042")]
@@ -136,7 +136,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet Bilateral_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", default(string));
 
     [CqlDeclaration("Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043")]
@@ -144,7 +144,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Bilateral_Modifier.Value;
 
 	private CqlValueSet Clinical_Bilateral_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", default(string));
 
     [CqlDeclaration("Clinical Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951")]
@@ -152,7 +152,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Bilateral_Modifier.Value;
 
 	private CqlValueSet Clinical_Left_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", default(string));
 
     [CqlDeclaration("Clinical Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949")]
@@ -160,7 +160,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Left_Modifier.Value;
 
 	private CqlValueSet Clinical_Right_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", default(string));
 
     [CqlDeclaration("Clinical Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950")]
@@ -168,7 +168,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Right_Modifier.Value;
 
 	private CqlValueSet Clinical_Unilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", default(string));
 
     [CqlDeclaration("Clinical Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948")]
@@ -176,7 +176,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Clinical_Unilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", default(string));
 
     [CqlDeclaration("History of Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331")]
@@ -184,7 +184,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__History_of_Bilateral_Mastectomy.Value;
 
 	private CqlValueSet Left_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", default(string));
 
     [CqlDeclaration("Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148")]
@@ -192,7 +192,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Left_Modifier.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", default(string));
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168")]
@@ -200,7 +200,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Mammography.Value;
 
 	private CqlValueSet Right_Modifier_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", default(string));
 
     [CqlDeclaration("Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230")]
@@ -208,7 +208,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Right_Modifier.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256")]
@@ -216,7 +216,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Unilateral_Mastectomy.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334")]
@@ -224,7 +224,7 @@ public class BCSEHEDISMY2022_1_0_0
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335")]
@@ -244,7 +244,7 @@ public class BCSEHEDISMY2022_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -286,13 +286,13 @@ public class BCSEHEDISMY2022_1_0_0
 
 	private IEnumerable<Coverage> Member_Coverage_Value()
 	{
-		IEnumerable<Coverage> a_ = context.Operators.RetrieveByValueSet<Coverage>(null, null);
+		IEnumerable<Coverage> a_ = context.Operators.RetrieveByValueSet<Coverage>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Coverage C)
 		{
 			Period d_ = C?.Period;
 			CqlInterval<CqlDateTime> e_ = NCQAFHIRBase_1_0_0.Normalize_Interval((d_ as object));
 			CqlInterval<CqlDateTime> f_ = this.Participation_Period();
-			bool? g_ = context.Operators.Overlaps(e_, f_, null);
+			bool? g_ = context.Operators.Overlaps(e_, f_, default(string));
 
 			return g_;
 		};
@@ -359,7 +359,7 @@ public class BCSEHEDISMY2022_1_0_0
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(52, 74, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		AdministrativeGender? m_ = l_?.Value;
 		string n_ = context.Operators.Convert<string>(m_);
@@ -389,7 +389,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Absence_of_Right_Breast();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition RightMastectomyDiagnosis)
 		{
@@ -397,7 +397,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, null);
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
 
 			return j_;
 		};
@@ -413,10 +413,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -436,7 +436,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -462,7 +462,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, null);
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
 
 			return ai_;
 		};
@@ -478,7 +478,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Absence_of_Left_Breast();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition LeftMastectomyDiagnosis)
 		{
@@ -486,7 +486,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, null);
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
 
 			return j_;
 		};
@@ -502,10 +502,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -525,7 +525,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -551,7 +551,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, null);
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
 
 			return ai_;
 		};
@@ -567,7 +567,7 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_Bilateral_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		IEnumerable<Condition> c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition BilateralMastectomyHistory)
 		{
@@ -575,7 +575,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.SameOrBefore(g_, i_, null);
+			bool? j_ = context.Operators.SameOrBefore(g_, i_, default(string));
 
 			return j_;
 		};
@@ -591,10 +591,10 @@ public class BCSEHEDISMY2022_1_0_0
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
 		CqlValueSet d_ = this.Unilateral_Mastectomy();
-		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
+		IEnumerable<Procedure> e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, default(PropertyInfo));
 		IEnumerable<Procedure> f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
@@ -614,7 +614,7 @@ public class BCSEHEDISMY2022_1_0_0
 		IEnumerable<Procedure> h_ = context.Operators.Where<Procedure>(f_, g_);
 		IEnumerable<Procedure> i_ = context.Operators.Union<Procedure>(c_, h_);
 		CqlValueSet j_ = this.Clinical_Unilateral_Mastectomy();
-		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
+		IEnumerable<Procedure> k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, default(PropertyInfo));
 		IEnumerable<Procedure> l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
@@ -640,7 +640,7 @@ public class BCSEHEDISMY2022_1_0_0
 			CqlDateTime af_ = context.Operators.End(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, null);
+			bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default(string));
 
 			return ai_;
 		};
@@ -701,14 +701,14 @@ public class BCSEHEDISMY2022_1_0_0
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Mammogram)
 		{
 			DataType f_ = Mammogram?.Effective;
 			CqlInterval<CqlDateTime> g_ = NCQAFHIRBase_1_0_0.Normalize_Interval(f_);
 			CqlDateTime h_ = context.Operators.End(g_);
 			CqlInterval<CqlDateTime> i_ = this.Participation_Period();
-			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, null);
+			bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, default(string));
 
 			return j_;
 		};

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("BCSEHEDISMY2022", "1.0.0")]
 public class BCSEHEDISMY2022_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("BreastCancerScreeningsFHIR", "0.0.009")]
 public class BreastCancerScreeningsFHIR_0_0_009
 {

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -120,7 +120,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
     #endregion
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
@@ -128,7 +128,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_bilateral_mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default);
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
@@ -136,7 +136,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__History_of_bilateral_mastectomy.Value;
 
 	private CqlValueSet Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default);
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
@@ -144,7 +144,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Left.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
@@ -152,7 +152,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Mammography.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -160,7 +160,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Online_Assessments.Value;
 
 	private CqlValueSet Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default);
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
@@ -168,7 +168,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Right.Value;
 
 	private CqlValueSet Status_Post_Left_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default);
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
@@ -176,7 +176,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Status_Post_Left_Mastectomy.Value;
 
 	private CqlValueSet Status_Post_Right_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default);
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
@@ -184,7 +184,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Status_Post_Right_Mastectomy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -192,7 +192,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
@@ -200,7 +200,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
@@ -208,7 +208,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Unilateral_Mastectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default);
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
@@ -217,8 +217,8 @@ public class BreastCancerScreeningsFHIR_0_0_009
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("BreastCancerScreeningsFHIR-0.0.009", "Measurement Period", c_);
 
@@ -231,7 +231,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -288,9 +288,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -300,7 +300,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -343,7 +343,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -375,9 +375,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Right_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -401,7 +401,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
 
 			return t_;
 		};
@@ -417,7 +417,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyRightPerformed?.StatusElement;
@@ -428,7 +428,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -445,9 +445,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Left_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -471,7 +471,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
 
 			return t_;
 		};
@@ -487,7 +487,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyLeftPerformed?.StatusElement;
@@ -498,7 +498,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -515,14 +515,14 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_bilateral_mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -538,7 +538,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			Code<EventStatus> e_ = BilateralMastectomyPerformed?.StatusElement;
@@ -549,7 +549,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -611,7 +611,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Observation_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -632,7 +632,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -653,7 +653,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Diagnostic_Report_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default);
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -674,7 +674,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -726,7 +726,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Observation_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -748,7 +748,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -769,7 +769,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Diagnostic_Report_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default);
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -791,7 +791,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -120,7 +120,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
     #endregion
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default(string));
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
@@ -128,7 +128,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_bilateral_mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default(string));
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
@@ -136,7 +136,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__History_of_bilateral_mastectomy.Value;
 
 	private CqlValueSet Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default(string));
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
@@ -144,7 +144,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Left.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default(string));
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
@@ -152,7 +152,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Mammography.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -160,7 +160,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Online_Assessments.Value;
 
 	private CqlValueSet Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default(string));
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
@@ -168,7 +168,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Right.Value;
 
 	private CqlValueSet Status_Post_Left_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default(string));
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
@@ -176,7 +176,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Status_Post_Left_Mastectomy.Value;
 
 	private CqlValueSet Status_Post_Right_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default(string));
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
@@ -184,7 +184,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Status_Post_Right_Mastectomy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -192,7 +192,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
@@ -200,7 +200,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
@@ -208,7 +208,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		__Unilateral_Mastectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
@@ -217,8 +217,8 @@ public class BreastCancerScreeningsFHIR_0_0_009
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("BreastCancerScreeningsFHIR-0.0.009", "Measurement Period", c_);
 
@@ -231,7 +231,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -288,9 +288,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -300,7 +300,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, null);
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -343,7 +343,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -375,9 +375,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Right_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -401,7 +401,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, null);
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
 
 			return t_;
 		};
@@ -417,7 +417,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyRightPerformed?.StatusElement;
@@ -428,7 +428,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -445,9 +445,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Left_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -471,7 +471,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, null);
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
 
 			return t_;
 		};
@@ -487,7 +487,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyLeftPerformed?.StatusElement;
@@ -498,7 +498,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -515,14 +515,14 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_bilateral_mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -538,7 +538,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			Code<EventStatus> e_ = BilateralMastectomyPerformed?.StatusElement;
@@ -549,7 +549,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -611,7 +611,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Observation_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -632,7 +632,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -653,7 +653,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Diagnostic_Report_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -674,7 +674,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -726,7 +726,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Observation_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -748,7 +748,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -769,7 +769,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 	private bool? Diagnostic_Report_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -791,7 +791,7 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -100,7 +100,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
     #endregion
 
 	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default);
 
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
@@ -108,7 +108,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Congenital_or_Acquired_Absence_of_Cervix.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -116,7 +116,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet HPV_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default);
 
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
@@ -124,7 +124,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__HPV_Test.Value;
 
 	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default);
 
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
@@ -132,7 +132,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Hysterectomy_with_No_Residual_Cervix.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -140,7 +140,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -148,7 +148,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default);
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -156,7 +156,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Pap_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -164,7 +164,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -172,7 +172,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -180,7 +180,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Telephone_Visits.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -189,7 +189,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -201,8 +201,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.005", "Measurement Period", c_);
 
@@ -215,7 +215,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -272,20 +272,20 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Telephone_Visits();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter ValidEncounter)
@@ -296,7 +296,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
 			Period x_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.ToInterval(x_);
-			bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, default(string));
+			bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, default);
 			bool? aa_ = context.Operators.And(v_, z_);
 
 			return aa_;
@@ -321,7 +321,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(23, 64, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -351,7 +351,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<object> Absence_of_Cervix_Value()
 	{
 		CqlValueSet a_ = this.Hysterectomy_with_No_Residual_Cervix();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure NoCervixProcedure)
 		{
 			Code<EventStatus> j_ = NoCervixProcedure?.StatusElement;
@@ -362,21 +362,21 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime o_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
 			CqlDateTime q_ = context.Operators.End(p_);
-			bool? r_ = context.Operators.SameOrBefore(o_, q_, default(string));
+			bool? r_ = context.Operators.SameOrBefore(o_, q_, default);
 			bool? s_ = context.Operators.And(l_, r_);
 
 			return s_;
 		};
 		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 		CqlValueSet e_ = this.Congenital_or_Acquired_Absence_of_Cervix();
-		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
+		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default);
 		bool? g_(Condition NoCervixDiagnosis)
 		{
 			CqlInterval<CqlDateTime> t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(NoCervixDiagnosis);
 			CqlDateTime u_ = context.Operators.Start(t_);
 			CqlInterval<CqlDateTime> v_ = this.Measurement_Period();
 			CqlDateTime w_ = context.Operators.End(v_);
-			bool? x_ = context.Operators.SameOrBefore(u_, w_, default(string));
+			bool? x_ = context.Operators.SameOrBefore(u_, w_, default);
 
 			return x_;
 		};
@@ -409,7 +409,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation CervicalCytology)
 		{
 			Code<ObservationStatus> e_ = CervicalCytology?.StatusElement;
@@ -441,7 +441,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
 			CqlDateTime u_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default);
 			CqlDateTime y_ = context.Operators.End(p_);
 			bool? z_ = context.Operators.Not((bool?)(y_ is null));
 			bool? aa_ = context.Operators.And(w_, z_);
@@ -464,7 +464,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation HPVTest)
 		{
 			Code<ObservationStatus> e_ = HPVTest?.StatusElement;
@@ -506,7 +506,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
 			CqlDateTime af_ = context.Operators.End(aa_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ad_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, default(string));
+			bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, default);
 			CqlDateTime aj_ = context.Operators.End(aa_);
 			bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
 			bool? al_ = context.Operators.And(ah_, ak_);
@@ -586,7 +586,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years__2__Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation CervicalCytology)
 		{
 			bool? e_ = this.isComplete(CervicalCytology);
@@ -600,7 +600,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -631,7 +631,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2__Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation HPVTest)
 		{
 			bool? e_ = this.isComplete(HPVTest);
@@ -655,7 +655,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 			CqlDateTime z_ = context.Operators.End(u_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-			bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default(string));
+			bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default);
 			CqlDateTime ad_ = context.Operators.End(u_);
 			bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
 			bool? af_ = context.Operators.And(ab_, ae_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -100,7 +100,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
     #endregion
 
 	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", default(string));
 
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
@@ -108,7 +108,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Congenital_or_Acquired_Absence_of_Cervix.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -116,7 +116,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet HPV_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", default(string));
 
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
@@ -124,7 +124,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__HPV_Test.Value;
 
 	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", default(string));
 
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
@@ -132,7 +132,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Hysterectomy_with_No_Residual_Cervix.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -140,7 +140,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -148,7 +148,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Online_Assessments.Value;
 
 	private CqlValueSet Pap_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", default(string));
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
@@ -156,7 +156,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Pap_Test.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -164,7 +164,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -172,7 +172,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -180,7 +180,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		__Telephone_Visits.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -189,7 +189,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -201,8 +201,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.005", "Measurement Period", c_);
 
@@ -215,7 +215,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -272,20 +272,20 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Home_Healthcare_Services();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Telephone_Visits();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Online_Assessments();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		bool? r_(Encounter ValidEncounter)
@@ -296,7 +296,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
 			Period x_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.ToInterval(x_);
-			bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, null);
+			bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, default(string));
 			bool? aa_ = context.Operators.And(v_, z_);
 
 			return aa_;
@@ -321,7 +321,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(23, 64, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -351,7 +351,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<object> Absence_of_Cervix_Value()
 	{
 		CqlValueSet a_ = this.Hysterectomy_with_No_Residual_Cervix();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure NoCervixProcedure)
 		{
 			Code<EventStatus> j_ = NoCervixProcedure?.StatusElement;
@@ -362,21 +362,21 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime o_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
 			CqlDateTime q_ = context.Operators.End(p_);
-			bool? r_ = context.Operators.SameOrBefore(o_, q_, null);
+			bool? r_ = context.Operators.SameOrBefore(o_, q_, default(string));
 			bool? s_ = context.Operators.And(l_, r_);
 
 			return s_;
 		};
 		IEnumerable<Procedure> d_ = context.Operators.Where<Procedure>(b_, c_);
 		CqlValueSet e_ = this.Congenital_or_Acquired_Absence_of_Cervix();
-		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
+		IEnumerable<Condition> f_ = context.Operators.RetrieveByValueSet<Condition>(e_, default(PropertyInfo));
 		bool? g_(Condition NoCervixDiagnosis)
 		{
 			CqlInterval<CqlDateTime> t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(NoCervixDiagnosis);
 			CqlDateTime u_ = context.Operators.Start(t_);
 			CqlInterval<CqlDateTime> v_ = this.Measurement_Period();
 			CqlDateTime w_ = context.Operators.End(v_);
-			bool? x_ = context.Operators.SameOrBefore(u_, w_, null);
+			bool? x_ = context.Operators.SameOrBefore(u_, w_, default(string));
 
 			return x_;
 		};
@@ -409,7 +409,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation CervicalCytology)
 		{
 			Code<ObservationStatus> e_ = CervicalCytology?.StatusElement;
@@ -441,7 +441,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime s_ = context.Operators.Subtract(q_, r_);
 			CqlDateTime u_ = context.Operators.End(p_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, null);
+			bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default(string));
 			CqlDateTime y_ = context.Operators.End(p_);
 			bool? z_ = context.Operators.Not((bool?)(y_ is null));
 			bool? aa_ = context.Operators.And(w_, z_);
@@ -464,7 +464,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation HPVTest)
 		{
 			Code<ObservationStatus> e_ = HPVTest?.StatusElement;
@@ -506,7 +506,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
 			CqlDateTime af_ = context.Operators.End(aa_);
 			CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ad_, af_, true, true);
-			bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, null);
+			bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, default(string));
 			CqlDateTime aj_ = context.Operators.End(aa_);
 			bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
 			bool? al_ = context.Operators.And(ah_, ak_);
@@ -586,7 +586,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years__2__Value()
 	{
 		CqlValueSet a_ = this.Pap_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation CervicalCytology)
 		{
 			bool? e_ = this.isComplete(CervicalCytology);
@@ -600,7 +600,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -631,7 +631,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2__Value()
 	{
 		CqlValueSet a_ = this.HPV_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation HPVTest)
 		{
 			bool? e_ = this.isComplete(HPVTest);
@@ -655,7 +655,7 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			CqlDateTime x_ = context.Operators.Subtract(v_, w_);
 			CqlDateTime z_ = context.Operators.End(u_);
 			CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-			bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, null);
+			bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default(string));
 			CqlDateTime ad_ = context.Operators.End(u_);
 			bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
 			bool? af_ = context.Operators.And(ab_, ae_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CervicalCancerScreeningFHIR", "0.0.005")]
 public class CervicalCancerScreeningFHIR_0_0_005
 {

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("ColorectalCancerScreeningsFHIR", "0.0.003")]
 public class ColorectalCancerScreeningsFHIR_0_0_003
 {

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -186,7 +186,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -194,7 +194,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -202,7 +202,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -210,7 +210,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -218,7 +218,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -226,7 +226,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -234,7 +234,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__CT_Colonography.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -242,7 +242,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -250,7 +250,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -258,7 +258,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -266,7 +266,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -274,7 +274,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet FIT_DNA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -282,7 +282,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__FIT_DNA.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -290,7 +290,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -298,7 +298,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -306,7 +306,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -314,7 +314,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -322,7 +322,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -330,7 +330,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -338,7 +338,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -346,7 +346,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -354,7 +354,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -362,7 +362,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -370,7 +370,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -378,7 +378,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -386,7 +386,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -394,7 +394,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Outpatient.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -402,7 +402,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -410,7 +410,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -418,7 +418,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -426,7 +426,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Total_Colectomy.Value;
 
 	private CqlValueSet Total_Colectomy_ICD9_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default(string));
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
@@ -434,7 +434,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Total_Colectomy_ICD9.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -443,7 +443,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -455,8 +455,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ColorectalCancerScreeningsFHIR-0.0.003", "Measurement Period", c_);
 
@@ -469,7 +469,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -526,9 +526,9 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -538,7 +538,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, null);
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -581,7 +581,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -609,14 +609,14 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ColorectalCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -632,7 +632,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colectomy)
 		{
 			Code<EventStatus> e_ = Colectomy?.StatusElement;
@@ -643,7 +643,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -660,14 +660,14 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Condition> Total_Colectomy_Condition_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy_ICD9();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ColectomyDx)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -719,7 +719,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			DataType g_ = FecalOccult?.Effective;
@@ -730,7 +730,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, false, false);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
 
 			return p_;
 		};
@@ -820,7 +820,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -881,7 +881,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default(string));
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -898,7 +898,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -976,7 +976,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			List<CodeableConcept> e_ = FecalOccult?.Category;
@@ -1046,7 +1046,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -1081,7 +1081,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			DataType g_ = FitDNA?.Effective;
@@ -1092,7 +1092,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
 			CqlDateTime r_ = context.Operators.End(i_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
 			bool? t_ = context.Operators.And(p_, s_);
@@ -1185,7 +1185,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1251,7 +1251,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, null);
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default(string));
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1271,7 +1271,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1357,7 +1357,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			List<CodeableConcept> e_ = FitDNA?.Category;
@@ -1435,7 +1435,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1478,7 +1478,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			DataType g_ = Colonography?.Effective;
@@ -1490,7 +1490,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1517,7 +1517,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1538,7 +1538,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1558,7 +1558,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1580,7 +1580,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -1600,7 +1600,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			DataType g_ = FlexibleSigmoidoscopy?.Performed;
@@ -1612,7 +1612,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1639,7 +1639,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1654,7 +1654,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1674,7 +1674,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1690,7 +1690,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1710,7 +1710,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			DataType g_ = Colonoscopy?.Performed;
@@ -1722,7 +1722,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1749,7 +1749,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1764,7 +1764,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1784,7 +1784,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1800,7 +1800,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -186,7 +186,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -194,7 +194,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -202,7 +202,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -210,7 +210,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -218,7 +218,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default);
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -226,7 +226,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default);
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -234,7 +234,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__CT_Colonography.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -242,7 +242,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -250,7 +250,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -258,7 +258,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -266,7 +266,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default);
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -274,7 +274,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet FIT_DNA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default);
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -282,7 +282,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__FIT_DNA.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default);
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -290,7 +290,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -298,7 +298,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -306,7 +306,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -314,7 +314,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -322,7 +322,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -330,7 +330,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -338,7 +338,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default);
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -346,7 +346,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -354,7 +354,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -362,7 +362,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -370,7 +370,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -378,7 +378,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -386,7 +386,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -394,7 +394,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Outpatient.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -402,7 +402,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -410,7 +410,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -418,7 +418,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default);
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -426,7 +426,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Total_Colectomy.Value;
 
 	private CqlValueSet Total_Colectomy_ICD9_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default);
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
@@ -434,7 +434,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		__Total_Colectomy_ICD9.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -443,7 +443,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -455,8 +455,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("ColorectalCancerScreeningsFHIR-0.0.003", "Measurement Period", c_);
 
@@ -469,7 +469,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -526,9 +526,9 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -538,7 +538,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -581,7 +581,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -609,14 +609,14 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ColorectalCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -632,7 +632,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colectomy)
 		{
 			Code<EventStatus> e_ = Colectomy?.StatusElement;
@@ -643,7 +643,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -660,14 +660,14 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Condition> Total_Colectomy_Condition_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy_ICD9();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ColectomyDx)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -719,7 +719,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			DataType g_ = FecalOccult?.Effective;
@@ -730,7 +730,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, false, false);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default);
 
 			return p_;
 		};
@@ -820,7 +820,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -881,7 +881,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -898,7 +898,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -976,7 +976,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			List<CodeableConcept> e_ = FecalOccult?.Category;
@@ -1046,7 +1046,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -1081,7 +1081,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			DataType g_ = FitDNA?.Effective;
@@ -1092,7 +1092,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default);
 			CqlDateTime r_ = context.Operators.End(i_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
 			bool? t_ = context.Operators.And(p_, s_);
@@ -1185,7 +1185,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1251,7 +1251,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default(string));
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default);
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1271,7 +1271,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1357,7 +1357,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			List<CodeableConcept> e_ = FitDNA?.Category;
@@ -1435,7 +1435,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1478,7 +1478,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			DataType g_ = Colonography?.Effective;
@@ -1490,7 +1490,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1517,7 +1517,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1538,7 +1538,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1558,7 +1558,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1580,7 +1580,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -1600,7 +1600,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			DataType g_ = FlexibleSigmoidoscopy?.Performed;
@@ -1612,7 +1612,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1639,7 +1639,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1654,7 +1654,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1674,7 +1674,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1690,7 +1690,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1710,7 +1710,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			DataType g_ = Colonoscopy?.Performed;
@@ -1722,7 +1722,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1749,7 +1749,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1764,7 +1764,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1784,7 +1784,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1800,7 +1800,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -96,182 +96,182 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
     #endregion
 
 	private CqlCode AC_Value() => 
-		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("AC")]
 	public CqlCode AC() => 
 		__AC.Value;
 
 	private CqlCode ACD_Value() => 
-		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACD")]
 	public CqlCode ACD() => 
 		__ACD.Value;
 
 	private CqlCode ACM_Value() => 
-		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACM")]
 	public CqlCode ACM() => 
 		__ACM.Value;
 
 	private CqlCode ACV_Value() => 
-		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("ACV")]
 	public CqlCode ACV() => 
 		__ACV.Value;
 
 	private CqlCode AFT_Value() => 
-		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT")]
 	public CqlCode AFT() => 
 		__AFT.Value;
 
 	private CqlCode AFT_early_Value() => 
-		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT.early")]
 	public CqlCode AFT_early() => 
 		__AFT_early.Value;
 
 	private CqlCode AFT_late_Value() => 
-		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("AFT.late")]
 	public CqlCode AFT_late() => 
 		__AFT_late.Value;
 
 	private CqlCode C_Value() => 
-		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("C")]
 	public CqlCode C() => 
 		__C.Value;
 
 	private CqlCode CD_Value() => 
-		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CD")]
 	public CqlCode CD() => 
 		__CD.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode CV_Value() => 
-		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("CV")]
 	public CqlCode CV() => 
 		__CV.Value;
 
 	private CqlCode EVE_Value() => 
-		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE")]
 	public CqlCode EVE() => 
 		__EVE.Value;
 
 	private CqlCode EVE_early_Value() => 
-		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE.early")]
 	public CqlCode EVE_early() => 
 		__EVE_early.Value;
 
 	private CqlCode EVE_late_Value() => 
-		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("EVE.late")]
 	public CqlCode EVE_late() => 
 		__EVE_late.Value;
 
 	private CqlCode HS_Value() => 
-		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("HS")]
 	public CqlCode HS() => 
 		__HS.Value;
 
 	private CqlCode MORN_Value() => 
-		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN")]
 	public CqlCode MORN() => 
 		__MORN.Value;
 
 	private CqlCode MORN_early_Value() => 
-		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN.early")]
 	public CqlCode MORN_early() => 
 		__MORN_early.Value;
 
 	private CqlCode MORN_late_Value() => 
-		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("MORN.late")]
 	public CqlCode MORN_late() => 
 		__MORN_late.Value;
 
 	private CqlCode NIGHT_Value() => 
-		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("NIGHT")]
 	public CqlCode NIGHT() => 
 		__NIGHT.Value;
 
 	private CqlCode NOON_Value() => 
-		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("NOON")]
 	public CqlCode NOON() => 
 		__NOON.Value;
 
 	private CqlCode PC_Value() => 
-		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PC")]
 	public CqlCode PC() => 
 		__PC.Value;
 
 	private CqlCode PCD_Value() => 
-		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCD")]
 	public CqlCode PCD() => 
 		__PCD.Value;
 
 	private CqlCode PCM_Value() => 
-		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCM")]
 	public CqlCode PCM() => 
 		__PCM.Value;
 
 	private CqlCode PCV_Value() => 
-		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("PCV")]
 	public CqlCode PCV() => 
 		__PCV.Value;
 
 	private CqlCode PHS_Value() => 
-		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null);
+		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string));
 
     [CqlDeclaration("PHS")]
 	public CqlCode PHS() => 
 		__PHS.Value;
 
 	private CqlCode WAKE_Value() => 
-		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
+		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
 
     [CqlDeclaration("WAKE")]
 	public CqlCode WAKE() => 
@@ -280,20 +280,20 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	private CqlCode[] V3TimingEvent_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
-			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null),
+			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
 		];
 
 		return a_;
@@ -306,18 +306,18 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	private CqlCode[] EventTiming_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null),
-			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null),
+			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string)),
 		];
 
 		return a_;
@@ -340,7 +340,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -96,182 +96,182 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
     #endregion
 
 	private CqlCode AC_Value() => 
-		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("AC")]
 	public CqlCode AC() => 
 		__AC.Value;
 
 	private CqlCode ACD_Value() => 
-		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACD")]
 	public CqlCode ACD() => 
 		__ACD.Value;
 
 	private CqlCode ACM_Value() => 
-		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACM")]
 	public CqlCode ACM() => 
 		__ACM.Value;
 
 	private CqlCode ACV_Value() => 
-		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("ACV")]
 	public CqlCode ACV() => 
 		__ACV.Value;
 
 	private CqlCode AFT_Value() => 
-		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT")]
 	public CqlCode AFT() => 
 		__AFT.Value;
 
 	private CqlCode AFT_early_Value() => 
-		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT.early")]
 	public CqlCode AFT_early() => 
 		__AFT_early.Value;
 
 	private CqlCode AFT_late_Value() => 
-		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("AFT.late")]
 	public CqlCode AFT_late() => 
 		__AFT_late.Value;
 
 	private CqlCode C_Value() => 
-		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("C")]
 	public CqlCode C() => 
 		__C.Value;
 
 	private CqlCode CD_Value() => 
-		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CD")]
 	public CqlCode CD() => 
 		__CD.Value;
 
 	private CqlCode CM_Value() => 
-		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CM")]
 	public CqlCode CM() => 
 		__CM.Value;
 
 	private CqlCode CV_Value() => 
-		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("CV")]
 	public CqlCode CV() => 
 		__CV.Value;
 
 	private CqlCode EVE_Value() => 
-		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE")]
 	public CqlCode EVE() => 
 		__EVE.Value;
 
 	private CqlCode EVE_early_Value() => 
-		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE.early")]
 	public CqlCode EVE_early() => 
 		__EVE_early.Value;
 
 	private CqlCode EVE_late_Value() => 
-		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("EVE.late")]
 	public CqlCode EVE_late() => 
 		__EVE_late.Value;
 
 	private CqlCode HS_Value() => 
-		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("HS")]
 	public CqlCode HS() => 
 		__HS.Value;
 
 	private CqlCode MORN_Value() => 
-		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN")]
 	public CqlCode MORN() => 
 		__MORN.Value;
 
 	private CqlCode MORN_early_Value() => 
-		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN.early")]
 	public CqlCode MORN_early() => 
 		__MORN_early.Value;
 
 	private CqlCode MORN_late_Value() => 
-		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("MORN.late")]
 	public CqlCode MORN_late() => 
 		__MORN_late.Value;
 
 	private CqlCode NIGHT_Value() => 
-		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("NIGHT")]
 	public CqlCode NIGHT() => 
 		__NIGHT.Value;
 
 	private CqlCode NOON_Value() => 
-		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("NOON")]
 	public CqlCode NOON() => 
 		__NOON.Value;
 
 	private CqlCode PC_Value() => 
-		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PC")]
 	public CqlCode PC() => 
 		__PC.Value;
 
 	private CqlCode PCD_Value() => 
-		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCD")]
 	public CqlCode PCD() => 
 		__PCD.Value;
 
 	private CqlCode PCM_Value() => 
-		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCM")]
 	public CqlCode PCM() => 
 		__PCM.Value;
 
 	private CqlCode PCV_Value() => 
-		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("PCV")]
 	public CqlCode PCV() => 
 		__PCV.Value;
 
 	private CqlCode PHS_Value() => 
-		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string));
+		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default, default);
 
     [CqlDeclaration("PHS")]
 	public CqlCode PHS() => 
 		__PHS.Value;
 
 	private CqlCode WAKE_Value() => 
-		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string));
+		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default);
 
     [CqlDeclaration("WAKE")]
 	public CqlCode WAKE() => 
@@ -280,20 +280,20 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	private CqlCode[] V3TimingEvent_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
-			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default(string), default(string)),
+			new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
+			new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", default, default),
 		];
 
 		return a_;
@@ -306,18 +306,18 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	private CqlCode[] EventTiming_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default(string), default(string)),
-			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default(string), default(string)),
+			new CqlCode("AFT", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("MORN", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("NOON", "http://hl7.org/fhir/event-timing", default, default),
+			new CqlCode("PHS", "http://hl7.org/fhir/event-timing", default, default),
 		];
 
 		return a_;
@@ -340,7 +340,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("CumulativeMedicationDurationFHIR4", "1.0.000")]
 public class CumulativeMedicationDurationFHIR4_1_0_000
 {

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -120,7 +120,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -128,7 +128,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default);
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -136,7 +136,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default);
 
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
@@ -144,7 +144,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Level_of_Severity_of_Retinopathy_Findings.Value;
 
 	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default);
 
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
@@ -152,7 +152,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Macular_Edema_Findings_Present.Value;
 
 	private CqlValueSet Macular_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default);
 
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
@@ -160,7 +160,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Macular_Exam.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -168,7 +168,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -176,7 +176,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -184,7 +184,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -192,7 +192,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -200,7 +200,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default);
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -208,49 +208,49 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Patient_Reason.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Healthcare_professional__occupation__Value() => 
-		new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("223366009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Healthcare professional (occupation)")]
 	public CqlCode Healthcare_professional__occupation_() => 
 		__Healthcare_professional__occupation_.Value;
 
 	private CqlCode Macular_edema_absent__situation__Value() => 
-		new CqlCode("428341000124108", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428341000124108", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Macular edema absent (situation)")]
 	public CqlCode Macular_edema_absent__situation_() => 
 		__Macular_edema_absent__situation_.Value;
 
 	private CqlCode Medical_practitioner__occupation__Value() => 
-		new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("158965000", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Medical practitioner (occupation)")]
 	public CqlCode Medical_practitioner__occupation_() => 
 		__Medical_practitioner__occupation_.Value;
 
 	private CqlCode Ophthalmologist__occupation__Value() => 
-		new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("422234006", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Ophthalmologist (occupation)")]
 	public CqlCode Ophthalmologist__occupation_() => 
 		__Ophthalmologist__occupation_.Value;
 
 	private CqlCode Optometrist__occupation__Value() => 
-		new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("28229004", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Optometrist (occupation)")]
 	public CqlCode Optometrist__occupation_() => 
 		__Optometrist__occupation_.Value;
 
 	private CqlCode Physician__occupation__Value() => 
-		new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("309343006", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Physician (occupation)")]
 	public CqlCode Physician__occupation_() => 
@@ -259,7 +259,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -272,12 +272,12 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428341000124108", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("223366009", "http://snomed.info/sct", default, default),
+			new CqlCode("428341000124108", "http://snomed.info/sct", default, default),
+			new CqlCode("158965000", "http://snomed.info/sct", default, default),
+			new CqlCode("422234006", "http://snomed.info/sct", default, default),
+			new CqlCode("28229004", "http://snomed.info/sct", default, default),
+			new CqlCode("309343006", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -300,7 +300,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -357,25 +357,25 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_0_001.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default);
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			string v_ = FHIRHelpers_4_0_001.ToString(u_);
 			bool? w_ = context.Operators.Equal(v_, "finished");
@@ -398,7 +398,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default);
 			bool? f_(Condition DiabeticRetinopathy)
 			{
 				CodeableConcept j_ = DiabeticRetinopathy?.ClinicalStatus;
@@ -409,7 +409,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(DiabeticRetinopathy);
 				Period p_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
-				bool? r_ = context.Operators.Overlaps(o_, q_, default(string));
+				bool? r_ = context.Operators.Overlaps(o_, q_, default);
 				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
@@ -476,7 +476,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)LevelOfSeverityNotCommunicated, "qicore-recorded");
 				DataType p_ = o_?.Value;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval((p_ as Period));
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default(string));
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
 
 				return r_;
 			};
@@ -535,7 +535,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)MacularEdemaAbsentNotCommunicated, "qicore-recorded");
 				DataType q_ = p_?.Value;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_0_001.ToInterval((q_ as Period));
-				bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default(string));
+				bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
 
 				return s_;
 			};
@@ -593,7 +593,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)MacularEdemaPresentNotCommunicated, "qicore-recorded");
 				DataType p_ = o_?.Value;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval((p_ as Period));
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default(string));
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
 
 				return r_;
 			};
@@ -678,7 +678,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private IEnumerable<Observation> Macular_Exam_Performed_Value()
 	{
 		CqlValueSet a_ = this.Macular_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
 			IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter();
@@ -688,7 +688,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 				DataType n_ = MacularExam?.Effective;
 				CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(n_);
-				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, default(string));
+				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, default);
 
 				return p_;
 			};
@@ -754,7 +754,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, default(string));
+				bool? r_ = context.Operators.After(n_, q_, default);
 
 				return r_;
 			};
@@ -799,7 +799,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period p_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
 				CqlDateTime r_ = context.Operators.Start(q_);
-				bool? s_ = context.Operators.After(o_, r_, default(string));
+				bool? s_ = context.Operators.After(o_, r_, default);
 
 				return s_;
 			};
@@ -843,7 +843,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, default(string));
+				bool? r_ = context.Operators.After(n_, q_, default);
 
 				return r_;
 			};

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -120,7 +120,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
     #endregion
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -128,7 +128,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Diabetic_Retinopathy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", default(string));
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
@@ -136,7 +136,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Diabetic_Retinopathy.Value;
 
 	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", default(string));
 
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
@@ -144,7 +144,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Level_of_Severity_of_Retinopathy_Findings.Value;
 
 	private CqlValueSet Macular_Edema_Findings_Present_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", default(string));
 
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
@@ -152,7 +152,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Macular_Edema_Findings_Present.Value;
 
 	private CqlValueSet Macular_Exam_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", default(string));
 
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
@@ -160,7 +160,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Macular_Exam.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
@@ -168,7 +168,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Medical_Reason.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -176,7 +176,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -184,7 +184,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Office_Visit.Value;
 
 	private CqlValueSet Ophthalmological_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", default(string));
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
@@ -192,7 +192,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Ophthalmological_Services.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -200,7 +200,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Patient_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", default(string));
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
@@ -208,49 +208,49 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		__Patient_Reason.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Healthcare_professional__occupation__Value() => 
-		new CqlCode("223366009", "http://snomed.info/sct", null, null);
+		new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Healthcare professional (occupation)")]
 	public CqlCode Healthcare_professional__occupation_() => 
 		__Healthcare_professional__occupation_.Value;
 
 	private CqlCode Macular_edema_absent__situation__Value() => 
-		new CqlCode("428341000124108", "http://snomed.info/sct", null, null);
+		new CqlCode("428341000124108", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Macular edema absent (situation)")]
 	public CqlCode Macular_edema_absent__situation_() => 
 		__Macular_edema_absent__situation_.Value;
 
 	private CqlCode Medical_practitioner__occupation__Value() => 
-		new CqlCode("158965000", "http://snomed.info/sct", null, null);
+		new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Medical practitioner (occupation)")]
 	public CqlCode Medical_practitioner__occupation_() => 
 		__Medical_practitioner__occupation_.Value;
 
 	private CqlCode Ophthalmologist__occupation__Value() => 
-		new CqlCode("422234006", "http://snomed.info/sct", null, null);
+		new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Ophthalmologist (occupation)")]
 	public CqlCode Ophthalmologist__occupation_() => 
 		__Ophthalmologist__occupation_.Value;
 
 	private CqlCode Optometrist__occupation__Value() => 
-		new CqlCode("28229004", "http://snomed.info/sct", null, null);
+		new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Optometrist (occupation)")]
 	public CqlCode Optometrist__occupation_() => 
 		__Optometrist__occupation_.Value;
 
 	private CqlCode Physician__occupation__Value() => 
-		new CqlCode("309343006", "http://snomed.info/sct", null, null);
+		new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Physician (occupation)")]
 	public CqlCode Physician__occupation_() => 
@@ -259,7 +259,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -272,12 +272,12 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("223366009", "http://snomed.info/sct", null, null),
-			new CqlCode("428341000124108", "http://snomed.info/sct", null, null),
-			new CqlCode("158965000", "http://snomed.info/sct", null, null),
-			new CqlCode("422234006", "http://snomed.info/sct", null, null),
-			new CqlCode("28229004", "http://snomed.info/sct", null, null),
-			new CqlCode("309343006", "http://snomed.info/sct", null, null),
+			new CqlCode("223366009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428341000124108", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("158965000", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("422234006", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("28229004", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("309343006", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -300,7 +300,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -357,25 +357,25 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Ophthalmological_Services();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Nursing_Facility_Visit();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
 			CqlInterval<CqlDateTime> q_ = this.Measurement_Period();
 			Period r_ = QualifyingEncounter?.Period;
 			CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_0_001.ToInterval(r_);
-			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, null);
+			bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default(string));
 			Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
 			string v_ = FHIRHelpers_4_0_001.ToString(u_);
 			bool? w_ = context.Operators.Equal(v_, "finished");
@@ -398,7 +398,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Diabetic_Retinopathy();
-			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
+			IEnumerable<Condition> e_ = context.Operators.RetrieveByValueSet<Condition>(d_, default(PropertyInfo));
 			bool? f_(Condition DiabeticRetinopathy)
 			{
 				CodeableConcept j_ = DiabeticRetinopathy?.ClinicalStatus;
@@ -409,7 +409,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(DiabeticRetinopathy);
 				Period p_ = ValidQualifyingEncounter?.Period;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
-				bool? r_ = context.Operators.Overlaps(o_, q_, null);
+				bool? r_ = context.Operators.Overlaps(o_, q_, default(string));
 				bool? s_ = context.Operators.And(n_, r_);
 
 				return s_;
@@ -476,7 +476,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)LevelOfSeverityNotCommunicated, "qicore-recorded");
 				DataType p_ = o_?.Value;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval((p_ as Period));
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, null);
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default(string));
 
 				return r_;
 			};
@@ -535,7 +535,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)MacularEdemaAbsentNotCommunicated, "qicore-recorded");
 				DataType q_ = p_?.Value;
 				CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_0_001.ToInterval((q_ as Period));
-				bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, null);
+				bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default(string));
 
 				return s_;
 			};
@@ -593,7 +593,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Extension o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension((DomainResource)MacularEdemaPresentNotCommunicated, "qicore-recorded");
 				DataType p_ = o_?.Value;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval((p_ as Period));
-				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, null);
+				bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default(string));
 
 				return r_;
 			};
@@ -678,7 +678,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	private IEnumerable<Observation> Macular_Exam_Performed_Value()
 	{
 		CqlValueSet a_ = this.Macular_Exam();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
 			IEnumerable<Encounter> g_ = this.Diabetic_Retinopathy_Encounter();
@@ -688,7 +688,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 				DataType n_ = MacularExam?.Effective;
 				CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(n_);
-				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, null);
+				bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, default(string));
 
 				return p_;
 			};
@@ -754,7 +754,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, null);
+				bool? r_ = context.Operators.After(n_, q_, default(string));
 
 				return r_;
 			};
@@ -799,7 +799,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period p_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
 				CqlDateTime r_ = context.Operators.Start(q_);
-				bool? s_ = context.Operators.After(o_, r_, null);
+				bool? s_ = context.Operators.After(o_, r_, default(string));
 
 				return s_;
 			};
@@ -843,7 +843,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 				Period o_ = EncounterDiabeticRetinopathy?.Period;
 				CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.ToInterval(o_);
 				CqlDateTime q_ = context.Operators.Start(p_);
-				bool? r_ = context.Operators.After(n_, q_, null);
+				bool? r_ = context.Operators.After(n_, q_, default(string));
 
 				return r_;
 			};

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.0.004")]
 public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 {

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -54,14 +54,14 @@ public class DevDays_2023_0_0
     #endregion
 
 	private CqlCode Sucked_into_jet_engine_Value() => 
-		new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", null, null);
+		new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default(string), default(string));
 
     [CqlDeclaration("Sucked into jet engine")]
 	public CqlCode Sucked_into_jet_engine() => 
 		__Sucked_into_jet_engine.Value;
 
 	private CqlCode Sucked_into_jet_engine__subsequent_encounter_Value() => 
-		new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", null, null);
+		new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default(string), default(string));
 
     [CqlDeclaration("Sucked into jet engine, subsequent encounter")]
 	public CqlCode Sucked_into_jet_engine__subsequent_encounter() => 
@@ -70,8 +70,8 @@ public class DevDays_2023_0_0
 	private CqlCode[] ICD10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", null, null),
-			new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", null, null),
+			new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default(string), default(string)),
+			new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default(string), default(string)),
 		];
 
 		return a_;
@@ -94,7 +94,7 @@ public class DevDays_2023_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -106,7 +106,7 @@ public class DevDays_2023_0_0
 
 	private IEnumerable<Condition> Jet_engine_conditions_Value()
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Condition c)
 		{
 			CodeableConcept d_ = c?.Code;
@@ -124,7 +124,7 @@ public class DevDays_2023_0_0
 			DataType i_ = c?.Onset;
 			CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime((i_ as FhirDateTime));
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, null);
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
@@ -140,7 +140,7 @@ public class DevDays_2023_0_0
 
 	private IEnumerable<Condition> Subsequent_encounters_Value()
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Condition c)
 		{
 			CodeableConcept d_ = c?.Code;
@@ -158,7 +158,7 @@ public class DevDays_2023_0_0
 			DataType i_ = c?.Onset;
 			CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime((i_ as FhirDateTime));
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, null);
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DevDays", "2023.0.0")]
 public class DevDays_2023_0_0
 {

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -54,14 +54,14 @@ public class DevDays_2023_0_0
     #endregion
 
 	private CqlCode Sucked_into_jet_engine_Value() => 
-		new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default(string), default(string));
+		new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default, default);
 
     [CqlDeclaration("Sucked into jet engine")]
 	public CqlCode Sucked_into_jet_engine() => 
 		__Sucked_into_jet_engine.Value;
 
 	private CqlCode Sucked_into_jet_engine__subsequent_encounter_Value() => 
-		new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default(string), default(string));
+		new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default, default);
 
     [CqlDeclaration("Sucked into jet engine, subsequent encounter")]
 	public CqlCode Sucked_into_jet_engine__subsequent_encounter() => 
@@ -70,8 +70,8 @@ public class DevDays_2023_0_0
 	private CqlCode[] ICD10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default(string), default(string)),
-			new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default(string), default(string)),
+			new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", default, default),
+			new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", default, default),
 		];
 
 		return a_;
@@ -94,7 +94,7 @@ public class DevDays_2023_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -106,7 +106,7 @@ public class DevDays_2023_0_0
 
 	private IEnumerable<Condition> Jet_engine_conditions_Value()
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 		bool? b_(Condition c)
 		{
 			CodeableConcept d_ = c?.Code;
@@ -124,7 +124,7 @@ public class DevDays_2023_0_0
 			DataType i_ = c?.Onset;
 			CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime((i_ as FhirDateTime));
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;
@@ -140,7 +140,7 @@ public class DevDays_2023_0_0
 
 	private IEnumerable<Condition> Subsequent_encounters_Value()
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 		bool? b_(Condition c)
 		{
 			CodeableConcept d_ = c?.Code;
@@ -158,7 +158,7 @@ public class DevDays_2023_0_0
 			DataType i_ = c?.Onset;
 			CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime((i_ as FhirDateTime));
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
 			bool? m_ = context.Operators.And(h_, l_);
 
 			return m_;

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -108,7 +108,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -116,7 +116,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -124,7 +124,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Diabetes.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -132,7 +132,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -140,7 +140,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -148,7 +148,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default(string));
 
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
@@ -156,7 +156,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__HbA1c_Laboratory_Test.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -164,7 +164,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -172,7 +172,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -180,7 +180,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Office_Visit.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -188,7 +188,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -196,7 +196,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -204,7 +204,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Telephone_Visits.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -213,7 +213,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -236,7 +236,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -293,7 +293,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Telephone_Visits();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter TelehealthEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = TelehealthEncounter?.StatusElement;
@@ -302,7 +302,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			Period i_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((i_ as object));
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, null);
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, default(string));
 			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
@@ -327,19 +327,19 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
 		bool? n_ = context.Operators.Exists<Encounter>(m_);
 		bool? o_ = context.Operators.And(j_, n_);
 		CqlValueSet p_ = this.Diabetes();
-		IEnumerable<Condition> q_ = context.Operators.RetrieveByValueSet<Condition>(p_, null);
+		IEnumerable<Condition> q_ = context.Operators.RetrieveByValueSet<Condition>(p_, default(PropertyInfo));
 		bool? r_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
-			bool? x_ = context.Operators.Overlaps(v_, w_, null);
+			bool? x_ = context.Operators.Overlaps(v_, w_, default(string));
 
 			return x_;
 		};
@@ -368,7 +368,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private Observation Most_Recent_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation RecentHbA1c)
 		{
 			Code<ObservationStatus> h_ = RecentHbA1c?.StatusElement;
@@ -382,7 +382,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			DataType l_ = RecentHbA1c?.Effective;
 			CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
 			bool? p_ = context.Operators.And(k_, o_);
 
 			return p_;
@@ -438,7 +438,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private bool? Has_No_Record_Of_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation NoHbA1c)
 		{
 			Code<ObservationStatus> g_ = NoHbA1c?.StatusElement;
@@ -452,7 +452,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			DataType k_ = NoHbA1c?.Effective;
 			CqlDateTime l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(k_);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, null);
+			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR", "0.0.015")]
 public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 {

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -108,7 +108,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -116,7 +116,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -124,7 +124,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Diabetes.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -132,7 +132,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -140,7 +140,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -148,7 +148,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet HbA1c_Laboratory_Test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", default);
 
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
@@ -156,7 +156,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__HbA1c_Laboratory_Test.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -164,7 +164,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -172,7 +172,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -180,7 +180,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Office_Visit.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -188,7 +188,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -196,7 +196,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -204,7 +204,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		__Telephone_Visits.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -213,7 +213,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -236,7 +236,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -293,7 +293,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Telephone_Visits();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter TelehealthEncounter)
 		{
 			Code<Encounter.EncounterStatus> e_ = TelehealthEncounter?.StatusElement;
@@ -302,7 +302,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			Period i_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((i_ as object));
-			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, default(string));
+			bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, default);
 			bool? l_ = context.Operators.And(g_, k_);
 
 			return l_;
@@ -327,19 +327,19 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
 		bool? n_ = context.Operators.Exists<Encounter>(m_);
 		bool? o_ = context.Operators.And(j_, n_);
 		CqlValueSet p_ = this.Diabetes();
-		IEnumerable<Condition> q_ = context.Operators.RetrieveByValueSet<Condition>(p_, default(PropertyInfo));
+		IEnumerable<Condition> q_ = context.Operators.RetrieveByValueSet<Condition>(p_, default);
 		bool? r_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
 			CqlInterval<CqlDateTime> w_ = this.Measurement_Period();
-			bool? x_ = context.Operators.Overlaps(v_, w_, default(string));
+			bool? x_ = context.Operators.Overlaps(v_, w_, default);
 
 			return x_;
 		};
@@ -368,7 +368,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private Observation Most_Recent_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation RecentHbA1c)
 		{
 			Code<ObservationStatus> h_ = RecentHbA1c?.StatusElement;
@@ -382,7 +382,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			DataType l_ = RecentHbA1c?.Effective;
 			CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(l_);
 			CqlInterval<CqlDateTime> n_ = this.Measurement_Period();
-			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
+			bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
 			bool? p_ = context.Operators.And(k_, o_);
 
 			return p_;
@@ -438,7 +438,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 	private bool? Has_No_Record_Of_HbA1c_Value()
 	{
 		CqlValueSet a_ = this.HbA1c_Laboratory_Test();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation NoHbA1c)
 		{
 			Code<ObservationStatus> g_ = NoHbA1c?.StatusElement;
@@ -452,7 +452,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 			DataType k_ = NoHbA1c?.Effective;
 			CqlDateTime l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(k_);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default(string));
+			bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -102,7 +102,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
     #endregion
 
 	private CqlValueSet Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", default);
 
     [CqlDeclaration("Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201")]
@@ -110,7 +110,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Antithrombotic_Therapy.Value;
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default);
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -118,7 +118,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -126,7 +126,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -134,7 +134,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -142,7 +142,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -150,7 +150,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default);
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -158,7 +158,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -166,7 +166,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -174,7 +174,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -182,7 +182,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Medical_Reason.Value;
 
 	private CqlValueSet Non_Elective_Inpatient_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default);
 
     [CqlDeclaration("Non-Elective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -190,7 +190,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Non_Elective_Inpatient_Encounter.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -198,7 +198,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Patient_Expired.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default);
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -206,7 +206,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Patient_Refusal.Value;
 
 	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default);
 
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
@@ -226,7 +226,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -250,7 +250,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Antithrombotic_Not_Given_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		bool? c_(MedicationRequest NoAntithromboticDischarge)
 		{
 			FhirBoolean e_ = NoAntithromboticDischarge?.DoNotPerformElement;
@@ -330,7 +330,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};
@@ -353,7 +353,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		bool? c_(MedicationRequest Pharmacological)
 		{
 			FhirBoolean e_ = Pharmacological?.DoNotPerformElement;
@@ -413,7 +413,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};
@@ -473,7 +473,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		bool? c_(MedicationRequest Antithrombotic)
 		{
 			FhirBoolean e_ = Antithrombotic?.DoNotPerformElement;
@@ -533,7 +533,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
 
 				return m_;
 			};

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.0.010")]
 public class DischargedonAntithromboticTherapyFHIR_0_0_010
 {

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -102,7 +102,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
     #endregion
 
 	private CqlValueSet Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", default(string));
 
     [CqlDeclaration("Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201")]
@@ -110,7 +110,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Antithrombotic_Therapy.Value;
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -118,7 +118,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -126,7 +126,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -134,7 +134,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -142,7 +142,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -150,7 +150,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -158,7 +158,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -166,7 +166,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -174,7 +174,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Medical_Reason_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", default(string));
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
@@ -182,7 +182,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Medical_Reason.Value;
 
 	private CqlValueSet Non_Elective_Inpatient_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
 
     [CqlDeclaration("Non-Elective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -190,7 +190,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Non_Elective_Inpatient_Encounter.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -198,7 +198,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Patient_Expired.Value;
 
 	private CqlValueSet Patient_Refusal_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", default(string));
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
@@ -206,7 +206,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		__Patient_Refusal.Value;
 
 	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", default(string));
 
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
@@ -226,7 +226,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -250,7 +250,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Antithrombotic_Not_Given_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		bool? c_(MedicationRequest NoAntithromboticDischarge)
 		{
 			FhirBoolean e_ = NoAntithromboticDischarge?.DoNotPerformElement;
@@ -330,7 +330,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};
@@ -353,7 +353,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		bool? c_(MedicationRequest Pharmacological)
 		{
 			FhirBoolean e_ = Pharmacological?.DoNotPerformElement;
@@ -413,7 +413,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};
@@ -473,7 +473,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value()
 	{
 		CqlValueSet a_ = this.Antithrombotic_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		bool? c_(MedicationRequest Antithrombotic)
 		{
 			FhirBoolean e_ = Antithrombotic?.DoNotPerformElement;
@@ -533,7 +533,7 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 				CqlDateTime j_ = FHIRHelpers_4_0_001.ToDateTime(i_);
 				Period k_ = IschemicStrokeEncounter?.Period;
 				CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.ToInterval(k_);
-				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default(string));
 
 				return m_;
 			};

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Exam125FHIR", "0.0.009")]
 public class Exam125FHIR_0_0_009
 {

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -120,7 +120,7 @@ public class Exam125FHIR_0_0_009
     #endregion
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
@@ -128,7 +128,7 @@ public class Exam125FHIR_0_0_009
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_bilateral_mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default);
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
@@ -136,7 +136,7 @@ public class Exam125FHIR_0_0_009
 		__History_of_bilateral_mastectomy.Value;
 
 	private CqlValueSet Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default);
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
@@ -144,7 +144,7 @@ public class Exam125FHIR_0_0_009
 		__Left.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
@@ -152,7 +152,7 @@ public class Exam125FHIR_0_0_009
 		__Mammography.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -160,7 +160,7 @@ public class Exam125FHIR_0_0_009
 		__Online_Assessments.Value;
 
 	private CqlValueSet Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default);
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
@@ -168,7 +168,7 @@ public class Exam125FHIR_0_0_009
 		__Right.Value;
 
 	private CqlValueSet Status_Post_Left_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default);
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
@@ -176,7 +176,7 @@ public class Exam125FHIR_0_0_009
 		__Status_Post_Left_Mastectomy.Value;
 
 	private CqlValueSet Status_Post_Right_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default);
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
@@ -184,7 +184,7 @@ public class Exam125FHIR_0_0_009
 		__Status_Post_Right_Mastectomy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -192,7 +192,7 @@ public class Exam125FHIR_0_0_009
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
@@ -200,7 +200,7 @@ public class Exam125FHIR_0_0_009
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
@@ -208,7 +208,7 @@ public class Exam125FHIR_0_0_009
 		__Unilateral_Mastectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default);
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
@@ -217,8 +217,8 @@ public class Exam125FHIR_0_0_009
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Exam125FHIR-0.0.009", "Measurement Period", c_);
 
@@ -231,7 +231,7 @@ public class Exam125FHIR_0_0_009
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -288,9 +288,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -300,7 +300,7 @@ public class Exam125FHIR_0_0_009
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -343,7 +343,7 @@ public class Exam125FHIR_0_0_009
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -375,9 +375,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Right_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -401,7 +401,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
 
 			return t_;
 		};
@@ -417,7 +417,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyRightPerformed?.StatusElement;
@@ -428,7 +428,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -445,9 +445,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Left_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -471,7 +471,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
 
 			return t_;
 		};
@@ -487,7 +487,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyLeftPerformed?.StatusElement;
@@ -498,7 +498,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -515,14 +515,14 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_bilateral_mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -538,7 +538,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			Code<EventStatus> e_ = BilateralMastectomyPerformed?.StatusElement;
@@ -549,7 +549,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -611,7 +611,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Observation_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -632,7 +632,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -653,7 +653,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Diagnostic_Report_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default);
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -674,7 +674,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -726,7 +726,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Observation_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -748,7 +748,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -769,7 +769,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Diagnostic_Report_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default);
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -791,7 +791,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -120,7 +120,7 @@ public class Exam125FHIR_0_0_009
     #endregion
 
 	private CqlValueSet Bilateral_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", default(string));
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
@@ -128,7 +128,7 @@ public class Exam125FHIR_0_0_009
 		__Bilateral_Mastectomy.Value;
 
 	private CqlValueSet History_of_bilateral_mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", default(string));
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
@@ -136,7 +136,7 @@ public class Exam125FHIR_0_0_009
 		__History_of_bilateral_mastectomy.Value;
 
 	private CqlValueSet Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", default(string));
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
@@ -144,7 +144,7 @@ public class Exam125FHIR_0_0_009
 		__Left.Value;
 
 	private CqlValueSet Mammography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", default(string));
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
@@ -152,7 +152,7 @@ public class Exam125FHIR_0_0_009
 		__Mammography.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -160,7 +160,7 @@ public class Exam125FHIR_0_0_009
 		__Online_Assessments.Value;
 
 	private CqlValueSet Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", default(string));
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
@@ -168,7 +168,7 @@ public class Exam125FHIR_0_0_009
 		__Right.Value;
 
 	private CqlValueSet Status_Post_Left_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", default(string));
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
@@ -176,7 +176,7 @@ public class Exam125FHIR_0_0_009
 		__Status_Post_Left_Mastectomy.Value;
 
 	private CqlValueSet Status_Post_Right_Mastectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", default(string));
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
@@ -184,7 +184,7 @@ public class Exam125FHIR_0_0_009
 		__Status_Post_Right_Mastectomy.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -192,7 +192,7 @@ public class Exam125FHIR_0_0_009
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Left_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
@@ -200,7 +200,7 @@ public class Exam125FHIR_0_0_009
 		__Unilateral_Mastectomy_Left.Value;
 
 	private CqlValueSet Unilateral_Mastectomy_Right_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
@@ -208,7 +208,7 @@ public class Exam125FHIR_0_0_009
 		__Unilateral_Mastectomy_Right.Value;
 
 	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", default(string));
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
@@ -217,8 +217,8 @@ public class Exam125FHIR_0_0_009
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Exam125FHIR-0.0.009", "Measurement Period", c_);
 
@@ -231,7 +231,7 @@ public class Exam125FHIR_0_0_009
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -288,9 +288,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -300,7 +300,7 @@ public class Exam125FHIR_0_0_009
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, null);
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -343,7 +343,7 @@ public class Exam125FHIR_0_0_009
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		Code<AdministrativeGender> l_ = a_?.GenderElement;
 		string m_ = FHIRHelpers_4_0_001.ToString(l_);
 		bool? n_ = context.Operators.Equal(m_, "female");
@@ -375,9 +375,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Right_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -401,7 +401,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, null);
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
 
 			return t_;
 		};
@@ -417,7 +417,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Right();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyRightPerformed?.StatusElement;
@@ -428,7 +428,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -445,9 +445,9 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Status_Post_Left_Mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			List<CodeableConcept> j_ = UnilateralMastectomyDiagnosis?.BodySite;
@@ -471,7 +471,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Start(p_);
 			CqlInterval<CqlDateTime> r_ = this.Measurement_Period();
 			CqlDateTime s_ = context.Operators.End(r_);
-			bool? t_ = context.Operators.SameOrBefore(q_, s_, null);
+			bool? t_ = context.Operators.SameOrBefore(q_, s_, default(string));
 
 			return t_;
 		};
@@ -487,7 +487,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Unilateral_Mastectomy_Left();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			Code<EventStatus> e_ = UnilateralMastectomyLeftPerformed?.StatusElement;
@@ -498,7 +498,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -515,14 +515,14 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.History_of_bilateral_mastectomy();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -538,7 +538,7 @@ public class Exam125FHIR_0_0_009
 	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value()
 	{
 		CqlValueSet a_ = this.Bilateral_Mastectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			Code<EventStatus> e_ = BilateralMastectomyPerformed?.StatusElement;
@@ -549,7 +549,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -611,7 +611,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Observation_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -632,7 +632,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -653,7 +653,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Diagnostic_Report_with_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -674,7 +674,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -726,7 +726,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Observation_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Mammogram)
 		{
 			Code<ObservationStatus> f_ = Mammogram?.StatusElement;
@@ -748,7 +748,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);
@@ -769,7 +769,7 @@ public class Exam125FHIR_0_0_009
 	private bool? Diagnostic_Report_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Mammography();
-		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
+		IEnumerable<DiagnosticReport> b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, default(PropertyInfo));
 		bool? c_(DiagnosticReport Mammogram)
 		{
 			Code<DiagnosticReport.DiagnosticReportStatus> f_ = Mammogram?.StatusElement;
@@ -791,7 +791,7 @@ public class Exam125FHIR_0_0_009
 			CqlDateTime q_ = context.Operators.Subtract(o_, p_);
 			CqlDateTime s_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, null);
+			bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default(string));
 			CqlDateTime w_ = context.Operators.End(n_);
 			bool? x_ = context.Operators.Not((bool?)(w_ is null));
 			bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -186,7 +186,7 @@ public class Exam130FHIR_0_0_003
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -194,7 +194,7 @@ public class Exam130FHIR_0_0_003
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -202,7 +202,7 @@ public class Exam130FHIR_0_0_003
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -210,7 +210,7 @@ public class Exam130FHIR_0_0_003
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -218,7 +218,7 @@ public class Exam130FHIR_0_0_003
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -226,7 +226,7 @@ public class Exam130FHIR_0_0_003
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -234,7 +234,7 @@ public class Exam130FHIR_0_0_003
 		__CT_Colonography.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -242,7 +242,7 @@ public class Exam130FHIR_0_0_003
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -250,7 +250,7 @@ public class Exam130FHIR_0_0_003
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -258,7 +258,7 @@ public class Exam130FHIR_0_0_003
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -266,7 +266,7 @@ public class Exam130FHIR_0_0_003
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -274,7 +274,7 @@ public class Exam130FHIR_0_0_003
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet FIT_DNA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -282,7 +282,7 @@ public class Exam130FHIR_0_0_003
 		__FIT_DNA.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -290,7 +290,7 @@ public class Exam130FHIR_0_0_003
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -298,7 +298,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -306,7 +306,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -314,7 +314,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -322,7 +322,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -330,7 +330,7 @@ public class Exam130FHIR_0_0_003
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -338,7 +338,7 @@ public class Exam130FHIR_0_0_003
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -346,7 +346,7 @@ public class Exam130FHIR_0_0_003
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -354,7 +354,7 @@ public class Exam130FHIR_0_0_003
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -362,7 +362,7 @@ public class Exam130FHIR_0_0_003
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -370,7 +370,7 @@ public class Exam130FHIR_0_0_003
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -378,7 +378,7 @@ public class Exam130FHIR_0_0_003
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -386,7 +386,7 @@ public class Exam130FHIR_0_0_003
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -394,7 +394,7 @@ public class Exam130FHIR_0_0_003
 		__Outpatient.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -402,7 +402,7 @@ public class Exam130FHIR_0_0_003
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -410,7 +410,7 @@ public class Exam130FHIR_0_0_003
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -418,7 +418,7 @@ public class Exam130FHIR_0_0_003
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -426,7 +426,7 @@ public class Exam130FHIR_0_0_003
 		__Total_Colectomy.Value;
 
 	private CqlValueSet Total_Colectomy_ICD9_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default(string));
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
@@ -434,7 +434,7 @@ public class Exam130FHIR_0_0_003
 		__Total_Colectomy_ICD9.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -443,7 +443,7 @@ public class Exam130FHIR_0_0_003
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -455,8 +455,8 @@ public class Exam130FHIR_0_0_003
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Exam130FHIR-0.0.003", "Measurement Period", c_);
 
@@ -469,7 +469,7 @@ public class Exam130FHIR_0_0_003
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -526,9 +526,9 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -538,7 +538,7 @@ public class Exam130FHIR_0_0_003
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, null);
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -581,7 +581,7 @@ public class Exam130FHIR_0_0_003
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -609,14 +609,14 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ColorectalCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -632,7 +632,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colectomy)
 		{
 			Code<EventStatus> e_ = Colectomy?.StatusElement;
@@ -643,7 +643,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, null);
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -660,14 +660,14 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Condition> Total_Colectomy_Condition_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy_ICD9();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ColectomyDx)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, null);
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
 
 			return i_;
 		};
@@ -719,7 +719,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			DataType g_ = FecalOccult?.Effective;
@@ -730,7 +730,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, false, false);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
 
 			return p_;
 		};
@@ -820,7 +820,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -881,7 +881,7 @@ public class Exam130FHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default(string));
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -898,7 +898,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -976,7 +976,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			List<CodeableConcept> e_ = FecalOccult?.Category;
@@ -1046,7 +1046,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -1081,7 +1081,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			DataType g_ = FitDNA?.Effective;
@@ -1092,7 +1092,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, null);
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
 			CqlDateTime r_ = context.Operators.End(i_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
 			bool? t_ = context.Operators.And(p_, s_);
@@ -1185,7 +1185,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1251,7 +1251,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, null);
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default(string));
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1271,7 +1271,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1357,7 +1357,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			List<CodeableConcept> e_ = FitDNA?.Category;
@@ -1435,7 +1435,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1478,7 +1478,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			DataType g_ = Colonography?.Effective;
@@ -1490,7 +1490,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1517,7 +1517,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1538,7 +1538,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1558,7 +1558,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1580,7 +1580,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, null);
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -1600,7 +1600,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			DataType g_ = FlexibleSigmoidoscopy?.Performed;
@@ -1612,7 +1612,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1639,7 +1639,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1654,7 +1654,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1674,7 +1674,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1690,7 +1690,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1710,7 +1710,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			DataType g_ = Colonoscopy?.Performed;
@@ -1722,7 +1722,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1749,7 +1749,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1764,7 +1764,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, null);
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1784,7 +1784,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1800,7 +1800,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, null);
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -186,7 +186,7 @@ public class Exam130FHIR_0_0_003
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
@@ -194,7 +194,7 @@ public class Exam130FHIR_0_0_003
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", default);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
@@ -202,7 +202,7 @@ public class Exam130FHIR_0_0_003
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -210,7 +210,7 @@ public class Exam130FHIR_0_0_003
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", default);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
@@ -218,7 +218,7 @@ public class Exam130FHIR_0_0_003
 		__Care_Services_in_Long_Term_Residential_Facility.Value;
 
 	private CqlValueSet Colonoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", default);
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
@@ -226,7 +226,7 @@ public class Exam130FHIR_0_0_003
 		__Colonoscopy.Value;
 
 	private CqlValueSet CT_Colonography_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", default);
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
@@ -234,7 +234,7 @@ public class Exam130FHIR_0_0_003
 		__CT_Colonography.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", default);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
@@ -242,7 +242,7 @@ public class Exam130FHIR_0_0_003
 		__Dementia_Medications.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -250,7 +250,7 @@ public class Exam130FHIR_0_0_003
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -258,7 +258,7 @@ public class Exam130FHIR_0_0_003
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -266,7 +266,7 @@ public class Exam130FHIR_0_0_003
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", default);
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
@@ -274,7 +274,7 @@ public class Exam130FHIR_0_0_003
 		__Fecal_Occult_Blood_Test__FOBT_.Value;
 
 	private CqlValueSet FIT_DNA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", default);
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
@@ -282,7 +282,7 @@ public class Exam130FHIR_0_0_003
 		__FIT_DNA.Value;
 
 	private CqlValueSet Flexible_Sigmoidoscopy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", default);
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
@@ -290,7 +290,7 @@ public class Exam130FHIR_0_0_003
 		__Flexible_Sigmoidoscopy.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", default);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
@@ -298,7 +298,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", default);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
@@ -306,7 +306,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", default);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
@@ -314,7 +314,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", default);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
@@ -322,7 +322,7 @@ public class Exam130FHIR_0_0_003
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Home_Healthcare_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", default);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
@@ -330,7 +330,7 @@ public class Exam130FHIR_0_0_003
 		__Home_Healthcare_Services.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -338,7 +338,7 @@ public class Exam130FHIR_0_0_003
 		__Hospice_care_ambulatory.Value;
 
 	private CqlValueSet Malignant_Neoplasm_of_Colon_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", default);
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
@@ -346,7 +346,7 @@ public class Exam130FHIR_0_0_003
 		__Malignant_Neoplasm_of_Colon.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", default);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
@@ -354,7 +354,7 @@ public class Exam130FHIR_0_0_003
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Nursing_Facility_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", default);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
@@ -362,7 +362,7 @@ public class Exam130FHIR_0_0_003
 		__Nursing_Facility_Visit.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
@@ -370,7 +370,7 @@ public class Exam130FHIR_0_0_003
 		__Observation.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -378,7 +378,7 @@ public class Exam130FHIR_0_0_003
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -386,7 +386,7 @@ public class Exam130FHIR_0_0_003
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", default);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
@@ -394,7 +394,7 @@ public class Exam130FHIR_0_0_003
 		__Outpatient.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -402,7 +402,7 @@ public class Exam130FHIR_0_0_003
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -410,7 +410,7 @@ public class Exam130FHIR_0_0_003
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -418,7 +418,7 @@ public class Exam130FHIR_0_0_003
 		__Telephone_Visits.Value;
 
 	private CqlValueSet Total_Colectomy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", default);
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
@@ -426,7 +426,7 @@ public class Exam130FHIR_0_0_003
 		__Total_Colectomy.Value;
 
 	private CqlValueSet Total_Colectomy_ICD9_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", default);
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
@@ -434,7 +434,7 @@ public class Exam130FHIR_0_0_003
 		__Total_Colectomy_ICD9.Value;
 
 	private CqlCode laboratory_Value() => 
-		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("laboratory")]
 	public CqlCode laboratory() => 
@@ -443,7 +443,7 @@ public class Exam130FHIR_0_0_003
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -455,8 +455,8 @@ public class Exam130FHIR_0_0_003
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("Exam130FHIR-0.0.003", "Measurement Period", c_);
 
@@ -469,7 +469,7 @@ public class Exam130FHIR_0_0_003
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -526,9 +526,9 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Encounter> Telehealth_Services_Value()
 	{
 		CqlValueSet a_ = this.Online_Assessments();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Telephone_Visits();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
@@ -538,7 +538,7 @@ public class Exam130FHIR_0_0_003
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			Period l_ = TelehealthEncounter?.Period;
 			CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((l_ as object));
-			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default(string));
+			bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
 			bool? o_ = context.Operators.And(j_, n_);
 
 			return o_;
@@ -581,7 +581,7 @@ public class Exam130FHIR_0_0_003
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
 		IEnumerable<Encounter> l_ = this.Telehealth_Services();
 		IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -609,14 +609,14 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Condition> Malignant_Neoplasm_Value()
 	{
 		CqlValueSet a_ = this.Malignant_Neoplasm_of_Colon();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ColorectalCancer)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -632,7 +632,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Total_Colectomy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colectomy)
 		{
 			Code<EventStatus> e_ = Colectomy?.StatusElement;
@@ -643,7 +643,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
 			CqlDateTime l_ = context.Operators.End(k_);
-			bool? m_ = context.Operators.SameOrBefore(j_, l_, default(string));
+			bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
 			bool? n_ = context.Operators.And(g_, m_);
 
 			return n_;
@@ -660,14 +660,14 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Condition> Total_Colectomy_Condition_Value()
 	{
 		CqlValueSet a_ = this.Total_Colectomy_ICD9();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ColectomyDx)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.SameOrBefore(f_, h_, default(string));
+			bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
 
 			return i_;
 		};
@@ -719,7 +719,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			DataType g_ = FecalOccult?.Effective;
@@ -730,7 +730,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, false, false);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default);
 
 			return p_;
 		};
@@ -820,7 +820,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -881,7 +881,7 @@ public class Exam130FHIR_0_0_003
 			DataType q_ = FecalOccult?.Effective;
 			CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(q_);
 			CqlInterval<CqlDateTime> s_ = this.Measurement_Period();
-			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
 			bool? u_ = context.Operators.And(p_, t_);
 
 			return u_;
@@ -898,7 +898,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -976,7 +976,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			List<CodeableConcept> e_ = FecalOccult?.Category;
@@ -1046,7 +1046,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.Fecal_Occult_Blood_Test__FOBT_();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FecalOccult)
 		{
 			Code<ObservationStatus> e_ = FecalOccult?.StatusElement;
@@ -1081,7 +1081,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<(CqlDateTime occultDate, IEnumerable<FhirString> occultResult, IEnumerable<string> occultCategoryCode, Code<ObservationStatus> occultStatus)?> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			DataType g_ = FitDNA?.Effective;
@@ -1092,7 +1092,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime l_ = context.Operators.Subtract(j_, k_);
 			CqlDateTime n_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> o_ = context.Operators.Interval(l_, n_, true, true);
-			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default(string));
+			bool? p_ = context.Operators.In<CqlDateTime>(h_, o_, default);
 			CqlDateTime r_ = context.Operators.End(i_);
 			bool? s_ = context.Operators.Not((bool?)(r_ is null));
 			bool? t_ = context.Operators.And(p_, s_);
@@ -1185,7 +1185,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1251,7 +1251,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime v_ = context.Operators.Subtract(t_, u_);
 			CqlDateTime x_ = context.Operators.End(s_);
 			CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default(string));
+			bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default);
 			CqlDateTime ab_ = context.Operators.End(s_);
 			bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
 			bool? ad_ = context.Operators.And(z_, ac_);
@@ -1271,7 +1271,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1357,7 +1357,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			List<CodeableConcept> e_ = FitDNA?.Category;
@@ -1435,7 +1435,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value()
 	{
 		CqlValueSet a_ = this.FIT_DNA();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FitDNA)
 		{
 			Code<ObservationStatus> e_ = FitDNA?.StatusElement;
@@ -1478,7 +1478,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			DataType g_ = Colonography?.Effective;
@@ -1490,7 +1490,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1517,7 +1517,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1538,7 +1538,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1558,7 +1558,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.CT_Colonography();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation Colonography)
 		{
 			Code<ObservationStatus> e_ = Colonography?.StatusElement;
@@ -1580,7 +1580,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime p_ = context.Operators.Subtract(n_, o_);
 			CqlDateTime r_ = context.Operators.End(m_);
 			CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default(string));
+			bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
 			CqlDateTime v_ = context.Operators.End(m_);
 			bool? w_ = context.Operators.Not((bool?)(v_ is null));
 			bool? x_ = context.Operators.And(t_, w_);
@@ -1600,7 +1600,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			DataType g_ = FlexibleSigmoidoscopy?.Performed;
@@ -1612,7 +1612,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1639,7 +1639,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1654,7 +1654,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1674,7 +1674,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Flexible_Sigmoidoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			Code<EventStatus> e_ = FlexibleSigmoidoscopy?.StatusElement;
@@ -1690,7 +1690,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);
@@ -1710,7 +1710,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			DataType g_ = Colonoscopy?.Performed;
@@ -1722,7 +1722,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime m_ = context.Operators.Subtract(k_, l_);
 			CqlDateTime o_ = context.Operators.End(j_);
 			CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
 			CqlDateTime s_ = context.Operators.End(j_);
 			bool? t_ = context.Operators.Not((bool?)(s_ is null));
 			bool? u_ = context.Operators.And(q_, t_);
@@ -1749,7 +1749,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1764,7 +1764,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime n_ = context.Operators.Subtract(l_, m_);
 			CqlDateTime p_ = context.Operators.End(k_);
 			CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default(string));
+			bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
 			CqlDateTime t_ = context.Operators.End(k_);
 			bool? u_ = context.Operators.Not((bool?)(t_ is null));
 			bool? v_ = context.Operators.And(r_, u_);
@@ -1784,7 +1784,7 @@ public class Exam130FHIR_0_0_003
 	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value()
 	{
 		CqlValueSet a_ = this.Colonoscopy();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure Colonoscopy)
 		{
 			Code<EventStatus> e_ = Colonoscopy?.StatusElement;
@@ -1800,7 +1800,7 @@ public class Exam130FHIR_0_0_003
 			CqlDateTime o_ = context.Operators.Subtract(m_, n_);
 			CqlDateTime q_ = context.Operators.End(l_);
 			CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default(string));
+			bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
 			CqlDateTime u_ = context.Operators.End(l_);
 			bool? v_ = context.Operators.Not((bool?)(u_ is null));
 			bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("Exam130FHIR", "0.0.003")]
 public class Exam130FHIR_0_0_003
 {

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -176,7 +176,7 @@ public class FHIR347_0_1_021
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -184,7 +184,7 @@ public class FHIR347_0_1_021
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Atherosclerosis_and_Peripheral_Arterial_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", default);
 
     [CqlDeclaration("Atherosclerosis and Peripheral Arterial Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21")]
@@ -192,7 +192,7 @@ public class FHIR347_0_1_021
 		__Atherosclerosis_and_Peripheral_Arterial_Disease.Value;
 
 	private CqlValueSet Breastfeeding_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", default);
 
     [CqlDeclaration("Breastfeeding")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73")]
@@ -200,7 +200,7 @@ public class FHIR347_0_1_021
 		__Breastfeeding.Value;
 
 	private CqlValueSet CABG_Surgeries_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", default);
 
     [CqlDeclaration("CABG Surgeries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694")]
@@ -208,7 +208,7 @@ public class FHIR347_0_1_021
 		__CABG_Surgeries.Value;
 
 	private CqlValueSet CABG__PCI_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", default);
 
     [CqlDeclaration("CABG, PCI Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566")]
@@ -216,7 +216,7 @@ public class FHIR347_0_1_021
 		__CABG__PCI_Procedure.Value;
 
 	private CqlValueSet Carotid_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", default);
 
     [CqlDeclaration("Carotid Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204")]
@@ -224,7 +224,7 @@ public class FHIR347_0_1_021
 		__Carotid_Intervention.Value;
 
 	private CqlValueSet Cerebrovascular_Disease__Stroke__TIA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", default);
 
     [CqlDeclaration("Cerebrovascular Disease, Stroke, TIA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44")]
@@ -232,7 +232,7 @@ public class FHIR347_0_1_021
 		__Cerebrovascular_Disease__Stroke__TIA.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -240,7 +240,7 @@ public class FHIR347_0_1_021
 		__Diabetes.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default);
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -248,7 +248,7 @@ public class FHIR347_0_1_021
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Hepatitis_A_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default);
 
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
@@ -256,7 +256,7 @@ public class FHIR347_0_1_021
 		__Hepatitis_A.Value;
 
 	private CqlValueSet Hepatitis_B_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", default);
 
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269")]
@@ -264,7 +264,7 @@ public class FHIR347_0_1_021
 		__Hepatitis_B.Value;
 
 	private CqlValueSet High_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", default);
 
     [CqlDeclaration("High Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572")]
@@ -272,7 +272,7 @@ public class FHIR347_0_1_021
 		__High_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default);
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -280,7 +280,7 @@ public class FHIR347_0_1_021
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Hypercholesterolemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", default);
 
     [CqlDeclaration("Hypercholesterolemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100")]
@@ -288,7 +288,7 @@ public class FHIR347_0_1_021
 		__Hypercholesterolemia.Value;
 
 	private CqlValueSet Ischemic_Heart_Disease_or_Other_Related_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", default);
 
     [CqlDeclaration("Ischemic Heart Disease or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46")]
@@ -296,7 +296,7 @@ public class FHIR347_0_1_021
 		__Ischemic_Heart_Disease_or_Other_Related_Diagnoses.Value;
 
 	private CqlValueSet LDL_Cholesterol_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", default);
 
     [CqlDeclaration("LDL Cholesterol")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573")]
@@ -304,7 +304,7 @@ public class FHIR347_0_1_021
 		__LDL_Cholesterol.Value;
 
 	private CqlValueSet Liver_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", default);
 
     [CqlDeclaration("Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42")]
@@ -312,7 +312,7 @@ public class FHIR347_0_1_021
 		__Liver_Disease.Value;
 
 	private CqlValueSet Low_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", default);
 
     [CqlDeclaration("Low Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574")]
@@ -320,7 +320,7 @@ public class FHIR347_0_1_021
 		__Low_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Moderate_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", default);
 
     [CqlDeclaration("Moderate Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575")]
@@ -328,7 +328,7 @@ public class FHIR347_0_1_021
 		__Moderate_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Myocardial_Infarction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", default);
 
     [CqlDeclaration("Myocardial Infarction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403")]
@@ -336,7 +336,7 @@ public class FHIR347_0_1_021
 		__Myocardial_Infarction.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -344,7 +344,7 @@ public class FHIR347_0_1_021
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -352,7 +352,7 @@ public class FHIR347_0_1_021
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Outpatient_Encounters_for_Preventive_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", default);
 
     [CqlDeclaration("Outpatient Encounters for Preventive Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576")]
@@ -360,7 +360,7 @@ public class FHIR347_0_1_021
 		__Outpatient_Encounters_for_Preventive_Care.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", default);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575")]
@@ -368,7 +368,7 @@ public class FHIR347_0_1_021
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default);
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -376,7 +376,7 @@ public class FHIR347_0_1_021
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet PCI_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", default);
 
     [CqlDeclaration("PCI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67")]
@@ -384,7 +384,7 @@ public class FHIR347_0_1_021
 		__PCI.Value;
 
 	private CqlValueSet Pregnancy_or_Other_Related_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", default);
 
     [CqlDeclaration("Pregnancy or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623")]
@@ -392,7 +392,7 @@ public class FHIR347_0_1_021
 		__Pregnancy_or_Other_Related_Diagnoses.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -400,7 +400,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services___Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default);
 
     [CqlDeclaration("Preventive Care Services - Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
@@ -408,7 +408,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services___Other.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default);
 
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -416,7 +416,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -424,7 +424,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Rhabdomyolysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", default);
 
     [CqlDeclaration("Rhabdomyolysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102")]
@@ -432,7 +432,7 @@ public class FHIR347_0_1_021
 		__Rhabdomyolysis.Value;
 
 	private CqlValueSet Stable_and_Unstable_Angina_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", default);
 
     [CqlDeclaration("Stable and Unstable Angina")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47")]
@@ -440,7 +440,7 @@ public class FHIR347_0_1_021
 		__Stable_and_Unstable_Angina.Value;
 
 	private CqlValueSet Statin_Allergen_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", default);
 
     [CqlDeclaration("Statin Allergen")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42")]
@@ -448,7 +448,7 @@ public class FHIR347_0_1_021
 		__Statin_Allergen.Value;
 
 	private CqlValueSet Statin_Associated_Muscle_Symptoms_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", default);
 
     [CqlDeclaration("Statin Associated Muscle Symptoms")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85")]
@@ -456,7 +456,7 @@ public class FHIR347_0_1_021
 		__Statin_Associated_Muscle_Symptoms.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -465,7 +465,7 @@ public class FHIR347_0_1_021
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -488,7 +488,7 @@ public class FHIR347_0_1_021
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -501,18 +501,18 @@ public class FHIR347_0_1_021
 	private IEnumerable<object> ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Myocardial_Infarction();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Cerebrovascular_Disease__Stroke__TIA();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Atherosclerosis_and_Peripheral_Arterial_Disease();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		CqlValueSet h_ = this.Ischemic_Heart_Disease_or_Other_Related_Diagnoses();
-		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
+		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default);
 		IEnumerable<Condition> j_ = context.Operators.Union<Condition>(g_, i_);
 		IEnumerable<Condition> k_ = context.Operators.Union<Condition>(e_, j_);
 		CqlValueSet l_ = this.Stable_and_Unstable_Angina();
-		IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(l_, default(PropertyInfo));
+		IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(l_, default);
 		IEnumerable<Condition> n_ = context.Operators.Union<Condition>(k_, m_);
 		bool? o_(Condition ASCVDDiagnosis)
 		{
@@ -520,20 +520,20 @@ public class FHIR347_0_1_021
 			CqlDateTime af_ = context.Operators.Start(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.Before(af_, ah_, default(string));
+			bool? ai_ = context.Operators.Before(af_, ah_, default);
 
 			return ai_;
 		};
 		IEnumerable<Condition> p_ = context.Operators.Where<Condition>(n_, o_);
 		CqlValueSet q_ = this.PCI();
-		IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(q_, default(PropertyInfo));
+		IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(q_, default);
 		CqlValueSet s_ = this.CABG_Surgeries();
-		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(s_, default(PropertyInfo));
+		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(s_, default);
 		IEnumerable<Procedure> u_ = context.Operators.Union<Procedure>(r_, t_);
 		CqlValueSet v_ = this.Carotid_Intervention();
-		IEnumerable<Procedure> w_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default(PropertyInfo));
+		IEnumerable<Procedure> w_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default);
 		CqlValueSet x_ = this.CABG__PCI_Procedure();
-		IEnumerable<Procedure> y_ = context.Operators.RetrieveByValueSet<Procedure>(x_, default(PropertyInfo));
+		IEnumerable<Procedure> y_ = context.Operators.RetrieveByValueSet<Procedure>(x_, default);
 		IEnumerable<Procedure> z_ = context.Operators.Union<Procedure>(w_, y_);
 		IEnumerable<Procedure> aa_ = context.Operators.Union<Procedure>(u_, z_);
 		bool? ab_(Procedure ASCVDProcedure)
@@ -543,7 +543,7 @@ public class FHIR347_0_1_021
 			CqlDateTime al_ = context.Operators.Start(ak_);
 			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
 			CqlDateTime an_ = context.Operators.End(am_);
-			bool? ao_ = context.Operators.Before(al_, an_, default(string));
+			bool? ao_ = context.Operators.Before(al_, an_, default);
 			Code<EventStatus> ap_ = ASCVDProcedure?.StatusElement;
 			string aq_ = FHIRHelpers_4_0_001.ToString(ap_);
 			bool? ar_ = context.Operators.Equal(aq_, "completed");
@@ -564,26 +564,26 @@ public class FHIR347_0_1_021
 	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Office_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Outpatient_Encounters_for_Preventive_Care();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Preventive_Care_Services___Other();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -591,7 +591,7 @@ public class FHIR347_0_1_021
 			CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 			Period aa_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_0_001.ToInterval(aa_);
-			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default(string));
+			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default);
 			Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -655,7 +655,7 @@ public class FHIR347_0_1_021
 	private IEnumerable<Observation> LDL_Result_Greater_Than_or_Equal_To_190_Value()
 	{
 		CqlValueSet a_ = this.LDL_Cholesterol();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation LDL)
 		{
 			DataType e_ = LDL?.Value;
@@ -667,7 +667,7 @@ public class FHIR347_0_1_021
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 			CqlDateTime m_ = context.Operators.End(l_);
-			bool? n_ = context.Operators.Before(k_, m_, default(string));
+			bool? n_ = context.Operators.Before(k_, m_, default);
 			bool? o_ = context.Operators.And(h_, n_);
 			Code<ObservationStatus> p_ = LDL?.StatusElement;
 			string q_ = FHIRHelpers_4_0_001.ToString(p_);
@@ -694,14 +694,14 @@ public class FHIR347_0_1_021
 	private IEnumerable<Condition> Hypercholesterolemia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hypercholesterolemia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Hypercholesterolemia)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Hypercholesterolemia);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.Before(f_, h_, default(string));
+			bool? i_ = context.Operators.Before(f_, h_, default);
 
 			return i_;
 		};
@@ -762,12 +762,12 @@ public class FHIR347_0_1_021
 	private bool? Has_Diabetes_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Diabetes();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 
 			return h_;
 		};
@@ -791,7 +791,7 @@ public class FHIR347_0_1_021
 		CqlDateTime f_ = context.Operators.Start(e_);
 		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
 		CqlInterval<int?> h_ = context.Operators.Interval(40, 75, true, true);
-		bool? i_ = context.Operators.In<int?>(g_, h_, default(string));
+		bool? i_ = context.Operators.In<int?>(g_, h_, default);
 		bool? j_ = this.Has_Diabetes_Diagnosis();
 		bool? k_ = context.Operators.And(i_, j_);
 		IEnumerable<object> l_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period();
@@ -886,7 +886,7 @@ public class FHIR347_0_1_021
 	private bool? Has_Allergy_to_Statin_Value()
 	{
 		CqlValueSet a_ = this.Statin_Allergen();
-		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default(PropertyInfo));
+		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default);
 		bool? c_(AllergyIntolerance StatinAllergy)
 		{
 			DataType f_ = StatinAllergy?.Onset;
@@ -894,7 +894,7 @@ public class FHIR347_0_1_021
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
 			CqlDateTime j_ = context.Operators.End(i_);
-			bool? k_ = context.Operators.Before(h_, j_, default(string));
+			bool? k_ = context.Operators.Before(h_, j_, default);
 
 			return k_;
 		};
@@ -911,9 +911,9 @@ public class FHIR347_0_1_021
 	private bool? Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care_Value()
 	{
 		CqlValueSet a_ = this.Hospice_Care_Ambulatory();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		CqlValueSet c_ = this.Palliative_or_Hospice_Care();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default);
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		bool? f_(ServiceRequest PalliativeOrHospiceCareOrder)
 		{
@@ -921,7 +921,7 @@ public class FHIR347_0_1_021
 			CqlDateTime z_ = FHIRHelpers_4_0_001.ToDateTime(y_);
 			CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
 			CqlDateTime ab_ = context.Operators.End(aa_);
-			bool? ac_ = context.Operators.SameOrBefore(z_, ab_, default(string));
+			bool? ac_ = context.Operators.SameOrBefore(z_, ab_, default);
 			Code<RequestStatus> ad_ = PalliativeOrHospiceCareOrder?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			string[] af_ = [
@@ -940,8 +940,8 @@ public class FHIR347_0_1_021
 		};
 		IEnumerable<ServiceRequest> g_ = context.Operators.Where<ServiceRequest>(e_, f_);
 		bool? h_ = context.Operators.Exists<ServiceRequest>(g_);
-		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
-		IEnumerable<Procedure> l_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default(PropertyInfo));
+		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
+		IEnumerable<Procedure> l_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default);
 		IEnumerable<Procedure> m_ = context.Operators.Union<Procedure>(j_, l_);
 		bool? n_(Procedure PalliativeOrHospiceCarePerformed)
 		{
@@ -950,7 +950,7 @@ public class FHIR347_0_1_021
 			CqlDateTime ao_ = context.Operators.Start(an_);
 			CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
 			CqlDateTime aq_ = context.Operators.End(ap_);
-			bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, default(string));
+			bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, default);
 			Code<EventStatus> as_ = PalliativeOrHospiceCarePerformed?.StatusElement;
 			string at_ = FHIRHelpers_4_0_001.ToString(as_);
 			bool? au_ = context.Operators.Equal(at_, "completed");
@@ -963,7 +963,7 @@ public class FHIR347_0_1_021
 		bool? q_ = context.Operators.Or(h_, p_);
 		CqlCode r_ = this.Encounter_for_palliative_care();
 		IEnumerable<CqlCode> s_ = context.Operators.ToList<CqlCode>(r_);
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByCodes<Encounter>(s_, default(PropertyInfo));
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByCodes<Encounter>(s_, default);
 		bool? u_(Encounter PalliativeEncounter)
 		{
 			Period aw_ = PalliativeEncounter?.Period;
@@ -971,7 +971,7 @@ public class FHIR347_0_1_021
 			CqlDateTime ay_ = context.Operators.Start(ax_);
 			CqlInterval<CqlDateTime> az_ = this.Measurement_Period();
 			CqlDateTime ba_ = context.Operators.End(az_);
-			bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, default(string));
+			bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, default);
 			Code<Encounter.EncounterStatus> bc_ = PalliativeEncounter?.StatusElement;
 			string bd_ = FHIRHelpers_4_0_001.ToString(bc_);
 			bool? be_ = context.Operators.Equal(bd_, "finished");
@@ -993,18 +993,18 @@ public class FHIR347_0_1_021
 	private bool? Has_Hepatitis_or_Liver_Disease_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Hepatitis_B();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Liver_Disease();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition HepatitisLiverDisease)
 		{
 			CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(HepatitisLiverDisease);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
+			bool? n_ = context.Operators.Overlaps(l_, m_, default);
 
 			return n_;
 		};
@@ -1021,14 +1021,14 @@ public class FHIR347_0_1_021
 	private bool? Has_Statin_Associated_Muscle_Symptoms_Value()
 	{
 		CqlValueSet a_ = this.Statin_Associated_Muscle_Symptoms();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition StatinMuscleSymptom)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(StatinMuscleSymptom);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.Before(g_, i_, default(string));
+			bool? j_ = context.Operators.Before(g_, i_, default);
 
 			return j_;
 		};
@@ -1045,12 +1045,12 @@ public class FHIR347_0_1_021
 	private bool? Has_ESRD_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		bool? c_(Condition ESRD)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ESRD);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
+			bool? h_ = context.Operators.Overlaps(f_, g_, default);
 
 			return h_;
 		};
@@ -1067,13 +1067,13 @@ public class FHIR347_0_1_021
 	private bool? Has_Adverse_Reaction_to_Statin_Value()
 	{
 		CqlValueSet a_ = this.Statin_Allergen();
-		IEnumerable<AdverseEvent> b_ = context.Operators.RetrieveByValueSet<AdverseEvent>(a_, default(PropertyInfo));
+		IEnumerable<AdverseEvent> b_ = context.Operators.RetrieveByValueSet<AdverseEvent>(a_, default);
 		bool? c_(AdverseEvent StatinReaction)
 		{
 			FhirDateTime f_ = StatinReaction?.DateElement;
 			CqlDateTime g_ = FHIRHelpers_4_0_001.ToDateTime(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, default(string));
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, default);
 
 			return i_;
 		};
@@ -1111,18 +1111,18 @@ public class FHIR347_0_1_021
 	private bool? Denominator_Exclusions_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_or_Other_Related_Diagnoses();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default);
 		CqlValueSet c_ = this.Breastfeeding();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default);
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Rhabdomyolysis();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition ExclusionDiagnosis)
 		{
 			CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ExclusionDiagnosis);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
+			bool? n_ = context.Operators.Overlaps(l_, m_, default);
 
 			return n_;
 		};
@@ -1139,17 +1139,17 @@ public class FHIR347_0_1_021
 	private IEnumerable<MedicationRequest> Statin_Therapy_Ordered_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Low_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Moderate_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.High_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		bool? r_(MedicationRequest StatinOrdered)
@@ -1157,7 +1157,7 @@ public class FHIR347_0_1_021
 			FhirDateTime t_ = StatinOrdered?.AuthoredOnElement;
 			CqlDateTime u_ = FHIRHelpers_4_0_001.ToDateTime(t_);
 			CqlInterval<CqlDateTime> v_ = this.Measurement_Period();
-			bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, default);
 			Code<MedicationRequest.MedicationrequestStatus> x_ = StatinOrdered?.StatusElement;
 			string y_ = FHIRHelpers_4_0_001.ToString(x_);
 			string[] z_ = [
@@ -1185,17 +1185,17 @@ public class FHIR347_0_1_021
 	private IEnumerable<MedicationRequest> Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Low_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default);
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Moderate_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default);
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.High_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default);
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		bool? r_(MedicationRequest ActiveStatin)
@@ -1257,7 +1257,7 @@ public class FHIR347_0_1_021
 				};
 				CqlInterval<CqlDateTime> ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(aj_());
 				CqlInterval<CqlDateTime> al_ = this.Measurement_Period();
-				bool? am_ = context.Operators.Overlaps(ak_, al_, default(string));
+				bool? am_ = context.Operators.Overlaps(ak_, al_, default);
 
 				return am_;
 			};

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIR347", "0.1.021")]
 public class FHIR347_0_1_021
 {

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -176,7 +176,7 @@ public class FHIR347_0_1_021
     #endregion
 
 	private CqlValueSet Annual_Wellness_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", default(string));
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
@@ -184,7 +184,7 @@ public class FHIR347_0_1_021
 		__Annual_Wellness_Visit.Value;
 
 	private CqlValueSet Atherosclerosis_and_Peripheral_Arterial_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", default(string));
 
     [CqlDeclaration("Atherosclerosis and Peripheral Arterial Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21")]
@@ -192,7 +192,7 @@ public class FHIR347_0_1_021
 		__Atherosclerosis_and_Peripheral_Arterial_Disease.Value;
 
 	private CqlValueSet Breastfeeding_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", default(string));
 
     [CqlDeclaration("Breastfeeding")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73")]
@@ -200,7 +200,7 @@ public class FHIR347_0_1_021
 		__Breastfeeding.Value;
 
 	private CqlValueSet CABG_Surgeries_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", default(string));
 
     [CqlDeclaration("CABG Surgeries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694")]
@@ -208,7 +208,7 @@ public class FHIR347_0_1_021
 		__CABG_Surgeries.Value;
 
 	private CqlValueSet CABG__PCI_Procedure_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", default(string));
 
     [CqlDeclaration("CABG, PCI Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566")]
@@ -216,7 +216,7 @@ public class FHIR347_0_1_021
 		__CABG__PCI_Procedure.Value;
 
 	private CqlValueSet Carotid_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", default(string));
 
     [CqlDeclaration("Carotid Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204")]
@@ -224,7 +224,7 @@ public class FHIR347_0_1_021
 		__Carotid_Intervention.Value;
 
 	private CqlValueSet Cerebrovascular_Disease__Stroke__TIA_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", default(string));
 
     [CqlDeclaration("Cerebrovascular Disease, Stroke, TIA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44")]
@@ -232,7 +232,7 @@ public class FHIR347_0_1_021
 		__Cerebrovascular_Disease__Stroke__TIA.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -240,7 +240,7 @@ public class FHIR347_0_1_021
 		__Diabetes.Value;
 
 	private CqlValueSet End_Stage_Renal_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", default(string));
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
@@ -248,7 +248,7 @@ public class FHIR347_0_1_021
 		__End_Stage_Renal_Disease.Value;
 
 	private CqlValueSet Hepatitis_A_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", default(string));
 
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
@@ -256,7 +256,7 @@ public class FHIR347_0_1_021
 		__Hepatitis_A.Value;
 
 	private CqlValueSet Hepatitis_B_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", default(string));
 
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269")]
@@ -264,7 +264,7 @@ public class FHIR347_0_1_021
 		__Hepatitis_B.Value;
 
 	private CqlValueSet High_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", default(string));
 
     [CqlDeclaration("High Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572")]
@@ -272,7 +272,7 @@ public class FHIR347_0_1_021
 		__High_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Hospice_Care_Ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", default(string));
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
@@ -280,7 +280,7 @@ public class FHIR347_0_1_021
 		__Hospice_Care_Ambulatory.Value;
 
 	private CqlValueSet Hypercholesterolemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", default(string));
 
     [CqlDeclaration("Hypercholesterolemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100")]
@@ -288,7 +288,7 @@ public class FHIR347_0_1_021
 		__Hypercholesterolemia.Value;
 
 	private CqlValueSet Ischemic_Heart_Disease_or_Other_Related_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", default(string));
 
     [CqlDeclaration("Ischemic Heart Disease or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46")]
@@ -296,7 +296,7 @@ public class FHIR347_0_1_021
 		__Ischemic_Heart_Disease_or_Other_Related_Diagnoses.Value;
 
 	private CqlValueSet LDL_Cholesterol_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", default(string));
 
     [CqlDeclaration("LDL Cholesterol")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573")]
@@ -304,7 +304,7 @@ public class FHIR347_0_1_021
 		__LDL_Cholesterol.Value;
 
 	private CqlValueSet Liver_Disease_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", default(string));
 
     [CqlDeclaration("Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42")]
@@ -312,7 +312,7 @@ public class FHIR347_0_1_021
 		__Liver_Disease.Value;
 
 	private CqlValueSet Low_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", default(string));
 
     [CqlDeclaration("Low Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574")]
@@ -320,7 +320,7 @@ public class FHIR347_0_1_021
 		__Low_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Moderate_Intensity_Statin_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", default(string));
 
     [CqlDeclaration("Moderate Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575")]
@@ -328,7 +328,7 @@ public class FHIR347_0_1_021
 		__Moderate_Intensity_Statin_Therapy.Value;
 
 	private CqlValueSet Myocardial_Infarction_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", default(string));
 
     [CqlDeclaration("Myocardial Infarction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403")]
@@ -336,7 +336,7 @@ public class FHIR347_0_1_021
 		__Myocardial_Infarction.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -344,7 +344,7 @@ public class FHIR347_0_1_021
 		__Office_Visit.Value;
 
 	private CqlValueSet Outpatient_Consultation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", default(string));
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
@@ -352,7 +352,7 @@ public class FHIR347_0_1_021
 		__Outpatient_Consultation.Value;
 
 	private CqlValueSet Outpatient_Encounters_for_Preventive_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", default(string));
 
     [CqlDeclaration("Outpatient Encounters for Preventive Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576")]
@@ -360,7 +360,7 @@ public class FHIR347_0_1_021
 		__Outpatient_Encounters_for_Preventive_Care.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", default(string));
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575")]
@@ -368,7 +368,7 @@ public class FHIR347_0_1_021
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -376,7 +376,7 @@ public class FHIR347_0_1_021
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet PCI_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", default(string));
 
     [CqlDeclaration("PCI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67")]
@@ -384,7 +384,7 @@ public class FHIR347_0_1_021
 		__PCI.Value;
 
 	private CqlValueSet Pregnancy_or_Other_Related_Diagnoses_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", default(string));
 
     [CqlDeclaration("Pregnancy or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623")]
@@ -392,7 +392,7 @@ public class FHIR347_0_1_021
 		__Pregnancy_or_Other_Related_Diagnoses.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -400,7 +400,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services___Other_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", default(string));
 
     [CqlDeclaration("Preventive Care Services - Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
@@ -408,7 +408,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services___Other.Value;
 
 	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", default(string));
 
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
@@ -416,7 +416,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services_Individual_Counseling.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -424,7 +424,7 @@ public class FHIR347_0_1_021
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Rhabdomyolysis_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", default(string));
 
     [CqlDeclaration("Rhabdomyolysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102")]
@@ -432,7 +432,7 @@ public class FHIR347_0_1_021
 		__Rhabdomyolysis.Value;
 
 	private CqlValueSet Stable_and_Unstable_Angina_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", default(string));
 
     [CqlDeclaration("Stable and Unstable Angina")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47")]
@@ -440,7 +440,7 @@ public class FHIR347_0_1_021
 		__Stable_and_Unstable_Angina.Value;
 
 	private CqlValueSet Statin_Allergen_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", default(string));
 
     [CqlDeclaration("Statin Allergen")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42")]
@@ -448,7 +448,7 @@ public class FHIR347_0_1_021
 		__Statin_Allergen.Value;
 
 	private CqlValueSet Statin_Associated_Muscle_Symptoms_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", default(string));
 
     [CqlDeclaration("Statin Associated Muscle Symptoms")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85")]
@@ -456,7 +456,7 @@ public class FHIR347_0_1_021
 		__Statin_Associated_Muscle_Symptoms.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -465,7 +465,7 @@ public class FHIR347_0_1_021
 	private CqlCode[] ICD10CM_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -488,7 +488,7 @@ public class FHIR347_0_1_021
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -501,18 +501,18 @@ public class FHIR347_0_1_021
 	private IEnumerable<object> ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Myocardial_Infarction();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Cerebrovascular_Disease__Stroke__TIA();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Atherosclerosis_and_Peripheral_Arterial_Disease();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Ischemic_Heart_Disease_or_Other_Related_Diagnoses();
-		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
+		IEnumerable<Condition> i_ = context.Operators.RetrieveByValueSet<Condition>(h_, default(PropertyInfo));
 		IEnumerable<Condition> j_ = context.Operators.Union<Condition>(g_, i_);
 		IEnumerable<Condition> k_ = context.Operators.Union<Condition>(e_, j_);
 		CqlValueSet l_ = this.Stable_and_Unstable_Angina();
-		IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
+		IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(l_, default(PropertyInfo));
 		IEnumerable<Condition> n_ = context.Operators.Union<Condition>(k_, m_);
 		bool? o_(Condition ASCVDDiagnosis)
 		{
@@ -520,20 +520,20 @@ public class FHIR347_0_1_021
 			CqlDateTime af_ = context.Operators.Start(ae_);
 			CqlInterval<CqlDateTime> ag_ = this.Measurement_Period();
 			CqlDateTime ah_ = context.Operators.End(ag_);
-			bool? ai_ = context.Operators.Before(af_, ah_, null);
+			bool? ai_ = context.Operators.Before(af_, ah_, default(string));
 
 			return ai_;
 		};
 		IEnumerable<Condition> p_ = context.Operators.Where<Condition>(n_, o_);
 		CqlValueSet q_ = this.PCI();
-		IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(q_, null);
+		IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(q_, default(PropertyInfo));
 		CqlValueSet s_ = this.CABG_Surgeries();
-		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(s_, null);
+		IEnumerable<Procedure> t_ = context.Operators.RetrieveByValueSet<Procedure>(s_, default(PropertyInfo));
 		IEnumerable<Procedure> u_ = context.Operators.Union<Procedure>(r_, t_);
 		CqlValueSet v_ = this.Carotid_Intervention();
-		IEnumerable<Procedure> w_ = context.Operators.RetrieveByValueSet<Procedure>(v_, null);
+		IEnumerable<Procedure> w_ = context.Operators.RetrieveByValueSet<Procedure>(v_, default(PropertyInfo));
 		CqlValueSet x_ = this.CABG__PCI_Procedure();
-		IEnumerable<Procedure> y_ = context.Operators.RetrieveByValueSet<Procedure>(x_, null);
+		IEnumerable<Procedure> y_ = context.Operators.RetrieveByValueSet<Procedure>(x_, default(PropertyInfo));
 		IEnumerable<Procedure> z_ = context.Operators.Union<Procedure>(w_, y_);
 		IEnumerable<Procedure> aa_ = context.Operators.Union<Procedure>(u_, z_);
 		bool? ab_(Procedure ASCVDProcedure)
@@ -543,7 +543,7 @@ public class FHIR347_0_1_021
 			CqlDateTime al_ = context.Operators.Start(ak_);
 			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
 			CqlDateTime an_ = context.Operators.End(am_);
-			bool? ao_ = context.Operators.Before(al_, an_, null);
+			bool? ao_ = context.Operators.Before(al_, an_, default(string));
 			Code<EventStatus> ap_ = ASCVDProcedure?.StatusElement;
 			string aq_ = FHIRHelpers_4_0_001.ToString(ap_);
 			bool? ar_ = context.Operators.Equal(aq_, "completed");
@@ -564,26 +564,26 @@ public class FHIR347_0_1_021
 	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Annual_Wellness_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Office_Visit();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Outpatient_Consultation();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Outpatient_Encounters_for_Preventive_Care();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Preventive_Care_Services___Other();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Preventive_Care_Services_Individual_Counseling();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -591,7 +591,7 @@ public class FHIR347_0_1_021
 			CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 			Period aa_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_0_001.ToInterval(aa_);
-			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, null);
+			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default(string));
 			Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -655,7 +655,7 @@ public class FHIR347_0_1_021
 	private IEnumerable<Observation> LDL_Result_Greater_Than_or_Equal_To_190_Value()
 	{
 		CqlValueSet a_ = this.LDL_Cholesterol();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation LDL)
 		{
 			DataType e_ = LDL?.Value;
@@ -667,7 +667,7 @@ public class FHIR347_0_1_021
 			CqlDateTime k_ = context.Operators.Start(j_);
 			CqlInterval<CqlDateTime> l_ = this.Measurement_Period();
 			CqlDateTime m_ = context.Operators.End(l_);
-			bool? n_ = context.Operators.Before(k_, m_, null);
+			bool? n_ = context.Operators.Before(k_, m_, default(string));
 			bool? o_ = context.Operators.And(h_, n_);
 			Code<ObservationStatus> p_ = LDL?.StatusElement;
 			string q_ = FHIRHelpers_4_0_001.ToString(p_);
@@ -694,14 +694,14 @@ public class FHIR347_0_1_021
 	private IEnumerable<Condition> Hypercholesterolemia_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hypercholesterolemia();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Hypercholesterolemia)
 		{
 			CqlInterval<CqlDateTime> e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Hypercholesterolemia);
 			CqlDateTime f_ = context.Operators.Start(e_);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
 			CqlDateTime h_ = context.Operators.End(g_);
-			bool? i_ = context.Operators.Before(f_, h_, null);
+			bool? i_ = context.Operators.Before(f_, h_, default(string));
 
 			return i_;
 		};
@@ -762,12 +762,12 @@ public class FHIR347_0_1_021
 	private bool? Has_Diabetes_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Diabetes();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition Diabetes)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 
 			return h_;
 		};
@@ -791,7 +791,7 @@ public class FHIR347_0_1_021
 		CqlDateTime f_ = context.Operators.Start(e_);
 		int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
 		CqlInterval<int?> h_ = context.Operators.Interval(40, 75, true, true);
-		bool? i_ = context.Operators.In<int?>(g_, h_, null);
+		bool? i_ = context.Operators.In<int?>(g_, h_, default(string));
 		bool? j_ = this.Has_Diabetes_Diagnosis();
 		bool? k_ = context.Operators.And(i_, j_);
 		IEnumerable<object> l_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period();
@@ -886,7 +886,7 @@ public class FHIR347_0_1_021
 	private bool? Has_Allergy_to_Statin_Value()
 	{
 		CqlValueSet a_ = this.Statin_Allergen();
-		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
+		IEnumerable<AllergyIntolerance> b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, default(PropertyInfo));
 		bool? c_(AllergyIntolerance StatinAllergy)
 		{
 			DataType f_ = StatinAllergy?.Onset;
@@ -894,7 +894,7 @@ public class FHIR347_0_1_021
 			CqlDateTime h_ = context.Operators.Start(g_);
 			CqlInterval<CqlDateTime> i_ = this.Measurement_Period();
 			CqlDateTime j_ = context.Operators.End(i_);
-			bool? k_ = context.Operators.Before(h_, j_, null);
+			bool? k_ = context.Operators.Before(h_, j_, default(string));
 
 			return k_;
 		};
@@ -911,9 +911,9 @@ public class FHIR347_0_1_021
 	private bool? Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care_Value()
 	{
 		CqlValueSet a_ = this.Hospice_Care_Ambulatory();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Palliative_or_Hospice_Care();
-		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
+		IEnumerable<ServiceRequest> d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, default(PropertyInfo));
 		IEnumerable<ServiceRequest> e_ = context.Operators.Union<ServiceRequest>(b_, d_);
 		bool? f_(ServiceRequest PalliativeOrHospiceCareOrder)
 		{
@@ -921,7 +921,7 @@ public class FHIR347_0_1_021
 			CqlDateTime z_ = FHIRHelpers_4_0_001.ToDateTime(y_);
 			CqlInterval<CqlDateTime> aa_ = this.Measurement_Period();
 			CqlDateTime ab_ = context.Operators.End(aa_);
-			bool? ac_ = context.Operators.SameOrBefore(z_, ab_, null);
+			bool? ac_ = context.Operators.SameOrBefore(z_, ab_, default(string));
 			Code<RequestStatus> ad_ = PalliativeOrHospiceCareOrder?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			string[] af_ = [
@@ -940,8 +940,8 @@ public class FHIR347_0_1_021
 		};
 		IEnumerable<ServiceRequest> g_ = context.Operators.Where<ServiceRequest>(e_, f_);
 		bool? h_ = context.Operators.Exists<ServiceRequest>(g_);
-		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		IEnumerable<Procedure> l_ = context.Operators.RetrieveByValueSet<Procedure>(c_, null);
+		IEnumerable<Procedure> j_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> l_ = context.Operators.RetrieveByValueSet<Procedure>(c_, default(PropertyInfo));
 		IEnumerable<Procedure> m_ = context.Operators.Union<Procedure>(j_, l_);
 		bool? n_(Procedure PalliativeOrHospiceCarePerformed)
 		{
@@ -950,7 +950,7 @@ public class FHIR347_0_1_021
 			CqlDateTime ao_ = context.Operators.Start(an_);
 			CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
 			CqlDateTime aq_ = context.Operators.End(ap_);
-			bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, null);
+			bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, default(string));
 			Code<EventStatus> as_ = PalliativeOrHospiceCarePerformed?.StatusElement;
 			string at_ = FHIRHelpers_4_0_001.ToString(as_);
 			bool? au_ = context.Operators.Equal(at_, "completed");
@@ -963,7 +963,7 @@ public class FHIR347_0_1_021
 		bool? q_ = context.Operators.Or(h_, p_);
 		CqlCode r_ = this.Encounter_for_palliative_care();
 		IEnumerable<CqlCode> s_ = context.Operators.ToList<CqlCode>(r_);
-		IEnumerable<Encounter> t_ = context.Operators.RetrieveByCodes<Encounter>(s_, null);
+		IEnumerable<Encounter> t_ = context.Operators.RetrieveByCodes<Encounter>(s_, default(PropertyInfo));
 		bool? u_(Encounter PalliativeEncounter)
 		{
 			Period aw_ = PalliativeEncounter?.Period;
@@ -971,7 +971,7 @@ public class FHIR347_0_1_021
 			CqlDateTime ay_ = context.Operators.Start(ax_);
 			CqlInterval<CqlDateTime> az_ = this.Measurement_Period();
 			CqlDateTime ba_ = context.Operators.End(az_);
-			bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, null);
+			bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, default(string));
 			Code<Encounter.EncounterStatus> bc_ = PalliativeEncounter?.StatusElement;
 			string bd_ = FHIRHelpers_4_0_001.ToString(bc_);
 			bool? be_ = context.Operators.Equal(bd_, "finished");
@@ -993,18 +993,18 @@ public class FHIR347_0_1_021
 	private bool? Has_Hepatitis_or_Liver_Disease_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.Hepatitis_A();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Hepatitis_B();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Liver_Disease();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition HepatitisLiverDisease)
 		{
 			CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(HepatitisLiverDisease);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, null);
+			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
 
 			return n_;
 		};
@@ -1021,14 +1021,14 @@ public class FHIR347_0_1_021
 	private bool? Has_Statin_Associated_Muscle_Symptoms_Value()
 	{
 		CqlValueSet a_ = this.Statin_Associated_Muscle_Symptoms();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition StatinMuscleSymptom)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(StatinMuscleSymptom);
 			CqlDateTime g_ = context.Operators.Start(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
 			CqlDateTime i_ = context.Operators.End(h_);
-			bool? j_ = context.Operators.Before(g_, i_, null);
+			bool? j_ = context.Operators.Before(g_, i_, default(string));
 
 			return j_;
 		};
@@ -1045,12 +1045,12 @@ public class FHIR347_0_1_021
 	private bool? Has_ESRD_Diagnosis_Value()
 	{
 		CqlValueSet a_ = this.End_Stage_Renal_Disease();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		bool? c_(Condition ESRD)
 		{
 			CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ESRD);
 			CqlInterval<CqlDateTime> g_ = this.Measurement_Period();
-			bool? h_ = context.Operators.Overlaps(f_, g_, null);
+			bool? h_ = context.Operators.Overlaps(f_, g_, default(string));
 
 			return h_;
 		};
@@ -1067,13 +1067,13 @@ public class FHIR347_0_1_021
 	private bool? Has_Adverse_Reaction_to_Statin_Value()
 	{
 		CqlValueSet a_ = this.Statin_Allergen();
-		IEnumerable<AdverseEvent> b_ = context.Operators.RetrieveByValueSet<AdverseEvent>(a_, null);
+		IEnumerable<AdverseEvent> b_ = context.Operators.RetrieveByValueSet<AdverseEvent>(a_, default(PropertyInfo));
 		bool? c_(AdverseEvent StatinReaction)
 		{
 			FhirDateTime f_ = StatinReaction?.DateElement;
 			CqlDateTime g_ = FHIRHelpers_4_0_001.ToDateTime(f_);
 			CqlInterval<CqlDateTime> h_ = this.Measurement_Period();
-			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, null);
+			bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, default(string));
 
 			return i_;
 		};
@@ -1111,18 +1111,18 @@ public class FHIR347_0_1_021
 	private bool? Denominator_Exclusions_Value()
 	{
 		CqlValueSet a_ = this.Pregnancy_or_Other_Related_Diagnoses();
-		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
+		IEnumerable<Condition> b_ = context.Operators.RetrieveByValueSet<Condition>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Breastfeeding();
-		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
+		IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(c_, default(PropertyInfo));
 		IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
 		CqlValueSet f_ = this.Rhabdomyolysis();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<Condition> h_ = context.Operators.Union<Condition>(e_, g_);
 		bool? i_(Condition ExclusionDiagnosis)
 		{
 			CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ExclusionDiagnosis);
 			CqlInterval<CqlDateTime> m_ = this.Measurement_Period();
-			bool? n_ = context.Operators.Overlaps(l_, m_, null);
+			bool? n_ = context.Operators.Overlaps(l_, m_, default(string));
 
 			return n_;
 		};
@@ -1139,17 +1139,17 @@ public class FHIR347_0_1_021
 	private IEnumerable<MedicationRequest> Statin_Therapy_Ordered_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Low_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Moderate_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.High_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		bool? r_(MedicationRequest StatinOrdered)
@@ -1157,7 +1157,7 @@ public class FHIR347_0_1_021
 			FhirDateTime t_ = StatinOrdered?.AuthoredOnElement;
 			CqlDateTime u_ = FHIRHelpers_4_0_001.ToDateTime(t_);
 			CqlInterval<CqlDateTime> v_ = this.Measurement_Period();
-			bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, null);
+			bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, default(string));
 			Code<MedicationRequest.MedicationrequestStatus> x_ = StatinOrdered?.StatusElement;
 			string y_ = FHIRHelpers_4_0_001.ToString(x_);
 			string[] z_ = [
@@ -1185,17 +1185,17 @@ public class FHIR347_0_1_021
 	private IEnumerable<MedicationRequest> Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Low_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
-		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
+		IEnumerable<MedicationRequest> b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> e_ = context.Operators.Union<MedicationRequest>(b_, d_);
 		CqlValueSet f_ = this.Moderate_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
-		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
+		IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> j_ = context.Operators.Union<MedicationRequest>(g_, i_);
 		IEnumerable<MedicationRequest> k_ = context.Operators.Union<MedicationRequest>(e_, j_);
 		CqlValueSet l_ = this.High_Intensity_Statin_Therapy();
-		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
-		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
+		IEnumerable<MedicationRequest> m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
+		IEnumerable<MedicationRequest> o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, default(PropertyInfo));
 		IEnumerable<MedicationRequest> p_ = context.Operators.Union<MedicationRequest>(m_, o_);
 		IEnumerable<MedicationRequest> q_ = context.Operators.Union<MedicationRequest>(k_, p_);
 		bool? r_(MedicationRequest ActiveStatin)
@@ -1257,7 +1257,7 @@ public class FHIR347_0_1_021
 				};
 				CqlInterval<CqlDateTime> ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(aj_());
 				CqlInterval<CqlDateTime> al_ = this.Measurement_Period();
-				bool? am_ = context.Operators.Overlaps(ak_, al_, null);
+				bool? am_ = context.Operators.Overlaps(ak_, al_, default(string));
 
 				return am_;
 			};

--- a/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("FHIRHelpers", "4.0.001")]
 public class FHIRHelpers_4_0_001
 {

--- a/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
@@ -32,7 +32,7 @@ public class FHIRHelpers_4_0_001
     }
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -97,7 +97,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((quantity is null))
 			{
-				return default(CqlQuantity);
+				return default;
 			}
 			else
 			{
@@ -120,7 +120,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((ratio is null))
 			{
-				return default(CqlRatio);
+				return default;
 			}
 			else
 			{
@@ -143,7 +143,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((coding is null))
 			{
-				return default(CqlCode);
+				return default;
 			}
 			else
 			{
@@ -170,7 +170,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((concept is null))
 			{
-				return default(CqlConcept);
+				return default;
 			}
 			else
 			{

--- a/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
@@ -32,7 +32,7 @@ public class FHIRHelpers_4_0_001
     }
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -97,7 +97,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((quantity is null))
 			{
-				return null;
+				return default(CqlQuantity);
 			}
 			else
 			{
@@ -120,7 +120,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((ratio is null))
 			{
-				return null;
+				return default(CqlRatio);
 			}
 			else
 			{
@@ -143,7 +143,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((coding is null))
 			{
-				return null;
+				return default(CqlCode);
 			}
 			else
 			{
@@ -170,7 +170,7 @@ public class FHIRHelpers_4_0_001
 		{
 			if ((concept is null))
 			{
-				return null;
+				return default(CqlConcept);
 			}
 			else
 			{

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -54,7 +54,7 @@ public class HospiceFHIR4_2_3_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -62,7 +62,7 @@ public class HospiceFHIR4_2_3_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -70,14 +70,14 @@ public class HospiceFHIR4_2_3_000
 		__Hospice_care_ambulatory.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
+		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
+		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
@@ -86,8 +86,8 @@ public class HospiceFHIR4_2_3_000
 	private CqlCode[] SNOMEDCT_2017_09_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", null, null),
-			new CqlCode("428361000124107", "http://snomed.info/sct", null, null),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -110,7 +110,7 @@ public class HospiceFHIR4_2_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -123,7 +123,7 @@ public class HospiceFHIR4_2_3_000
 	private bool? Has_Hospice_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter DischargeHospice)
 		{
 			Code<Encounter.EncounterStatus> r_ = DischargeHospice?.StatusElement;
@@ -146,7 +146,7 @@ public class HospiceFHIR4_2_3_000
 			CqlInterval<CqlDateTime> aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ai_ as object));
 			CqlDateTime ak_ = context.Operators.End(aj_);
 			CqlInterval<CqlDateTime> al_ = this.Measurement_Period();
-			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, null);
+			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default(string));
 			bool? an_ = context.Operators.And(ah_, am_);
 
 			return an_;
@@ -154,7 +154,7 @@ public class HospiceFHIR4_2_3_000
 		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		bool? e_ = context.Operators.Exists<Encounter>(d_);
 		CqlValueSet f_ = this.Hospice_care_ambulatory();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
 		bool? h_(ServiceRequest HospiceOrder)
 		{
 			Code<RequestStatus> ao_ = HospiceOrder?.StatusElement;
@@ -171,7 +171,7 @@ public class HospiceFHIR4_2_3_000
 			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
 			FhirDateTime ax_ = HospiceOrder?.AuthoredOnElement;
 			CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ax_ as object));
-			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, null);
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default(string));
 			bool? ba_ = context.Operators.And(av_, az_);
 
 			return ba_;
@@ -179,7 +179,7 @@ public class HospiceFHIR4_2_3_000
 		IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
 		bool? j_ = context.Operators.Exists<ServiceRequest>(i_);
 		bool? k_ = context.Operators.Or(e_, j_);
-		IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(f_, null);
+		IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
 		bool? n_(Procedure HospicePerformed)
 		{
 			Code<EventStatus> bb_ = HospicePerformed?.StatusElement;
@@ -188,7 +188,7 @@ public class HospiceFHIR4_2_3_000
 			DataType be_ = HospicePerformed?.Performed;
 			CqlInterval<CqlDateTime> bf_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(be_);
 			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
-			bool? bh_ = context.Operators.Overlaps(bf_, bg_, null);
+			bool? bh_ = context.Operators.Overlaps(bf_, bg_, default(string));
 			bool? bi_ = context.Operators.And(bd_, bh_);
 
 			return bi_;

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospiceFHIR4", "2.3.000")]
 public class HospiceFHIR4_2_3_000
 {

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -54,7 +54,7 @@ public class HospiceFHIR4_2_3_000
     #endregion
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -62,7 +62,7 @@ public class HospiceFHIR4_2_3_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_care_ambulatory_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", default);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
@@ -70,14 +70,14 @@ public class HospiceFHIR4_2_3_000
 		__Hospice_care_ambulatory.Value;
 
 	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value() => 
-		new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428371000124100", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
 	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
 		__Discharge_to_healthcare_facility_for_hospice_care__procedure_.Value;
 
 	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value() => 
-		new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("428361000124107", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Discharge to home for hospice care (procedure)")]
 	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
@@ -86,8 +86,8 @@ public class HospiceFHIR4_2_3_000
 	private CqlCode[] SNOMEDCT_2017_09_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("428371000124100", "http://snomed.info/sct", default(string), default(string)),
-			new CqlCode("428361000124107", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("428371000124100", "http://snomed.info/sct", default, default),
+			new CqlCode("428361000124107", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -110,7 +110,7 @@ public class HospiceFHIR4_2_3_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -123,7 +123,7 @@ public class HospiceFHIR4_2_3_000
 	private bool? Has_Hospice_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter DischargeHospice)
 		{
 			Code<Encounter.EncounterStatus> r_ = DischargeHospice?.StatusElement;
@@ -146,7 +146,7 @@ public class HospiceFHIR4_2_3_000
 			CqlInterval<CqlDateTime> aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ai_ as object));
 			CqlDateTime ak_ = context.Operators.End(aj_);
 			CqlInterval<CqlDateTime> al_ = this.Measurement_Period();
-			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default(string));
+			bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default);
 			bool? an_ = context.Operators.And(ah_, am_);
 
 			return an_;
@@ -154,7 +154,7 @@ public class HospiceFHIR4_2_3_000
 		IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
 		bool? e_ = context.Operators.Exists<Encounter>(d_);
 		CqlValueSet f_ = this.Hospice_care_ambulatory();
-		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, default);
 		bool? h_(ServiceRequest HospiceOrder)
 		{
 			Code<RequestStatus> ao_ = HospiceOrder?.StatusElement;
@@ -171,7 +171,7 @@ public class HospiceFHIR4_2_3_000
 			CqlInterval<CqlDateTime> aw_ = this.Measurement_Period();
 			FhirDateTime ax_ = HospiceOrder?.AuthoredOnElement;
 			CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ax_ as object));
-			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default(string));
+			bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default);
 			bool? ba_ = context.Operators.And(av_, az_);
 
 			return ba_;
@@ -179,7 +179,7 @@ public class HospiceFHIR4_2_3_000
 		IEnumerable<ServiceRequest> i_ = context.Operators.Where<ServiceRequest>(g_, h_);
 		bool? j_ = context.Operators.Exists<ServiceRequest>(i_);
 		bool? k_ = context.Operators.Or(e_, j_);
-		IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default(PropertyInfo));
+		IEnumerable<Procedure> m_ = context.Operators.RetrieveByValueSet<Procedure>(f_, default);
 		bool? n_(Procedure HospicePerformed)
 		{
 			Code<EventStatus> bb_ = HospicePerformed?.StatusElement;
@@ -188,7 +188,7 @@ public class HospiceFHIR4_2_3_000
 			DataType be_ = HospicePerformed?.Performed;
 			CqlInterval<CqlDateTime> bf_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(be_);
 			CqlInterval<CqlDateTime> bg_ = this.Measurement_Period();
-			bool? bh_ = context.Operators.Overlaps(bf_, bg_, default(string));
+			bool? bh_ = context.Operators.Overlaps(bf_, bg_, default);
 			bool? bi_ = context.Operators.And(bd_, bh_);
 
 			return bi_;

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -90,7 +90,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -98,7 +98,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__birth_date.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -106,7 +106,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Diabetes.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -114,7 +114,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -122,7 +122,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hypoglycemics_Treatment_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", default(string));
 
     [CqlDeclaration("Hypoglycemics Treatment Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394")]
@@ -130,7 +130,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Hypoglycemics_Treatment_Medications.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -139,7 +139,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -162,7 +162,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -219,7 +219,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 
 		return b_;
 	}
@@ -278,7 +278,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization)
 		{
 			CqlValueSet f_ = this.Diabetes();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			bool? h_(Condition DiabetesDiagnosis)
 			{
 				CodeableConcept l_ = DiabetesDiagnosis?.VerificationStatus;
@@ -290,7 +290,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				CqlDateTime r_ = context.Operators.Start(q_);
 				CqlInterval<CqlDateTime> s_ = EncounterWithHospitalization?.hospitalizationPeriod;
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(r_, t_, null);
+				bool? u_ = context.Operators.Before(r_, t_, default(string));
 				bool? v_ = context.Operators.And(p_, u_);
 
 				return v_;
@@ -322,8 +322,8 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	{
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> a_ = this.Qualifying_Encounters_With_Hospitalization_Period();
 		CqlValueSet b_ = this.Hypoglycemics_Treatment_Medications();
-		IEnumerable<MedicationAdministration> c_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, null);
-		IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, null);
+		IEnumerable<MedicationAdministration> c_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(c_, e_);
 		IEnumerable<ValueTuple<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>> g_ = context.Operators.CrossJoin<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>(a_, f_);
 		((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization, MedicationAdministration HypoglycemicMedication)? h_(ValueTuple<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration> _valueTuple)
@@ -341,7 +341,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 			CqlInterval<CqlDateTime> r_ = tuple_clxcrdeespovhrdozoxqzeieb?.EncounterWithHospitalization?.hospitalizationPeriod;
 			DataType s_ = tuple_clxcrdeespovhrdozoxqzeieb?.HypoglycemicMedication?.Effective;
 			CqlInterval<CqlDateTime> t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, null);
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default(string));
 			bool? v_ = context.Operators.And(q_, u_);
 
 			return v_;
@@ -368,13 +368,13 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization)
 		{
 			CqlValueSet f_ = this.Glucose_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
 			bool? h_(Observation BloodGlucoseLab)
 			{
 				DataType l_ = BloodGlucoseLab?.Effective;
 				CqlDateTime m_ = FHIRHelpers_4_0_001.ToDateTime((l_ as FhirDateTime));
 				CqlInterval<CqlDateTime> n_ = EncounterWithHospitalization?.hospitalizationPeriod;
-				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, null);
+				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
 				Code<ObservationStatus> p_ = BloodGlucoseLab?.StatusElement;
 				string q_ = FHIRHelpers_4_0_001.ToString(p_);
 				bool? r_ = context.Operators.Equal(q_, "final");
@@ -463,7 +463,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), null);
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
 		int? g_(CqlInterval<int?> DayExpand)
 		{
 			int? i_ = context.Operators.End(DayExpand);
@@ -570,7 +570,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				int? j_ = EncounterDay?.dayIndex;
 				CqlInterval<CqlDateTime> k_ = EncounterDay?.dayPeriod;
 				CqlValueSet l_ = this.Glucose_lab_test();
-				IEnumerable<Observation> m_ = context.Operators.RetrieveByValueSet<Observation>(l_, null);
+				IEnumerable<Observation> m_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
 				bool? n_(Observation BloodGlucoseLab1)
 				{
 					Code<ObservationStatus> ac_ = BloodGlucoseLab1?.StatusElement;
@@ -584,14 +584,14 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType ak_ = BloodGlucoseLab1?.Effective;
 					CqlDateTime al_ = FHIRHelpers_4_0_001.ToDateTime((ak_ as FhirDateTime));
 					CqlInterval<CqlDateTime> am_ = EncounterDay?.dayPeriod;
-					bool? an_ = context.Operators.In<CqlDateTime>(al_, am_, null);
+					bool? an_ = context.Operators.In<CqlDateTime>(al_, am_, default(string));
 					bool? ao_ = context.Operators.And(aj_, an_);
 
 					return ao_;
 				};
 				IEnumerable<Observation> o_ = context.Operators.Where<Observation>(m_, n_);
 				bool? p_ = context.Operators.Exists<Observation>(o_);
-				IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(l_, null);
+				IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
 				bool? s_(Observation BloodGlucoseLab2)
 				{
 					Code<ObservationStatus> ap_ = BloodGlucoseLab2?.StatusElement;
@@ -605,14 +605,14 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType ax_ = BloodGlucoseLab2?.Effective;
 					CqlDateTime ay_ = FHIRHelpers_4_0_001.ToDateTime((ax_ as FhirDateTime));
 					CqlInterval<CqlDateTime> az_ = EncounterDay?.dayPeriod;
-					bool? ba_ = context.Operators.In<CqlDateTime>(ay_, az_, null);
+					bool? ba_ = context.Operators.In<CqlDateTime>(ay_, az_, default(string));
 					bool? bb_ = context.Operators.And(aw_, ba_);
 
 					return bb_;
 				};
 				IEnumerable<Observation> t_ = context.Operators.Where<Observation>(r_, s_);
 				bool? u_ = context.Operators.Exists<Observation>(t_);
-				IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(l_, null);
+				IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
 				bool? x_(Observation BloodGlucoseLab3)
 				{
 					Code<ObservationStatus> bc_ = BloodGlucoseLab3?.StatusElement;
@@ -621,7 +621,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType bf_ = BloodGlucoseLab3?.Effective;
 					CqlDateTime bg_ = FHIRHelpers_4_0_001.ToDateTime((bf_ as FhirDateTime));
 					CqlInterval<CqlDateTime> bh_ = EncounterDay?.dayPeriod;
-					bool? bi_ = context.Operators.In<CqlDateTime>(bg_, bh_, null);
+					bool? bi_ = context.Operators.In<CqlDateTime>(bg_, bh_, default(string));
 					bool? bj_ = context.Operators.And(be_, bi_);
 
 					return bj_;

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -90,7 +90,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -98,7 +98,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__birth_date.Value;
 
 	private CqlValueSet Diabetes_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", default);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
@@ -106,7 +106,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Diabetes.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -114,7 +114,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -122,7 +122,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hypoglycemics_Treatment_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", default);
 
     [CqlDeclaration("Hypoglycemics Treatment Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394")]
@@ -130,7 +130,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		__Hypoglycemics_Treatment_Medications.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -139,7 +139,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -162,7 +162,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -219,7 +219,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 
 		return b_;
 	}
@@ -278,7 +278,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization)
 		{
 			CqlValueSet f_ = this.Diabetes();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			bool? h_(Condition DiabetesDiagnosis)
 			{
 				CodeableConcept l_ = DiabetesDiagnosis?.VerificationStatus;
@@ -290,7 +290,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				CqlDateTime r_ = context.Operators.Start(q_);
 				CqlInterval<CqlDateTime> s_ = EncounterWithHospitalization?.hospitalizationPeriod;
 				CqlDateTime t_ = context.Operators.End(s_);
-				bool? u_ = context.Operators.Before(r_, t_, default(string));
+				bool? u_ = context.Operators.Before(r_, t_, default);
 				bool? v_ = context.Operators.And(p_, u_);
 
 				return v_;
@@ -322,8 +322,8 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	{
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> a_ = this.Qualifying_Encounters_With_Hospitalization_Period();
 		CqlValueSet b_ = this.Hypoglycemics_Treatment_Medications();
-		IEnumerable<MedicationAdministration> c_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> c_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default);
+		IEnumerable<MedicationAdministration> e_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(b_, default);
 		IEnumerable<MedicationAdministration> f_ = context.Operators.Union<MedicationAdministration>(c_, e_);
 		IEnumerable<ValueTuple<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>> g_ = context.Operators.CrossJoin<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration>(a_, f_);
 		((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization, MedicationAdministration HypoglycemicMedication)? h_(ValueTuple<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?, MedicationAdministration> _valueTuple)
@@ -341,7 +341,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 			CqlInterval<CqlDateTime> r_ = tuple_clxcrdeespovhrdozoxqzeieb?.EncounterWithHospitalization?.hospitalizationPeriod;
 			DataType s_ = tuple_clxcrdeespovhrdozoxqzeieb?.HypoglycemicMedication?.Effective;
 			CqlInterval<CqlDateTime> t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(s_);
-			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default(string));
+			bool? u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(r_, t_, default);
 			bool? v_ = context.Operators.And(q_, u_);
 
 			return v_;
@@ -368,13 +368,13 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		IEnumerable<(Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)?> b_((Encounter encounter, CqlInterval<CqlDateTime> hospitalizationPeriod)? EncounterWithHospitalization)
 		{
 			CqlValueSet f_ = this.Glucose_lab_test();
-			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default(PropertyInfo));
+			IEnumerable<Observation> g_ = context.Operators.RetrieveByValueSet<Observation>(f_, default);
 			bool? h_(Observation BloodGlucoseLab)
 			{
 				DataType l_ = BloodGlucoseLab?.Effective;
 				CqlDateTime m_ = FHIRHelpers_4_0_001.ToDateTime((l_ as FhirDateTime));
 				CqlInterval<CqlDateTime> n_ = EncounterWithHospitalization?.hospitalizationPeriod;
-				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default(string));
+				bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
 				Code<ObservationStatus> p_ = BloodGlucoseLab?.StatusElement;
 				string q_ = FHIRHelpers_4_0_001.ToString(p_);
 				bool? r_ = context.Operators.Equal(q_, "final");
@@ -463,7 +463,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		CqlInterval<int?>[] e_ = [
 			d_,
 		];
-		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default(CqlQuantity));
+		IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((e_ as IEnumerable<CqlInterval<int?>>), default);
 		int? g_(CqlInterval<int?> DayExpand)
 		{
 			int? i_ = context.Operators.End(DayExpand);
@@ -570,7 +570,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				int? j_ = EncounterDay?.dayIndex;
 				CqlInterval<CqlDateTime> k_ = EncounterDay?.dayPeriod;
 				CqlValueSet l_ = this.Glucose_lab_test();
-				IEnumerable<Observation> m_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
+				IEnumerable<Observation> m_ = context.Operators.RetrieveByValueSet<Observation>(l_, default);
 				bool? n_(Observation BloodGlucoseLab1)
 				{
 					Code<ObservationStatus> ac_ = BloodGlucoseLab1?.StatusElement;
@@ -584,14 +584,14 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType ak_ = BloodGlucoseLab1?.Effective;
 					CqlDateTime al_ = FHIRHelpers_4_0_001.ToDateTime((ak_ as FhirDateTime));
 					CqlInterval<CqlDateTime> am_ = EncounterDay?.dayPeriod;
-					bool? an_ = context.Operators.In<CqlDateTime>(al_, am_, default(string));
+					bool? an_ = context.Operators.In<CqlDateTime>(al_, am_, default);
 					bool? ao_ = context.Operators.And(aj_, an_);
 
 					return ao_;
 				};
 				IEnumerable<Observation> o_ = context.Operators.Where<Observation>(m_, n_);
 				bool? p_ = context.Operators.Exists<Observation>(o_);
-				IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
+				IEnumerable<Observation> r_ = context.Operators.RetrieveByValueSet<Observation>(l_, default);
 				bool? s_(Observation BloodGlucoseLab2)
 				{
 					Code<ObservationStatus> ap_ = BloodGlucoseLab2?.StatusElement;
@@ -605,14 +605,14 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType ax_ = BloodGlucoseLab2?.Effective;
 					CqlDateTime ay_ = FHIRHelpers_4_0_001.ToDateTime((ax_ as FhirDateTime));
 					CqlInterval<CqlDateTime> az_ = EncounterDay?.dayPeriod;
-					bool? ba_ = context.Operators.In<CqlDateTime>(ay_, az_, default(string));
+					bool? ba_ = context.Operators.In<CqlDateTime>(ay_, az_, default);
 					bool? bb_ = context.Operators.And(aw_, ba_);
 
 					return bb_;
 				};
 				IEnumerable<Observation> t_ = context.Operators.Where<Observation>(r_, s_);
 				bool? u_ = context.Operators.Exists<Observation>(t_);
-				IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(l_, default(PropertyInfo));
+				IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(l_, default);
 				bool? x_(Observation BloodGlucoseLab3)
 				{
 					Code<ObservationStatus> bc_ = BloodGlucoseLab3?.StatusElement;
@@ -621,7 +621,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 					DataType bf_ = BloodGlucoseLab3?.Effective;
 					CqlDateTime bg_ = FHIRHelpers_4_0_001.ToDateTime((bf_ as FhirDateTime));
 					CqlInterval<CqlDateTime> bh_ = EncounterDay?.dayPeriod;
-					bool? bi_ = context.Operators.In<CqlDateTime>(bg_, bh_, default(string));
+					bool? bi_ = context.Operators.In<CqlDateTime>(bg_, bh_, default);
 					bool? bj_ = context.Operators.And(be_, bi_);
 
 					return bj_;

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR", "0.0.006")]
 public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.0.012")]
 public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -86,7 +86,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -94,7 +94,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__birth_date.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -102,7 +102,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -110,7 +110,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -118,7 +118,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hypoglycemics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", default);
 
     [CqlDeclaration("Hypoglycemics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3")]
@@ -126,7 +126,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Hypoglycemics.Value;
 
 	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default);
 
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
@@ -134,7 +134,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Hypoglycemics_Severe_Hypoglycemia.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -142,7 +142,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Observation_Services.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -151,7 +151,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -163,8 +163,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.0.012", "Measurement Period", c_);
 
@@ -177,7 +177,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,7 +223,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -233,7 +233,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_0_001.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
 			bool? m_ = context.Operators.And(g_, l_);
 
 			return m_;
@@ -275,8 +275,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
 	{
 		CqlValueSet a_ = this.Hypoglycemics_Severe_Hypoglycemia();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default);
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration HypoMedication)
 		{
@@ -311,7 +311,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(i_);
 				CqlDateTime k_ = context.Operators.Start(j_);
 				CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default);
 
 				return m_;
 			};
@@ -359,7 +359,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		bool? b_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Glucose_lab_test();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default);
 			IEnumerable<Observation> f_(Observation BloodGlucoseLab)
 			{
 				IEnumerable<MedicationAdministration> r_ = this.Hypoglycemic_Medication_Administration();
@@ -376,7 +376,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> af_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(z_);
 					CqlDateTime ag_ = context.Operators.Start(af_);
 					CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-					bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, default(string));
+					bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, default);
 					CqlInterval<CqlDateTime> ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(z_);
 					CqlDateTime al_ = context.Operators.Start(ak_);
 					bool? am_ = context.Operators.Not((bool?)(al_ is null));
@@ -392,7 +392,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(w_);
 					CqlDateTime az_ = context.Operators.Start(ay_);
 					CqlInterval<CqlDateTime> ba_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, default(string));
+					bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, default);
 					bool? bc_ = context.Operators.And(aw_, bb_);
 
 					return bc_;
@@ -405,7 +405,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				return v_;
 			};
 			IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
-			IEnumerable<Observation> i_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
+			IEnumerable<Observation> i_ = context.Operators.RetrieveByValueSet<Observation>(d_, default);
 			IEnumerable<Observation> j_(Observation BloodGlucoseLab)
 			{
 				IEnumerable<MedicationAdministration> bd_ = this.Hypoglycemic_Medication_Administration();
@@ -422,7 +422,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> br_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bl_);
 					CqlDateTime bs_ = context.Operators.Start(br_);
 					CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bp_, bs_, true, true);
-					bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, default(string));
+					bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, default);
 					CqlInterval<CqlDateTime> bw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bl_);
 					CqlDateTime bx_ = context.Operators.Start(bw_);
 					bool? by_ = context.Operators.Not((bool?)(bx_ is null));
@@ -438,7 +438,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> ck_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bi_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, default(string));
+					bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, default);
 					bool? co_ = context.Operators.And(ci_, cn_);
 
 					return co_;
@@ -454,14 +454,14 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			IEnumerable<Observation> l_(Observation BloodGlucoseLab)
 			{
 				CqlValueSet cp_ = this.Glucose_lab_test();
-				IEnumerable<Observation> cq_ = context.Operators.RetrieveByValueSet<Observation>(cp_, default(PropertyInfo));
+				IEnumerable<Observation> cq_ = context.Operators.RetrieveByValueSet<Observation>(cp_, default);
 				bool? cr_(Observation FollowupBloodGlucoseLab)
 				{
 					DataType cv_ = FollowupBloodGlucoseLab?.Effective;
 					CqlInterval<CqlDateTime> cw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(cv_);
 					CqlDateTime cx_ = context.Operators.Start(cw_);
 					CqlInterval<CqlDateTime> cy_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, default(string));
+					bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, default);
 					CqlInterval<CqlDateTime> db_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(cv_);
 					CqlDateTime dc_ = context.Operators.Start(db_);
 					DataType dd_ = BloodGlucoseLab?.Effective;
@@ -472,7 +472,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlQuantity dj_ = context.Operators.Quantity(5m, "minutes");
 					CqlDateTime dk_ = context.Operators.Add(di_, dj_);
 					CqlInterval<CqlDateTime> dl_ = context.Operators.Interval(df_, dk_, false, true);
-					bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, default(string));
+					bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, default);
 					CqlInterval<CqlDateTime> do_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(dd_);
 					CqlDateTime dp_ = context.Operators.Start(do_);
 					bool? dq_ = context.Operators.Not((bool?)(dp_ is null));
@@ -509,7 +509,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				CqlInterval<CqlDateTime> ei_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(eh_);
 				CqlDateTime ej_ = context.Operators.Start(ei_);
 				CqlInterval<CqlDateTime> ek_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-				bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, default(string));
+				bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, default);
 				DataType em_ = BloodGlucoseLab?.Value;
 				CqlQuantity en_ = FHIRHelpers_4_0_001.ToQuantity((em_ as Quantity));
 				CqlQuantity eo_ = context.Operators.Quantity(40m, "mg/dL");

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -86,7 +86,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
     #endregion
 
 	private CqlValueSet birth_date_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", default(string));
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
@@ -94,7 +94,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__birth_date.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -102,7 +102,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -110,7 +110,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -118,7 +118,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hypoglycemics_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", default(string));
 
     [CqlDeclaration("Hypoglycemics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3")]
@@ -126,7 +126,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Hypoglycemics.Value;
 
 	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", default(string));
 
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
@@ -134,7 +134,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Hypoglycemics_Severe_Hypoglycemia.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -142,7 +142,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		__Observation_Services.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -151,7 +151,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -163,8 +163,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.0.012", "Measurement Period", c_);
 
@@ -177,7 +177,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,7 +223,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -233,7 +233,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_0_001.ToInterval(h_);
 			CqlDateTime j_ = context.Operators.End(i_);
 			CqlInterval<CqlDateTime> k_ = this.Measurement_Period();
-			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, null);
+			bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default(string));
 			bool? m_ = context.Operators.And(g_, l_);
 
 			return m_;
@@ -275,8 +275,8 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value()
 	{
 		CqlValueSet a_ = this.Hypoglycemics_Severe_Hypoglycemia();
-		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
-		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
+		IEnumerable<MedicationAdministration> b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
+		IEnumerable<MedicationAdministration> d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, default(PropertyInfo));
 		IEnumerable<MedicationAdministration> e_ = context.Operators.Union<MedicationAdministration>(b_, d_);
 		bool? f_(MedicationAdministration HypoMedication)
 		{
@@ -311,7 +311,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(i_);
 				CqlDateTime k_ = context.Operators.Start(j_);
 				CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default(string));
 
 				return m_;
 			};
@@ -359,7 +359,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		bool? b_(Encounter QualifyingEncounter)
 		{
 			CqlValueSet d_ = this.Glucose_lab_test();
-			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			IEnumerable<Observation> e_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
 			IEnumerable<Observation> f_(Observation BloodGlucoseLab)
 			{
 				IEnumerable<MedicationAdministration> r_ = this.Hypoglycemic_Medication_Administration();
@@ -376,7 +376,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> af_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(z_);
 					CqlDateTime ag_ = context.Operators.Start(af_);
 					CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-					bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, null);
+					bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, default(string));
 					CqlInterval<CqlDateTime> ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(z_);
 					CqlDateTime al_ = context.Operators.Start(ak_);
 					bool? am_ = context.Operators.Not((bool?)(al_ is null));
@@ -392,7 +392,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(w_);
 					CqlDateTime az_ = context.Operators.Start(ay_);
 					CqlInterval<CqlDateTime> ba_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, null);
+					bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, default(string));
 					bool? bc_ = context.Operators.And(aw_, bb_);
 
 					return bc_;
@@ -405,7 +405,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				return v_;
 			};
 			IEnumerable<Observation> g_ = context.Operators.SelectMany<Observation, Observation>(e_, f_);
-			IEnumerable<Observation> i_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
+			IEnumerable<Observation> i_ = context.Operators.RetrieveByValueSet<Observation>(d_, default(PropertyInfo));
 			IEnumerable<Observation> j_(Observation BloodGlucoseLab)
 			{
 				IEnumerable<MedicationAdministration> bd_ = this.Hypoglycemic_Medication_Administration();
@@ -422,7 +422,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> br_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bl_);
 					CqlDateTime bs_ = context.Operators.Start(br_);
 					CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bp_, bs_, true, true);
-					bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, null);
+					bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, default(string));
 					CqlInterval<CqlDateTime> bw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bl_);
 					CqlDateTime bx_ = context.Operators.Start(bw_);
 					bool? by_ = context.Operators.Not((bool?)(bx_ is null));
@@ -438,7 +438,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlInterval<CqlDateTime> ck_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(bi_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, null);
+					bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, default(string));
 					bool? co_ = context.Operators.And(ci_, cn_);
 
 					return co_;
@@ -454,14 +454,14 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			IEnumerable<Observation> l_(Observation BloodGlucoseLab)
 			{
 				CqlValueSet cp_ = this.Glucose_lab_test();
-				IEnumerable<Observation> cq_ = context.Operators.RetrieveByValueSet<Observation>(cp_, null);
+				IEnumerable<Observation> cq_ = context.Operators.RetrieveByValueSet<Observation>(cp_, default(PropertyInfo));
 				bool? cr_(Observation FollowupBloodGlucoseLab)
 				{
 					DataType cv_ = FollowupBloodGlucoseLab?.Effective;
 					CqlInterval<CqlDateTime> cw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(cv_);
 					CqlDateTime cx_ = context.Operators.Start(cw_);
 					CqlInterval<CqlDateTime> cy_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-					bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, null);
+					bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, default(string));
 					CqlInterval<CqlDateTime> db_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(cv_);
 					CqlDateTime dc_ = context.Operators.Start(db_);
 					DataType dd_ = BloodGlucoseLab?.Effective;
@@ -472,7 +472,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					CqlQuantity dj_ = context.Operators.Quantity(5m, "minutes");
 					CqlDateTime dk_ = context.Operators.Add(di_, dj_);
 					CqlInterval<CqlDateTime> dl_ = context.Operators.Interval(df_, dk_, false, true);
-					bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, null);
+					bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, default(string));
 					CqlInterval<CqlDateTime> do_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(dd_);
 					CqlDateTime dp_ = context.Operators.Start(do_);
 					bool? dq_ = context.Operators.Not((bool?)(dp_ is null));
@@ -509,7 +509,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 				CqlInterval<CqlDateTime> ei_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(eh_);
 				CqlDateTime ej_ = context.Operators.Start(ei_);
 				CqlInterval<CqlDateTime> ek_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
-				bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, null);
+				bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, default(string));
 				DataType em_ = BloodGlucoseLab?.Value;
 				CqlQuantity en_ = FHIRHelpers_4_0_001.ToQuantity((em_ as Quantity));
 				CqlQuantity eo_ = context.Operators.Quantity(40m, "mg/dL");

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -98,7 +98,7 @@ public class HybridHWMFHIR_0_102_005
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -106,7 +106,7 @@ public class HybridHWMFHIR_0_102_005
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Body_temperature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default);
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
@@ -114,7 +114,7 @@ public class HybridHWMFHIR_0_102_005
 		__Body_temperature.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -122,7 +122,7 @@ public class HybridHWMFHIR_0_102_005
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -130,7 +130,7 @@ public class HybridHWMFHIR_0_102_005
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -138,7 +138,7 @@ public class HybridHWMFHIR_0_102_005
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -146,7 +146,7 @@ public class HybridHWMFHIR_0_102_005
 		__Ethnicity.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -154,7 +154,7 @@ public class HybridHWMFHIR_0_102_005
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default);
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -162,7 +162,7 @@ public class HybridHWMFHIR_0_102_005
 		__Medicare_payer.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -170,7 +170,7 @@ public class HybridHWMFHIR_0_102_005
 		__Observation_Services.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -178,7 +178,7 @@ public class HybridHWMFHIR_0_102_005
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -186,7 +186,7 @@ public class HybridHWMFHIR_0_102_005
 		__Payer.Value;
 
 	private CqlValueSet Platelet_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default);
 
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
@@ -194,7 +194,7 @@ public class HybridHWMFHIR_0_102_005
 		__Platelet_count_lab_test.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -202,7 +202,7 @@ public class HybridHWMFHIR_0_102_005
 		__Race.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -210,7 +210,7 @@ public class HybridHWMFHIR_0_102_005
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -218,28 +218,28 @@ public class HybridHWMFHIR_0_102_005
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("8867-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("59408-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -248,10 +248,10 @@ public class HybridHWMFHIR_0_102_005
 	private CqlCode[] LOINC_2_69_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
+			new CqlCode("8867-4", "http://loinc.org", default, default),
+			new CqlCode("59408-5", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -263,8 +263,8 @@ public class HybridHWMFHIR_0_102_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHWMFHIR-0.102.005", "Measurement Period", c_);
 
@@ -277,7 +277,7 @@ public class HybridHWMFHIR_0_102_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -344,9 +344,9 @@ public class HybridHWMFHIR_0_102_005
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Medicare_payer();
-		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default(PropertyInfo));
+		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default);
 		IEnumerable<ValueTuple<Encounter, Coverage>> e_ = context.Operators.CrossJoin<Encounter, Coverage>(b_, d_);
 		(Encounter InpatientEncounter, Coverage Payer)? f_(ValueTuple<Encounter, Coverage> _valueTuple)
 		{
@@ -379,7 +379,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlDate ag_ = context.Operators.DateFrom(af_);
 			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, "year");
 			CqlInterval<int?> ai_ = context.Operators.Interval(65, 94, true, true);
-			bool? aj_ = context.Operators.In<int?>(ah_, ai_, default(string));
+			bool? aj_ = context.Operators.In<int?>(ah_, ai_, default);
 			bool? ak_ = context.Operators.And(y_, aj_);
 
 			return ak_;
@@ -437,7 +437,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlQuantity as_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime at_ = context.Operators.Add(ar_, as_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default);
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -488,7 +488,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlQuantity bx_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime by_ = context.Operators.Add(bw_, bx_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default);
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -555,7 +555,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime an_ = context.Operators.Start(am_);
 				CqlDateTime ap_ = context.Operators.Add(an_, aj_);
 				CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ak_, ap_, true, true);
-				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default(string));
+				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default);
 				bool? as_ = context.Operators.And(ad_, ar_);
 				Code<ObservationStatus> at_ = Lab?.StatusElement;
 				string au_ = FHIRHelpers_4_0_001.ToString(at_);
@@ -600,7 +600,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlDateTime bp_ = context.Operators.Add(bn_, bj_);
 				CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bk_, bp_, true, true);
-				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default(string));
+				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default);
 				bool? bs_ = context.Operators.And(bd_, br_);
 				Code<ObservationStatus> bt_ = Lab?.StatusElement;
 				string bu_ = FHIRHelpers_4_0_001.ToString(bt_);
@@ -642,36 +642,36 @@ public class HybridHWMFHIR_0_102_005
 	{
 		CqlCode a_ = this.Heart_rate();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<string> d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
 		CqlCode e_ = this.Systolic_blood_pressure();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<string> h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
 		CqlValueSet i_ = this.Body_temperature();
-		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(i_, default(PropertyInfo));
+		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(i_, default);
 		IEnumerable<string> k_ = this.FirstPhysicalExamWithEncounterId(j_, "FirstTemperature");
 		CqlCode l_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		IEnumerable<CqlCode> m_ = context.Operators.ToList<CqlCode>(l_);
-		IEnumerable<Observation> n_ = context.Operators.RetrieveByCodes<Observation>(m_, default(PropertyInfo));
+		IEnumerable<Observation> n_ = context.Operators.RetrieveByCodes<Observation>(m_, default);
 		IEnumerable<string> o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstO2Saturation");
 		CqlValueSet p_ = this.Hematocrit_lab_test();
-		IEnumerable<Observation> q_ = context.Operators.RetrieveByValueSet<Observation>(p_, default(PropertyInfo));
+		IEnumerable<Observation> q_ = context.Operators.RetrieveByValueSet<Observation>(p_, default);
 		IEnumerable<string> r_ = this.FirstLabTestWithEncounterId(q_, "FirstHematocrit");
 		CqlValueSet s_ = this.Platelet_count_lab_test();
-		IEnumerable<Observation> t_ = context.Operators.RetrieveByValueSet<Observation>(s_, default(PropertyInfo));
+		IEnumerable<Observation> t_ = context.Operators.RetrieveByValueSet<Observation>(s_, default);
 		IEnumerable<string> u_ = this.FirstLabTestWithEncounterId(t_, "FirstPlateletCount");
 		CqlValueSet v_ = this.White_blood_cells_count_lab_test();
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(v_, default(PropertyInfo));
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(v_, default);
 		IEnumerable<string> x_ = this.FirstLabTestWithEncounterId(w_, "FirstWhiteBloodCell");
 		CqlValueSet y_ = this.Sodium_lab_test();
-		IEnumerable<Observation> z_ = context.Operators.RetrieveByValueSet<Observation>(y_, default(PropertyInfo));
+		IEnumerable<Observation> z_ = context.Operators.RetrieveByValueSet<Observation>(y_, default);
 		IEnumerable<string> aa_ = this.FirstLabTestWithEncounterId(z_, "FirstSodium");
 		CqlValueSet ab_ = this.Bicarbonate_lab_test();
-		IEnumerable<Observation> ac_ = context.Operators.RetrieveByValueSet<Observation>(ab_, default(PropertyInfo));
+		IEnumerable<Observation> ac_ = context.Operators.RetrieveByValueSet<Observation>(ab_, default);
 		IEnumerable<string> ad_ = this.FirstLabTestWithEncounterId(ac_, "FirstBicarbonate");
 		CqlValueSet ae_ = this.Creatinine_lab_test();
-		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default(PropertyInfo));
+		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default);
 		IEnumerable<string> ag_ = this.FirstLabTestWithEncounterId(af_, "FirstCreatinine");
 		IEnumerable<string>[] ah_ = [
 			d_,
@@ -735,14 +735,14 @@ public class HybridHWMFHIR_0_102_005
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -756,7 +756,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default);
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -783,7 +783,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -797,7 +797,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default);
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -822,8 +822,8 @@ public class HybridHWMFHIR_0_102_005
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default);
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -837,7 +837,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default);
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -881,7 +881,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -895,7 +895,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default);
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HybridHWMFHIR", "0.102.005")]
 public class HybridHWMFHIR_0_102_005
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -98,7 +98,7 @@ public class HybridHWMFHIR_0_102_005
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -106,7 +106,7 @@ public class HybridHWMFHIR_0_102_005
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Body_temperature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default(string));
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
@@ -114,7 +114,7 @@ public class HybridHWMFHIR_0_102_005
 		__Body_temperature.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -122,7 +122,7 @@ public class HybridHWMFHIR_0_102_005
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -130,7 +130,7 @@ public class HybridHWMFHIR_0_102_005
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -138,7 +138,7 @@ public class HybridHWMFHIR_0_102_005
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -146,7 +146,7 @@ public class HybridHWMFHIR_0_102_005
 		__Ethnicity.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -154,7 +154,7 @@ public class HybridHWMFHIR_0_102_005
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -162,7 +162,7 @@ public class HybridHWMFHIR_0_102_005
 		__Medicare_payer.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -170,7 +170,7 @@ public class HybridHWMFHIR_0_102_005
 		__Observation_Services.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -178,7 +178,7 @@ public class HybridHWMFHIR_0_102_005
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -186,7 +186,7 @@ public class HybridHWMFHIR_0_102_005
 		__Payer.Value;
 
 	private CqlValueSet Platelet_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", default(string));
 
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
@@ -194,7 +194,7 @@ public class HybridHWMFHIR_0_102_005
 		__Platelet_count_lab_test.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -202,7 +202,7 @@ public class HybridHWMFHIR_0_102_005
 		__Race.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -210,7 +210,7 @@ public class HybridHWMFHIR_0_102_005
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -218,28 +218,28 @@ public class HybridHWMFHIR_0_102_005
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", null, null);
+		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", null, null);
+		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -248,10 +248,10 @@ public class HybridHWMFHIR_0_102_005
 	private CqlCode[] LOINC_2_69_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
-			new CqlCode("8867-4", "http://loinc.org", null, null),
-			new CqlCode("59408-5", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -263,8 +263,8 @@ public class HybridHWMFHIR_0_102_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHWMFHIR-0.102.005", "Measurement Period", c_);
 
@@ -277,7 +277,7 @@ public class HybridHWMFHIR_0_102_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -344,9 +344,9 @@ public class HybridHWMFHIR_0_102_005
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Medicare_payer();
-		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, null);
+		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Coverage>> e_ = context.Operators.CrossJoin<Encounter, Coverage>(b_, d_);
 		(Encounter InpatientEncounter, Coverage Payer)? f_(ValueTuple<Encounter, Coverage> _valueTuple)
 		{
@@ -379,7 +379,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlDate ag_ = context.Operators.DateFrom(af_);
 			int? ah_ = context.Operators.CalculateAgeAt(ac_, ag_, "year");
 			CqlInterval<int?> ai_ = context.Operators.Interval(65, 94, true, true);
-			bool? aj_ = context.Operators.In<int?>(ah_, ai_, null);
+			bool? aj_ = context.Operators.In<int?>(ah_, ai_, default(string));
 			bool? ak_ = context.Operators.And(y_, aj_);
 
 			return ak_;
@@ -437,7 +437,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlQuantity as_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime at_ = context.Operators.Add(ar_, as_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, null);
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -488,7 +488,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlQuantity bx_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime by_ = context.Operators.Add(bw_, bx_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, null);
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -555,7 +555,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime an_ = context.Operators.Start(am_);
 				CqlDateTime ap_ = context.Operators.Add(an_, aj_);
 				CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ak_, ap_, true, true);
-				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, null);
+				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default(string));
 				bool? as_ = context.Operators.And(ad_, ar_);
 				Code<ObservationStatus> at_ = Lab?.StatusElement;
 				string au_ = FHIRHelpers_4_0_001.ToString(at_);
@@ -600,7 +600,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlDateTime bp_ = context.Operators.Add(bn_, bj_);
 				CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bk_, bp_, true, true);
-				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, null);
+				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default(string));
 				bool? bs_ = context.Operators.And(bd_, br_);
 				Code<ObservationStatus> bt_ = Lab?.StatusElement;
 				string bu_ = FHIRHelpers_4_0_001.ToString(bt_);
@@ -642,36 +642,36 @@ public class HybridHWMFHIR_0_102_005
 	{
 		CqlCode a_ = this.Heart_rate();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<string> d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
 		CqlCode e_ = this.Systolic_blood_pressure();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<string> h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
 		CqlValueSet i_ = this.Body_temperature();
-		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
+		IEnumerable<Observation> j_ = context.Operators.RetrieveByValueSet<Observation>(i_, default(PropertyInfo));
 		IEnumerable<string> k_ = this.FirstPhysicalExamWithEncounterId(j_, "FirstTemperature");
 		CqlCode l_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		IEnumerable<CqlCode> m_ = context.Operators.ToList<CqlCode>(l_);
-		IEnumerable<Observation> n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
+		IEnumerable<Observation> n_ = context.Operators.RetrieveByCodes<Observation>(m_, default(PropertyInfo));
 		IEnumerable<string> o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstO2Saturation");
 		CqlValueSet p_ = this.Hematocrit_lab_test();
-		IEnumerable<Observation> q_ = context.Operators.RetrieveByValueSet<Observation>(p_, null);
+		IEnumerable<Observation> q_ = context.Operators.RetrieveByValueSet<Observation>(p_, default(PropertyInfo));
 		IEnumerable<string> r_ = this.FirstLabTestWithEncounterId(q_, "FirstHematocrit");
 		CqlValueSet s_ = this.Platelet_count_lab_test();
-		IEnumerable<Observation> t_ = context.Operators.RetrieveByValueSet<Observation>(s_, null);
+		IEnumerable<Observation> t_ = context.Operators.RetrieveByValueSet<Observation>(s_, default(PropertyInfo));
 		IEnumerable<string> u_ = this.FirstLabTestWithEncounterId(t_, "FirstPlateletCount");
 		CqlValueSet v_ = this.White_blood_cells_count_lab_test();
-		IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(v_, null);
+		IEnumerable<Observation> w_ = context.Operators.RetrieveByValueSet<Observation>(v_, default(PropertyInfo));
 		IEnumerable<string> x_ = this.FirstLabTestWithEncounterId(w_, "FirstWhiteBloodCell");
 		CqlValueSet y_ = this.Sodium_lab_test();
-		IEnumerable<Observation> z_ = context.Operators.RetrieveByValueSet<Observation>(y_, null);
+		IEnumerable<Observation> z_ = context.Operators.RetrieveByValueSet<Observation>(y_, default(PropertyInfo));
 		IEnumerable<string> aa_ = this.FirstLabTestWithEncounterId(z_, "FirstSodium");
 		CqlValueSet ab_ = this.Bicarbonate_lab_test();
-		IEnumerable<Observation> ac_ = context.Operators.RetrieveByValueSet<Observation>(ab_, null);
+		IEnumerable<Observation> ac_ = context.Operators.RetrieveByValueSet<Observation>(ab_, default(PropertyInfo));
 		IEnumerable<string> ad_ = this.FirstLabTestWithEncounterId(ac_, "FirstBicarbonate");
 		CqlValueSet ae_ = this.Creatinine_lab_test();
-		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, null);
+		IEnumerable<Observation> af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, default(PropertyInfo));
 		IEnumerable<string> ag_ = this.FirstLabTestWithEncounterId(af_, "FirstCreatinine");
 		IEnumerable<string>[] ah_ = [
 			d_,
@@ -735,14 +735,14 @@ public class HybridHWMFHIR_0_102_005
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -756,7 +756,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, null);
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -783,7 +783,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -797,7 +797,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, null);
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -822,8 +822,8 @@ public class HybridHWMFHIR_0_102_005
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -837,7 +837,7 @@ public class HybridHWMFHIR_0_102_005
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, null);
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -881,7 +881,7 @@ public class HybridHWMFHIR_0_102_005
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -895,7 +895,7 @@ public class HybridHWMFHIR_0_102_005
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, null);
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("HybridHWRFHIR", "1.3.005")]
 public class HybridHWRFHIR_1_3_005
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -104,7 +104,7 @@ public class HybridHWRFHIR_1_3_005
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -112,7 +112,7 @@ public class HybridHWRFHIR_1_3_005
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Body_temperature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default);
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
@@ -120,7 +120,7 @@ public class HybridHWRFHIR_1_3_005
 		__Body_temperature.Value;
 
 	private CqlValueSet Body_weight_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", default);
 
     [CqlDeclaration("Body weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159")]
@@ -128,7 +128,7 @@ public class HybridHWRFHIR_1_3_005
 		__Body_weight.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -136,7 +136,7 @@ public class HybridHWRFHIR_1_3_005
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -144,7 +144,7 @@ public class HybridHWRFHIR_1_3_005
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -152,7 +152,7 @@ public class HybridHWRFHIR_1_3_005
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -160,7 +160,7 @@ public class HybridHWRFHIR_1_3_005
 		__Ethnicity.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -168,7 +168,7 @@ public class HybridHWRFHIR_1_3_005
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -176,7 +176,7 @@ public class HybridHWRFHIR_1_3_005
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default);
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -184,7 +184,7 @@ public class HybridHWRFHIR_1_3_005
 		__Medicare_payer.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -192,7 +192,7 @@ public class HybridHWRFHIR_1_3_005
 		__Observation_Services.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -200,7 +200,7 @@ public class HybridHWRFHIR_1_3_005
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -208,7 +208,7 @@ public class HybridHWRFHIR_1_3_005
 		__Payer.Value;
 
 	private CqlValueSet Potassium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default);
 
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
@@ -216,7 +216,7 @@ public class HybridHWRFHIR_1_3_005
 		__Potassium_lab_test.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -224,7 +224,7 @@ public class HybridHWRFHIR_1_3_005
 		__Race.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -232,7 +232,7 @@ public class HybridHWRFHIR_1_3_005
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -240,35 +240,35 @@ public class HybridHWRFHIR_1_3_005
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
+		new CqlCode("8867-4", "http://loinc.org", default, default);
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
+		new CqlCode("59408-5", "http://loinc.org", default, default);
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Respiratory_rate_Value() => 
-		new CqlCode("9279-1", "http://loinc.org", default(string), default(string));
+		new CqlCode("9279-1", "http://loinc.org", default, default);
 
     [CqlDeclaration("Respiratory rate")]
 	public CqlCode Respiratory_rate() => 
 		__Respiratory_rate.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
+		new CqlCode("8480-6", "http://loinc.org", default, default);
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -277,11 +277,11 @@ public class HybridHWRFHIR_1_3_005
 	private CqlCode[] LOINC_2_69_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
-			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
-			new CqlCode("9279-1", "http://loinc.org", default(string), default(string)),
-			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
+			new CqlCode("8867-4", "http://loinc.org", default, default),
+			new CqlCode("59408-5", "http://loinc.org", default, default),
+			new CqlCode("9279-1", "http://loinc.org", default, default),
+			new CqlCode("8480-6", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -293,8 +293,8 @@ public class HybridHWRFHIR_1_3_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHWRFHIR-1.3.005", "Measurement Period", c_);
 
@@ -307,7 +307,7 @@ public class HybridHWRFHIR_1_3_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -370,14 +370,14 @@ public class HybridHWRFHIR_1_3_005
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -391,7 +391,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default);
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -418,7 +418,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -432,7 +432,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default);
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -457,8 +457,8 @@ public class HybridHWRFHIR_1_3_005
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default);
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -472,7 +472,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default);
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -516,7 +516,7 @@ public class HybridHWRFHIR_1_3_005
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -530,7 +530,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default);
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));
@@ -580,9 +580,9 @@ public class HybridHWRFHIR_1_3_005
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Medicare_payer();
-		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default(PropertyInfo));
+		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default);
 		IEnumerable<ValueTuple<Encounter, Coverage>> e_ = context.Operators.CrossJoin<Encounter, Coverage>(b_, d_);
 		(Encounter InpatientEncounter, Coverage Payer)? f_(ValueTuple<Encounter, Coverage> _valueTuple)
 		{
@@ -672,7 +672,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlQuantity as_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime at_ = context.Operators.Add(ar_, as_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default);
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -723,7 +723,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlQuantity bx_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime by_ = context.Operators.Add(bw_, bx_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default);
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -793,7 +793,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime ar_ = context.Operators.Start(aq_);
 				CqlDateTime at_ = context.Operators.Add(ar_, an_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default);
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -843,7 +843,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime bw_ = context.Operators.Start(bv_);
 				CqlDateTime by_ = context.Operators.Add(bw_, bs_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default);
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -910,7 +910,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime an_ = context.Operators.Start(am_);
 				CqlDateTime ap_ = context.Operators.Add(an_, aj_);
 				CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ak_, ap_, true, true);
-				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default(string));
+				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default);
 				bool? as_ = context.Operators.And(ad_, ar_);
 				Code<ObservationStatus> at_ = Lab?.StatusElement;
 				string au_ = FHIRHelpers_4_0_001.ToString(at_);
@@ -955,7 +955,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlDateTime bp_ = context.Operators.Add(bn_, bj_);
 				CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bk_, bp_, true, true);
-				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default(string));
+				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default);
 				bool? bs_ = context.Operators.And(bd_, br_);
 				Code<ObservationStatus> bt_ = Lab?.StatusElement;
 				string bu_ = FHIRHelpers_4_0_001.ToString(bt_);
@@ -997,46 +997,46 @@ public class HybridHWRFHIR_1_3_005
 	{
 		CqlCode a_ = this.Heart_rate();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		IEnumerable<string> d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
 		CqlCode e_ = this.Systolic_blood_pressure();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default);
 		IEnumerable<string> h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
 		CqlCode i_ = this.Respiratory_rate();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default);
 		IEnumerable<string> l_ = this.FirstPhysicalExamWithEncounterId(k_, "FirstRespRate");
 		CqlValueSet m_ = this.Body_temperature();
-		IEnumerable<Observation> n_ = context.Operators.RetrieveByValueSet<Observation>(m_, default(PropertyInfo));
+		IEnumerable<Observation> n_ = context.Operators.RetrieveByValueSet<Observation>(m_, default);
 		IEnumerable<string> o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstTemperature");
 		CqlCode p_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		IEnumerable<CqlCode> q_ = context.Operators.ToList<CqlCode>(p_);
-		IEnumerable<Observation> r_ = context.Operators.RetrieveByCodes<Observation>(q_, default(PropertyInfo));
+		IEnumerable<Observation> r_ = context.Operators.RetrieveByCodes<Observation>(q_, default);
 		IEnumerable<string> s_ = this.FirstPhysicalExamWithEncounterId(r_, "FirstO2Saturation");
 		CqlValueSet t_ = this.Body_weight();
-		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default(PropertyInfo));
+		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default);
 		IEnumerable<string> v_ = this.FirstPhysicalExamWithEncounterIdUsingLabTiming(u_, "FirstWeight");
 		CqlValueSet w_ = this.Hematocrit_lab_test();
-		IEnumerable<Observation> x_ = context.Operators.RetrieveByValueSet<Observation>(w_, default(PropertyInfo));
+		IEnumerable<Observation> x_ = context.Operators.RetrieveByValueSet<Observation>(w_, default);
 		IEnumerable<string> y_ = this.FirstLabTestWithEncounterId(x_, "FirstHematocrit");
 		CqlValueSet z_ = this.White_blood_cells_count_lab_test();
-		IEnumerable<Observation> aa_ = context.Operators.RetrieveByValueSet<Observation>(z_, default(PropertyInfo));
+		IEnumerable<Observation> aa_ = context.Operators.RetrieveByValueSet<Observation>(z_, default);
 		IEnumerable<string> ab_ = this.FirstLabTestWithEncounterId(aa_, "FirstWhiteBloodCell");
 		CqlValueSet ac_ = this.Potassium_lab_test();
-		IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(ac_, default(PropertyInfo));
+		IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(ac_, default);
 		IEnumerable<string> ae_ = this.FirstLabTestWithEncounterId(ad_, "FirstPotassium");
 		CqlValueSet af_ = this.Sodium_lab_test();
-		IEnumerable<Observation> ag_ = context.Operators.RetrieveByValueSet<Observation>(af_, default(PropertyInfo));
+		IEnumerable<Observation> ag_ = context.Operators.RetrieveByValueSet<Observation>(af_, default);
 		IEnumerable<string> ah_ = this.FirstLabTestWithEncounterId(ag_, "FirstSodium");
 		CqlValueSet ai_ = this.Bicarbonate_lab_test();
-		IEnumerable<Observation> aj_ = context.Operators.RetrieveByValueSet<Observation>(ai_, default(PropertyInfo));
+		IEnumerable<Observation> aj_ = context.Operators.RetrieveByValueSet<Observation>(ai_, default);
 		IEnumerable<string> ak_ = this.FirstLabTestWithEncounterId(aj_, "FirstBicarbonate");
 		CqlValueSet al_ = this.Creatinine_lab_test();
-		IEnumerable<Observation> am_ = context.Operators.RetrieveByValueSet<Observation>(al_, default(PropertyInfo));
+		IEnumerable<Observation> am_ = context.Operators.RetrieveByValueSet<Observation>(al_, default);
 		IEnumerable<string> an_ = this.FirstLabTestWithEncounterId(am_, "FirstCreatinine");
 		CqlValueSet ao_ = this.Glucose_lab_test();
-		IEnumerable<Observation> ap_ = context.Operators.RetrieveByValueSet<Observation>(ao_, default(PropertyInfo));
+		IEnumerable<Observation> ap_ = context.Operators.RetrieveByValueSet<Observation>(ao_, default);
 		IEnumerable<string> aq_ = this.FirstLabTestWithEncounterId(ap_, "FirstGlucose");
 		IEnumerable<string>[] ar_ = [
 			d_,

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -104,7 +104,7 @@ public class HybridHWRFHIR_1_3_005
     #endregion
 
 	private CqlValueSet Bicarbonate_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", default(string));
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
@@ -112,7 +112,7 @@ public class HybridHWRFHIR_1_3_005
 		__Bicarbonate_lab_test.Value;
 
 	private CqlValueSet Body_temperature_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", default(string));
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
@@ -120,7 +120,7 @@ public class HybridHWRFHIR_1_3_005
 		__Body_temperature.Value;
 
 	private CqlValueSet Body_weight_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", default(string));
 
     [CqlDeclaration("Body weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159")]
@@ -128,7 +128,7 @@ public class HybridHWRFHIR_1_3_005
 		__Body_weight.Value;
 
 	private CqlValueSet Creatinine_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", default(string));
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
@@ -136,7 +136,7 @@ public class HybridHWRFHIR_1_3_005
 		__Creatinine_lab_test.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -144,7 +144,7 @@ public class HybridHWRFHIR_1_3_005
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -152,7 +152,7 @@ public class HybridHWRFHIR_1_3_005
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -160,7 +160,7 @@ public class HybridHWRFHIR_1_3_005
 		__Ethnicity.Value;
 
 	private CqlValueSet Glucose_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", default(string));
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
@@ -168,7 +168,7 @@ public class HybridHWRFHIR_1_3_005
 		__Glucose_lab_test.Value;
 
 	private CqlValueSet Hematocrit_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", default(string));
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
@@ -176,7 +176,7 @@ public class HybridHWRFHIR_1_3_005
 		__Hematocrit_lab_test.Value;
 
 	private CqlValueSet Medicare_payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", default(string));
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
@@ -184,7 +184,7 @@ public class HybridHWRFHIR_1_3_005
 		__Medicare_payer.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -192,7 +192,7 @@ public class HybridHWRFHIR_1_3_005
 		__Observation_Services.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -200,7 +200,7 @@ public class HybridHWRFHIR_1_3_005
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -208,7 +208,7 @@ public class HybridHWRFHIR_1_3_005
 		__Payer.Value;
 
 	private CqlValueSet Potassium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", default(string));
 
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
@@ -216,7 +216,7 @@ public class HybridHWRFHIR_1_3_005
 		__Potassium_lab_test.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -224,7 +224,7 @@ public class HybridHWRFHIR_1_3_005
 		__Race.Value;
 
 	private CqlValueSet Sodium_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", default(string));
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
@@ -232,7 +232,7 @@ public class HybridHWRFHIR_1_3_005
 		__Sodium_lab_test.Value;
 
 	private CqlValueSet White_blood_cells_count_lab_test_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", default(string));
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
@@ -240,35 +240,35 @@ public class HybridHWRFHIR_1_3_005
 		__White_blood_cells_count_lab_test.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
 		__Birth_date.Value;
 
 	private CqlCode Heart_rate_Value() => 
-		new CqlCode("8867-4", "http://loinc.org", null, null);
+		new CqlCode("8867-4", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Heart rate")]
 	public CqlCode Heart_rate() => 
 		__Heart_rate.Value;
 
 	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value() => 
-		new CqlCode("59408-5", "http://loinc.org", null, null);
+		new CqlCode("59408-5", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
 	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
 		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry.Value;
 
 	private CqlCode Respiratory_rate_Value() => 
-		new CqlCode("9279-1", "http://loinc.org", null, null);
+		new CqlCode("9279-1", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Respiratory rate")]
 	public CqlCode Respiratory_rate() => 
 		__Respiratory_rate.Value;
 
 	private CqlCode Systolic_blood_pressure_Value() => 
-		new CqlCode("8480-6", "http://loinc.org", null, null);
+		new CqlCode("8480-6", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Systolic blood pressure")]
 	public CqlCode Systolic_blood_pressure() => 
@@ -277,11 +277,11 @@ public class HybridHWRFHIR_1_3_005
 	private CqlCode[] LOINC_2_69_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
-			new CqlCode("8867-4", "http://loinc.org", null, null),
-			new CqlCode("59408-5", "http://loinc.org", null, null),
-			new CqlCode("9279-1", "http://loinc.org", null, null),
-			new CqlCode("8480-6", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8867-4", "http://loinc.org", default(string), default(string)),
+			new CqlCode("59408-5", "http://loinc.org", default(string), default(string)),
+			new CqlCode("9279-1", "http://loinc.org", default(string), default(string)),
+			new CqlCode("8480-6", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -293,8 +293,8 @@ public class HybridHWRFHIR_1_3_005
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("HybridHWRFHIR-1.3.005", "Measurement Period", c_);
 
@@ -307,7 +307,7 @@ public class HybridHWRFHIR_1_3_005
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -370,14 +370,14 @@ public class HybridHWRFHIR_1_3_005
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -391,7 +391,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, null);
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -418,7 +418,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -432,7 +432,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, null);
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -457,8 +457,8 @@ public class HybridHWRFHIR_1_3_005
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -472,7 +472,7 @@ public class HybridHWRFHIR_1_3_005
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, null);
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -516,7 +516,7 @@ public class HybridHWRFHIR_1_3_005
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -530,7 +530,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, null);
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));
@@ -580,9 +580,9 @@ public class HybridHWRFHIR_1_3_005
 	private IEnumerable<Encounter> Inpatient_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Medicare_payer();
-		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, null);
+		IEnumerable<Coverage> d_ = context.Operators.RetrieveByValueSet<Coverage>(c_, default(PropertyInfo));
 		IEnumerable<ValueTuple<Encounter, Coverage>> e_ = context.Operators.CrossJoin<Encounter, Coverage>(b_, d_);
 		(Encounter InpatientEncounter, Coverage Payer)? f_(ValueTuple<Encounter, Coverage> _valueTuple)
 		{
@@ -672,7 +672,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlQuantity as_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime at_ = context.Operators.Add(ar_, as_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, null);
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -723,7 +723,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlQuantity bx_ = context.Operators.Quantity(120m, "minutes");
 				CqlDateTime by_ = context.Operators.Add(bw_, bx_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, null);
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -793,7 +793,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime ar_ = context.Operators.Start(aq_);
 				CqlDateTime at_ = context.Operators.Add(ar_, an_);
 				CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ao_, at_, true, true);
-				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, null);
+				bool? av_ = context.Operators.In<CqlDateTime>(aj_, au_, default(string));
 				bool? aw_ = context.Operators.And(ag_, av_);
 				Code<ObservationStatus> ax_ = Exam?.StatusElement;
 				string ay_ = FHIRHelpers_4_0_001.ToString(ax_);
@@ -843,7 +843,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime bw_ = context.Operators.Start(bv_);
 				CqlDateTime by_ = context.Operators.Add(bw_, bs_);
 				CqlInterval<CqlDateTime> bz_ = context.Operators.Interval(bt_, by_, true, true);
-				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, null);
+				bool? ca_ = context.Operators.In<CqlDateTime>(bo_, bz_, default(string));
 				bool? cb_ = context.Operators.And(bl_, ca_);
 				Code<ObservationStatus> cc_ = Exam?.StatusElement;
 				string cd_ = FHIRHelpers_4_0_001.ToString(cc_);
@@ -910,7 +910,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime an_ = context.Operators.Start(am_);
 				CqlDateTime ap_ = context.Operators.Add(an_, aj_);
 				CqlInterval<CqlDateTime> aq_ = context.Operators.Interval(ak_, ap_, true, true);
-				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, null);
+				bool? ar_ = context.Operators.In<CqlDateTime>(af_, aq_, default(string));
 				bool? as_ = context.Operators.And(ad_, ar_);
 				Code<ObservationStatus> at_ = Lab?.StatusElement;
 				string au_ = FHIRHelpers_4_0_001.ToString(at_);
@@ -955,7 +955,7 @@ public class HybridHWRFHIR_1_3_005
 				CqlDateTime bn_ = context.Operators.Start(bm_);
 				CqlDateTime bp_ = context.Operators.Add(bn_, bj_);
 				CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bk_, bp_, true, true);
-				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, null);
+				bool? br_ = context.Operators.In<CqlDateTime>(bf_, bq_, default(string));
 				bool? bs_ = context.Operators.And(bd_, br_);
 				Code<ObservationStatus> bt_ = Lab?.StatusElement;
 				string bu_ = FHIRHelpers_4_0_001.ToString(bt_);
@@ -997,46 +997,46 @@ public class HybridHWRFHIR_1_3_005
 	{
 		CqlCode a_ = this.Heart_rate();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		IEnumerable<string> d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
 		CqlCode e_ = this.Systolic_blood_pressure();
 		IEnumerable<CqlCode> f_ = context.Operators.ToList<CqlCode>(e_);
-		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
+		IEnumerable<Observation> g_ = context.Operators.RetrieveByCodes<Observation>(f_, default(PropertyInfo));
 		IEnumerable<string> h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
 		CqlCode i_ = this.Respiratory_rate();
 		IEnumerable<CqlCode> j_ = context.Operators.ToList<CqlCode>(i_);
-		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
+		IEnumerable<Observation> k_ = context.Operators.RetrieveByCodes<Observation>(j_, default(PropertyInfo));
 		IEnumerable<string> l_ = this.FirstPhysicalExamWithEncounterId(k_, "FirstRespRate");
 		CqlValueSet m_ = this.Body_temperature();
-		IEnumerable<Observation> n_ = context.Operators.RetrieveByValueSet<Observation>(m_, null);
+		IEnumerable<Observation> n_ = context.Operators.RetrieveByValueSet<Observation>(m_, default(PropertyInfo));
 		IEnumerable<string> o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstTemperature");
 		CqlCode p_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		IEnumerable<CqlCode> q_ = context.Operators.ToList<CqlCode>(p_);
-		IEnumerable<Observation> r_ = context.Operators.RetrieveByCodes<Observation>(q_, null);
+		IEnumerable<Observation> r_ = context.Operators.RetrieveByCodes<Observation>(q_, default(PropertyInfo));
 		IEnumerable<string> s_ = this.FirstPhysicalExamWithEncounterId(r_, "FirstO2Saturation");
 		CqlValueSet t_ = this.Body_weight();
-		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, null);
+		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default(PropertyInfo));
 		IEnumerable<string> v_ = this.FirstPhysicalExamWithEncounterIdUsingLabTiming(u_, "FirstWeight");
 		CqlValueSet w_ = this.Hematocrit_lab_test();
-		IEnumerable<Observation> x_ = context.Operators.RetrieveByValueSet<Observation>(w_, null);
+		IEnumerable<Observation> x_ = context.Operators.RetrieveByValueSet<Observation>(w_, default(PropertyInfo));
 		IEnumerable<string> y_ = this.FirstLabTestWithEncounterId(x_, "FirstHematocrit");
 		CqlValueSet z_ = this.White_blood_cells_count_lab_test();
-		IEnumerable<Observation> aa_ = context.Operators.RetrieveByValueSet<Observation>(z_, null);
+		IEnumerable<Observation> aa_ = context.Operators.RetrieveByValueSet<Observation>(z_, default(PropertyInfo));
 		IEnumerable<string> ab_ = this.FirstLabTestWithEncounterId(aa_, "FirstWhiteBloodCell");
 		CqlValueSet ac_ = this.Potassium_lab_test();
-		IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(ac_, null);
+		IEnumerable<Observation> ad_ = context.Operators.RetrieveByValueSet<Observation>(ac_, default(PropertyInfo));
 		IEnumerable<string> ae_ = this.FirstLabTestWithEncounterId(ad_, "FirstPotassium");
 		CqlValueSet af_ = this.Sodium_lab_test();
-		IEnumerable<Observation> ag_ = context.Operators.RetrieveByValueSet<Observation>(af_, null);
+		IEnumerable<Observation> ag_ = context.Operators.RetrieveByValueSet<Observation>(af_, default(PropertyInfo));
 		IEnumerable<string> ah_ = this.FirstLabTestWithEncounterId(ag_, "FirstSodium");
 		CqlValueSet ai_ = this.Bicarbonate_lab_test();
-		IEnumerable<Observation> aj_ = context.Operators.RetrieveByValueSet<Observation>(ai_, null);
+		IEnumerable<Observation> aj_ = context.Operators.RetrieveByValueSet<Observation>(ai_, default(PropertyInfo));
 		IEnumerable<string> ak_ = this.FirstLabTestWithEncounterId(aj_, "FirstBicarbonate");
 		CqlValueSet al_ = this.Creatinine_lab_test();
-		IEnumerable<Observation> am_ = context.Operators.RetrieveByValueSet<Observation>(al_, null);
+		IEnumerable<Observation> am_ = context.Operators.RetrieveByValueSet<Observation>(al_, default(PropertyInfo));
 		IEnumerable<string> an_ = this.FirstLabTestWithEncounterId(am_, "FirstCreatinine");
 		CqlValueSet ao_ = this.Glucose_lab_test();
-		IEnumerable<Observation> ap_ = context.Operators.RetrieveByValueSet<Observation>(ao_, null);
+		IEnumerable<Observation> ap_ = context.Operators.RetrieveByValueSet<Observation>(ao_, default(PropertyInfo));
 		IEnumerable<string> aq_ = this.FirstLabTestWithEncounterId(ap_, "FirstGlucose");
 		IEnumerable<string>[] ar_ = [
 			d_,

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -118,7 +118,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -126,7 +126,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -134,7 +134,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -142,7 +142,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default);
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -150,175 +150,175 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default);
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
+		new CqlCode("419099009", "http://snomed.info/sct", default, default);
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default);
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
@@ -327,12 +327,12 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -345,9 +345,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
 		];
 
 		return a_;
@@ -360,9 +360,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
 		];
 
 		return a_;
@@ -375,7 +375,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default, default),
 		];
 
 		return a_;
@@ -388,7 +388,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -401,8 +401,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
 		];
 
 		return a_;
@@ -415,12 +415,12 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
 		];
 
 		return a_;
@@ -433,7 +433,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
+			new CqlCode("419099009", "http://snomed.info/sct", default, default),
 		];
 
 		return a_;
@@ -446,8 +446,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default, default),
 		];
 
 		return a_;
@@ -459,8 +459,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("MATGlobalCommonFunctionsFHIR4-6.1.000", "Measurement Period", c_);
 
@@ -473,7 +473,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -496,7 +496,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -510,7 +510,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_0_001.ToInterval(h_);
 			CqlDateTime o_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
-			bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
 			bool? r_ = context.Operators.And(l_, q_);
 
 			return r_;
@@ -528,7 +528,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -545,7 +545,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			CqlDateTime u_ = context.Operators.Start(t_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
 			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			CqlDateTime z_ = context.Operators.Start(y_);
 			bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -706,14 +706,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default);
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -727,7 +727,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default);
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -754,7 +754,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -768,7 +768,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default);
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -793,8 +793,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default);
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default);
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -808,7 +808,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default);
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -852,7 +852,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default);
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -866,7 +866,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default);
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));
@@ -1326,7 +1326,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -1352,7 +1352,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("GetCondition")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -1460,7 +1460,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		];
 		Condition f_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(default, default);
 			bool? n_(Condition C)
 			{
 				Id q_ = C?.IdElement;
@@ -1487,7 +1487,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("GetLocation")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default, default);
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -1591,7 +1591,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else
 			{
-				IEnumerable<Medication> f_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
+				IEnumerable<Medication> f_ = context.Operators.RetrieveByValueSet<Medication>(default, default);
 				bool? g_(Medication M)
 				{
 					Id k_ = M?.IdElement;

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -118,7 +118,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     #endregion
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -126,7 +126,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -134,7 +134,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -142,7 +142,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", default(string));
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
@@ -150,175 +150,175 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		__Present_on_Admission_or_Clinically_Undetermined.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode Billing_Value() => 
-		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
+		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string));
 
     [CqlDeclaration("Billing")]
 	public CqlCode Billing() => 
 		__Billing.Value;
 
 	private CqlCode Birthdate_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birthdate")]
 	public CqlCode Birthdate() => 
 		__Birthdate.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode Dead_Value() => 
-		new CqlCode("419099009", "http://snomed.info/sct", null, null);
+		new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string));
 
     [CqlDeclaration("Dead")]
 	public CqlCode Dead() => 
 		__Dead.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode ER_Value() => 
-		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ER")]
 	public CqlCode ER() => 
 		__ER.Value;
 
 	private CqlCode ICU_Value() => 
-		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
+		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string));
 
     [CqlDeclaration("ICU")]
 	public CqlCode ICU() => 
 		__ICU.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string));
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
@@ -327,12 +327,12 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -345,9 +345,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -360,9 +360,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -375,7 +375,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] Diagnosis_Role_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null),
+			new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", default(string), default(string)),
 		];
 
 		return a_;
@@ -388,7 +388,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -401,8 +401,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -415,12 +415,12 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default(string), default(string)),
 		];
 
 		return a_;
@@ -433,7 +433,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] SNOMEDCT_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("419099009", "http://snomed.info/sct", null, null),
+			new CqlCode("419099009", "http://snomed.info/sct", default(string), default(string)),
 		];
 
 		return a_;
@@ -446,8 +446,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private CqlCode[] RoleCode_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
-			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null),
+			new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
+			new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -459,8 +459,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("MATGlobalCommonFunctionsFHIR4-6.1.000", "Measurement Period", c_);
 
@@ -473,7 +473,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -496,7 +496,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	private IEnumerable<Encounter> Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Encounter_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EncounterInpatient)
 		{
 			Code<Encounter.EncounterStatus> e_ = EncounterInpatient?.StatusElement;
@@ -510,7 +510,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_0_001.ToInterval(h_);
 			CqlDateTime o_ = context.Operators.End(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
-			bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, null);
+			bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default(string));
 			bool? r_ = context.Operators.And(l_, q_);
 
 			return r_;
@@ -528,7 +528,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	public Encounter ED_Visit(Encounter TheEncounter)
 	{
 		CqlValueSet a_ = this.Emergency_Department_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter EDVisit)
 		{
 			Code<Encounter.EncounterStatus> h_ = EDVisit?.StatusElement;
@@ -545,7 +545,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			CqlDateTime u_ = context.Operators.Start(t_);
 			CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, null);
+			bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default(string));
 			CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			CqlDateTime z_ = context.Operators.Start(y_);
 			bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -706,14 +706,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
 			CqlValueSet e_ = this.Emergency_Department_Visit();
-			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
+			IEnumerable<Encounter> f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, default(PropertyInfo));
 			bool? g_(Encounter LastED)
 			{
 				Period af_ = LastED?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
 				CqlDateTime ah_ = context.Operators.End(ag_);
 				CqlValueSet ai_ = this.Observation_Services();
-				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> aj_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? ak_(Encounter LastObs)
 				{
 					Period cb_ = LastObs?.Period;
@@ -727,7 +727,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cl_ = context.Operators.Start(ck_);
 					CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ci_, cl_, true, true);
-					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, null);
+					bool? cn_ = context.Operators.In<CqlDateTime>(cd_, cm_, default(string));
 					CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_0_001.ToInterval(ce_);
 					CqlDateTime cq_ = context.Operators.Start(cp_);
 					bool? cr_ = context.Operators.Not((bool?)(cq_ is null));
@@ -754,7 +754,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlDateTime au_ = context.Operators.Start(at_);
 				CqlQuantity av_ = context.Operators.Quantity(1m, "hour");
 				CqlDateTime aw_ = context.Operators.Subtract((ar_ ?? au_), av_);
-				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				IEnumerable<Encounter> ay_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? az_(Encounter LastObs)
 				{
 					Period cw_ = LastObs?.Period;
@@ -768,7 +768,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> df_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dg_ = context.Operators.Start(df_);
 					CqlInterval<CqlDateTime> dh_ = context.Operators.Interval(dd_, dg_, true, true);
-					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, null);
+					bool? di_ = context.Operators.In<CqlDateTime>(cy_, dh_, default(string));
 					CqlInterval<CqlDateTime> dk_ = FHIRHelpers_4_0_001.ToInterval(cz_);
 					CqlDateTime dl_ = context.Operators.Start(dk_);
 					bool? dm_ = context.Operators.Not((bool?)(dl_ is null));
@@ -793,8 +793,8 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_0_001.ToInterval(as_);
 				CqlDateTime bj_ = context.Operators.Start(bi_);
 				CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(aw_, (bg_ ?? bj_), true, true);
-				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, null);
-				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, null);
+				bool? bl_ = context.Operators.In<CqlDateTime>(ah_, bk_, default(string));
+				IEnumerable<Encounter> bn_ = context.Operators.RetrieveByValueSet<Encounter>(ai_, default(PropertyInfo));
 				bool? bo_(Encounter LastObs)
 				{
 					Period dr_ = LastObs?.Period;
@@ -808,7 +808,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 					CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eb_ = context.Operators.Start(ea_);
 					CqlInterval<CqlDateTime> ec_ = context.Operators.Interval(dy_, eb_, true, true);
-					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, null);
+					bool? ed_ = context.Operators.In<CqlDateTime>(dt_, ec_, default(string));
 					CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_0_001.ToInterval(du_);
 					CqlDateTime eg_ = context.Operators.Start(ef_);
 					bool? eh_ = context.Operators.Not((bool?)(eg_ is null));
@@ -852,7 +852,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.ToInterval(l_);
 			CqlDateTime n_ = context.Operators.Start(m_);
 			CqlValueSet o_ = this.Observation_Services();
-			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, null);
+			IEnumerable<Encounter> p_ = context.Operators.RetrieveByValueSet<Encounter>(o_, default(PropertyInfo));
 			bool? q_(Encounter LastObs)
 			{
 				Period ep_ = LastObs?.Period;
@@ -866,7 +866,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				CqlInterval<CqlDateTime> ey_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime ez_ = context.Operators.Start(ey_);
 				CqlInterval<CqlDateTime> fa_ = context.Operators.Interval(ew_, ez_, true, true);
-				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, null);
+				bool? fb_ = context.Operators.In<CqlDateTime>(er_, fa_, default(string));
 				CqlInterval<CqlDateTime> fd_ = FHIRHelpers_4_0_001.ToInterval(es_);
 				CqlDateTime fe_ = context.Operators.Start(fd_);
 				bool? ff_ = context.Operators.Not((bool?)(fe_ is null));
@@ -1326,7 +1326,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		List<Encounter.DiagnosisComponent> a_ = Encounter?.Diagnosis;
 		Condition b_(Encounter.DiagnosisComponent D)
 		{
-			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> d_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Condition C)
 			{
 				Id h_ = C?.IdElement;
@@ -1352,7 +1352,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("GetCondition")]
 	public Condition GetCondition(ResourceReference reference)
 	{
-		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		IEnumerable<Condition> a_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Condition C)
 		{
 			Id e_ = C?.IdElement;
@@ -1460,7 +1460,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		];
 		Condition f_(Encounter.DiagnosisComponent PD)
 		{
-			IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+			IEnumerable<Condition> m_ = context.Operators.RetrieveByValueSet<Condition>(default(CqlValueSet), default(PropertyInfo));
 			bool? n_(Condition C)
 			{
 				Id q_ = C?.IdElement;
@@ -1487,7 +1487,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("GetLocation")]
 	public Location GetLocation(ResourceReference reference)
 	{
-		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+		IEnumerable<Location> a_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
 		bool? b_(Location L)
 		{
 			Id e_ = L?.IdElement;
@@ -1591,7 +1591,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else
 			{
-				IEnumerable<Medication> f_ = context.Operators.RetrieveByValueSet<Medication>(null, null);
+				IEnumerable<Medication> f_ = context.Operators.RetrieveByValueSet<Medication>(default(CqlValueSet), default(PropertyInfo));
 				bool? g_(Medication M)
 				{
 					Id k_ = M?.IdElement;

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("MATGlobalCommonFunctionsFHIR4", "6.1.000")]
 public class MATGlobalCommonFunctionsFHIR4_6_1_000
 {

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -94,7 +94,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", default);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810")]
@@ -102,7 +102,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", default);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465")]
@@ -110,7 +110,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", default);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729")]
@@ -118,7 +118,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Dementia_Medications.Value;
 
 	private CqlValueSet ED_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", default);
 
     [CqlDeclaration("ED")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086")]
@@ -126,7 +126,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__ED.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", default);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530")]
@@ -134,7 +134,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", default);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531")]
@@ -142,7 +142,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", default);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532")]
@@ -150,7 +150,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", default);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533")]
@@ -158,7 +158,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", default);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189")]
@@ -166,7 +166,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", default);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191")]
@@ -174,7 +174,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Observation.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446")]
@@ -182,7 +182,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", default);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202")]
@@ -190,7 +190,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Outpatient.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246")]
@@ -210,7 +210,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,26 +223,26 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation FrailtyDeviceApplied)
 		{
 			DataType z_ = FrailtyDeviceApplied?.Effective;
 			CqlInterval<CqlDateTime> aa_ = NCQAFHIRBase_1_0_0.Normalize_Interval(z_);
 			CqlInterval<CqlDateTime> ab_ = this.Measurement_Period();
-			bool? ac_ = context.Operators.Overlaps(aa_, ab_, default(string));
+			bool? ac_ = context.Operators.Overlaps(aa_, ab_, default);
 
 			return ac_;
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 		IEnumerable<Condition> h_ = NCQAStatus_1_0_0.Active_Condition(g_);
 		bool? i_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> ad_ = NCQAFHIRBase_1_0_0.Prevalence_Period(FrailtyDiagnosis);
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
-			bool? af_ = context.Operators.Overlaps(ad_, ae_, default(string));
+			bool? af_ = context.Operators.Overlaps(ad_, ae_, default);
 
 			return af_;
 		};
@@ -250,14 +250,14 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		bool? k_ = context.Operators.Exists<Condition>(j_);
 		bool? l_ = context.Operators.Or(e_, k_);
 		CqlValueSet m_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default);
 		IEnumerable<Encounter> o_ = NCQAStatus_1_0_0.Finished_Encounter(n_);
 		bool? p_(Encounter FrailtyEncounter)
 		{
 			Period ag_ = FrailtyEncounter?.Period;
 			CqlInterval<CqlDateTime> ah_ = NCQAFHIRBase_1_0_0.Normalize_Interval((ag_ as object));
 			CqlInterval<CqlDateTime> ai_ = this.Measurement_Period();
-			bool? aj_ = context.Operators.Overlaps(ah_, ai_, default(string));
+			bool? aj_ = context.Operators.Overlaps(ah_, ai_, default);
 
 			return aj_;
 		};
@@ -265,13 +265,13 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		bool? r_ = context.Operators.Exists<Encounter>(q_);
 		bool? s_ = context.Operators.Or(l_, r_);
 		CqlValueSet t_ = this.Frailty_Symptom();
-		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default(PropertyInfo));
+		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default);
 		bool? v_(Observation FrailtySymptom)
 		{
 			DataType ak_ = FrailtySymptom?.Effective;
 			CqlInterval<CqlDateTime> al_ = NCQAFHIRBase_1_0_0.Normalize_Interval(ak_);
 			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
-			bool? an_ = context.Operators.Overlaps(al_, am_, default(string));
+			bool? an_ = context.Operators.Overlaps(al_, am_, default);
 
 			return an_;
 		};
@@ -289,27 +289,27 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private IEnumerable<CqlDate> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.ED();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Telephone_Visits();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Online_Assessments();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		IEnumerable<Encounter> r_ = NCQAStatus_1_0_0.Finished_Encounter(q_);
 		bool? s_(Encounter OutpatientEncounter)
 		{
 			CqlValueSet w_ = this.Advanced_Illness();
-			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default(PropertyInfo));
+			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default);
 			bool? y_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(OutpatientEncounter, x_);
 			Period z_ = OutpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> aa_ = NCQAFHIRBase_1_0_0.Normalize_Interval((z_ as object));
@@ -323,7 +323,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime aj_ = context.Operators.End(ad_);
 			CqlDate ak_ = context.Operators.DateFrom(aj_);
 			CqlInterval<CqlDate> al_ = context.Operators.Interval(ah_, ak_, true, true);
-			bool? am_ = context.Operators.In<CqlDate>(ac_, al_, default(string));
+			bool? am_ = context.Operators.In<CqlDate>(ac_, al_, default);
 			bool? an_ = context.Operators.And(y_, am_);
 
 			return an_;
@@ -349,7 +349,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private IEnumerable<CqlDate> Nonacute_Inpatient_Discharge_with_Advanced_Illness_Value()
 	{
-		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default, default);
 		(IEnumerable<Claim> InpatientDischarge, IEnumerable<Claim> NonacuteInpatientDischarge, IEnumerable<Claim> AcuteInpatientDischarge)? b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
 		IEnumerable<Claim> c_ = b_?.NonacuteInpatientDischarge;
 		CqlValueSet d_ = this.Advanced_Illness();
@@ -368,7 +368,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default);
 
 			return w_;
 		};
@@ -450,7 +450,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		{
 			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
 			CqlDate m_ = context.Operators.Add(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit1, l_);
-			bool? n_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, m_, default(string));
+			bool? n_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, m_, default);
 
 			return n_;
 		};
@@ -470,12 +470,12 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Acute_Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		IEnumerable<Encounter> c_ = NCQAStatus_1_0_0.Finished_Encounter(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
 			CqlValueSet g_ = this.Advanced_Illness();
-			IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default(PropertyInfo));
+			IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default);
 			bool? i_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(InpatientEncounter, h_);
 			Period j_ = InpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> k_ = NCQAFHIRBase_1_0_0.Normalize_Interval((j_ as object));
@@ -489,7 +489,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default);
 			bool? x_ = context.Operators.And(i_, w_);
 
 			return x_;
@@ -506,7 +506,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private bool? Acute_Inpatient_Discharge_with_Advanced_Illness_Value()
 	{
-		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default, default);
 		(IEnumerable<Claim> InpatientDischarge, IEnumerable<Claim> NonacuteInpatientDischarge, IEnumerable<Claim> AcuteInpatientDischarge)? b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
 		IEnumerable<Claim> c_ = b_?.AcuteInpatientDischarge;
 		CqlValueSet d_ = this.Advanced_Illness();
@@ -525,7 +525,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime s_ = context.Operators.End(m_);
 			CqlDate t_ = context.Operators.DateFrom(s_);
 			CqlInterval<CqlDate> u_ = context.Operators.Interval(q_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDate>(l_, u_, default(string));
+			bool? v_ = context.Operators.In<CqlDate>(l_, u_, default);
 
 			return v_;
 		};
@@ -542,8 +542,8 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default);
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = NCQAStatus_1_0_0.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense DementiaMedDispensed)
@@ -560,7 +560,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default);
 
 			return w_;
 		};
@@ -585,7 +585,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service();

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAAdvancedIllnessandFrailty", "1.0.0")]
 public class NCQAAdvancedIllnessandFrailty_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -94,7 +94,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
     #endregion
 
 	private CqlValueSet Acute_Inpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", default(string));
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810")]
@@ -102,7 +102,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Acute_Inpatient.Value;
 
 	private CqlValueSet Advanced_Illness_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", default(string));
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465")]
@@ -110,7 +110,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Advanced_Illness.Value;
 
 	private CqlValueSet Dementia_Medications_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", default(string));
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729")]
@@ -118,7 +118,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Dementia_Medications.Value;
 
 	private CqlValueSet ED_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", default(string));
 
     [CqlDeclaration("ED")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086")]
@@ -126,7 +126,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__ED.Value;
 
 	private CqlValueSet Frailty_Device_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", default(string));
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530")]
@@ -134,7 +134,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Device.Value;
 
 	private CqlValueSet Frailty_Diagnosis_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", default(string));
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531")]
@@ -142,7 +142,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Diagnosis.Value;
 
 	private CqlValueSet Frailty_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", default(string));
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532")]
@@ -150,7 +150,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Encounter.Value;
 
 	private CqlValueSet Frailty_Symptom_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", default(string));
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533")]
@@ -158,7 +158,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Frailty_Symptom.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", default(string));
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189")]
@@ -166,7 +166,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Nonacute_Inpatient.Value;
 
 	private CqlValueSet Observation_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", default(string));
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191")]
@@ -174,7 +174,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Observation.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446")]
@@ -182,7 +182,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Online_Assessments.Value;
 
 	private CqlValueSet Outpatient_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", default(string));
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202")]
@@ -190,7 +190,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		__Outpatient.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246")]
@@ -210,7 +210,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -223,26 +223,26 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Has_Criteria_Indicating_Frailty_Value()
 	{
 		CqlValueSet a_ = this.Frailty_Device();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation FrailtyDeviceApplied)
 		{
 			DataType z_ = FrailtyDeviceApplied?.Effective;
 			CqlInterval<CqlDateTime> aa_ = NCQAFHIRBase_1_0_0.Normalize_Interval(z_);
 			CqlInterval<CqlDateTime> ab_ = this.Measurement_Period();
-			bool? ac_ = context.Operators.Overlaps(aa_, ab_, null);
+			bool? ac_ = context.Operators.Overlaps(aa_, ab_, default(string));
 
 			return ac_;
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Frailty_Diagnosis();
-		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+		IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 		IEnumerable<Condition> h_ = NCQAStatus_1_0_0.Active_Condition(g_);
 		bool? i_(Condition FrailtyDiagnosis)
 		{
 			CqlInterval<CqlDateTime> ad_ = NCQAFHIRBase_1_0_0.Prevalence_Period(FrailtyDiagnosis);
 			CqlInterval<CqlDateTime> ae_ = this.Measurement_Period();
-			bool? af_ = context.Operators.Overlaps(ad_, ae_, null);
+			bool? af_ = context.Operators.Overlaps(ad_, ae_, default(string));
 
 			return af_;
 		};
@@ -250,14 +250,14 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		bool? k_ = context.Operators.Exists<Condition>(j_);
 		bool? l_ = context.Operators.Or(e_, k_);
 		CqlValueSet m_ = this.Frailty_Encounter();
-		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
+		IEnumerable<Encounter> n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, default(PropertyInfo));
 		IEnumerable<Encounter> o_ = NCQAStatus_1_0_0.Finished_Encounter(n_);
 		bool? p_(Encounter FrailtyEncounter)
 		{
 			Period ag_ = FrailtyEncounter?.Period;
 			CqlInterval<CqlDateTime> ah_ = NCQAFHIRBase_1_0_0.Normalize_Interval((ag_ as object));
 			CqlInterval<CqlDateTime> ai_ = this.Measurement_Period();
-			bool? aj_ = context.Operators.Overlaps(ah_, ai_, null);
+			bool? aj_ = context.Operators.Overlaps(ah_, ai_, default(string));
 
 			return aj_;
 		};
@@ -265,13 +265,13 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		bool? r_ = context.Operators.Exists<Encounter>(q_);
 		bool? s_ = context.Operators.Or(l_, r_);
 		CqlValueSet t_ = this.Frailty_Symptom();
-		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, null);
+		IEnumerable<Observation> u_ = context.Operators.RetrieveByValueSet<Observation>(t_, default(PropertyInfo));
 		bool? v_(Observation FrailtySymptom)
 		{
 			DataType ak_ = FrailtySymptom?.Effective;
 			CqlInterval<CqlDateTime> al_ = NCQAFHIRBase_1_0_0.Normalize_Interval(ak_);
 			CqlInterval<CqlDateTime> am_ = this.Measurement_Period();
-			bool? an_ = context.Operators.Overlaps(al_, am_, null);
+			bool? an_ = context.Operators.Overlaps(al_, am_, default(string));
 
 			return an_;
 		};
@@ -289,27 +289,27 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private IEnumerable<CqlDate> Outpatient_Encounters_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Outpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Observation();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.ED();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Telephone_Visits();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Online_Assessments();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Nonacute_Inpatient();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		IEnumerable<Encounter> r_ = NCQAStatus_1_0_0.Finished_Encounter(q_);
 		bool? s_(Encounter OutpatientEncounter)
 		{
 			CqlValueSet w_ = this.Advanced_Illness();
-			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
+			IEnumerable<Condition> x_ = context.Operators.RetrieveByValueSet<Condition>(w_, default(PropertyInfo));
 			bool? y_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(OutpatientEncounter, x_);
 			Period z_ = OutpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> aa_ = NCQAFHIRBase_1_0_0.Normalize_Interval((z_ as object));
@@ -323,7 +323,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime aj_ = context.Operators.End(ad_);
 			CqlDate ak_ = context.Operators.DateFrom(aj_);
 			CqlInterval<CqlDate> al_ = context.Operators.Interval(ah_, ak_, true, true);
-			bool? am_ = context.Operators.In<CqlDate>(ac_, al_, null);
+			bool? am_ = context.Operators.In<CqlDate>(ac_, al_, default(string));
 			bool? an_ = context.Operators.And(y_, am_);
 
 			return an_;
@@ -349,7 +349,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private IEnumerable<CqlDate> Nonacute_Inpatient_Discharge_with_Advanced_Illness_Value()
 	{
-		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(null, null);
+		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default(CqlValueSet), default(PropertyInfo));
 		(IEnumerable<Claim> InpatientDischarge, IEnumerable<Claim> NonacuteInpatientDischarge, IEnumerable<Claim> AcuteInpatientDischarge)? b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
 		IEnumerable<Claim> c_ = b_?.NonacuteInpatientDischarge;
 		CqlValueSet d_ = this.Advanced_Illness();
@@ -368,7 +368,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, null);
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
 
 			return w_;
 		};
@@ -450,7 +450,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		{
 			CqlQuantity l_ = context.Operators.Quantity(1m, "day");
 			CqlDate m_ = context.Operators.Add(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit1, l_);
-			bool? n_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, m_, null);
+			bool? n_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, m_, default(string));
 
 			return n_;
 		};
@@ -470,12 +470,12 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Acute_Inpatient_Encounter_with_Advanced_Illness_Value()
 	{
 		CqlValueSet a_ = this.Acute_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		IEnumerable<Encounter> c_ = NCQAStatus_1_0_0.Finished_Encounter(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
 			CqlValueSet g_ = this.Advanced_Illness();
-			IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
+			IEnumerable<Condition> h_ = context.Operators.RetrieveByValueSet<Condition>(g_, default(PropertyInfo));
 			bool? i_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(InpatientEncounter, h_);
 			Period j_ = InpatientEncounter?.Period;
 			CqlInterval<CqlDateTime> k_ = NCQAFHIRBase_1_0_0.Normalize_Interval((j_ as object));
@@ -489,7 +489,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, null);
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
 			bool? x_ = context.Operators.And(i_, w_);
 
 			return x_;
@@ -506,7 +506,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 
 	private bool? Acute_Inpatient_Discharge_with_Advanced_Illness_Value()
 	{
-		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(null, null);
+		IEnumerable<Claim> a_ = context.Operators.RetrieveByValueSet<Claim>(default(CqlValueSet), default(PropertyInfo));
 		(IEnumerable<Claim> InpatientDischarge, IEnumerable<Claim> NonacuteInpatientDischarge, IEnumerable<Claim> AcuteInpatientDischarge)? b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
 		IEnumerable<Claim> c_ = b_?.AcuteInpatientDischarge;
 		CqlValueSet d_ = this.Advanced_Illness();
@@ -525,7 +525,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime s_ = context.Operators.End(m_);
 			CqlDate t_ = context.Operators.DateFrom(s_);
 			CqlInterval<CqlDate> u_ = context.Operators.Interval(q_, t_, true, true);
-			bool? v_ = context.Operators.In<CqlDate>(l_, u_, null);
+			bool? v_ = context.Operators.In<CqlDate>(l_, u_, default(string));
 
 			return v_;
 		};
@@ -542,8 +542,8 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 	private bool? Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value()
 	{
 		CqlValueSet a_ = this.Dementia_Medications();
-		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
-		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
+		IEnumerable<MedicationDispense> b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
+		IEnumerable<MedicationDispense> d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, default(PropertyInfo));
 		IEnumerable<MedicationDispense> e_ = context.Operators.Union<MedicationDispense>(b_, d_);
 		IEnumerable<MedicationDispense> f_ = NCQAStatus_1_0_0.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense DementiaMedDispensed)
@@ -560,7 +560,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 			CqlDateTime t_ = context.Operators.End(n_);
 			CqlDate u_ = context.Operators.DateFrom(t_);
 			CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-			bool? w_ = context.Operators.In<CqlDate>(m_, v_, null);
+			bool? w_ = context.Operators.In<CqlDate>(m_, v_, default(string));
 
 			return w_;
 		};
@@ -585,7 +585,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 		bool? k_ = this.Has_Criteria_Indicating_Frailty();
 		bool? l_ = context.Operators.And(j_, k_);
 		bool? m_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service();

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQACQLBase", "1.0.0")]
 public class NCQACQLBase_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -204,7 +204,7 @@ public class NCQACQLBase_1_0_0
 				{
 					bool? j_(CqlInterval<CqlDate> J)
 					{
-						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, default(string));
+						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, default);
 
 						return n_;
 					};
@@ -256,7 +256,7 @@ public class NCQACQLBase_1_0_0
 				{
 					bool? j_(CqlInterval<CqlDateTime> J)
 					{
-						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, default(string));
+						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, default);
 
 						return n_;
 					};
@@ -267,7 +267,7 @@ public class NCQACQLBase_1_0_0
 					return m_;
 				};
 				IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(intervals, g_);
-				IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, default(string));
+				IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, default);
 
 				return i_;
 			}
@@ -1062,7 +1062,7 @@ public class NCQACQLBase_1_0_0
 			int? ch_ = i?.StartMinute;
 			int? ci_ = i?.StartSecond;
 			int? cj_ = i?.StartMillisecond;
-			CqlDateTime ck_ = context.Operators.DateTime(cd_, ce_, cf_, cg_, ch_, ci_, cj_, default(decimal));
+			CqlDateTime ck_ = context.Operators.DateTime(cd_, ce_, cf_, cg_, ch_, ci_, cj_, default);
 			int? cl_ = i?.EndYear;
 			int? cm_ = i?.EndMonth;
 			int? cn_ = i?.EndDay;
@@ -1070,7 +1070,7 @@ public class NCQACQLBase_1_0_0
 			int? cp_ = i?.EndMinute;
 			int? cq_ = i?.EndSecond;
 			int? cr_ = i?.EndMillisecond;
-			CqlDateTime cs_ = context.Operators.DateTime(cl_, cm_, cn_, co_, cp_, cq_, cr_, default(decimal));
+			CqlDateTime cs_ = context.Operators.DateTime(cl_, cm_, cn_, co_, cp_, cq_, cr_, default);
 			CqlInterval<CqlDateTime> ct_ = context.Operators.Interval(ck_, cs_, true, true);
 
 			return ct_;

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -204,7 +204,7 @@ public class NCQACQLBase_1_0_0
 				{
 					bool? j_(CqlInterval<CqlDate> J)
 					{
-						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, null);
+						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, default(string));
 
 						return n_;
 					};
@@ -256,7 +256,7 @@ public class NCQACQLBase_1_0_0
 				{
 					bool? j_(CqlInterval<CqlDateTime> J)
 					{
-						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, null);
+						bool? n_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, default(string));
 
 						return n_;
 					};
@@ -267,7 +267,7 @@ public class NCQACQLBase_1_0_0
 					return m_;
 				};
 				IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(intervals, g_);
-				IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, null);
+				IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, default(string));
 
 				return i_;
 			}
@@ -1062,7 +1062,7 @@ public class NCQACQLBase_1_0_0
 			int? ch_ = i?.StartMinute;
 			int? ci_ = i?.StartSecond;
 			int? cj_ = i?.StartMillisecond;
-			CqlDateTime ck_ = context.Operators.DateTime(cd_, ce_, cf_, cg_, ch_, ci_, cj_, default);
+			CqlDateTime ck_ = context.Operators.DateTime(cd_, ce_, cf_, cg_, ch_, ci_, cj_, default(decimal));
 			int? cl_ = i?.EndYear;
 			int? cm_ = i?.EndMonth;
 			int? cn_ = i?.EndDay;
@@ -1070,7 +1070,7 @@ public class NCQACQLBase_1_0_0
 			int? cp_ = i?.EndMinute;
 			int? cq_ = i?.EndSecond;
 			int? cr_ = i?.EndMillisecond;
-			CqlDateTime cs_ = context.Operators.DateTime(cl_, cm_, cn_, co_, cp_, cq_, cr_, default);
+			CqlDateTime cs_ = context.Operators.DateTime(cl_, cm_, cn_, co_, cp_, cq_, cr_, default(decimal));
 			CqlInterval<CqlDateTime> ct_ = context.Operators.Interval(ck_, cs_, true, true);
 
 			return ct_;

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -44,7 +44,7 @@ public class NCQAClaims_1_0_0
     #endregion
 
 	private CqlValueSet Inpatient_Stay_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", default);
 
     [CqlDeclaration("Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395")]
@@ -52,7 +52,7 @@ public class NCQAClaims_1_0_0
 		__Inpatient_Stay.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Stay_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", default);
 
     [CqlDeclaration("Nonacute Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398")]
@@ -984,7 +984,7 @@ public class NCQAClaims_1_0_0
 					{
 						if ((ClaimofInterest is null))
 						{
-							return default(Claim);
+							return default;
 						}
 						else
 						{
@@ -1189,7 +1189,7 @@ public class NCQAClaims_1_0_0
 				{
 					if ((ClaimofInterest is null))
 					{
-						return default(Claim);
+						return default;
 					}
 					else
 					{
@@ -1314,7 +1314,7 @@ public class NCQAClaims_1_0_0
 						{
 							if ((ClaimforDiagnosis is null))
 							{
-								return default(Claim);
+								return default;
 							}
 							else
 							{
@@ -1859,7 +1859,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return default(Id);
+									return default;
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2270,7 +2270,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return default(Id);
+									return default;
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2575,7 +2575,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return default(Id);
+									return default;
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2810,7 +2810,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return default(Id);
+									return default;
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -3384,7 +3384,7 @@ public class NCQAClaims_1_0_0
 		];
 		(int? IdentifierCount, nint _)? e_((IEnumerable<(Claim SingleCareTeam, IEnumerable<ResourceReference> CareTeamsProvider, IEnumerable<string> CareTeamsProviderID)?> CareTeams, nint _)? ClaimProperties)
 		{
-			IEnumerable<Practitioner> at_ = context.Operators.RetrieveByValueSet<Practitioner>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Practitioner> at_ = context.Operators.RetrieveByValueSet<Practitioner>(default, default);
 			bool? au_(Practitioner p)
 			{
 				Id bb_ = p?.IdElement;
@@ -3677,7 +3677,7 @@ public class NCQAClaims_1_0_0
 		];
 		(int? IdentifierCount, nint _)? e_((IEnumerable<(IEnumerable<Claim.ItemComponent> SingleItem, IEnumerable<ResourceReference> ItemLocation, IEnumerable<string> ItemLocationID)?> ItemsLocationReferences, nint _)? ClaimProperties)
 		{
-			IEnumerable<Location> aw_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Location> aw_ = context.Operators.RetrieveByValueSet<Location>(default, default);
 			bool? ax_(Location l)
 			{
 				Id be_ = l?.IdElement;

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAClaims", "1.0.0")]
 public class NCQAClaims_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -44,7 +44,7 @@ public class NCQAClaims_1_0_0
     #endregion
 
 	private CqlValueSet Inpatient_Stay_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", default(string));
 
     [CqlDeclaration("Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395")]
@@ -52,7 +52,7 @@ public class NCQAClaims_1_0_0
 		__Inpatient_Stay.Value;
 
 	private CqlValueSet Nonacute_Inpatient_Stay_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", default(string));
 
     [CqlDeclaration("Nonacute Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398")]
@@ -984,7 +984,7 @@ public class NCQAClaims_1_0_0
 					{
 						if ((ClaimofInterest is null))
 						{
-							return null;
+							return default(Claim);
 						}
 						else
 						{
@@ -1189,7 +1189,7 @@ public class NCQAClaims_1_0_0
 				{
 					if ((ClaimofInterest is null))
 					{
-						return null;
+						return default(Claim);
 					}
 					else
 					{
@@ -1314,7 +1314,7 @@ public class NCQAClaims_1_0_0
 						{
 							if ((ClaimforDiagnosis is null))
 							{
-								return null;
+								return default(Claim);
 							}
 							else
 							{
@@ -1859,7 +1859,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return null;
+									return default(Id);
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2270,7 +2270,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return null;
+									return default(Id);
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2575,7 +2575,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return null;
+									return default(Id);
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -2810,7 +2810,7 @@ public class NCQAClaims_1_0_0
 								}
 								else
 								{
-									return null;
+									return default(Id);
 								}
 							};
 							string ad_ = FHIRHelpers_4_0_001.ToString(ac_());
@@ -3384,7 +3384,7 @@ public class NCQAClaims_1_0_0
 		];
 		(int? IdentifierCount, nint _)? e_((IEnumerable<(Claim SingleCareTeam, IEnumerable<ResourceReference> CareTeamsProvider, IEnumerable<string> CareTeamsProviderID)?> CareTeams, nint _)? ClaimProperties)
 		{
-			IEnumerable<Practitioner> at_ = context.Operators.RetrieveByValueSet<Practitioner>(null, null);
+			IEnumerable<Practitioner> at_ = context.Operators.RetrieveByValueSet<Practitioner>(default(CqlValueSet), default(PropertyInfo));
 			bool? au_(Practitioner p)
 			{
 				Id bb_ = p?.IdElement;
@@ -3677,7 +3677,7 @@ public class NCQAClaims_1_0_0
 		];
 		(int? IdentifierCount, nint _)? e_((IEnumerable<(IEnumerable<Claim.ItemComponent> SingleItem, IEnumerable<ResourceReference> ItemLocation, IEnumerable<string> ItemLocationID)?> ItemsLocationReferences, nint _)? ClaimProperties)
 		{
-			IEnumerable<Location> aw_ = context.Operators.RetrieveByValueSet<Location>(null, null);
+			IEnumerable<Location> aw_ = context.Operators.RetrieveByValueSet<Location>(default(CqlValueSet), default(PropertyInfo));
 			bool? ax_(Location l)
 			{
 				Id be_ = l?.IdElement;

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAEncounter", "1.0.0")]
 public class NCQAEncounter_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -128,7 +128,7 @@ public class NCQAEncounter_1_0_0
 			Period e_ = EncounterPeriod?.Period;
 			CqlInterval<CqlDateTime> f_ = NCQAFHIRBase_1_0_0.Normalize_Interval((e_ as object));
 			CqlDateTime g_ = context.Operators.End(f_);
-			bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, default(string));
+			bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, default);
 
 			return h_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -128,7 +128,7 @@ public class NCQAEncounter_1_0_0
 			Period e_ = EncounterPeriod?.Period;
 			CqlInterval<CqlDateTime> f_ = NCQAFHIRBase_1_0_0.Normalize_Interval((e_ as object));
 			CqlDateTime g_ = context.Operators.End(f_);
-			bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, null);
+			bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, default(string));
 
 			return h_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -39,7 +39,7 @@ public class NCQAFHIRBase_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -724,7 +724,7 @@ public class NCQAFHIRBase_1_0_0
 					CqlQuantity al_ = context.Operators.Quantity(30m, "days");
 					CqlDate am_ = context.Operators.Add((ak_ as CqlDate), al_);
 					CqlInterval<CqlDate> an_ = context.Operators.Interval(ah_, am_, true, true);
-					bool? ao_ = context.Operators.In<CqlDate>(X, an_, null);
+					bool? ao_ = context.Operators.In<CqlDate>(X, an_, default(string));
 					bool? ap_ = context.Operators.Not(ao_);
 
 					return ap_;
@@ -767,7 +767,7 @@ public class NCQAFHIRBase_1_0_0
 								CqlQuantity bq_ = context.Operators.Quantity(30m, "days");
 								CqlDate br_ = context.Operators.Add((bp_ as CqlDate), bq_);
 								CqlInterval<CqlDate> bs_ = context.Operators.Interval(bm_, br_, true, true);
-								bool? bt_ = context.Operators.In<CqlDate>(X, bs_, null);
+								bool? bt_ = context.Operators.In<CqlDate>(X, bs_, default(string));
 								bool? bu_ = context.Operators.Not(bt_);
 
 								return bu_;
@@ -810,7 +810,7 @@ public class NCQAFHIRBase_1_0_0
 											CqlQuantity cv_ = context.Operators.Quantity(30m, "days");
 											CqlDate cw_ = context.Operators.Add((cu_ as CqlDate), cv_);
 											CqlInterval<CqlDate> cx_ = context.Operators.Interval(cr_, cw_, true, true);
-											bool? cy_ = context.Operators.In<CqlDate>(X, cx_, null);
+											bool? cy_ = context.Operators.In<CqlDate>(X, cx_, default(string));
 											bool? cz_ = context.Operators.Not(cy_);
 
 											return cz_;
@@ -853,7 +853,7 @@ public class NCQAFHIRBase_1_0_0
 														CqlQuantity ea_ = context.Operators.Quantity(30m, "days");
 														CqlDate eb_ = context.Operators.Add((dz_ as CqlDate), ea_);
 														CqlInterval<CqlDate> ec_ = context.Operators.Interval(dw_, eb_, true, true);
-														bool? ed_ = context.Operators.In<CqlDate>(X, ec_, null);
+														bool? ed_ = context.Operators.In<CqlDate>(X, ec_, default(string));
 														bool? ee_ = context.Operators.Not(ed_);
 
 														return ee_;
@@ -896,7 +896,7 @@ public class NCQAFHIRBase_1_0_0
 																	CqlQuantity ff_ = context.Operators.Quantity(30m, "days");
 																	CqlDate fg_ = context.Operators.Add((fe_ as CqlDate), ff_);
 																	CqlInterval<CqlDate> fh_ = context.Operators.Interval(fb_, fg_, true, true);
-																	bool? fi_ = context.Operators.In<CqlDate>(X, fh_, null);
+																	bool? fi_ = context.Operators.In<CqlDate>(X, fh_, default(string));
 																	bool? fj_ = context.Operators.Not(fi_);
 
 																	return fj_;
@@ -939,7 +939,7 @@ public class NCQAFHIRBase_1_0_0
 																				CqlQuantity gk_ = context.Operators.Quantity(30m, "days");
 																				CqlDate gl_ = context.Operators.Add((gj_ as CqlDate), gk_);
 																				CqlInterval<CqlDate> gm_ = context.Operators.Interval(gg_, gl_, true, true);
-																				bool? gn_ = context.Operators.In<CqlDate>(X, gm_, null);
+																				bool? gn_ = context.Operators.In<CqlDate>(X, gm_, default(string));
 																				bool? go_ = context.Operators.Not(gn_);
 
 																				return go_;
@@ -982,7 +982,7 @@ public class NCQAFHIRBase_1_0_0
 																							CqlQuantity hp_ = context.Operators.Quantity(30m, "days");
 																							CqlDate hq_ = context.Operators.Add((ho_ as CqlDate), hp_);
 																							CqlInterval<CqlDate> hr_ = context.Operators.Interval(hl_, hq_, true, true);
-																							bool? hs_ = context.Operators.In<CqlDate>(X, hr_, null);
+																							bool? hs_ = context.Operators.In<CqlDate>(X, hr_, default(string));
 																							bool? ht_ = context.Operators.Not(hs_);
 
 																							return ht_;
@@ -1025,7 +1025,7 @@ public class NCQAFHIRBase_1_0_0
 																										CqlQuantity iu_ = context.Operators.Quantity(30m, "days");
 																										CqlDate iv_ = context.Operators.Add((it_ as CqlDate), iu_);
 																										CqlInterval<CqlDate> iw_ = context.Operators.Interval(iq_, iv_, true, true);
-																										bool? ix_ = context.Operators.In<CqlDate>(X, iw_, null);
+																										bool? ix_ = context.Operators.In<CqlDate>(X, iw_, default(string));
 																										bool? iy_ = context.Operators.Not(ix_);
 
 																										return iy_;
@@ -1068,7 +1068,7 @@ public class NCQAFHIRBase_1_0_0
 																													CqlQuantity jz_ = context.Operators.Quantity(30m, "days");
 																													CqlDate ka_ = context.Operators.Add((jy_ as CqlDate), jz_);
 																													CqlInterval<CqlDate> kb_ = context.Operators.Interval(jv_, ka_, true, true);
-																													bool? kc_ = context.Operators.In<CqlDate>(X, kb_, null);
+																													bool? kc_ = context.Operators.In<CqlDate>(X, kb_, default(string));
 																													bool? kd_ = context.Operators.Not(kc_);
 
 																													return kd_;
@@ -1111,7 +1111,7 @@ public class NCQAFHIRBase_1_0_0
 																																CqlQuantity le_ = context.Operators.Quantity(30m, "days");
 																																CqlDate lf_ = context.Operators.Add((ld_ as CqlDate), le_);
 																																CqlInterval<CqlDate> lg_ = context.Operators.Interval(la_, lf_, true, true);
-																																bool? lh_ = context.Operators.In<CqlDate>(X, lg_, null);
+																																bool? lh_ = context.Operators.In<CqlDate>(X, lg_, default(string));
 																																bool? li_ = context.Operators.Not(lh_);
 
 																																return li_;
@@ -1154,7 +1154,7 @@ public class NCQAFHIRBase_1_0_0
 																																			CqlQuantity mj_ = context.Operators.Quantity(30m, "days");
 																																			CqlDate mk_ = context.Operators.Add((mi_ as CqlDate), mj_);
 																																			CqlInterval<CqlDate> ml_ = context.Operators.Interval(mf_, mk_, true, true);
-																																			bool? mm_ = context.Operators.In<CqlDate>(X, ml_, null);
+																																			bool? mm_ = context.Operators.In<CqlDate>(X, ml_, default(string));
 																																			bool? mn_ = context.Operators.Not(mm_);
 
 																																			return mn_;
@@ -1197,7 +1197,7 @@ public class NCQAFHIRBase_1_0_0
 																																						CqlQuantity nk_ = context.Operators.Quantity(30m, "days");
 																																						CqlDate nl_ = context.Operators.Add((nj_ as CqlDate), nk_);
 																																						CqlInterval<CqlDate> nm_ = context.Operators.Interval(ng_, nl_, true, true);
-																																						bool? nn_ = context.Operators.In<CqlDate>(X, nm_, null);
+																																						bool? nn_ = context.Operators.In<CqlDate>(X, nm_, default(string));
 																																						bool? no_ = context.Operators.Not(nn_);
 
 																																						return no_;

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -39,7 +39,7 @@ public class NCQAFHIRBase_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -724,7 +724,7 @@ public class NCQAFHIRBase_1_0_0
 					CqlQuantity al_ = context.Operators.Quantity(30m, "days");
 					CqlDate am_ = context.Operators.Add((ak_ as CqlDate), al_);
 					CqlInterval<CqlDate> an_ = context.Operators.Interval(ah_, am_, true, true);
-					bool? ao_ = context.Operators.In<CqlDate>(X, an_, default(string));
+					bool? ao_ = context.Operators.In<CqlDate>(X, an_, default);
 					bool? ap_ = context.Operators.Not(ao_);
 
 					return ap_;
@@ -767,7 +767,7 @@ public class NCQAFHIRBase_1_0_0
 								CqlQuantity bq_ = context.Operators.Quantity(30m, "days");
 								CqlDate br_ = context.Operators.Add((bp_ as CqlDate), bq_);
 								CqlInterval<CqlDate> bs_ = context.Operators.Interval(bm_, br_, true, true);
-								bool? bt_ = context.Operators.In<CqlDate>(X, bs_, default(string));
+								bool? bt_ = context.Operators.In<CqlDate>(X, bs_, default);
 								bool? bu_ = context.Operators.Not(bt_);
 
 								return bu_;
@@ -810,7 +810,7 @@ public class NCQAFHIRBase_1_0_0
 											CqlQuantity cv_ = context.Operators.Quantity(30m, "days");
 											CqlDate cw_ = context.Operators.Add((cu_ as CqlDate), cv_);
 											CqlInterval<CqlDate> cx_ = context.Operators.Interval(cr_, cw_, true, true);
-											bool? cy_ = context.Operators.In<CqlDate>(X, cx_, default(string));
+											bool? cy_ = context.Operators.In<CqlDate>(X, cx_, default);
 											bool? cz_ = context.Operators.Not(cy_);
 
 											return cz_;
@@ -853,7 +853,7 @@ public class NCQAFHIRBase_1_0_0
 														CqlQuantity ea_ = context.Operators.Quantity(30m, "days");
 														CqlDate eb_ = context.Operators.Add((dz_ as CqlDate), ea_);
 														CqlInterval<CqlDate> ec_ = context.Operators.Interval(dw_, eb_, true, true);
-														bool? ed_ = context.Operators.In<CqlDate>(X, ec_, default(string));
+														bool? ed_ = context.Operators.In<CqlDate>(X, ec_, default);
 														bool? ee_ = context.Operators.Not(ed_);
 
 														return ee_;
@@ -896,7 +896,7 @@ public class NCQAFHIRBase_1_0_0
 																	CqlQuantity ff_ = context.Operators.Quantity(30m, "days");
 																	CqlDate fg_ = context.Operators.Add((fe_ as CqlDate), ff_);
 																	CqlInterval<CqlDate> fh_ = context.Operators.Interval(fb_, fg_, true, true);
-																	bool? fi_ = context.Operators.In<CqlDate>(X, fh_, default(string));
+																	bool? fi_ = context.Operators.In<CqlDate>(X, fh_, default);
 																	bool? fj_ = context.Operators.Not(fi_);
 
 																	return fj_;
@@ -939,7 +939,7 @@ public class NCQAFHIRBase_1_0_0
 																				CqlQuantity gk_ = context.Operators.Quantity(30m, "days");
 																				CqlDate gl_ = context.Operators.Add((gj_ as CqlDate), gk_);
 																				CqlInterval<CqlDate> gm_ = context.Operators.Interval(gg_, gl_, true, true);
-																				bool? gn_ = context.Operators.In<CqlDate>(X, gm_, default(string));
+																				bool? gn_ = context.Operators.In<CqlDate>(X, gm_, default);
 																				bool? go_ = context.Operators.Not(gn_);
 
 																				return go_;
@@ -982,7 +982,7 @@ public class NCQAFHIRBase_1_0_0
 																							CqlQuantity hp_ = context.Operators.Quantity(30m, "days");
 																							CqlDate hq_ = context.Operators.Add((ho_ as CqlDate), hp_);
 																							CqlInterval<CqlDate> hr_ = context.Operators.Interval(hl_, hq_, true, true);
-																							bool? hs_ = context.Operators.In<CqlDate>(X, hr_, default(string));
+																							bool? hs_ = context.Operators.In<CqlDate>(X, hr_, default);
 																							bool? ht_ = context.Operators.Not(hs_);
 
 																							return ht_;
@@ -1025,7 +1025,7 @@ public class NCQAFHIRBase_1_0_0
 																										CqlQuantity iu_ = context.Operators.Quantity(30m, "days");
 																										CqlDate iv_ = context.Operators.Add((it_ as CqlDate), iu_);
 																										CqlInterval<CqlDate> iw_ = context.Operators.Interval(iq_, iv_, true, true);
-																										bool? ix_ = context.Operators.In<CqlDate>(X, iw_, default(string));
+																										bool? ix_ = context.Operators.In<CqlDate>(X, iw_, default);
 																										bool? iy_ = context.Operators.Not(ix_);
 
 																										return iy_;
@@ -1068,7 +1068,7 @@ public class NCQAFHIRBase_1_0_0
 																													CqlQuantity jz_ = context.Operators.Quantity(30m, "days");
 																													CqlDate ka_ = context.Operators.Add((jy_ as CqlDate), jz_);
 																													CqlInterval<CqlDate> kb_ = context.Operators.Interval(jv_, ka_, true, true);
-																													bool? kc_ = context.Operators.In<CqlDate>(X, kb_, default(string));
+																													bool? kc_ = context.Operators.In<CqlDate>(X, kb_, default);
 																													bool? kd_ = context.Operators.Not(kc_);
 
 																													return kd_;
@@ -1111,7 +1111,7 @@ public class NCQAFHIRBase_1_0_0
 																																CqlQuantity le_ = context.Operators.Quantity(30m, "days");
 																																CqlDate lf_ = context.Operators.Add((ld_ as CqlDate), le_);
 																																CqlInterval<CqlDate> lg_ = context.Operators.Interval(la_, lf_, true, true);
-																																bool? lh_ = context.Operators.In<CqlDate>(X, lg_, default(string));
+																																bool? lh_ = context.Operators.In<CqlDate>(X, lg_, default);
 																																bool? li_ = context.Operators.Not(lh_);
 
 																																return li_;
@@ -1154,7 +1154,7 @@ public class NCQAFHIRBase_1_0_0
 																																			CqlQuantity mj_ = context.Operators.Quantity(30m, "days");
 																																			CqlDate mk_ = context.Operators.Add((mi_ as CqlDate), mj_);
 																																			CqlInterval<CqlDate> ml_ = context.Operators.Interval(mf_, mk_, true, true);
-																																			bool? mm_ = context.Operators.In<CqlDate>(X, ml_, default(string));
+																																			bool? mm_ = context.Operators.In<CqlDate>(X, ml_, default);
 																																			bool? mn_ = context.Operators.Not(mm_);
 
 																																			return mn_;
@@ -1197,7 +1197,7 @@ public class NCQAFHIRBase_1_0_0
 																																						CqlQuantity nk_ = context.Operators.Quantity(30m, "days");
 																																						CqlDate nl_ = context.Operators.Add((nj_ as CqlDate), nk_);
 																																						CqlInterval<CqlDate> nm_ = context.Operators.Interval(ng_, nl_, true, true);
-																																						bool? nn_ = context.Operators.In<CqlDate>(X, nm_, default(string));
+																																						bool? nn_ = context.Operators.In<CqlDate>(X, nm_, default);
 																																						bool? no_ = context.Operators.Not(nn_);
 
 																																						return no_;

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAFHIRBase", "1.0.0")]
 public class NCQAFHIRBase_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -93,7 +93,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 			CqlDate l_ = context.Operators.Subtract(j_, k_);
 			CqlDate o_ = context.Operators.Add(j_, k_);
 			CqlInterval<CqlDate> p_ = context.Operators.Interval(l_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDate>(i_, p_, default(string));
+			bool? q_ = context.Operators.In<CqlDate>(i_, p_, default);
 			bool? s_ = context.Operators.Not((bool?)(j_ is null));
 			bool? t_ = context.Operators.And(q_, s_);
 
@@ -191,12 +191,12 @@ public class NCQAHealthPlanEnrollment_1_0_0
 		{
 			bool b_()
 			{
-				bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default(string));
+				bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default);
 				bool? d_ = context.Operators.Not(c_);
 
 				return (d_ ?? false);
 			};
-			if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default(string)) ?? false))
+			if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default) ?? false))
 			{
 				IEnumerable<(IEnumerable<CqlInterval<CqlDate>> IntervalInfo, IEnumerable<CqlInterval<CqlDate>> Collapsed, IEnumerable<CqlInterval<CqlDate>> Adjacent, IEnumerable<CqlInterval<CqlDate>> CollapsedFinal)?> e_ = this.All_Coverage_Info(Coverage, participationPeriod);
 				bool? f_((IEnumerable<CqlInterval<CqlDate>> IntervalInfo, IEnumerable<CqlInterval<CqlDate>> Collapsed, IEnumerable<CqlInterval<CqlDate>> Adjacent, IEnumerable<CqlInterval<CqlDate>> CollapsedFinal)? @this)
@@ -217,7 +217,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 				IEnumerable<CqlInterval<CqlDate>> j_ = context.Operators.Flatten<CqlInterval<CqlDate>>(i_);
 				bool? k_(CqlInterval<CqlDate> FinalInterval)
 				{
-					bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, default(string));
+					bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, default);
 
 					return q_;
 				};
@@ -251,7 +251,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 					CqlDateTime af_ = context.Operators.End(ab_);
 					CqlDate ag_ = context.Operators.DateFrom(af_);
 					CqlInterval<CqlDate> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-					bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, default(string));
+					bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, default);
 
 					return ai_;
 				};

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -93,7 +93,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 			CqlDate l_ = context.Operators.Subtract(j_, k_);
 			CqlDate o_ = context.Operators.Add(j_, k_);
 			CqlInterval<CqlDate> p_ = context.Operators.Interval(l_, o_, true, true);
-			bool? q_ = context.Operators.In<CqlDate>(i_, p_, null);
+			bool? q_ = context.Operators.In<CqlDate>(i_, p_, default(string));
 			bool? s_ = context.Operators.Not((bool?)(j_ is null));
 			bool? t_ = context.Operators.And(q_, s_);
 
@@ -191,12 +191,12 @@ public class NCQAHealthPlanEnrollment_1_0_0
 		{
 			bool b_()
 			{
-				bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, null);
+				bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default(string));
 				bool? d_ = context.Operators.Not(c_);
 
 				return (d_ ?? false);
 			};
-			if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, null) ?? false))
+			if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default(string)) ?? false))
 			{
 				IEnumerable<(IEnumerable<CqlInterval<CqlDate>> IntervalInfo, IEnumerable<CqlInterval<CqlDate>> Collapsed, IEnumerable<CqlInterval<CqlDate>> Adjacent, IEnumerable<CqlInterval<CqlDate>> CollapsedFinal)?> e_ = this.All_Coverage_Info(Coverage, participationPeriod);
 				bool? f_((IEnumerable<CqlInterval<CqlDate>> IntervalInfo, IEnumerable<CqlInterval<CqlDate>> Collapsed, IEnumerable<CqlInterval<CqlDate>> Adjacent, IEnumerable<CqlInterval<CqlDate>> CollapsedFinal)? @this)
@@ -217,7 +217,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 				IEnumerable<CqlInterval<CqlDate>> j_ = context.Operators.Flatten<CqlInterval<CqlDate>>(i_);
 				bool? k_(CqlInterval<CqlDate> FinalInterval)
 				{
-					bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, null);
+					bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, default(string));
 
 					return q_;
 				};
@@ -251,7 +251,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 					CqlDateTime af_ = context.Operators.End(ab_);
 					CqlDate ag_ = context.Operators.DateFrom(af_);
 					CqlInterval<CqlDate> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-					bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, null);
+					bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, default(string));
 
 					return ai_;
 				};

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAHealthPlanEnrollment", "1.0.0")]
 public class NCQAHealthPlanEnrollment_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -50,7 +50,7 @@ public class NCQAHospice_1_0_0
     #endregion
 
 	private CqlValueSet Hospice_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", default);
 
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761")]
@@ -58,7 +58,7 @@ public class NCQAHospice_1_0_0
 		__Hospice_Encounter.Value;
 
 	private CqlValueSet Hospice_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", default);
 
     [CqlDeclaration("Hospice Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762")]
@@ -78,7 +78,7 @@ public class NCQAHospice_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -91,28 +91,28 @@ public class NCQAHospice_1_0_0
 	private bool? Hospice_Intervention_or_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Hospice_Intervention();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(b_);
 		bool? d_(Procedure HospiceInt)
 		{
 			DataType n_ = HospiceInt?.Performed;
 			CqlInterval<CqlDateTime> o_ = NCQAFHIRBase_1_0_0.Normalize_Interval(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
-			bool? q_ = context.Operators.Overlaps(o_, p_, default(string));
+			bool? q_ = context.Operators.Overlaps(o_, p_, default);
 
 			return q_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		bool? f_ = context.Operators.Exists<Procedure>(e_);
 		CqlValueSet g_ = this.Hospice_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default);
 		IEnumerable<Encounter> i_ = NCQAStatus_1_0_0.Finished_Encounter(h_);
 		bool? j_(Encounter HospiceEnc)
 		{
 			Period r_ = HospiceEnc?.Period;
 			CqlInterval<CqlDateTime> s_ = NCQAFHIRBase_1_0_0.Normalize_Interval((r_ as object));
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
-			bool? u_ = context.Operators.Overlaps(s_, t_, default(string));
+			bool? u_ = context.Operators.Overlaps(s_, t_, default);
 
 			return u_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAHospice", "1.0.0")]
 public class NCQAHospice_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -50,7 +50,7 @@ public class NCQAHospice_1_0_0
     #endregion
 
 	private CqlValueSet Hospice_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", default(string));
 
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761")]
@@ -58,7 +58,7 @@ public class NCQAHospice_1_0_0
 		__Hospice_Encounter.Value;
 
 	private CqlValueSet Hospice_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", default(string));
 
     [CqlDeclaration("Hospice Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762")]
@@ -78,7 +78,7 @@ public class NCQAHospice_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -91,28 +91,28 @@ public class NCQAHospice_1_0_0
 	private bool? Hospice_Intervention_or_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Hospice_Intervention();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		IEnumerable<Procedure> c_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(b_);
 		bool? d_(Procedure HospiceInt)
 		{
 			DataType n_ = HospiceInt?.Performed;
 			CqlInterval<CqlDateTime> o_ = NCQAFHIRBase_1_0_0.Normalize_Interval(n_);
 			CqlInterval<CqlDateTime> p_ = this.Measurement_Period();
-			bool? q_ = context.Operators.Overlaps(o_, p_, null);
+			bool? q_ = context.Operators.Overlaps(o_, p_, default(string));
 
 			return q_;
 		};
 		IEnumerable<Procedure> e_ = context.Operators.Where<Procedure>(c_, d_);
 		bool? f_ = context.Operators.Exists<Procedure>(e_);
 		CqlValueSet g_ = this.Hospice_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
 		IEnumerable<Encounter> i_ = NCQAStatus_1_0_0.Finished_Encounter(h_);
 		bool? j_(Encounter HospiceEnc)
 		{
 			Period r_ = HospiceEnc?.Period;
 			CqlInterval<CqlDateTime> s_ = NCQAFHIRBase_1_0_0.Normalize_Interval((r_ as object));
 			CqlInterval<CqlDateTime> t_ = this.Measurement_Period();
-			bool? u_ = context.Operators.Overlaps(s_, t_, null);
+			bool? u_ = context.Operators.Overlaps(s_, t_, default(string));
 
 			return u_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -50,7 +50,7 @@ public class NCQAPalliativeCare_1_0_0
     #endregion
 
 	private CqlValueSet Palliative_Care_Assessment_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default(string));
 
     [CqlDeclaration("Palliative Care Assessment")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225")]
@@ -58,7 +58,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Assessment.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default(string));
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450")]
@@ -66,7 +66,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", null);
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default(string));
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224")]
@@ -74,7 +74,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -83,7 +83,7 @@ public class NCQAPalliativeCare_1_0_0
 	private CqlCode[] ICD_10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
 		];
 
 		return a_;
@@ -97,7 +97,7 @@ public class NCQAPalliativeCare_1_0_0
 	public bool? Palliative_Care_Overlapping_Period(CqlInterval<CqlDateTime> Period)
 	{
 		CqlValueSet a_ = this.Palliative_Care_Assessment();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
 		bool? c_(Observation PalliativeAssessment)
 		{
 			DataType ab_ = PalliativeAssessment?.Effective;
@@ -113,14 +113,14 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime am_ = context.Operators.End(Period);
 			CqlDate an_ = context.Operators.DateFrom(am_);
 			CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-			bool? ap_ = context.Operators.Overlaps(aj_, ao_, null);
+			bool? ap_ = context.Operators.Overlaps(aj_, ao_, default(string));
 
 			return ap_;
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		IEnumerable<Encounter> h_ = NCQAStatus_1_0_0.Finished_Encounter(g_);
 		bool? i_(Encounter PalliativeEncounter)
 		{
@@ -137,7 +137,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime bb_ = context.Operators.End(Period);
 			CqlDate bc_ = context.Operators.DateFrom(bb_);
 			CqlInterval<CqlDate> bd_ = context.Operators.Interval(ba_, bc_, true, true);
-			bool? be_ = context.Operators.Overlaps(ay_, bd_, null);
+			bool? be_ = context.Operators.Overlaps(ay_, bd_, default(string));
 
 			return be_;
 		};
@@ -145,7 +145,7 @@ public class NCQAPalliativeCare_1_0_0
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
 		bool? l_ = context.Operators.Or(e_, k_);
 		CqlValueSet m_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, null);
+		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default(PropertyInfo));
 		IEnumerable<Procedure> o_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(n_);
 		bool? p_(Procedure PalliativeIntervention)
 		{
@@ -162,7 +162,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime bq_ = context.Operators.End(Period);
 			CqlDate br_ = context.Operators.DateFrom(bq_);
 			CqlInterval<CqlDate> bs_ = context.Operators.Interval(bp_, br_, true, true);
-			bool? bt_ = context.Operators.Overlaps(bn_, bs_, null);
+			bool? bt_ = context.Operators.Overlaps(bn_, bs_, default(string));
 
 			return bt_;
 		};
@@ -171,7 +171,7 @@ public class NCQAPalliativeCare_1_0_0
 		bool? s_ = context.Operators.Or(l_, r_);
 		CqlCode t_ = this.Encounter_for_palliative_care();
 		IEnumerable<CqlCode> u_ = context.Operators.ToList<CqlCode>(t_);
-		IEnumerable<Condition> v_ = context.Operators.RetrieveByCodes<Condition>(u_, null);
+		IEnumerable<Condition> v_ = context.Operators.RetrieveByCodes<Condition>(u_, default(PropertyInfo));
 		IEnumerable<Condition> w_ = NCQAStatus_1_0_0.Active_Condition(v_);
 		bool? x_(Condition PalliativeDiagnosis)
 		{
@@ -186,7 +186,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime cd_ = context.Operators.End(Period);
 			CqlDate ce_ = context.Operators.DateFrom(cd_);
 			CqlInterval<CqlDate> cf_ = context.Operators.Interval(cc_, ce_, true, true);
-			bool? cg_ = context.Operators.Overlaps(ca_, cf_, null);
+			bool? cg_ = context.Operators.Overlaps(ca_, cf_, default(string));
 
 			return cg_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -50,7 +50,7 @@ public class NCQAPalliativeCare_1_0_0
     #endregion
 
 	private CqlValueSet Palliative_Care_Assessment_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", default);
 
     [CqlDeclaration("Palliative Care Assessment")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225")]
@@ -58,7 +58,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Assessment.Value;
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", default);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450")]
@@ -66,7 +66,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default(string));
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", default);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224")]
@@ -74,7 +74,7 @@ public class NCQAPalliativeCare_1_0_0
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Encounter_for_palliative_care_Value() => 
-		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string));
+		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default);
 
     [CqlDeclaration("Encounter for palliative care")]
 	public CqlCode Encounter_for_palliative_care() => 
@@ -83,7 +83,7 @@ public class NCQAPalliativeCare_1_0_0
 	private CqlCode[] ICD_10_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default(string), default(string)),
+			new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", default, default),
 		];
 
 		return a_;
@@ -97,7 +97,7 @@ public class NCQAPalliativeCare_1_0_0
 	public bool? Palliative_Care_Overlapping_Period(CqlInterval<CqlDateTime> Period)
 	{
 		CqlValueSet a_ = this.Palliative_Care_Assessment();
-		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default(PropertyInfo));
+		IEnumerable<Observation> b_ = context.Operators.RetrieveByValueSet<Observation>(a_, default);
 		bool? c_(Observation PalliativeAssessment)
 		{
 			DataType ab_ = PalliativeAssessment?.Effective;
@@ -113,14 +113,14 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime am_ = context.Operators.End(Period);
 			CqlDate an_ = context.Operators.DateFrom(am_);
 			CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-			bool? ap_ = context.Operators.Overlaps(aj_, ao_, default(string));
+			bool? ap_ = context.Operators.Overlaps(aj_, ao_, default);
 
 			return ap_;
 		};
 		IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
 		bool? e_ = context.Operators.Exists<Observation>(d_);
 		CqlValueSet f_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		IEnumerable<Encounter> h_ = NCQAStatus_1_0_0.Finished_Encounter(g_);
 		bool? i_(Encounter PalliativeEncounter)
 		{
@@ -137,7 +137,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime bb_ = context.Operators.End(Period);
 			CqlDate bc_ = context.Operators.DateFrom(bb_);
 			CqlInterval<CqlDate> bd_ = context.Operators.Interval(ba_, bc_, true, true);
-			bool? be_ = context.Operators.Overlaps(ay_, bd_, default(string));
+			bool? be_ = context.Operators.Overlaps(ay_, bd_, default);
 
 			return be_;
 		};
@@ -145,7 +145,7 @@ public class NCQAPalliativeCare_1_0_0
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
 		bool? l_ = context.Operators.Or(e_, k_);
 		CqlValueSet m_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default(PropertyInfo));
+		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default);
 		IEnumerable<Procedure> o_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(n_);
 		bool? p_(Procedure PalliativeIntervention)
 		{
@@ -162,7 +162,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime bq_ = context.Operators.End(Period);
 			CqlDate br_ = context.Operators.DateFrom(bq_);
 			CqlInterval<CqlDate> bs_ = context.Operators.Interval(bp_, br_, true, true);
-			bool? bt_ = context.Operators.Overlaps(bn_, bs_, default(string));
+			bool? bt_ = context.Operators.Overlaps(bn_, bs_, default);
 
 			return bt_;
 		};
@@ -171,7 +171,7 @@ public class NCQAPalliativeCare_1_0_0
 		bool? s_ = context.Operators.Or(l_, r_);
 		CqlCode t_ = this.Encounter_for_palliative_care();
 		IEnumerable<CqlCode> u_ = context.Operators.ToList<CqlCode>(t_);
-		IEnumerable<Condition> v_ = context.Operators.RetrieveByCodes<Condition>(u_, default(PropertyInfo));
+		IEnumerable<Condition> v_ = context.Operators.RetrieveByCodes<Condition>(u_, default);
 		IEnumerable<Condition> w_ = NCQAStatus_1_0_0.Active_Condition(v_);
 		bool? x_(Condition PalliativeDiagnosis)
 		{
@@ -186,7 +186,7 @@ public class NCQAPalliativeCare_1_0_0
 			CqlDateTime cd_ = context.Operators.End(Period);
 			CqlDate ce_ = context.Operators.DateFrom(cd_);
 			CqlInterval<CqlDate> cf_ = context.Operators.Interval(cc_, ce_, true, true);
-			bool? cg_ = context.Operators.Overlaps(ca_, cf_, default(string));
+			bool? cg_ = context.Operators.Overlaps(ca_, cf_, default);
 
 			return cg_;
 		};

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAPalliativeCare", "1.0.0")]
 public class NCQAPalliativeCare_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -41,7 +41,7 @@ public class NCQAStatus_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -41,7 +41,7 @@ public class NCQAStatus_1_0_0
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQAStatus", "1.0.0")]
 public class NCQAStatus_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
@@ -166,336 +166,336 @@ public class NCQATerminology_1_0_0
     #endregion
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode food_Value() => 
-		new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
+		new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
 
     [CqlDeclaration("food")]
 	public CqlCode food() => 
 		__food.Value;
 
 	private CqlCode medication_Value() => 
-		new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
+		new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
 
     [CqlDeclaration("medication")]
 	public CqlCode medication() => 
 		__medication.Value;
 
 	private CqlCode environment_Value() => 
-		new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
+		new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
 
     [CqlDeclaration("environment")]
 	public CqlCode environment() => 
 		__environment.Value;
 
 	private CqlCode biologic_Value() => 
-		new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
+		new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
 
     [CqlDeclaration("biologic")]
 	public CqlCode biologic() => 
 		__biologic.Value;
 
 	private CqlCode Allergy_Value() => 
-		new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", null, null);
+		new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string));
 
     [CqlDeclaration("Allergy")]
 	public CqlCode Allergy() => 
 		__Allergy.Value;
 
 	private CqlCode Intolerance_Value() => 
-		new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", null, null);
+		new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string));
 
     [CqlDeclaration("Intolerance")]
 	public CqlCode Intolerance() => 
 		__Intolerance.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode Pharmacy_Value() => 
-		new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
+		new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
 
     [CqlDeclaration("Pharmacy")]
 	public CqlCode Pharmacy() => 
 		__Pharmacy.Value;
 
 	private CqlCode Institutional_Value() => 
-		new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
+		new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
 
     [CqlDeclaration("Institutional")]
 	public CqlCode Institutional() => 
 		__Institutional.Value;
 
 	private CqlCode Professional_Value() => 
-		new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
+		new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
 
     [CqlDeclaration("Professional")]
 	public CqlCode Professional() => 
 		__Professional.Value;
 
 	private CqlCode Oral_Value() => 
-		new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
+		new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
 
     [CqlDeclaration("Oral")]
 	public CqlCode Oral() => 
 		__Oral.Value;
 
 	private CqlCode Vision_Value() => 
-		new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
+		new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
 
     [CqlDeclaration("Vision")]
 	public CqlCode Vision() => 
 		__Vision.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
+		new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode drug_policy_Value() => 
-		new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("drug policy")]
 	public CqlCode drug_policy() => 
 		__drug_policy.Value;
 
 	private CqlCode mental_health_policy_Value() => 
-		new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("mental health policy")]
 	public CqlCode mental_health_policy() => 
 		__mental_health_policy.Value;
 
 	private CqlCode managed_care_policy_Value() => 
-		new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("managed care policy")]
 	public CqlCode managed_care_policy() => 
 		__managed_care_policy.Value;
 
 	private CqlCode subsidized_health_program_Value() => 
-		new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("subsidized health program")]
 	public CqlCode subsidized_health_program() => 
 		__subsidized_health_program.Value;
 
 	private CqlCode retiree_health_program_Value() => 
-		new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("retiree health program")]
 	public CqlCode retiree_health_program() => 
 		__retiree_health_program.Value;
 
 	private CqlCode substance_use_policy_Value() => 
-		new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
+		new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
 
     [CqlDeclaration("substance use policy")]
 	public CqlCode substance_use_policy() => 
 		__substance_use_policy.Value;
 
 	private CqlCode Provider_number_Value() => 
-		new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", null, null);
+		new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default(string), default(string));
 
     [CqlDeclaration("Provider number")]
 	public CqlCode Provider_number() => 
@@ -564,10 +564,10 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -580,12 +580,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -598,12 +598,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -616,9 +616,9 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
 		];
 
 		return a_;
@@ -631,9 +631,9 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
 		];
 
 		return a_;
@@ -646,8 +646,8 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceType_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", null, null),
-			new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", null, null),
+			new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string)),
+			new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string)),
 		];
 
 		return a_;
@@ -660,10 +660,10 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", null, null),
-			new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", null, null),
-			new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", null, null),
-			new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", null, null),
+			new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
+			new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
+			new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
+			new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -676,8 +676,8 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -690,11 +690,11 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] claim_type_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", null, null),
-			new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null),
-			new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null),
-			new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", null, null),
-			new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", null, null),
+			new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
+			new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
+			new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
+			new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
+			new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
 		];
 
 		return a_;
@@ -707,12 +707,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ActEncounterCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
-			new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
-			new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
-			new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
-			new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null),
+			new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -725,12 +725,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] coverage_type_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
-			new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
-			new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
-			new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
-			new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
-			new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null),
+			new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
 		];
 
 		return a_;
@@ -743,7 +743,7 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] IdentifierType_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", null, null),
+			new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default(string), default(string)),
 		];
 
 		return a_;

--- a/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
@@ -166,336 +166,336 @@ public class NCQATerminology_1_0_0
     #endregion
 
 	private CqlCode problem_list_item_Value() => 
-		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("problem-list-item")]
 	public CqlCode problem_list_item() => 
 		__problem_list_item.Value;
 
 	private CqlCode encounter_diagnosis_Value() => 
-		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string));
+		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default);
 
     [CqlDeclaration("encounter-diagnosis")]
 	public CqlCode encounter_diagnosis() => 
 		__encounter_diagnosis.Value;
 
 	private CqlCode active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("active")]
 	public CqlCode active() => 
 		__active.Value;
 
 	private CqlCode recurrence_Value() => 
-		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("recurrence")]
 	public CqlCode recurrence() => 
 		__recurrence.Value;
 
 	private CqlCode relapse_Value() => 
-		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("relapse")]
 	public CqlCode relapse() => 
 		__relapse.Value;
 
 	private CqlCode inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("inactive")]
 	public CqlCode inactive() => 
 		__inactive.Value;
 
 	private CqlCode remission_Value() => 
-		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("remission")]
 	public CqlCode remission() => 
 		__remission.Value;
 
 	private CqlCode resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default);
 
     [CqlDeclaration("resolved")]
 	public CqlCode resolved() => 
 		__resolved.Value;
 
 	private CqlCode unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("unconfirmed")]
 	public CqlCode unconfirmed() => 
 		__unconfirmed.Value;
 
 	private CqlCode provisional_Value() => 
-		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("provisional")]
 	public CqlCode provisional() => 
 		__provisional.Value;
 
 	private CqlCode differential_Value() => 
-		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("differential")]
 	public CqlCode differential() => 
 		__differential.Value;
 
 	private CqlCode confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("confirmed")]
 	public CqlCode confirmed() => 
 		__confirmed.Value;
 
 	private CqlCode refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("refuted")]
 	public CqlCode refuted() => 
 		__refuted.Value;
 
 	private CqlCode entered_in_error_Value() => 
-		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string));
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default);
 
     [CqlDeclaration("entered-in-error")]
 	public CqlCode entered_in_error() => 
 		__entered_in_error.Value;
 
 	private CqlCode allergy_active_Value() => 
-		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-active")]
 	public CqlCode allergy_active() => 
 		__allergy_active.Value;
 
 	private CqlCode allergy_inactive_Value() => 
-		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-inactive")]
 	public CqlCode allergy_inactive() => 
 		__allergy_inactive.Value;
 
 	private CqlCode allergy_resolved_Value() => 
-		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string));
+		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default);
 
     [CqlDeclaration("allergy-resolved")]
 	public CqlCode allergy_resolved() => 
 		__allergy_resolved.Value;
 
 	private CqlCode allergy_unconfirmed_Value() => 
-		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-unconfirmed")]
 	public CqlCode allergy_unconfirmed() => 
 		__allergy_unconfirmed.Value;
 
 	private CqlCode allergy_confirmed_Value() => 
-		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-confirmed")]
 	public CqlCode allergy_confirmed() => 
 		__allergy_confirmed.Value;
 
 	private CqlCode allergy_refuted_Value() => 
-		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string));
+		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default);
 
     [CqlDeclaration("allergy-refuted")]
 	public CqlCode allergy_refuted() => 
 		__allergy_refuted.Value;
 
 	private CqlCode food_Value() => 
-		new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
+		new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default, default);
 
     [CqlDeclaration("food")]
 	public CqlCode food() => 
 		__food.Value;
 
 	private CqlCode medication_Value() => 
-		new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
+		new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default, default);
 
     [CqlDeclaration("medication")]
 	public CqlCode medication() => 
 		__medication.Value;
 
 	private CqlCode environment_Value() => 
-		new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
+		new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default, default);
 
     [CqlDeclaration("environment")]
 	public CqlCode environment() => 
 		__environment.Value;
 
 	private CqlCode biologic_Value() => 
-		new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string));
+		new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default, default);
 
     [CqlDeclaration("biologic")]
 	public CqlCode biologic() => 
 		__biologic.Value;
 
 	private CqlCode Allergy_Value() => 
-		new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string));
+		new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default, default);
 
     [CqlDeclaration("Allergy")]
 	public CqlCode Allergy() => 
 		__Allergy.Value;
 
 	private CqlCode Intolerance_Value() => 
-		new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string));
+		new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default, default);
 
     [CqlDeclaration("Intolerance")]
 	public CqlCode Intolerance() => 
 		__Intolerance.Value;
 
 	private CqlCode Inpatient_Value() => 
-		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Inpatient")]
 	public CqlCode Inpatient() => 
 		__Inpatient.Value;
 
 	private CqlCode Outpatient_Value() => 
-		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Outpatient")]
 	public CqlCode Outpatient() => 
 		__Outpatient.Value;
 
 	private CqlCode Community_Value() => 
-		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Community")]
 	public CqlCode Community() => 
 		__Community.Value;
 
 	private CqlCode Discharge_Value() => 
-		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string));
+		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default);
 
     [CqlDeclaration("Discharge")]
 	public CqlCode Discharge() => 
 		__Discharge.Value;
 
 	private CqlCode Pharmacy_Value() => 
-		new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
+		new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default, default);
 
     [CqlDeclaration("Pharmacy")]
 	public CqlCode Pharmacy() => 
 		__Pharmacy.Value;
 
 	private CqlCode Institutional_Value() => 
-		new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
+		new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default, default);
 
     [CqlDeclaration("Institutional")]
 	public CqlCode Institutional() => 
 		__Institutional.Value;
 
 	private CqlCode Professional_Value() => 
-		new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
+		new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default, default);
 
     [CqlDeclaration("Professional")]
 	public CqlCode Professional() => 
 		__Professional.Value;
 
 	private CqlCode Oral_Value() => 
-		new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
+		new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default, default);
 
     [CqlDeclaration("Oral")]
 	public CqlCode Oral() => 
 		__Oral.Value;
 
 	private CqlCode Vision_Value() => 
-		new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string));
+		new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default, default);
 
     [CqlDeclaration("Vision")]
 	public CqlCode Vision() => 
 		__Vision.Value;
 
 	private CqlCode @virtual_Value() => 
-		new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("virtual")]
 	public CqlCode @virtual() => 
 		__virtual.Value;
 
 	private CqlCode ambulatory_Value() => 
-		new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("ambulatory")]
 	public CqlCode ambulatory() => 
 		__ambulatory.Value;
 
 	private CqlCode home_health_Value() => 
-		new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("home health")]
 	public CqlCode home_health() => 
 		__home_health.Value;
 
 	private CqlCode inpatient_non_acute_Value() => 
-		new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("inpatient non-acute")]
 	public CqlCode inpatient_non_acute() => 
 		__inpatient_non_acute.Value;
 
 	private CqlCode emergency_Value() => 
-		new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("emergency")]
 	public CqlCode emergency() => 
 		__emergency.Value;
 
 	private CqlCode inpatient_acute_Value() => 
-		new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string));
+		new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default);
 
     [CqlDeclaration("inpatient acute")]
 	public CqlCode inpatient_acute() => 
 		__inpatient_acute.Value;
 
 	private CqlCode drug_policy_Value() => 
-		new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("drug policy")]
 	public CqlCode drug_policy() => 
 		__drug_policy.Value;
 
 	private CqlCode mental_health_policy_Value() => 
-		new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("mental health policy")]
 	public CqlCode mental_health_policy() => 
 		__mental_health_policy.Value;
 
 	private CqlCode managed_care_policy_Value() => 
-		new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("managed care policy")]
 	public CqlCode managed_care_policy() => 
 		__managed_care_policy.Value;
 
 	private CqlCode subsidized_health_program_Value() => 
-		new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("subsidized health program")]
 	public CqlCode subsidized_health_program() => 
 		__subsidized_health_program.Value;
 
 	private CqlCode retiree_health_program_Value() => 
-		new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("retiree health program")]
 	public CqlCode retiree_health_program() => 
 		__retiree_health_program.Value;
 
 	private CqlCode substance_use_policy_Value() => 
-		new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string));
+		new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default);
 
     [CqlDeclaration("substance use policy")]
 	public CqlCode substance_use_policy() => 
 		__substance_use_policy.Value;
 
 	private CqlCode Provider_number_Value() => 
-		new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default(string), default(string));
+		new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default, default);
 
     [CqlDeclaration("Provider number")]
 	public CqlCode Provider_number() => 
@@ -564,10 +564,10 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] MedicationRequestCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
-			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default(string), default(string)),
+			new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
+			new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", default, default),
 		];
 
 		return a_;
@@ -580,12 +580,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", default, default),
 		];
 
 		return a_;
@@ -598,12 +598,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
-			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
-			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
-			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
+			new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
+			new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", default, default),
 		];
 
 		return a_;
@@ -616,9 +616,9 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
-			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default(string), default(string)),
+			new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
+			new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", default, default),
 		];
 
 		return a_;
@@ -631,9 +631,9 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
-			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default(string), default(string)),
+			new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
+			new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", default, default),
 		];
 
 		return a_;
@@ -646,8 +646,8 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceType_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string)),
-			new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default(string), default(string)),
+			new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", default, default),
+			new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", default, default),
 		];
 
 		return a_;
@@ -660,10 +660,10 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] AllergyIntoleranceCategory_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
-			new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
-			new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
-			new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default(string), default(string)),
+			new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", default, default),
+			new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", default, default),
+			new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", default, default),
+			new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", default, default),
 		];
 
 		return a_;
@@ -676,8 +676,8 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ConditionCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
-			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default(string), default(string)),
+			new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
+			new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", default, default),
 		];
 
 		return a_;
@@ -690,11 +690,11 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] claim_type_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
-			new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
-			new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
-			new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
-			new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default(string), default(string)),
+			new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", default, default),
+			new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", default, default),
+			new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", default, default),
+			new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", default, default),
+			new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", default, default),
 		];
 
 		return a_;
@@ -707,12 +707,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] ActEncounterCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
-			new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
-			new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
-			new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
-			new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
-			new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default(string), default(string)),
+			new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
+			new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
+			new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
+			new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
+			new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
+			new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", default, default),
 		];
 
 		return a_;
@@ -725,12 +725,12 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] coverage_type_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
-			new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
-			new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
-			new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
-			new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
-			new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default(string), default(string)),
+			new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
+			new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
+			new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
+			new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
+			new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
+			new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", default, default),
 		];
 
 		return a_;
@@ -743,7 +743,7 @@ public class NCQATerminology_1_0_0
 	private CqlCode[] IdentifierType_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default(string), default(string)),
+			new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", default, default),
 		];
 
 		return a_;

--- a/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("NCQATerminology", "1.0.0")]
 public class NCQATerminology_1_0_0
 {

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -56,7 +56,7 @@ public class PalliativeCareFHIR_0_6_000
     #endregion
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default(string));
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
@@ -64,7 +64,7 @@ public class PalliativeCareFHIR_0_6_000
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default(string));
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
@@ -72,14 +72,14 @@ public class PalliativeCareFHIR_0_6_000
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
-		new CqlCode("71007-9", "http://loinc.org", null, null);
+		new CqlCode("71007-9", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
 	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
 		__Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
@@ -88,7 +88,7 @@ public class PalliativeCareFHIR_0_6_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71007-9", "http://loinc.org", null, null),
+			new CqlCode("71007-9", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -101,7 +101,7 @@ public class PalliativeCareFHIR_0_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
 		];
 
 		return a_;
@@ -124,7 +124,7 @@ public class PalliativeCareFHIR_0_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -138,7 +138,7 @@ public class PalliativeCareFHIR_0_6_000
 	{
 		CqlCode a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
 		bool? d_(Observation PalliativeAssessment)
 		{
 			Code<ObservationStatus> s_ = PalliativeAssessment?.StatusElement;
@@ -165,7 +165,7 @@ public class PalliativeCareFHIR_0_6_000
 			DataType ab_ = PalliativeAssessment?.Effective;
 			CqlInterval<CqlDateTime> ac_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ab_);
 			CqlInterval<CqlDateTime> ad_ = this.Measurement_Period();
-			bool? ae_ = context.Operators.Overlaps(ac_, ad_, null);
+			bool? ae_ = context.Operators.Overlaps(ac_, ad_, default(string));
 			bool? af_ = context.Operators.And(aa_, ae_);
 
 			return af_;
@@ -173,7 +173,7 @@ public class PalliativeCareFHIR_0_6_000
 		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		bool? f_ = context.Operators.Exists<Observation>(e_);
 		CqlValueSet g_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
 		bool? i_(Encounter PalliativeEncounter)
 		{
 			Code<Encounter.EncounterStatus> ak_ = PalliativeEncounter?.StatusElement;
@@ -182,7 +182,7 @@ public class PalliativeCareFHIR_0_6_000
 			Period an_ = PalliativeEncounter?.Period;
 			CqlInterval<CqlDateTime> ao_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((an_ as object));
 			CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
-			bool? aq_ = context.Operators.Overlaps(ao_, ap_, null);
+			bool? aq_ = context.Operators.Overlaps(ao_, ap_, default(string));
 			bool? ar_ = context.Operators.And(am_, aq_);
 
 			return ar_;
@@ -191,7 +191,7 @@ public class PalliativeCareFHIR_0_6_000
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
 		bool? l_ = context.Operators.Or(f_, k_);
 		CqlValueSet m_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, null);
+		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default(PropertyInfo));
 		bool? o_(Procedure PalliativeIntervention)
 		{
 			Code<EventStatus> as_ = PalliativeIntervention?.StatusElement;
@@ -204,7 +204,7 @@ public class PalliativeCareFHIR_0_6_000
 			DataType aw_ = PalliativeIntervention?.Performed;
 			CqlInterval<CqlDateTime> ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(aw_);
 			CqlInterval<CqlDateTime> ay_ = this.Measurement_Period();
-			bool? az_ = context.Operators.Overlaps(ax_, ay_, null);
+			bool? az_ = context.Operators.Overlaps(ax_, ay_, default(string));
 			bool? ba_ = context.Operators.And(av_, az_);
 
 			return ba_;

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PalliativeCareFHIR", "0.6.000")]
 public class PalliativeCareFHIR_0_6_000
 {

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -56,7 +56,7 @@ public class PalliativeCareFHIR_0_6_000
     #endregion
 
 	private CqlValueSet Palliative_Care_Encounter_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", default);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
@@ -64,7 +64,7 @@ public class PalliativeCareFHIR_0_6_000
 		__Palliative_Care_Encounter.Value;
 
 	private CqlValueSet Palliative_Care_Intervention_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", default);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
@@ -72,14 +72,14 @@ public class PalliativeCareFHIR_0_6_000
 		__Palliative_Care_Intervention.Value;
 
 	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value() => 
-		new CqlCode("71007-9", "http://loinc.org", default(string), default(string));
+		new CqlCode("71007-9", "http://loinc.org", default, default);
 
     [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
 	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
 		__Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_.Value;
 
 	private CqlCode survey_Value() => 
-		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string));
+		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default);
 
     [CqlDeclaration("survey")]
 	public CqlCode survey() => 
@@ -88,7 +88,7 @@ public class PalliativeCareFHIR_0_6_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("71007-9", "http://loinc.org", default(string), default(string)),
+			new CqlCode("71007-9", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -101,7 +101,7 @@ public class PalliativeCareFHIR_0_6_000
 	private CqlCode[] ObservationCategoryCodes_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default(string), default(string)),
+			new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", default, default),
 		];
 
 		return a_;
@@ -124,7 +124,7 @@ public class PalliativeCareFHIR_0_6_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -138,7 +138,7 @@ public class PalliativeCareFHIR_0_6_000
 	{
 		CqlCode a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
 		IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
-		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default(PropertyInfo));
+		IEnumerable<Observation> c_ = context.Operators.RetrieveByCodes<Observation>(b_, default);
 		bool? d_(Observation PalliativeAssessment)
 		{
 			Code<ObservationStatus> s_ = PalliativeAssessment?.StatusElement;
@@ -165,7 +165,7 @@ public class PalliativeCareFHIR_0_6_000
 			DataType ab_ = PalliativeAssessment?.Effective;
 			CqlInterval<CqlDateTime> ac_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ab_);
 			CqlInterval<CqlDateTime> ad_ = this.Measurement_Period();
-			bool? ae_ = context.Operators.Overlaps(ac_, ad_, default(string));
+			bool? ae_ = context.Operators.Overlaps(ac_, ad_, default);
 			bool? af_ = context.Operators.And(aa_, ae_);
 
 			return af_;
@@ -173,7 +173,7 @@ public class PalliativeCareFHIR_0_6_000
 		IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
 		bool? f_ = context.Operators.Exists<Observation>(e_);
 		CqlValueSet g_ = this.Palliative_Care_Encounter();
-		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default(PropertyInfo));
+		IEnumerable<Encounter> h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, default);
 		bool? i_(Encounter PalliativeEncounter)
 		{
 			Code<Encounter.EncounterStatus> ak_ = PalliativeEncounter?.StatusElement;
@@ -182,7 +182,7 @@ public class PalliativeCareFHIR_0_6_000
 			Period an_ = PalliativeEncounter?.Period;
 			CqlInterval<CqlDateTime> ao_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((an_ as object));
 			CqlInterval<CqlDateTime> ap_ = this.Measurement_Period();
-			bool? aq_ = context.Operators.Overlaps(ao_, ap_, default(string));
+			bool? aq_ = context.Operators.Overlaps(ao_, ap_, default);
 			bool? ar_ = context.Operators.And(am_, aq_);
 
 			return ar_;
@@ -191,7 +191,7 @@ public class PalliativeCareFHIR_0_6_000
 		bool? k_ = context.Operators.Exists<Encounter>(j_);
 		bool? l_ = context.Operators.Or(f_, k_);
 		CqlValueSet m_ = this.Palliative_Care_Intervention();
-		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default(PropertyInfo));
+		IEnumerable<Procedure> n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, default);
 		bool? o_(Procedure PalliativeIntervention)
 		{
 			Code<EventStatus> as_ = PalliativeIntervention?.StatusElement;
@@ -204,7 +204,7 @@ public class PalliativeCareFHIR_0_6_000
 			DataType aw_ = PalliativeIntervention?.Performed;
 			CqlInterval<CqlDateTime> ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(aw_);
 			CqlInterval<CqlDateTime> ay_ = this.Measurement_Period();
-			bool? az_ = context.Operators.Overlaps(ax_, ay_, default(string));
+			bool? az_ = context.Operators.Overlaps(ax_, ay_, default);
 			bool? ba_ = context.Operators.And(av_, az_);
 
 			return ba_;

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -92,7 +92,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default);
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -100,7 +100,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default);
 
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
@@ -108,7 +108,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Fluoride_Varnish_Application_for_Children.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -116,7 +116,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -124,7 +124,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care___Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default);
 
     [CqlDeclaration("Preventive Care - Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -132,7 +132,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care___Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -140,7 +140,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -148,7 +148,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default);
 
     [CqlDeclaration("Preventive Care- Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -156,7 +156,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -164,7 +164,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Telephone_Visits.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -173,7 +173,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -196,7 +196,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -253,26 +253,26 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		CqlValueSet c_ = this.Preventive_Care___Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default);
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default);
 		CqlValueSet h_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default);
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default);
 		CqlValueSet n_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default);
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default);
 		CqlValueSet t_ = this.Online_Assessments();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default);
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -280,7 +280,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 			CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 			Period aa_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((aa_ as object));
-			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default(string));
+			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default);
 			Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -387,7 +387,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(5, 11, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -407,7 +407,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 20, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
+		bool? j_ = context.Operators.In<int?>(h_, i_, default);
 
 		return j_;
 	}
@@ -419,13 +419,13 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Fluoride_Varnish_Application_for_Children();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? c_(Procedure FluorideApplication)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = FluorideApplication?.Performed;
 			CqlInterval<CqlDateTime> h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default(string));
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default);
 			Code<EventStatus> j_ = FluorideApplication?.StatusElement;
 			string k_ = FHIRHelpers_4_0_001.ToString(j_);
 			bool? l_ = context.Operators.Equal(k_, "completed");

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -92,7 +92,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
     #endregion
 
 	private CqlValueSet Clinical_Oral_Evaluation_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", default(string));
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
@@ -100,7 +100,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Clinical_Oral_Evaluation.Value;
 
 	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", default(string));
 
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
@@ -108,7 +108,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Fluoride_Varnish_Application_for_Children.Value;
 
 	private CqlValueSet Office_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", default(string));
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
@@ -116,7 +116,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Office_Visit.Value;
 
 	private CqlValueSet Online_Assessments_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", default(string));
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
@@ -124,7 +124,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Online_Assessments.Value;
 
 	private CqlValueSet Preventive_Care___Established_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", default(string));
 
     [CqlDeclaration("Preventive Care - Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
@@ -132,7 +132,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care___Established_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", default(string));
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
@@ -140,7 +140,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care_Services___Established_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", default(string));
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
@@ -148,7 +148,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up.Value;
 
 	private CqlValueSet Preventive_Care__Initial_Office_Visit__0_to_17_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", default(string));
 
     [CqlDeclaration("Preventive Care- Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
@@ -156,7 +156,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Preventive_Care__Initial_Office_Visit__0_to_17.Value;
 
 	private CqlValueSet Telephone_Visits_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", default(string));
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
@@ -164,7 +164,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		__Telephone_Visits.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -173,7 +173,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -196,7 +196,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -253,26 +253,26 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private IEnumerable<Encounter> Qualifying_Encounters_Value()
 	{
 		CqlValueSet a_ = this.Office_Visit();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		CqlValueSet c_ = this.Preventive_Care___Established_Office_Visit__0_to_17();
-		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
+		IEnumerable<Encounter> d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, default(PropertyInfo));
 		IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
 		CqlValueSet f_ = this.Preventive_Care__Initial_Office_Visit__0_to_17();
-		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
+		IEnumerable<Encounter> g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, default(PropertyInfo));
 		CqlValueSet h_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
+		IEnumerable<Encounter> i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, default(PropertyInfo));
 		IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
 		IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
 		CqlValueSet l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
-		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
+		IEnumerable<Encounter> m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, default(PropertyInfo));
 		CqlValueSet n_ = this.Clinical_Oral_Evaluation();
-		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
+		IEnumerable<Encounter> o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, default(PropertyInfo));
 		IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
 		IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
 		CqlValueSet r_ = this.Telephone_Visits();
-		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
+		IEnumerable<Encounter> s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, default(PropertyInfo));
 		CqlValueSet t_ = this.Online_Assessments();
-		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
+		IEnumerable<Encounter> u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, default(PropertyInfo));
 		IEnumerable<Encounter> v_ = context.Operators.Union<Encounter>(s_, u_);
 		IEnumerable<Encounter> w_ = context.Operators.Union<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
@@ -280,7 +280,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 			CqlInterval<CqlDateTime> z_ = this.Measurement_Period();
 			Period aa_ = ValidEncounter?.Period;
 			CqlInterval<CqlDateTime> ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((aa_ as object));
-			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, null);
+			bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default(string));
 			Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
 			string ae_ = FHIRHelpers_4_0_001.ToString(ad_);
 			bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -387,7 +387,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(5, 11, true, true);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -407,7 +407,7 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		CqlDate g_ = context.Operators.DateFrom(f_);
 		int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
 		CqlInterval<int?> i_ = context.Operators.Interval(12, 20, true, false);
-		bool? j_ = context.Operators.In<int?>(h_, i_, null);
+		bool? j_ = context.Operators.In<int?>(h_, i_, default(string));
 
 		return j_;
 	}
@@ -419,13 +419,13 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 	private bool? Numerator_Value()
 	{
 		CqlValueSet a_ = this.Fluoride_Varnish_Application_for_Children();
-		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? c_(Procedure FluorideApplication)
 		{
 			CqlInterval<CqlDateTime> f_ = this.Measurement_Period();
 			DataType g_ = FluorideApplication?.Performed;
 			CqlInterval<CqlDateTime> h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(g_);
-			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, null);
+			bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default(string));
 			Code<EventStatus> j_ = FluorideApplication?.StatusElement;
 			string k_ = FHIRHelpers_4_0_001.ToString(j_);
 			bool? l_ = context.Operators.Equal(k_, "completed");

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR", "0.0.008")]
 public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 {

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -82,7 +82,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
     #endregion
 
 	private CqlValueSet All_Primary_and_Secondary_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", default(string));
 
     [CqlDeclaration("All Primary and Secondary Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161")]
@@ -90,7 +90,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__All_Primary_and_Secondary_Cancer.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -98,7 +98,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -106,7 +106,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_Care_Referral_or_Admission_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", default(string));
 
     [CqlDeclaration("Hospice Care Referral or Admission")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365")]
@@ -114,7 +114,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Hospice_Care_Referral_or_Admission.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -122,7 +122,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -130,7 +130,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Patient_Expired.Value;
 
 	private CqlValueSet Schedule_II_and_III_Opioid_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", default(string));
 
     [CqlDeclaration("Schedule II & III Opioid Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165")]
@@ -138,7 +138,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Schedule_II_and_III_Opioid_Medications.Value;
 
 	private CqlValueSet Schedule_IV_Benzodiazepines_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", default(string));
 
     [CqlDeclaration("Schedule IV Benzodiazepines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1")]
@@ -146,7 +146,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Schedule_IV_Benzodiazepines.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -155,7 +155,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -178,7 +178,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -225,12 +225,12 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet d_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			CqlValueSet i_ = this.Schedule_IV_Benzodiazepines();
-			IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, null);
-			IEnumerable<MedicationRequest> l_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, null);
+			IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> l_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default(PropertyInfo));
 			IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(j_, l_);
 			bool? n_(MedicationRequest Medications)
 			{
@@ -257,7 +257,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 				CqlDateTime ad_ = FHIRHelpers_4_0_001.ToDateTime(ac_);
 				Period ae_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_0_001.ToInterval(ae_);
-				bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, null);
+				bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, default(string));
 				Code<MedicationRequest.MedicationrequestStatus> ah_ = OpioidOrBenzodiazepineDischargeMedication?.StatusElement;
 				string ai_ = FHIRHelpers_4_0_001.ToString(ah_);
 				bool? aj_ = context.Operators.Equal(ai_, "active");
@@ -346,14 +346,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		bool? b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet j_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
+			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
 			bool? l_(MedicationRequest Opioids)
 			{
 				FhirDateTime r_ = Opioids?.AuthoredOnElement;
 				CqlDateTime s_ = FHIRHelpers_4_0_001.ToDateTime(r_);
 				Period t_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_0_001.ToInterval(t_);
-				bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, null);
+				bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, default(string));
 
 				return v_;
 			};
@@ -374,14 +374,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
 			CqlValueSet x_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, null);
+			IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
 			bool? z_(MedicationRequest OpioidsDischarge)
 			{
 				FhirDateTime ad_ = OpioidsDischarge?.AuthoredOnElement;
 				CqlDateTime ae_ = FHIRHelpers_4_0_001.ToDateTime(ad_);
 				Period af_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
-				bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, null);
+				bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default(string));
 
 				return ah_;
 			};
@@ -396,14 +396,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> g_(Encounter InpatientEncounter)
 		{
 			CqlValueSet ai_ = this.Schedule_IV_Benzodiazepines();
-			IEnumerable<MedicationRequest> aj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, null);
+			IEnumerable<MedicationRequest> aj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, default(PropertyInfo));
 			bool? ak_(MedicationRequest BenzodiazepinesDischarge)
 			{
 				FhirDateTime ao_ = BenzodiazepinesDischarge?.AuthoredOnElement;
 				CqlDateTime ap_ = FHIRHelpers_4_0_001.ToDateTime(ao_);
 				Period aq_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_0_001.ToInterval(aq_);
-				bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, null);
+				bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, default(string));
 
 				return as_;
 			};
@@ -430,27 +430,27 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		bool? b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet f_ = this.All_Primary_and_Secondary_Cancer();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
 			bool? h_(Condition Cancer)
 			{
 				CqlInterval<CqlDateTime> ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Cancer);
 				Period ac_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_0_001.ToInterval(ac_);
-				bool? ae_ = context.Operators.Overlaps(ab_, ad_, null);
+				bool? ae_ = context.Operators.Overlaps(ab_, ad_, default(string));
 
 				return ae_;
 			};
 			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 			bool? j_ = context.Operators.Exists<Condition>(i_);
 			CqlValueSet k_ = this.Palliative_or_Hospice_Care();
-			IEnumerable<ServiceRequest> l_ = context.Operators.RetrieveByValueSet<ServiceRequest>(k_, null);
+			IEnumerable<ServiceRequest> l_ = context.Operators.RetrieveByValueSet<ServiceRequest>(k_, default(PropertyInfo));
 			bool? m_(ServiceRequest PalliativeOrHospiceCareOrder)
 			{
 				FhirDateTime af_ = PalliativeOrHospiceCareOrder?.AuthoredOnElement;
 				CqlDateTime ag_ = FHIRHelpers_4_0_001.ToDateTime(af_);
 				Period ah_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_0_001.ToInterval(ah_);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ag_, ai_, null);
+				bool? aj_ = context.Operators.In<CqlDateTime>(ag_, ai_, default(string));
 				Code<RequestIntent> ak_ = PalliativeOrHospiceCareOrder?.IntentElement;
 				string al_ = FHIRHelpers_4_0_001.ToString(ak_);
 				bool? am_ = context.Operators.Equal(al_, "order");
@@ -461,14 +461,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			IEnumerable<ServiceRequest> n_ = context.Operators.Where<ServiceRequest>(l_, m_);
 			bool? o_ = context.Operators.Exists<ServiceRequest>(n_);
 			bool? p_ = context.Operators.Or(j_, o_);
-			IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(k_, null);
+			IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(k_, default(PropertyInfo));
 			bool? s_(Procedure PalliativeOrHospiceCarePerformed)
 			{
 				DataType ao_ = PalliativeOrHospiceCarePerformed?.Performed;
 				CqlInterval<CqlDateTime> ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ao_);
 				Period aq_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_0_001.ToInterval(aq_);
-				bool? as_ = context.Operators.Overlaps(ap_, ar_, null);
+				bool? as_ = context.Operators.Overlaps(ap_, ar_, default(string));
 
 				return as_;
 			};

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -82,7 +82,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
     #endregion
 
 	private CqlValueSet All_Primary_and_Secondary_Cancer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", default);
 
     [CqlDeclaration("All Primary and Secondary Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161")]
@@ -90,7 +90,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__All_Primary_and_Secondary_Cancer.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -98,7 +98,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -106,7 +106,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hospice_Care_Referral_or_Admission_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", default);
 
     [CqlDeclaration("Hospice Care Referral or Admission")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365")]
@@ -114,7 +114,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Hospice_Care_Referral_or_Admission.Value;
 
 	private CqlValueSet Palliative_or_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", default);
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
@@ -122,7 +122,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Palliative_or_Hospice_Care.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -130,7 +130,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Patient_Expired.Value;
 
 	private CqlValueSet Schedule_II_and_III_Opioid_Medications_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", default);
 
     [CqlDeclaration("Schedule II & III Opioid Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165")]
@@ -138,7 +138,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Schedule_II_and_III_Opioid_Medications.Value;
 
 	private CqlValueSet Schedule_IV_Benzodiazepines_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", default);
 
     [CqlDeclaration("Schedule IV Benzodiazepines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1")]
@@ -146,7 +146,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		__Schedule_IV_Benzodiazepines.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -155,7 +155,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -178,7 +178,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -225,12 +225,12 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet d_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
+			IEnumerable<MedicationRequest> g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, default);
 			IEnumerable<MedicationRequest> h_ = context.Operators.Union<MedicationRequest>(e_, g_);
 			CqlValueSet i_ = this.Schedule_IV_Benzodiazepines();
-			IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default(PropertyInfo));
-			IEnumerable<MedicationRequest> l_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default);
+			IEnumerable<MedicationRequest> l_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, default);
 			IEnumerable<MedicationRequest> m_ = context.Operators.Union<MedicationRequest>(j_, l_);
 			bool? n_(MedicationRequest Medications)
 			{
@@ -257,7 +257,7 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 				CqlDateTime ad_ = FHIRHelpers_4_0_001.ToDateTime(ac_);
 				Period ae_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_0_001.ToInterval(ae_);
-				bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, default(string));
+				bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, default);
 				Code<MedicationRequest.MedicationrequestStatus> ah_ = OpioidOrBenzodiazepineDischargeMedication?.StatusElement;
 				string ai_ = FHIRHelpers_4_0_001.ToString(ah_);
 				bool? aj_ = context.Operators.Equal(ai_, "active");
@@ -346,14 +346,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		bool? b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet j_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, default);
 			bool? l_(MedicationRequest Opioids)
 			{
 				FhirDateTime r_ = Opioids?.AuthoredOnElement;
 				CqlDateTime s_ = FHIRHelpers_4_0_001.ToDateTime(r_);
 				Period t_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_0_001.ToInterval(t_);
-				bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, default(string));
+				bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, default);
 
 				return v_;
 			};
@@ -374,14 +374,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
 			CqlValueSet x_ = this.Schedule_II_and_III_Opioid_Medications();
-			IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> y_ = context.Operators.RetrieveByValueSet<MedicationRequest>(x_, default);
 			bool? z_(MedicationRequest OpioidsDischarge)
 			{
 				FhirDateTime ad_ = OpioidsDischarge?.AuthoredOnElement;
 				CqlDateTime ae_ = FHIRHelpers_4_0_001.ToDateTime(ad_);
 				Period af_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_0_001.ToInterval(af_);
-				bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default(string));
+				bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default);
 
 				return ah_;
 			};
@@ -396,14 +396,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		IEnumerable<Encounter> g_(Encounter InpatientEncounter)
 		{
 			CqlValueSet ai_ = this.Schedule_IV_Benzodiazepines();
-			IEnumerable<MedicationRequest> aj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, default(PropertyInfo));
+			IEnumerable<MedicationRequest> aj_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ai_, default);
 			bool? ak_(MedicationRequest BenzodiazepinesDischarge)
 			{
 				FhirDateTime ao_ = BenzodiazepinesDischarge?.AuthoredOnElement;
 				CqlDateTime ap_ = FHIRHelpers_4_0_001.ToDateTime(ao_);
 				Period aq_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_0_001.ToInterval(aq_);
-				bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, default(string));
+				bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, default);
 
 				return as_;
 			};
@@ -430,27 +430,27 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		bool? b_(Encounter InpatientEncounter)
 		{
 			CqlValueSet f_ = this.All_Primary_and_Secondary_Cancer();
-			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default(PropertyInfo));
+			IEnumerable<Condition> g_ = context.Operators.RetrieveByValueSet<Condition>(f_, default);
 			bool? h_(Condition Cancer)
 			{
 				CqlInterval<CqlDateTime> ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Cancer);
 				Period ac_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_0_001.ToInterval(ac_);
-				bool? ae_ = context.Operators.Overlaps(ab_, ad_, default(string));
+				bool? ae_ = context.Operators.Overlaps(ab_, ad_, default);
 
 				return ae_;
 			};
 			IEnumerable<Condition> i_ = context.Operators.Where<Condition>(g_, h_);
 			bool? j_ = context.Operators.Exists<Condition>(i_);
 			CqlValueSet k_ = this.Palliative_or_Hospice_Care();
-			IEnumerable<ServiceRequest> l_ = context.Operators.RetrieveByValueSet<ServiceRequest>(k_, default(PropertyInfo));
+			IEnumerable<ServiceRequest> l_ = context.Operators.RetrieveByValueSet<ServiceRequest>(k_, default);
 			bool? m_(ServiceRequest PalliativeOrHospiceCareOrder)
 			{
 				FhirDateTime af_ = PalliativeOrHospiceCareOrder?.AuthoredOnElement;
 				CqlDateTime ag_ = FHIRHelpers_4_0_001.ToDateTime(af_);
 				Period ah_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_0_001.ToInterval(ah_);
-				bool? aj_ = context.Operators.In<CqlDateTime>(ag_, ai_, default(string));
+				bool? aj_ = context.Operators.In<CqlDateTime>(ag_, ai_, default);
 				Code<RequestIntent> ak_ = PalliativeOrHospiceCareOrder?.IntentElement;
 				string al_ = FHIRHelpers_4_0_001.ToString(ak_);
 				bool? am_ = context.Operators.Equal(al_, "order");
@@ -461,14 +461,14 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			IEnumerable<ServiceRequest> n_ = context.Operators.Where<ServiceRequest>(l_, m_);
 			bool? o_ = context.Operators.Exists<ServiceRequest>(n_);
 			bool? p_ = context.Operators.Or(j_, o_);
-			IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(k_, default(PropertyInfo));
+			IEnumerable<Procedure> r_ = context.Operators.RetrieveByValueSet<Procedure>(k_, default);
 			bool? s_(Procedure PalliativeOrHospiceCarePerformed)
 			{
 				DataType ao_ = PalliativeOrHospiceCarePerformed?.Performed;
 				CqlInterval<CqlDateTime> ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ao_);
 				Period aq_ = InpatientEncounter?.Period;
 				CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_0_001.ToInterval(aq_);
-				bool? as_ = context.Operators.Overlaps(ap_, ar_, default(string));
+				bool? as_ = context.Operators.Overlaps(ap_, ar_, default);
 
 				return as_;
 			};

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("SafeUseofOpioidsConcurrentPrescribingFHIR", "0.0.012")]
 public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 {

--- a/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__Payer.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return null;
+				return default(IEnumerable<Extension>);
 			}
 		};
 		bool? b_(Extension Extension)
@@ -169,7 +169,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 	private IEnumerable<(CodeableConcept code, Period period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
 		(CodeableConcept code, Period period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -206,7 +206,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return null;
+				return default(IEnumerable<Extension>);
 			}
 		};
 		bool? b_(Extension Extension)
@@ -288,7 +288,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return null;
+				return default(CqlCode);
 			}
 		};
 

--- a/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
@@ -54,7 +54,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
     #endregion
 
 	private CqlValueSet Ethnicity_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", default);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
@@ -62,7 +62,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__Ethnicity.Value;
 
 	private CqlValueSet ONC_Administrative_Sex_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", default);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
@@ -70,7 +70,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__ONC_Administrative_Sex.Value;
 
 	private CqlValueSet Payer_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", default);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
@@ -78,7 +78,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		__Payer.Value;
 
 	private CqlValueSet Race_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", default);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
@@ -87,7 +87,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -116,7 +116,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return default(IEnumerable<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension Extension)
@@ -169,7 +169,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 	private IEnumerable<(CodeableConcept code, Period period)?> SDE_Payer_Value()
 	{
 		CqlValueSet a_ = this.Payer();
-		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default(PropertyInfo));
+		IEnumerable<Coverage> b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, default);
 		(CodeableConcept code, Period period)? c_(Coverage Payer)
 		{
 			CodeableConcept e_ = Payer?.Type;
@@ -206,7 +206,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return default(IEnumerable<Extension>);
+				return default;
 			}
 		};
 		bool? b_(Extension Extension)
@@ -288,7 +288,7 @@ public class SupplementalDataElementsFHIR4_2_0_000
 			}
 			else
 			{
-				return default(CqlCode);
+				return default;
 			}
 		};
 

--- a/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("SupplementalDataElementsFHIR4", "2.0.000")]
 public class SupplementalDataElementsFHIR4_2_0_000
 {

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -88,7 +88,7 @@ public class TJCOverallFHIR_1_8_000
     #endregion
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -96,7 +96,7 @@ public class TJCOverallFHIR_1_8_000
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -104,7 +104,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -112,7 +112,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -120,7 +120,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -128,7 +128,7 @@ public class TJCOverallFHIR_1_8_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -136,7 +136,7 @@ public class TJCOverallFHIR_1_8_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -144,7 +144,7 @@ public class TJCOverallFHIR_1_8_000
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -152,7 +152,7 @@ public class TJCOverallFHIR_1_8_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -160,7 +160,7 @@ public class TJCOverallFHIR_1_8_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Non_Elective_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
 
     [CqlDeclaration("Non-Elective Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -168,7 +168,7 @@ public class TJCOverallFHIR_1_8_000
 		__Non_Elective_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -176,7 +176,7 @@ public class TJCOverallFHIR_1_8_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -184,7 +184,7 @@ public class TJCOverallFHIR_1_8_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Ticagrelor_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", default(string));
 
     [CqlDeclaration("Ticagrelor Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39")]
@@ -192,7 +192,7 @@ public class TJCOverallFHIR_1_8_000
 		__Ticagrelor_Therapy.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", null, null);
+		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -201,7 +201,7 @@ public class TJCOverallFHIR_1_8_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", null, null),
+			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
 		];
 
 		return a_;
@@ -213,8 +213,8 @@ public class TJCOverallFHIR_1_8_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("TJCOverallFHIR-1.8.000", "Measurement Period", c_);
 
@@ -227,7 +227,7 @@ public class TJCOverallFHIR_1_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -240,7 +240,7 @@ public class TJCOverallFHIR_1_8_000
 	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Non_Elective_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
 		bool? c_(Encounter NonElectiveEncounter)
 		{
 			Period e_ = NonElectiveEncounter?.Period;
@@ -296,7 +296,7 @@ public class TJCOverallFHIR_1_8_000
 		IEnumerable<Encounter> a_ = this.All_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter AllStrokeEncounter)
 		{
-			IEnumerable<Patient> d_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+			IEnumerable<Patient> d_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 			bool? e_(Patient BirthDate)
 			{
 				Patient i_ = this.Patient();
@@ -394,7 +394,7 @@ public class TJCOverallFHIR_1_8_000
 	private IEnumerable<object> Intervention_Comfort_Measures_Value()
 	{
 		CqlValueSet a_ = this.Comfort_Measures();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
 		bool? c_(ServiceRequest P)
 		{
 			Code<RequestIntent> j_ = P?.IntentElement;
@@ -404,7 +404,7 @@ public class TJCOverallFHIR_1_8_000
 			return l_;
 		};
 		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
 		bool? g_(Procedure InterventionPerformed)
 		{
 			Code<EventStatus> m_ = InterventionPerformed?.StatusElement;
@@ -439,7 +439,7 @@ public class TJCOverallFHIR_1_8_000
 				FhirDateTime j_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
 				CqlDateTime k_ = FHIRHelpers_4_0_001.ToDateTime(((i_ as FhirDateTime) ?? j_));
 				CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, null);
+				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default(string));
 
 				return m_;
 			};
@@ -473,7 +473,7 @@ public class TJCOverallFHIR_1_8_000
 				FhirDateTime l_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
 				CqlDateTime m_ = FHIRHelpers_4_0_001.ToDateTime(l_);
 				CqlInterval<CqlDateTime> n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? o_ = context.Operators.In<CqlDateTime>((k_ ?? m_), n_, null);
+				bool? o_ = context.Operators.In<CqlDateTime>((k_ ?? m_), n_, default(string));
 
 				return o_;
 			};

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -88,7 +88,7 @@ public class TJCOverallFHIR_1_8_000
     #endregion
 
 	private CqlValueSet Comfort_Measures_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", default);
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
@@ -96,7 +96,7 @@ public class TJCOverallFHIR_1_8_000
 		__Comfort_Measures.Value;
 
 	private CqlValueSet Discharge_To_Acute_Care_Facility_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", default);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
@@ -104,7 +104,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharge_To_Acute_Care_Facility.Value;
 
 	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", default);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
@@ -112,7 +112,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharged_to_Health_Care_Facility_for_Hospice_Care.Value;
 
 	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", default);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
@@ -120,7 +120,7 @@ public class TJCOverallFHIR_1_8_000
 		__Discharged_to_Home_for_Hospice_Care.Value;
 
 	private CqlValueSet Emergency_Department_Visit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", default);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
@@ -128,7 +128,7 @@ public class TJCOverallFHIR_1_8_000
 		__Emergency_Department_Visit.Value;
 
 	private CqlValueSet Encounter_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", default);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
@@ -136,7 +136,7 @@ public class TJCOverallFHIR_1_8_000
 		__Encounter_Inpatient.Value;
 
 	private CqlValueSet Hemorrhagic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", default);
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
@@ -144,7 +144,7 @@ public class TJCOverallFHIR_1_8_000
 		__Hemorrhagic_Stroke.Value;
 
 	private CqlValueSet Ischemic_Stroke_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", default);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
@@ -152,7 +152,7 @@ public class TJCOverallFHIR_1_8_000
 		__Ischemic_Stroke.Value;
 
 	private CqlValueSet Left_Against_Medical_Advice_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", default);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
@@ -160,7 +160,7 @@ public class TJCOverallFHIR_1_8_000
 		__Left_Against_Medical_Advice.Value;
 
 	private CqlValueSet Non_Elective_Inpatient_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", default);
 
     [CqlDeclaration("Non-Elective Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
@@ -168,7 +168,7 @@ public class TJCOverallFHIR_1_8_000
 		__Non_Elective_Inpatient.Value;
 
 	private CqlValueSet Observation_Services_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", default);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
@@ -176,7 +176,7 @@ public class TJCOverallFHIR_1_8_000
 		__Observation_Services.Value;
 
 	private CqlValueSet Patient_Expired_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", default);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
@@ -184,7 +184,7 @@ public class TJCOverallFHIR_1_8_000
 		__Patient_Expired.Value;
 
 	private CqlValueSet Ticagrelor_Therapy_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", default);
 
     [CqlDeclaration("Ticagrelor Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39")]
@@ -192,7 +192,7 @@ public class TJCOverallFHIR_1_8_000
 		__Ticagrelor_Therapy.Value;
 
 	private CqlCode Birth_date_Value() => 
-		new CqlCode("21112-8", "http://loinc.org", default(string), default(string));
+		new CqlCode("21112-8", "http://loinc.org", default, default);
 
     [CqlDeclaration("Birth date")]
 	public CqlCode Birth_date() => 
@@ -201,7 +201,7 @@ public class TJCOverallFHIR_1_8_000
 	private CqlCode[] LOINC_Value()
 	{
 		CqlCode[] a_ = [
-			new CqlCode("21112-8", "http://loinc.org", default(string), default(string)),
+			new CqlCode("21112-8", "http://loinc.org", default, default),
 		];
 
 		return a_;
@@ -213,8 +213,8 @@ public class TJCOverallFHIR_1_8_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("TJCOverallFHIR-1.8.000", "Measurement Period", c_);
 
@@ -227,7 +227,7 @@ public class TJCOverallFHIR_1_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -240,7 +240,7 @@ public class TJCOverallFHIR_1_8_000
 	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value()
 	{
 		CqlValueSet a_ = this.Non_Elective_Inpatient();
-		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default(PropertyInfo));
+		IEnumerable<Encounter> b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, default);
 		bool? c_(Encounter NonElectiveEncounter)
 		{
 			Period e_ = NonElectiveEncounter?.Period;
@@ -296,7 +296,7 @@ public class TJCOverallFHIR_1_8_000
 		IEnumerable<Encounter> a_ = this.All_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter AllStrokeEncounter)
 		{
-			IEnumerable<Patient> d_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+			IEnumerable<Patient> d_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 			bool? e_(Patient BirthDate)
 			{
 				Patient i_ = this.Patient();
@@ -394,7 +394,7 @@ public class TJCOverallFHIR_1_8_000
 	private IEnumerable<object> Intervention_Comfort_Measures_Value()
 	{
 		CqlValueSet a_ = this.Comfort_Measures();
-		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default(PropertyInfo));
+		IEnumerable<ServiceRequest> b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, default);
 		bool? c_(ServiceRequest P)
 		{
 			Code<RequestIntent> j_ = P?.IntentElement;
@@ -404,7 +404,7 @@ public class TJCOverallFHIR_1_8_000
 			return l_;
 		};
 		IEnumerable<ServiceRequest> d_ = context.Operators.Where<ServiceRequest>(b_, c_);
-		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default(PropertyInfo));
+		IEnumerable<Procedure> f_ = context.Operators.RetrieveByValueSet<Procedure>(a_, default);
 		bool? g_(Procedure InterventionPerformed)
 		{
 			Code<EventStatus> m_ = InterventionPerformed?.StatusElement;
@@ -439,7 +439,7 @@ public class TJCOverallFHIR_1_8_000
 				FhirDateTime j_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
 				CqlDateTime k_ = FHIRHelpers_4_0_001.ToDateTime(((i_ as FhirDateTime) ?? j_));
 				CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default(string));
+				bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default);
 
 				return m_;
 			};
@@ -473,7 +473,7 @@ public class TJCOverallFHIR_1_8_000
 				FhirDateTime l_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
 				CqlDateTime m_ = FHIRHelpers_4_0_001.ToDateTime(l_);
 				CqlInterval<CqlDateTime> n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
-				bool? o_ = context.Operators.In<CqlDateTime>((k_ ?? m_), n_, default(string));
+				bool? o_ = context.Operators.In<CqlDateTime>((k_ ?? m_), n_, default);
 
 				return o_;
 			};

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("TJCOverallFHIR", "1.8.000")]
 public class TJCOverallFHIR_1_8_000
 {

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.1.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.2.0")]
 [CqlLibrary("VTEFHIR4", "4.8.000")]
 public class VTEFHIR4_4_8_000
 {

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -44,7 +44,7 @@ public class VTEFHIR4_4_8_000
     #endregion
 
 	private CqlValueSet Intensive_Care_Unit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default(string));
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default);
 
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
@@ -53,8 +53,8 @@ public class VTEFHIR4_4_8_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("VTEFHIR4-4.8.000", "Measurement Period", c_);
 
@@ -67,7 +67,7 @@ public class VTEFHIR4_4_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -99,7 +99,7 @@ public class VTEFHIR4_4_8_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -44,7 +44,7 @@ public class VTEFHIR4_4_8_000
     #endregion
 
 	private CqlValueSet Intensive_Care_Unit_Value() => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", null);
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", default(string));
 
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
@@ -53,8 +53,8 @@ public class VTEFHIR4_4_8_000
 
 	private CqlInterval<CqlDateTime> Measurement_Period_Value()
 	{
-		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+		CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default(decimal));
+		CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default(decimal));
 		CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
 		object d_ = context.ResolveParameter("VTEFHIR4-4.8.000", "Measurement Period", c_);
 
@@ -67,7 +67,7 @@ public class VTEFHIR4_4_8_000
 
 	private Patient Patient_Value()
 	{
-		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default(CqlValueSet), default(PropertyInfo));
 		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
 
 		return b_;
@@ -99,7 +99,7 @@ public class VTEFHIR4_4_8_000
 			CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_0_001.ToInterval(n_);
 			Period p_ = HospitalLocation?.Period;
 			CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.ToInterval(p_);
-			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, null);
+			bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default(string));
 			bool? s_ = context.Operators.And(m_, r_);
 
 			return s_;

--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -10,7 +10,10 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.1</VersionPrefix>
+		<!--
+			Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
+			-->
+		<VersionPrefix>2.0.2</VersionPrefix>
 		<VersionSuffix>alpha</VersionSuffix>
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>
 		<Copyright>Copyright 2013-2024 NCQA, Firely. Contains materials (C) HL7 International</Copyright>

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -6,7 +6,10 @@
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>
-		<VersionPrefix>2.0.1</VersionPrefix>
+		<!--
+			Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
+			-->
+		<VersionPrefix>2.0.2</VersionPrefix>
 		<VersionSuffix>alpha</VersionSuffix>
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>
 		<Copyright>Copyright 2013-2024 NCQA, Firely. Contains materials (C) HL7 International</Copyright>


### PR DESCRIPTION
One more effort.

> This PR enables the translation of FunctionRef/ExpressionRef to rely on the ref's resultTypeSpecifier instead of having to look the definition up in the DefinitionDictionary. Not using the DefinitionDictionary avoids running into the situation where the ref is a forwards reference whereby the DefinitionDictionary does not yet contain the translated function we want to call.

This PR uses the recent functionality added to LibrarySet to lookup a symbol, and expands this to be able to lookup functions by signature. Given the function name in the FUnctionRef/ExpressionRef, and, in the case of an overload, the signature, we can now lookup any function defined in any library in the LibrarySet, so we can copy over the resultTypeSpecifier.

Filling out this resultTypeSpecifier is now done in a pre-processing step, happening when we are constructing the LibrarySet. The pre-processing step will find all Refs, and then do this:

Try to find the function by name. If it is not an overload, use the resultTypeSpecifier
If there is an overload, use the Ref's signature, if available.
If there is no signature, use the types from the Ref's parameters and match on those.
Otherwise, we cannot find the overload, and we will raise an error. This ensures that after the pre-processor has run, all Refs > have a resultTypeSpecifier, and we can depend on that fact.

This PR re-uses the OverloadedFunctionDefinition, and there are some updates to the CanCombine function to make sure the pre-processor fix and the CanCombine use the same criteria.

I also added a bunch of useful extension methods for working with the Elm function elements and signatures.