### PR TITLE
503 Additional work - Moving AmbiguousOverloadCorrector and use ChangeType

### DIFF
--- a/Cql/Cql.Compiler/Expressions/ExpressionExtensions.cs
+++ b/Cql/Cql.Compiler/Expressions/ExpressionExtensions.cs
@@ -65,15 +65,6 @@ internal static class ExpressionExtensions
             }
         }
 
-        var isAssignableTo =
-            expression.Type == typeof(object) // Choice?
-            || expression.Type.IsAssignableTo(type);
-        if (isAssignableTo || throwError)
-        {
-            Expression cast = Expression.Convert(expression, type);
-            return (cast, TypeConversion.ExpressionCast);
-        }
-
         if (safeUpcastAllowed)
         {
             var isAssignableFrom =
@@ -84,6 +75,15 @@ internal static class ExpressionExtensions
                 Expression cast = Expression.TypeAs(expression, type);
                 return (cast, TypeConversion.ExpressionTypeAs);
             }
+        }
+
+        var isAssignableTo =
+            expression.Type == typeof(object) // Choice?
+            || expression.Type.IsAssignableTo(type);
+        if (isAssignableTo || throwError)
+        {
+            Expression cast = Expression.Convert(expression, type);
+            return (cast, TypeConversion.ExpressionCast);
         }
 
         return (null, TypeConversion.NoMatch);

--- a/Cql/Cql.Compiler/LibrarySetExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/LibrarySetExpressionBuilderContext.cs
@@ -33,16 +33,8 @@ internal partial class LibrarySetExpressionBuilderContext
     public DefinitionDictionary<LambdaExpression> ProcessLibrarySet() =>
         this.CatchRethrowExpressionBuildingException(_ =>
         {
-            var ambiguousOverloadCorrector = new AmbiguousOverloadCorrector();
-
             foreach (var library in LibrarySet)
             {
-                // Make sure all overloads in the library are unique.
-                // This is a fix for QICore-based CQL, where the functions only differ by profiles on the same resource.
-                // We should remove this when the compiler is fixed.
-                // See https://github.com/FirelyTeam/firely-cql-sdk/issues/438.
-                ambiguousOverloadCorrector.Fix(library);
-
                 var librarySetDefinitions = _libraryExpressionBuilder.ProcessLibrary(library, null, this);
                 LibrarySetDefinitions.Merge(librarySetDefinitions);
             }


### PR DESCRIPTION
Work for #503 

1. Cherrypick [Paul's commit Move ambiguous fix from LibrarySetExpressionBuilderContext to LibraryExpressionBuilderContext](https://github.com/FirelyTeam/firely-cql-sdk/pull/468 after Evan's work)
2. Use `ChangeType` method as mentioned in [PR discussion](https://github.com/FirelyTeam/firely-cql-sdk/pull/487#discussion_r1741829270)
