### PR TITLE
509 Fix equivalence

### DIFF
--- a/Cql/Cql.Abstractions/ICqlComparer.cs
+++ b/Cql/Cql.Abstractions/ICqlComparer.cs
@@ -46,7 +46,7 @@ namespace Hl7.Cql.Abstractions
         /// </summary>
         /// <param name="x">The object whose hash code to compute.</param>
         /// <returns>The hash code for <paramref name="x"/>.</returns>
-        int GetHashCode(object x);
+        int GetHashCode(object? x);
     }
 
     internal abstract class CqlComparerDecorator(ICqlComparer inner) : ICqlComparer
@@ -59,7 +59,8 @@ namespace Hl7.Cql.Abstractions
         public virtual int? Compare(object? x, object? y, string? precision) =>
             Inner.Compare(x, y, precision);
 
-        public virtual int GetHashCode(object x) => Inner.GetHashCode(x);
+        public virtual int GetHashCode(object? x) =>
+            Inner.GetHashCode(x);
 
         public virtual bool Equivalent(object? x, object? y, string? precision) =>
             Inner.Equivalent(x, y, precision);

--- a/Cql/Cql.Abstractions/IEquivalenceComparer.cs
+++ b/Cql/Cql.Abstractions/IEquivalenceComparer.cs
@@ -23,6 +23,7 @@ namespace Hl7.Cql.Abstractions
         /// <returns><see langword="true"/> if the objects are equivalent, and <see langword="false"/> if not. Equivalence computations are never <see langword="null"/> and will return <see langword="false"/> in uncertainty situations.</returns>
         bool Equivalent(object? x, object? y, string? precision);
     }
+
     /// <summary>
     /// Defines a method that a type implements to compare two objects for equivalence.
     /// See https://cql.hl7.org/09-b-cqlreference.html#equivalent.

--- a/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Abstractions/PublicAPI.Unshipped.txt
@@ -35,7 +35,7 @@ Hl7.Cql.Abstractions.ICqlComparable<T>.CompareTo(T? other, string? precision = n
 Hl7.Cql.Abstractions.ICqlComparer
 Hl7.Cql.Abstractions.ICqlComparer.Compare(object? x, object? y, string? precision) -> int?
 Hl7.Cql.Abstractions.ICqlComparer.Equals(object? x, object? y, string? precision) -> bool?
-Hl7.Cql.Abstractions.ICqlComparer.GetHashCode(object! x) -> int
+Hl7.Cql.Abstractions.ICqlComparer.GetHashCode(object? x) -> int
 Hl7.Cql.Abstractions.ICqlComparer<T>
 Hl7.Cql.Abstractions.ICqlComparer<T>.Compare(T? x, T? y, string? precision) -> int?
 Hl7.Cql.Abstractions.ICqlComparer<T>.Equals(T? x, T? y, string? precision) -> bool?

--- a/Cql/Cql.Comparers/CharCqlComparer.cs
+++ b/Cql/Cql.Comparers/CharCqlComparer.cs
@@ -36,7 +36,7 @@ internal class CharCqlComparer(StringCqlComparer inner) : ICqlComparer, ICqlComp
     public bool Equivalent(char? x, char? y, string? precision = null) =>
         Inner.Equivalent(CharToString(x), CharToString(y), precision);
 
-    public int GetHashCode(object x) =>
+    public int GetHashCode(object? x) =>
         Inner.GetHashCode(ObjectAsCharToString(x));
 
     public int GetHashCode(char? x) =>

--- a/Cql/Cql.Comparers/CqlCodeCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlCodeCqlComparer.cs
@@ -95,7 +95,8 @@ namespace Hl7.Cql.Comparers
             ? typeof(CqlCode).GetHashCode()
             : $"{x.code ?? "null"}\0{x.system}\0".GetHashCode();
 
-        public int GetHashCode(object? x) => GetHashCode(x as CqlCode);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as CqlCode);
     }
 }
 

--- a/Cql/Cql.Comparers/CqlCodeCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlCodeCqlComparer.cs
@@ -74,22 +74,18 @@ namespace Hl7.Cql.Comparers
 
         public bool Equivalent(CqlCode x, CqlCode y, string? precision)
         {
-            if (x == null || y == null)
+            if (CqlComparers.EquivalentOnNullsOnly(x?.code, y?.code) is { } r)
+                return r;
+
+            var cc = CodeComparer.Compare(x!.code, y!.code);
+            if (cc != 0)
                 return false;
-            if (x.code == null || y.code == null)
+
+            if ((x.system == null) ^ (y.system == null))
                 return false;
-            else
-            {
-                var cc = CodeComparer.Compare(x.code, y.code);
-                if (cc == 0)
-                {
-                    if ((x.system == null) ^ (y.system == null))
-                        return false;
-                    var sc = StringComparer.OrdinalIgnoreCase.Compare(x.system, y.system);
-                    return sc == 0;
-                }
-                else return cc == 0;
-            }
+
+            var sc = StringComparer.OrdinalIgnoreCase.Compare(x.system, y.system);
+            return sc == 0;
         }
 
         public bool Equivalent(object? x, object? y, string? precision) => Equivalent((x as CqlCode)!, (y as CqlCode)!, precision);

--- a/Cql/Cql.Comparers/CqlCodeCqlEquivalentComparer.cs
+++ b/Cql/Cql.Comparers/CqlCodeCqlEquivalentComparer.cs
@@ -62,22 +62,18 @@ namespace Hl7.Cql.Comparers
 
         public bool Equivalent(CqlCode x, CqlCode y, string? precision)
         {
-            if (x == null || y == null)
+            if (CqlComparers.EquivalentOnNullsOnly(x?.code, y?.code) is { } r)
+                return r;
+
+            var cc = CodeComparer.Compare(x!.code, y!.code);
+            if (cc != 0)
                 return false;
-            if (x.code == null || y.code == null)
+
+            if ((x.system == null) ^ (y.system == null))
                 return false;
-            else
-            {
-                var cc = CodeComparer.Compare(x.code, y.code);
-                if (cc == 0)
-                {
-                    if ((x.system == null) ^ (y.system == null))
-                        return false;
-                    var sc = StringComparer.OrdinalIgnoreCase.Compare(x.system, y.system);
-                    return sc == 0;
-                }
-                else return cc == 0;
-            }
+
+            var sc = StringComparer.OrdinalIgnoreCase.Compare(x.system, y.system);
+            return sc == 0;
         }
 
         public bool Equivalent(object? x, object? y, string? precision) => Equivalent((x as CqlCode)!, (y as CqlCode)!, precision);

--- a/Cql/Cql.Comparers/CqlCodeCqlEquivalentComparer.cs
+++ b/Cql/Cql.Comparers/CqlCodeCqlEquivalentComparer.cs
@@ -83,7 +83,8 @@ namespace Hl7.Cql.Comparers
             ? typeof(CqlCode).GetHashCode()
             : $"{x.code ?? "null"}\0{x.system}\0".GetHashCode();
 
-        public int GetHashCode(object? x) => GetHashCode(x as CqlCode);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as CqlCode);
     }
 }
 

--- a/Cql/Cql.Comparers/CqlComparerBase.cs
+++ b/Cql/Cql.Comparers/CqlComparerBase.cs
@@ -22,7 +22,11 @@ namespace Hl7.Cql.Comparers
         /// <inheritdoc />
         public abstract int? Compare(T? x, T? y, string? precision);
         /// <inheritdoc />
-        public abstract bool Equivalent(T? x, T? y, string? precision);
+        public bool Equivalent(T? x, T? y, string? precision) =>
+            CqlComparers.EquivalentOnNullsOnly(x, y)
+            ?? EquivalentImpl(x!, y!, precision);
+
+        protected abstract bool EquivalentImpl(T x, T y, string? precision);
 
         /// <inheritdoc />
         public virtual bool? Equals(T? x, T? y, string? precision)
@@ -43,9 +47,9 @@ namespace Hl7.Cql.Comparers
         public bool Equivalent(object? x, object? y, string? precision) => Equivalent(x as T, y as T, precision);
 
         /// <inheritdoc />
-        public abstract int GetHashCode(T x);
+        public abstract int GetHashCode(T? x);
 
         /// <inheritdoc />
-        public int GetHashCode(object x) => GetHashCode((x as T)!);
+        public int GetHashCode(object? x) => GetHashCode(x as T);
     }
 }

--- a/Cql/Cql.Comparers/CqlComparers.cs
+++ b/Cql/Cql.Comparers/CqlComparers.cs
@@ -12,6 +12,8 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
 
 namespace Hl7.Cql.Comparers
 {
@@ -20,6 +22,28 @@ namespace Hl7.Cql.Comparers
     /// </summary>
     internal sealed class CqlComparers : ICqlComparer
     {
+
+        /*
+         *
+         * Equivalence : https://cql.hl7.org/04-logicalspecification.html#equivalent
+         *
+         * The Equivalent operator returns:
+         * - true if the arguments are the same value, or if they are both null;
+         * - and false otherwise.
+         *
+         * With the exception of null behavior and the semantics for specific types defined below, equivalence is the same as equality.
+         */
+
+        internal static bool? EquivalentOnNullsOnly<T>(
+            [NoEnumeration, NotNullWhen(true)] T? left,
+            [NoEnumeration, NotNullWhen(true)] T? right) =>
+            (left, right) switch
+            {
+                (null, null) => true,
+                (null, _)    => false,
+                (_, null)    => false,
+                _            => null
+            };
 
         internal ConcurrentDictionary<Type, ICqlComparer> Comparers { get; } = new ConcurrentDictionary<Type, ICqlComparer>();
         internal ConcurrentDictionary<Type, Func<Type, CqlComparers, ICqlComparer>> ComparerFactories { get; } = new ConcurrentDictionary<Type, Func<Type, CqlComparers, ICqlComparer>>();

--- a/Cql/Cql.Comparers/CqlConceptCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlConceptCqlComparer.cs
@@ -118,7 +118,8 @@ namespace Hl7.Cql.Comparers
             }
             return baseCode;
         }
-        public int GetHashCode(object? x) => GetHashCode(x as CqlConcept);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as CqlConcept);
 
     }
 }

--- a/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
@@ -95,12 +95,11 @@ namespace Hl7.Cql.Comparers
 
         /// <inheritdoc />
         public int GetHashCode(CqlQuantity? x) =>
-            x == null
-            ? typeof(CqlQuantity).GetHashCode()
-            : x.ToString()!.GetHashCode();
+            x?.ToString()?.GetHashCode() ?? typeof(CqlQuantity).GetHashCode();
 
         /// <inheritdoc />
-        public int GetHashCode(object x) => GetHashCode(x as CqlQuantity);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as CqlQuantity);
     }
 }
 

--- a/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
+++ b/Cql/Cql.Comparers/CqlQuantityCqlComparer.cs
@@ -77,18 +77,17 @@ namespace Hl7.Cql.Comparers
         /// <inheritdoc />
         public bool Equivalent(CqlQuantity? x, CqlQuantity? y, string? precision = null)
         {
-            if (x == null)
-                throw new ArgumentNullException(nameof(x));
-            if (y == null)
-                throw new ArgumentNullException(nameof(y));
+            if (CqlComparers.EquivalentOnNullsOnly(x, y) is { } r)
+                return r;
 
-            var unitCompare = UnitComparer.Equivalent(x.unit!, y.unit!, precision);
+            var unitCompare = UnitComparer.Equivalent(x!.unit, y!.unit, precision);
             if (unitCompare || x.unit == "1" || y.unit == "1")
             {
-                var valueComparison = ValueComparer.Equivalent(x.value!, y.value!, precision);
+                var valueComparison = ValueComparer.Equivalent(x.value, y.value, precision);
                 return valueComparison;
             }
-            else return false;
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/Cql/Cql.Comparers/DecimalCqlComparer.cs
+++ b/Cql/Cql.Comparers/DecimalCqlComparer.cs
@@ -56,14 +56,9 @@ namespace Hl7.Cql.Comparers
 
         public bool Equivalent(decimal? x, decimal? y, string? precision = null)
         {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else return false;
-            }
-            else if (y == null)
-                return false;
+            if (CqlComparers.EquivalentOnNullsOnly(x, y) is { } r)
+                return r;
+
             var @thisPrecision = GetPrecision(x!.Value!);
             var otherPrecision = GetPrecision(y!.Value!);
             if (@thisPrecision < otherPrecision)

--- a/Cql/Cql.Comparers/DecimalCqlComparer.cs
+++ b/Cql/Cql.Comparers/DecimalCqlComparer.cs
@@ -70,11 +70,10 @@ namespace Hl7.Cql.Comparers
         }
 
         public int GetHashCode(decimal? x) =>
-            x == null
-            ? typeof(decimal).GetHashCode()
-            : x.GetHashCode();
+            x?.GetHashCode() ?? typeof(decimal).GetHashCode();
 
-        public int GetHashCode(object x) => GetHashCode(x as decimal?);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as decimal?);
 
         public int GetPrecision(decimal value) => BitConverter.GetBytes(decimal.GetBits(value)[3])[2];
         private decimal TruncateDigits(decimal value, int places)

--- a/Cql/Cql.Comparers/DefaultCqlComparer.cs
+++ b/Cql/Cql.Comparers/DefaultCqlComparer.cs
@@ -56,6 +56,6 @@ namespace Hl7.Cql.Comparers
 
         /// <inheritdoc />
         public int GetHashCode(object? x) =>
-            GetHashCode((T?)t)
+            GetHashCode((T?)x);
     }
 }

--- a/Cql/Cql.Comparers/DefaultCqlComparer.cs
+++ b/Cql/Cql.Comparers/DefaultCqlComparer.cs
@@ -44,15 +44,18 @@ namespace Hl7.Cql.Comparers
             Compare(x, y, precision) == 0;
 
         /// <inheritdoc />
-        public bool Equivalent(T? x, T? y, string? precision = null) => Compare(x, y, precision) == 0;
+        public bool Equivalent(T? x, T? y, string? precision = null) =>
+            CqlComparers.EquivalentOnNullsOnly(x, y)
+            ?? Compare(x, y, precision) == 0;
 
         /// <inheritdoc />
-        public int GetHashCode(T x) => x is not null ? EqualityComparer<T>.Default.GetHashCode(x) : typeof(T).GetHashCode();
+        public int GetHashCode(T? x) =>
+            x is null
+                ? typeof(T).GetHashCode()
+                : EqualityComparer<T>.Default.GetHashCode(x);
 
         /// <inheritdoc />
-        public int GetHashCode(object x) =>
-            x is T t
-            ? GetHashCode(t)
-            : throw new InvalidCastException();
+        public int GetHashCode(object? x) =>
+            GetHashCode((T?)t)
     }
 }

--- a/Cql/Cql.Comparers/EnumComparer.cs
+++ b/Cql/Cql.Comparers/EnumComparer.cs
@@ -63,10 +63,7 @@ namespace Hl7.Cql.Comparers
         public bool Equivalent(object? x, object? y, string? precision) => (Equals(x, y, precision) ?? false) == false;
 
         /// <inheritdoc/>
-        public int GetHashCode(object x)
-        {
-            if (x == null) return typeof(object).GetHashCode();
-            else return x.GetHashCode();
-        }
+        public int GetHashCode(object? x) =>
+            x?.GetHashCode() ?? typeof(object).GetHashCode();
     }
 }

--- a/Cql/Cql.Comparers/InterfaceCqlComparer.cs
+++ b/Cql/Cql.Comparers/InterfaceCqlComparer.cs
@@ -34,20 +34,9 @@ namespace Hl7.Cql.Comparers
 
         public bool? Equals(object? x, object? y, string? precision) => Equals((x as T)!, (y as T)!, precision);
 
-        public bool Equivalent(T? x, T? y, string? precision)
-        {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else
-                    return false;
-            }
-            else if (y == null)
-                return false;
-
-            return x.Equivalent(y, precision);
-        }
+        public bool Equivalent(T? x, T? y, string? precision) =>
+            CqlComparers.EquivalentOnNullsOnly(x, y)
+            ?? x!.Equivalent(y, precision);
 
         public bool Equivalent(object? x, object? y, string? precision) => Equivalent(x as T, y as T, precision);
 

--- a/Cql/Cql.Comparers/InterfaceCqlComparer.cs
+++ b/Cql/Cql.Comparers/InterfaceCqlComparer.cs
@@ -41,11 +41,10 @@ namespace Hl7.Cql.Comparers
         public bool Equivalent(object? x, object? y, string? precision) => Equivalent(x as T, y as T, precision);
 
         public int GetHashCode(T? x) =>
-            x == null
-            ? typeof(T).GetHashCode()
-            : x.GetHashCode();
+            x?.GetHashCode() ?? typeof(T).GetHashCode();
 
-        public int GetHashCode(object x) => GetHashCode(x as T);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as T);
     }
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/Cql/Cql.Comparers/IntervalComparer.cs
+++ b/Cql/Cql.Comparers/IntervalComparer.cs
@@ -13,18 +13,15 @@ using System;
 
 namespace Hl7.Cql.Comparers
 {
-    internal class IntervalComparer<T> : CqlComparerBase<CqlInterval<T>>
+    internal class IntervalComparer<T>(
+        ICqlComparer pointComparer,
+        Func<T, T> predecessor,
+        Func<T, T> successor)
+        : CqlComparerBase<CqlInterval<T>>
     {
-        public IntervalComparer(ICqlComparer pointComparer, Func<T, T> predecessor, Func<T, T> successor)
-        {
-            PointComparer = pointComparer ?? throw new ArgumentNullException(nameof(pointComparer));
-            Predecessor = predecessor ?? throw new ArgumentNullException(nameof(predecessor));
-            Successor = successor ?? throw new ArgumentNullException(nameof(successor));
-        }
-
-        public ICqlComparer PointComparer { get; }
-        public Func<T, T> Predecessor { get; }
-        public Func<T, T> Successor { get; }
+        public ICqlComparer PointComparer { get; } = pointComparer ?? throw new ArgumentNullException(nameof(pointComparer));
+        public Func<T, T> Predecessor { get; } = predecessor ?? throw new ArgumentNullException(nameof(predecessor));
+        public Func<T, T> Successor { get; } = successor ?? throw new ArgumentNullException(nameof(successor));
 
         public override int? Compare(CqlInterval<T>? x, CqlInterval<T>? y, string? precision)
         {

--- a/Cql/Cql.Comparers/IntervalComparer.cs
+++ b/Cql/Cql.Comparers/IntervalComparer.cs
@@ -73,10 +73,10 @@ namespace Hl7.Cql.Comparers
             }
         }
 
-        public override bool Equivalent(CqlInterval<T>? x, CqlInterval<T>? y, string? precision) =>
-            Compare(x, y, precision) == 0 ? true : false;
+        protected override bool EquivalentImpl(CqlInterval<T> x, CqlInterval<T> y, string? precision) =>
+            Compare(x, y, precision) == 0;
 
-        public override int GetHashCode(CqlInterval<T> x) =>
+        public override int GetHashCode(CqlInterval<T>? x) =>
             x == null
             ? typeof(object).GetHashCode()
             : x.ToString()!.GetHashCode();

--- a/Cql/Cql.Comparers/KeyValuePairComparer.cs
+++ b/Cql/Cql.Comparers/KeyValuePairComparer.cs
@@ -53,7 +53,9 @@ internal class KeyValuePairComparer<TKey,TValue> : ICqlComparer, ICqlComparer<Ke
         Compare(x, y, precision) == 0;
 
     /// <inheritdoc />
-    public bool Equivalent(KeyValuePair<TKey, TValue> x, KeyValuePair<TKey, TValue> y, string? precision = null) => Compare(x, y, precision) == 0;
+    public bool Equivalent(KeyValuePair<TKey, TValue> x, KeyValuePair<TKey, TValue> y, string? precision = null) =>
+        CqlComparers.EquivalentOnNullsOnly(x, y)
+        ?? Compare(x, y, precision) == 0;
 
     /// <inheritdoc />
     public int GetHashCode(KeyValuePair<TKey, TValue> x) => x.GetHashCode();

--- a/Cql/Cql.Comparers/KeyValuePairComparer.cs
+++ b/Cql/Cql.Comparers/KeyValuePairComparer.cs
@@ -58,11 +58,12 @@ internal class KeyValuePairComparer<TKey,TValue> : ICqlComparer, ICqlComparer<Ke
         ?? Compare(x, y, precision) == 0;
 
     /// <inheritdoc />
-    public int GetHashCode(KeyValuePair<TKey, TValue> x) => x.GetHashCode();
+    public int GetHashCode(KeyValuePair<TKey, TValue> x) =>
+        x.GetHashCode();
 
     /// <inheritdoc />
-    public int GetHashCode(object x) =>
-        x is KeyValuePair<TKey, TValue> t
-            ? GetHashCode(t)
-            : throw new InvalidCastException();
+    public int GetHashCode(object? x) =>
+        x is null
+            ? typeof(KeyValuePair<TKey, TValue>).GetHashCode()
+            : GetHashCode((KeyValuePair<TKey, TValue>)x);
 }

--- a/Cql/Cql.Comparers/ListEqualComparer.cs
+++ b/Cql/Cql.Comparers/ListEqualComparer.cs
@@ -7,8 +7,10 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using System;
 using Hl7.Cql.Abstractions;
 using System.Collections;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Hl7.Cql.Comparers
 {
@@ -106,18 +108,15 @@ namespace Hl7.Cql.Comparers
 
         public bool Equivalent(IEnumerable? x, IEnumerable? y, string? precision = null)
         {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else
-                    return false;
-            }
-            else if (y == null)
-                return false;
+            if (CqlComparers.EquivalentOnNullsOnly(x, y) is { } r)
+                return r;
 
             var lit = x!.GetEnumerator();
+            using var litd = lit as IDisposable;
+
             var rit = y!.GetEnumerator();
+            using var ritd = rit as IDisposable;
+
             while (lit.MoveNext())
             {
                 if (!rit.MoveNext())
@@ -138,12 +137,12 @@ namespace Hl7.Cql.Comparers
             return true;
         }
 
-        public int GetHashCode(IEnumerable x) =>
+        public int GetHashCode(IEnumerable? x) =>
             x == null
             ? typeof(IEnumerable).GetHashCode()
             : x.GetHashCode();
 
-        public int GetHashCode(object x) => GetHashCode((x as IEnumerable)!);
+        public int GetHashCode(object? x) => GetHashCode(x as IEnumerable);
     }
 }
 

--- a/Cql/Cql.Comparers/ListEqualComparer.cs
+++ b/Cql/Cql.Comparers/ListEqualComparer.cs
@@ -138,11 +138,10 @@ namespace Hl7.Cql.Comparers
         }
 
         public int GetHashCode(IEnumerable? x) =>
-            x == null
-            ? typeof(IEnumerable).GetHashCode()
-            : x.GetHashCode();
+            x?.GetHashCode() ?? typeof(IEnumerable).GetHashCode();
 
-        public int GetHashCode(object? x) => GetHashCode(x as IEnumerable);
+        public int GetHashCode(object? x) =>
+            GetHashCode(x as IEnumerable);
     }
 }
 

--- a/Cql/Cql.Comparers/StringCqlComparer.cs
+++ b/Cql/Cql.Comparers/StringCqlComparer.cs
@@ -59,14 +59,9 @@ namespace Hl7.Cql.Comparers
         /// <inheritdoc/>
         public bool Equivalent(string? x, string? y, string? precision = null)
         {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else return false;
-            }
-            else if (y == null)
-                return false;
+            if (CqlComparers.EquivalentOnNullsOnly(x, y) is { } r)
+                return r;
+
             var thisNormalized = x!.Normalize();
             var otherNormalized = y!.Normalize();
             var areEqual = _comparer.Equals(thisNormalized, otherNormalized);

--- a/Cql/Cql.Comparers/StringCqlComparer.cs
+++ b/Cql/Cql.Comparers/StringCqlComparer.cs
@@ -70,9 +70,7 @@ namespace Hl7.Cql.Comparers
 
         /// <inheritdoc/>
         public int GetHashCode(string? x) =>
-            x == null
-            ? typeof(string).GetHashCode()
-            : x.GetHashCode();
+            x?.GetHashCode() ?? typeof(string).GetHashCode();
 
         /// <inheritdoc/>
         public int GetHashCode(object? x) => GetHashCode(x as string);

--- a/Cql/Cql.Comparers/TupleBaseTypeComparer.cs
+++ b/Cql/Cql.Comparers/TupleBaseTypeComparer.cs
@@ -68,17 +68,11 @@ namespace Hl7.Cql.Comparers
 
         public bool Equivalent(TupleBaseType? x, TupleBaseType? y, string? precision = null)
         {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else return false;
-            }
-            else if (y == null)
-                return false;
+            if (CqlComparers.EquivalentOnNullsOnly(x, y) is { } r)
+                return r;
 
-            var xType = x.GetType();
-            var yType = y.GetType();
+            var xType = x!.GetType();
+            var yType = y!.GetType();
             if (xType != yType)
                 return false;
             var joined = from xProp in xType.GetProperties()
@@ -104,8 +98,11 @@ namespace Hl7.Cql.Comparers
         public bool Equivalent(object? x, object? y, string? precision = null) =>
             Equivalent(x as TupleBaseType, y as TupleBaseType);
 
-        public int GetHashCode(TupleBaseType? obj) => obj?.GetHashCode() ?? typeof(TupleBaseType).GetHashCode() ^ 098174506;
-        public int GetHashCode(object obj) => GetHashCode(obj as TupleBaseType);
+        public int GetHashCode(TupleBaseType? obj) =>
+            obj?.GetHashCode()
+            ?? typeof(TupleBaseType).GetHashCode() ^ 098174506;
+
+        public int GetHashCode(object? obj) => GetHashCode(obj as TupleBaseType);
     }
 }
 

--- a/Cql/Cql.Comparers/TupleBaseTypeComparer.cs
+++ b/Cql/Cql.Comparers/TupleBaseTypeComparer.cs
@@ -99,8 +99,7 @@ namespace Hl7.Cql.Comparers
             Equivalent(x as TupleBaseType, y as TupleBaseType);
 
         public int GetHashCode(TupleBaseType? obj) =>
-            obj?.GetHashCode()
-            ?? typeof(TupleBaseType).GetHashCode() ^ 098174506;
+            obj?.GetHashCode() ?? typeof(TupleBaseType).GetHashCode() ^ 098174506;
 
         public int GetHashCode(object? obj) => GetHashCode(obj as TupleBaseType);
     }

--- a/Cql/Cql.Firely/Comparers/CodeComparer.cs
+++ b/Cql/Cql.Firely/Comparers/CodeComparer.cs
@@ -48,24 +48,10 @@ namespace Hl7.Cql.Fhir.Comparers
             return CompareFunction(x.Value!, y.Value!, precision);
         }
 
-        public override bool Equivalent(Code<T>? x, Code<T>? y, string? precision)
-        {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else return false;
-            }
-            else if (y == null)
-                return false;
-            else
-                return EquivalentFunction(x.Value!, y.Value!, precision);
-        }
+        protected override bool EquivalentImpl(Code<T> x, Code<T> y, string? precision) =>
+            EquivalentFunction(x.Value!, y.Value!, precision);
 
-        public override int GetHashCode(Code<T> x)
-        {
-            if (x == null) return typeof(Code<T>).GetHashCode();
-            else return typeof(Code<T>).GetHashCode() ^ x.Value.GetHashCode();
-        }
+        public override int GetHashCode(Code<T>? x) =>
+            x == null ? typeof(Code<T>).GetHashCode() : typeof(Code<T>).GetHashCode() ^ x.Value.GetHashCode();
     }
 }

--- a/Cql/Cql.Firely/Comparers/FhirEnumComparer.cs
+++ b/Cql/Cql.Firely/Comparers/FhirEnumComparer.cs
@@ -61,13 +61,11 @@ namespace Hl7.Cql.Fhir.Comparers
         }
 
         /// <inheritdoc/>
-        public bool Equivalent(object? x, object? y, string? precision) => (Equals(x, y, precision) ?? false) == false;
+        public bool Equivalent(object? x, object? y, string? precision) =>
+            (Equals(x, y, precision) ?? false) == false;
 
         /// <inheritdoc/>
-        public int GetHashCode(object? x)
-        {
-            if (x == null) return typeof(object).GetHashCode();
-            else return x.GetHashCode();
-        }
+        public int GetHashCode(object? x) =>
+            x?.GetHashCode() ?? typeof(object).GetHashCode();
     }
 }

--- a/Cql/Cql.Firely/Comparers/IValueComparer.cs
+++ b/Cql/Cql.Firely/Comparers/IValueComparer.cs
@@ -17,9 +17,9 @@ namespace Hl7.Cql.Fhir.Comparers
             ? null
             : Comparer<T>.Default.Compare(x.Value, y.Value);
 
-        public override bool Equivalent(IValue<T>? x, IValue<T>? y, string? precision) => Compare(x, y, precision) == 0;
+        protected override bool EquivalentImpl(IValue<T> x, IValue<T> y, string? precision) => Compare(x, y, precision) == 0;
 
-        public override int GetHashCode(IValue<T> x)
+        public override int GetHashCode(IValue<T>? x)
         {
             if (x == null || x.Value == null)
                 return typeof(Integer).GetHashCode();

--- a/Cql/Cql.Firely/Comparers/IdentifierComparer.cs
+++ b/Cql/Cql.Firely/Comparers/IdentifierComparer.cs
@@ -37,10 +37,10 @@ namespace Hl7.Cql.Fhir.Comparers
             }
         }
 
-        public override bool Equivalent(Identifier? x, Identifier? y, string? precision) =>
+        protected override bool EquivalentImpl(Identifier x, Identifier y, string? precision) =>
             (Compare(x, y, precision) ?? -1) == 0;
 
-        public override int GetHashCode(Identifier x)
+        public override int GetHashCode(Identifier? x)
         {
             if (x == null || x.Value == null)
                 return typeof(Identifier).GetHashCode();

--- a/Cql/Cql.Firely/Comparers/ResourceIdComparer.cs
+++ b/Cql/Cql.Firely/Comparers/ResourceIdComparer.cs
@@ -41,11 +41,8 @@ namespace Hl7.Cql.Fhir.Comparers
             return compareId;
         }
 
-        protected override bool EquivalentImpl(Resource x, Resource y, string? precision)
-        {
-            var compareId = IdComparer.Equivalent(x.Id, y.Id, precision);
-            return compareId;
-        }
+        protected override bool EquivalentImpl(Resource x, Resource y, string? precision) =>
+            IdComparer.Equivalent(x.Id, y.Id, precision);
 
         public override int GetHashCode(Resource? x)
         {

--- a/Cql/Cql.Firely/Comparers/ResourceIdComparer.cs
+++ b/Cql/Cql.Firely/Comparers/ResourceIdComparer.cs
@@ -41,16 +41,8 @@ namespace Hl7.Cql.Fhir.Comparers
             return compareId;
         }
 
-        public override bool Equivalent(Resource? x, Resource? y, string? precision)
+        protected override bool EquivalentImpl(Resource x, Resource y, string? precision)
         {
-            if (x == null)
-            {
-                if (y == null)
-                    return true;
-                else return false;
-            }
-            else if (y == null)
-                return false;
             var compareId = IdComparer.Equivalent(x.Id, y.Id, precision);
             return compareId;
         }

--- a/Cql/Cql.Operators/Cql.Operators.csproj
+++ b/Cql/Cql.Operators/Cql.Operators.csproj
@@ -4,7 +4,7 @@
 
 	<PropertyGroup>
 		<AssemblyName>Hl7.Cql.Operators</AssemblyName>
-		<RootNamespace>Hl7.Cql.Operators</RootNamespace>
+		<RootNamespace>Hl7.Cql.Runtime</RootNamespace>
 		<Product>CQL operators implementation</Product>
 		<Description>Support package for Hl7.Cql. Implementation of the various operators and methods in the Cql spec.</Description>
 	</PropertyGroup>

--- a/Cql/Cql.Operators/CqlOperators.ComparisonOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ComparisonOperators.cs
@@ -91,15 +91,6 @@ namespace Hl7.Cql.Runtime
         }
         #endregion
 
-        #region Equal
-        public bool? Equal(object? x, object? y) => x == null || y == null ? null : Equals(x, y, null);
-        #endregion
-
-
-        #region Equivalent
-        public bool? Equivalent(object? x, object? y) => Equivalent(x!, y!, null);
-        #endregion
-
         #region Greater
 
         public bool? Greater(object? left, object? right)
@@ -151,24 +142,14 @@ namespace Hl7.Cql.Runtime
         #endregion
 
         #region  Not Equal
-        public bool? NotEqual(object? left, object? right)
-        {
-            var eq = Equal(left, right);
-            if (eq is null)
-                return null;
-            else return !eq.Value;
-        }
+
+        // bool? NotEqual(object? left, object? right) is located in CqlOperators.EqualityAndEquivalence.cs
+
         #endregion
 
         #region  Not Equivalent
 
-        public bool? NotEquivalent(object? left, object? right)
-        {
-            var eq = Equal(left, right);
-            if (eq is null)
-                return null;
-            else return !eq.Value;
-        }
+        // bool? NotEquivalent(object? left, object? right) is located in CqlOperators.EqualityAndEquivalence.cs
 
         #endregion
 

--- a/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
+++ b/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
@@ -11,12 +11,12 @@ internal partial class CqlOperators
     /*
      * Equality : https://cql.hl7.org/04-logicalspecification.html#equal
      *
-     * The Equal operator returns:
+     * Spec: The Equal operator returns:
      * - true if the arguments are equal;
      * - false if the arguments are known unequal,
      * - and null otherwise.
      *
-     * Equality semantics are defined to be value-based.
+     * Spec: Equality semantics are defined to be value-based.
      *
      */
 
@@ -85,11 +85,11 @@ internal partial class CqlOperators
      *
      * Equivalence : https://cql.hl7.org/04-logicalspecification.html#equivalent
      *
-     * The Equivalent operator returns:
+     * Spec: The Equivalent operator returns:
      * - true if the arguments are the same value, or if they are both null;
      * - and false otherwise.
      *
-     * With the exception of null behavior and the semantics for specific types defined below, equivalence is the same as equality.
+     * Spec: With the exception of null behavior and the semantics for specific types defined below, equivalence is the same as equality.
      */
 
     public bool Equivalent(object? x, object? y, string? precision) =>
@@ -100,6 +100,8 @@ internal partial class CqlOperators
 
     public bool? Equivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right)
     {
+        // Spec: For list types, this means that two lists are equivalent if and only if the lists contain elements of the same type, have the same number of elements, and for each element in the lists, in order, the elements are equivalent.
+
         if (CqlComparers.EquivalentOnNullsOnly(left, right) is {} r)
             return r;
 

--- a/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
+++ b/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
@@ -131,5 +131,7 @@ internal partial class CqlOperators
 
     public bool? NotEquivalent(object? left, object? right) => !Equivalent(left, right);
 
+    public bool? ListNotEquivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right) => !Equivalent(left, right);
+
     #endregion
 }

--- a/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
+++ b/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Hl7.Cql.Comparers;
-using Hl7.Cql.Operators;
 
 namespace Hl7.Cql.Runtime;
 
 internal partial class CqlOperators
 {
-    #region Equal
+    #region Equality
 
     /*
      * Equality : https://cql.hl7.org/04-logicalspecification.html#equal
@@ -38,7 +34,11 @@ internal partial class CqlOperators
         var onlyNull = true;
         var notEmpty = false;
         var lit = left!.GetEnumerator();
+        using var litd = lit as IDisposable;
+
         var rit = right!.GetEnumerator();
+        using var ritd = lit as IDisposable;
+
         while (lit.MoveNext())
         {
             if (!rit.MoveNext())
@@ -67,10 +67,6 @@ internal partial class CqlOperators
             return true;
     }
 
-    #endregion
-
-    #region NotEqual
-
     public bool? NotEqual(object? left, object? right) =>
         Equal(left, right) switch
         {
@@ -83,7 +79,18 @@ internal partial class CqlOperators
 
     #endregion
 
-    #region Equivalent
+    #region Equivalence
+
+    /*
+     *
+     * Equivalence : https://cql.hl7.org/04-logicalspecification.html#equivalent
+     *
+     * The Equivalent operator returns:
+     * - true if the arguments are the same value, or if they are both null;
+     * - and false otherwise.
+     *
+     * With the exception of null behavior and the semantics for specific types defined below, equivalence is the same as equality.
+     */
 
     public bool Equivalent(object? x, object? y, string? precision) =>
         CqlComparers.EquivalentOnNullsOnly(x, y)
@@ -102,30 +109,6 @@ internal partial class CqlOperators
         var rit = right!.GetEnumerator();
         using var ritd = lit as IDisposable;
 
-        while (lit.MoveNext())
-        {
-            if (!rit.MoveNext())
-                return false;
-
-            var lv = lit.Current;
-            var rv = rit.Current;
-            if (lv == null)
-            {
-                if (rv != null) return false;
-            }
-            else if (rv == null) return false;
-            else if (Equivalent(lv!, rv!, null) == false)
-                return false;
-        }
-        if (rit.MoveNext()) // the 2nd list is longer than the 1st.
-            return false;
-        return true;
-    }
-
-    private bool? EquivalentNotNull<T>(IEnumerable<T> left, IEnumerable<T> right)
-    {
-        var lit = left!.GetEnumerator();
-        var rit = right!.GetEnumerator();
         while (lit.MoveNext())
         {
             if (!rit.MoveNext())

--- a/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
+++ b/Cql/Cql.Operators/CqlOperators.EqualityAndEquivalence.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hl7.Cql.Operators;
+
+namespace Hl7.Cql.Runtime;
+
+internal partial class CqlOperators
+{
+    #region Equal
+
+    /*
+     * Equality : https://cql.hl7.org/04-logicalspecification.html#equal
+     *
+     * The Equal operator returns:
+     * - true if the arguments are equal;
+     * - false if the arguments are known unequal,
+     * - and null otherwise.
+     *
+     * Equality semantics are defined to be value-based.
+     *
+     */
+
+    internal IEqualityComparer<object> EqualityComparer { get; }
+
+    public bool? Equals(object? x, object? y, string? precision) => Comparer.Equals(x, y, precision);
+
+    public bool? Equal(object? x, object? y) => x == null || y == null ? null : Equals(x, y, null);
+
+    public bool? ListEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right)
+    {
+        if (left == null || right == null)
+            return null;
+
+        var onlyNull = true;
+        var notEmpty = false;
+        var lit = left!.GetEnumerator();
+        var rit = right!.GetEnumerator();
+        while (lit.MoveNext())
+        {
+            if (!rit.MoveNext())
+                return false;
+            notEmpty = true;
+            var lv = lit.Current;
+            var rv = rit.Current;
+            if (lv == null)
+            {
+                if (rv != null) return false;
+            }
+            else if (rv == null) return false;
+            else
+            {
+                onlyNull = false;
+                if (Compare(lv!, rv!, null) != 0)
+                    return false;
+            }
+        }
+        if (rit.MoveNext()) // the 2nd list is longer than the 1st.
+            return false;
+
+        if (notEmpty && onlyNull)
+            return null;
+        else
+            return true;
+    }
+
+    #endregion
+
+    #region NotEqual
+
+    public bool? NotEqual(object? left, object? right) =>
+        Equal(left, right) switch
+        {
+            null  => null,
+            true  => false,
+            false => true
+        };
+
+    public bool? ListNotEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right) => !ListEqual(left, right);
+
+    #endregion
+
+    #region Equivalent
+
+    /*
+     *
+     * Equivalence : https://cql.hl7.org/04-logicalspecification.html#equivalent
+     *
+     * The Equivalent operator returns:
+     * - true if the arguments are the same value, or if they are both null;
+     * - and false otherwise.
+     *
+     * With the exception of null behavior and the semantics for specific types defined below, equivalence is the same as equality.
+     */
+
+    internal static bool? NullEquivalent<T>(T? left, T? right) where T : class =>
+        (left, right) switch
+        {
+            (null, null) => true,
+            (null, _) => false,
+            (_, null) => false,
+            _ => null
+        };
+
+    public bool Equivalent(object? x, object? y, string? precision) =>
+        NullEquivalent(x, y) ?? Comparer.Equivalent(x, y, precision);
+
+    public bool? Equivalent(object? x, object? y) => Equivalent(x!, y!, null);
+
+    public bool? Equivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right) =>
+        NullEquivalent(left, right) ??  EquivalentNotNull(left!, right!);
+
+    private bool? EquivalentNotNull<T>(IEnumerable<T> left, IEnumerable<T> right)
+    {
+        var lit = left!.GetEnumerator();
+        var rit = right!.GetEnumerator();
+        while (lit.MoveNext())
+        {
+            if (!rit.MoveNext())
+                return false;
+
+            var lv = lit.Current;
+            var rv = rit.Current;
+            if (lv == null)
+            {
+                if (rv != null) return false;
+            }
+            else if (rv == null) return false;
+            else if (Equivalent(lv!, rv!, null) == false)
+                return false;
+        }
+        if (rit.MoveNext()) // the 2nd list is longer than the 1st.
+            return false;
+        return true;
+    }
+
+    public bool? NotEquivalent(object? left, object? right) => !Equivalent(left, right);
+
+    #endregion
+}

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -993,9 +993,15 @@ namespace Hl7.Cql.Runtime
 
         #endregion
 
+        #region Not Equal
+
+        // public bool? ListNotEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right) moved to CqlOperators.ListOperators.cs
+
+        #endregion
+
         #region Not Equivalent
 
-        public bool? ListNotEquivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right) => !Equivalent(left, right);
+        // public bool? ListNotEquivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right) moved to CqlOperators.ListOperators.cs
 
         #endregion
 

--- a/Cql/Cql.Operators/CqlOperators.ListOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.ListOperators.cs
@@ -64,79 +64,13 @@ namespace Hl7.Cql.Runtime
 
         #region Equal
 
-        public bool? ListEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right)
-        {
-            if (left == null || right == null)
-                return null;
-
-            var onlyNull = true;
-            var notEmpty = false;
-            var lit = left!.GetEnumerator();
-            var rit = right!.GetEnumerator();
-            while (lit.MoveNext())
-            {
-                if (!rit.MoveNext())
-                    return false;
-                notEmpty = true;
-                var lv = lit.Current;
-                var rv = rit.Current;
-                if (lv == null)
-                {
-                    if (rv != null) return false;
-                }
-                else if (rv == null) return false;
-                else
-                {
-                    onlyNull = false;
-                    if (Compare(lv!, rv!, null) != 0)
-                        return false;
-                }
-            }
-            if (rit.MoveNext()) // the 2nd list is longer than the 1st.
-                return false;
-
-            if (notEmpty && onlyNull)
-                return null;
-            else
-                return true;
-        }
+        // bool? ListEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right) is located in CqlOperators.EqualityAndEquivalence.cs
 
         #endregion
 
         #region Equivalent
 
-        public bool? Equivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right)
-        {
-            if (left == null)
-            {
-                if (right == null)
-                    return true;
-                else return null;
-            }
-            else if (right == null)
-                return null;
-
-            var lit = left!.GetEnumerator();
-            var rit = right!.GetEnumerator();
-            while (lit.MoveNext())
-            {
-                if (!rit.MoveNext())
-                    return false;
-
-                var lv = lit.Current;
-                var rv = rit.Current;
-                if (lv == null)
-                {
-                    if (rv != null) return false;
-                }
-                else if (rv == null) return false;
-                else if (Equivalent(lv!, rv!, null) == false)
-                    return false;
-            }
-            if (rit.MoveNext()) // the 2nd list is longer than the 1st.
-                return false;
-            return true;
-        }
+        // bool? Equivalent<T>(IEnumerable<T>? left, IEnumerable<T>? right) is located in CqlOperators.EqualityAndEquivalence.cs
 
         #endregion
 
@@ -1056,12 +990,6 @@ namespace Hl7.Cql.Runtime
             };
             return length;
         }
-
-        #endregion
-
-        #region Not Equal
-
-        public bool? ListNotEqual<T>(IEnumerable<T>? left, IEnumerable<T>? right) => !ListEqual(left, right);
 
         #endregion
 

--- a/Cql/Cql.Operators/CqlOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.cs
@@ -105,7 +105,6 @@ namespace Hl7.Cql.Runtime
         public IDataSource DataSource { get; }
         public CqlDateTime NowValue { get; }
 
-        internal IEqualityComparer<object> EqualityComparer { get; }
         internal IComparer<object> DataComparer { get; }
         internal ICqlComparer EnumComparer { get; }
 
@@ -182,13 +181,9 @@ namespace Hl7.Cql.Runtime
 
         public object NotSupported() => throw new NotSupportedException();
 
-        public bool? Equals(object? x, object? y, string? precision) => Comparer.Equals(x, y, precision);
-
         public int? Compare(object? x, object? y, string? precision) => Comparer.Compare(x, y, precision);
 
         public int GetHashCode(object x) => Comparer.GetHashCode(x);
-
-        public bool Equivalent(object? x, object? y, string? precision) => Comparer.Equivalent(x, y, precision);
 
         public T? Convert<T>(object? from) => TypeConverter.Convert<T>(from);
 

--- a/Cql/Cql.Operators/CqlOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.cs
@@ -185,9 +185,7 @@ namespace Hl7.Cql.Runtime
             Comparer.Compare(x, y, precision);
 
         public int GetHashCode(object? x) =>
-            x is null
-                ? typeof(object).GetHashCode()
-                : Comparer.GetHashCode(x);
+            Comparer.GetHashCode(x);
 
         public T? Convert<T>(object? from) => TypeConverter.Convert<T>(from);
 

--- a/Cql/Cql.Operators/CqlOperators.cs
+++ b/Cql/Cql.Operators/CqlOperators.cs
@@ -181,9 +181,13 @@ namespace Hl7.Cql.Runtime
 
         public object NotSupported() => throw new NotSupportedException();
 
-        public int? Compare(object? x, object? y, string? precision) => Comparer.Compare(x, y, precision);
+        public int? Compare(object? x, object? y, string? precision) =>
+            Comparer.Compare(x, y, precision);
 
-        public int GetHashCode(object x) => Comparer.GetHashCode(x);
+        public int GetHashCode(object? x) =>
+            x is null
+                ? typeof(object).GetHashCode()
+                : Comparer.GetHashCode(x);
 
         public T? Convert<T>(object? from) => TypeConverter.Convert<T>(from);
 


### PR DESCRIPTION
Fix for #509

Unlike with equality, equivalence returns `true` instead of `null`, if both inputs are `null`. It also never returns `null`
This logic is placed in a common method `CqlComparers.EquivalentOnNullsOnly()` 
Updated equivalence methods, to first go through this logic, reducing repetitive code.

Also,
* Moved all equality and equivalence from `CqlOperators` into a file `CqlOperators.EqualityAndEquivalence.cs`
* `CqlComparerBase` allowed derived types to avoid this duplication by implementing `Equivalent` through the nullability checks, then passing on to the non-null abstract method `EquivalentImpl`
* Some types had incorrect nullability for `GetHashCode`. Since these are only compile-time hints, the changes won't change at runtime 

