### PR TITLE
Fix 499 - generating parameter names for external functions

### DIFF
--- a/Cql/CodeGeneration.NET/AssemblyCompiler.cs
+++ b/Cql/CodeGeneration.NET/AssemblyCompiler.cs
@@ -71,9 +71,10 @@ namespace Hl7.Cql.CodeGeneration.NET
 
         public IReadOnlyDictionary<string, AssemblyData> Compile(
             LibrarySet librarySet,
-            DefinitionDictionary<LambdaExpression>? definitions = null)
+            DefinitionDictionary<LambdaExpression> definitions)
         {
-            definitions ??= new();
+            if (definitions is null)
+                throw new ArgumentNullException(nameof(definitions));
 
             Dictionary<string, AssemblyData> results = new();
 

--- a/Cql/Cql.Compiler/ExpressionBuilderContext.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilderContext.StaticHelpers.cs
@@ -143,7 +143,10 @@ partial class ExpressionBuilderContext
         var typeName = type.Name.ToLowerInvariant();
         if (type.IsGenericType)
         {
-            var genericTypeNames = string.Join("_", type.GetGenericArguments().Select(t => TypeNameToIdentifier(t, ctx)));
+            var typeNames = type.GetGenericArguments()
+                .Select(t => TypeNameToIdentifier(t, ctx)
+                .TrimStart('@'));
+            var genericTypeNames = string.Join("_", typeNames);
             var tick = typeName.IndexOf('`');
             if (tick > -1)
                 typeName = typeName[..tick];

--- a/Cql/CqlToElmTests/FunctionDefinitionTest.cs
+++ b/Cql/CqlToElmTests/FunctionDefinitionTest.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using Antlr4.Runtime;
 using FluentAssertions;
+using Hl7.Cql.Compiler;
 using Hl7.Cql.CqlToElm.Grammar;
 using Hl7.Cql.CqlToElm.LibraryProviders;
 using Hl7.Cql.CqlToElm.Visitors;
@@ -278,6 +279,18 @@ namespace Hl7.Cql.CqlToElm.Test
             fd.external.Should().BeTrue();
             fd.externalSpecified.Should().BeTrue();
             fd.expression.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void CSharp_Keyword_Parameter_Name()
+        {
+            var lib = MakeLibrary(@"
+                library FuncTest version '1.0.0'
+
+                define function ToInteger(decimal System.Decimal) returns System.Integer: external
+            ");
+            var asm = Compile(lib);
+
         }
     }
 }


### PR DESCRIPTION
When generating an automatic parameter name for a generic type, we strip the `@` character if it was added normalizing the generic type argument name (e.g., because it's a C# keyword like `decimal`).  Example of a bad name was `nullable_@decimal` which is now produced as `nullable_decimal`.

Also made the `definitions` parameter of `AssemblyCompiler.Compile` no longer optional.  When not specified, the function does nothing.

Tested by CqlToElmTests/FunctionDefinitionTest/External_Function