### PR TITLE
Context TypeConverter fix

### DIFF
--- a/Cql/Cql.Firely/FhirCqlContext.cs
+++ b/Cql/Cql.Firely/FhirCqlContext.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using Hl7.Cql.Conversion;
 using Hl7.Cql.Operators;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;
@@ -24,9 +25,10 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null) =>
+            FhirModelBindingOptions? options = null,
+            TypeConverter? typeConverter = null) =>
             new CqlContext(
-                new FhirModelBindingSetup(dataSource, valueSets, now, options).Operators,
+                new FhirModelBindingSetup(dataSource, valueSets, now, options, typeConverter).Operators,
                 parameters,
                 delegates);
 
@@ -38,13 +40,14 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null)
+            FhirModelBindingOptions? options = null,
+            TypeConverter? typeConverter = null)
         {
             IDataSource source = bundle is not null ?
               new BundleDataSource(bundle, valueSets ?? new HashValueSetDictionary()) :
               new CompositeDataSource();
 
-            return WithDataSource(source, parameters, valueSets, now, delegates, options);
+            return WithDataSource(source, parameters, valueSets, now, delegates, options, typeConverter);
         }
 
         /// <summary>
@@ -55,9 +58,10 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null)
+            FhirModelBindingOptions? options = null,
+            TypeConverter? typeConverter = null)
         {
-            return createContext(source, parameters, valueSets, now, delegates, options);
+            return createContext(source, parameters, valueSets, now, delegates, options, typeConverter);
         }
     }
 }

--- a/Cql/Cql.Firely/FhirCqlContext.cs
+++ b/Cql/Cql.Firely/FhirCqlContext.cs
@@ -25,10 +25,9 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null,
-            TypeConverter? typeConverter = null) =>
+            FhirModelBindingOptions? options = null) =>
             new CqlContext(
-                new FhirModelBindingSetup(dataSource, valueSets, now, options, typeConverter).Operators,
+                new FhirModelBindingSetup(dataSource, valueSets, now, options).Operators,
                 parameters,
                 delegates);
 
@@ -40,14 +39,13 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null,
-            TypeConverter? typeConverter = null)
+            FhirModelBindingOptions? options = null)
         {
             IDataSource source = bundle is not null ?
               new BundleDataSource(bundle, valueSets ?? new HashValueSetDictionary()) :
               new CompositeDataSource();
 
-            return WithDataSource(source, parameters, valueSets, now, delegates, options, typeConverter);
+            return WithDataSource(source, parameters, valueSets, now, delegates, options);
         }
 
         /// <summary>
@@ -58,10 +56,9 @@ namespace Hl7.Cql.Fhir
             IValueSetDictionary? valueSets = null,
             DateTimeOffset? now = null,
             DefinitionDictionary<Delegate>? delegates = null,
-            FhirModelBindingOptions? options = null,
-            TypeConverter? typeConverter = null)
+            FhirModelBindingOptions? options = null)
         {
-            return createContext(source, parameters, valueSets, now, delegates, options, typeConverter);
+            return createContext(source, parameters, valueSets, now, delegates, options);
         }
     }
 }

--- a/Cql/Cql.Firely/FhirCqlContext.cs
+++ b/Cql/Cql.Firely/FhirCqlContext.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using Hl7.Cql.Conversion;
 using Hl7.Cql.Operators;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;

--- a/Cql/Cql.Firely/FhirModelBindingSetup.cs
+++ b/Cql/Cql.Firely/FhirModelBindingSetup.cs
@@ -33,17 +33,16 @@ namespace Hl7.Cql.Fhir
             IDataSource? dataSource,
             IValueSetDictionary? valuesets,
             DateTimeOffset? now,
-            FhirModelBindingOptions? options,
-            TypeConverter? typeConverter)
+            FhirModelBindingOptions? options)
         {
             _options = options ?? FhirModelBindingOptions.Default;
 
-            _typeConverter = typeConverter ?? FhirTypeConverter.Create(ModelInfo.ModelInspector, _options.LRUCacheSize);
+            FhirTypeConverter.InitializeCache(_options.LRUCacheSize);
 
             Comparers = new CqlComparers();
             Operators = CqlOperators.Create(
                     TypeResolver,
-                    _typeConverter,
+                    TypeConverter,
                     dataSource,
                     Comparers,
                     valuesets,
@@ -64,8 +63,6 @@ namespace Hl7.Cql.Fhir
         }
         
         private readonly FhirModelBindingOptions? _options;
-
-        private readonly TypeConverter _typeConverter;
 
         public override TypeResolver TypeResolver => FhirTypeResolver.Default;
 

--- a/Cql/Cql.Firely/FhirModelBindingSetup.cs
+++ b/Cql/Cql.Firely/FhirModelBindingSetup.cs
@@ -61,7 +61,19 @@ namespace Hl7.Cql.Fhir
             if (_options?.CodeInOperatorType == FhirModelBindingOptions.CodeInOperatorSemantics.Equivalent)
                 Comparers.Register(typeof(CqlCode), new CqlCodeCqlEquivalentComparer(StringComparer.OrdinalIgnoreCase));
         }
-        
+
+        /// <summary>
+        /// Creates a model binding for the .NET SDK POCO's with the default 
+        /// <see cref="FhirModelBindingOptions"/>.
+        /// </summary>
+        public FhirModelBindingSetup(
+            IDataSource? dataSource,
+            IValueSetDictionary? valuesets,
+            DateTimeOffset? now) : this(dataSource, valuesets, now, FhirModelBindingOptions.Default)
+        {
+            // Nothing
+        }
+
         private readonly FhirModelBindingOptions? _options;
 
         public override TypeResolver TypeResolver => FhirTypeResolver.Default;

--- a/Cql/Cql.Firely/FhirTypeConverter.cs
+++ b/Cql/Cql.Firely/FhirTypeConverter.cs
@@ -29,22 +29,24 @@ namespace Hl7.Cql.Fhir
         /// </summary>
         public static readonly TypeConverter Default = Create(ModelInfo.ModelInspector);
 
-        static LRUCache<CqlDateTime>? dateTimes;
+        private static LRUCache<CqlDateTime>? dateTimes = null;
 
+        /// <summary>
+        /// Sets up the cache size for the LRU cache
+        /// </summary>
+        /// <param name="cacheSize">the size of the LRU cache</param>
+        public static void InitializeCache(int cacheSize)
+        {
+            if (dateTimes == null)
+                dateTimes = new LRUCache<CqlDateTime>(cacheSize);
+        }
         /// <summary>
         /// Allows for the creation of a converter with the specified model 
         /// </summary>
         /// <param name="model">the model</param>
-        /// <param name="cacheSize">the size of the LRU cache</param>
         /// <returns>the type converter</returns>
-        public static TypeConverter Create(ModelInspector model, int? cacheSize = null)
+        public static TypeConverter Create(ModelInspector model)
         {
-            var lruCacheSize = cacheSize ?? 0;  
-            if (lruCacheSize > 0 && dateTimes is null)
-            {
-                dateTimes = new LRUCache<CqlDateTime>(lruCacheSize);
-            }
-
             return TypeConverter
                 .Create()
                 .ConvertSystemTypes()

--- a/Cql/Cql.Packaging/LibraryPackager.cs
+++ b/Cql/Cql.Packaging/LibraryPackager.cs
@@ -31,12 +31,14 @@ namespace Hl7.Cql.Packaging
     {
         internal LibraryPackager()
         {
-            TypeConverter = FhirTypeConverter.Create(ModelInfo.ModelInspector, 0);
+            FhirTypeConverter.InitializeCache(0);
+            TypeConverter = FhirTypeConverter.Default;
         }
 
         internal LibraryPackager(TypeConverter? typeConverter)
         {
-            TypeConverter = typeConverter ?? FhirTypeConverter.Create(ModelInfo.ModelInspector, 0);
+            FhirTypeConverter.InitializeCache(0);
+            TypeConverter = typeConverter ?? FhirTypeConverter.Default;
         }
 
         public static IDictionary<string, elm.Library> LoadLibraries(DirectoryInfo elmDir)
@@ -115,7 +117,8 @@ namespace Hl7.Cql.Packaging
                 .ToArray();
 
             var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
-            var typeConverter = FhirTypeConverter.Create(ModelInfo.ModelInspector, cacheSize);
+            FhirTypeConverter.InitializeCache(cacheSize);
+            var typeConverter = FhirTypeConverter.Default;
             var typeManager = new TypeManager(typeResolver);
             var operatorBinding = new CqlOperatorsBinding(typeResolver, typeConverter);
             var compiler = new AssemblyCompiler(typeResolver, typeManager, operatorBinding);


### PR DESCRIPTION
Fix for https://github.com/FirelyTeam/firely-cql-sdk/issues/511

Pass in TypeConverter when creating a context to avoid the recreation for new contexts with new datasources