### PR TITLE
533 Quote strings to c#, escaping as necessary

### DIFF
--- a/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
@@ -18,15 +18,20 @@ using System.Runtime.Serialization;
 using System.Text;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Microsoft.Extensions.Options;
-using TypeExtensions = Hl7.Cql.Abstractions.Infrastructure.TypeExtensions;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
     internal class ExpressionToCSharpConverter(
-        string libraryName,
         IOptions<CSharpCodeWriterOptions> csharpCodeWriterOptions,
-        TypeToCSharpConverter typeToCSharpConverter)
+        TypeToCSharpConverter typeToCSharpConverter,
+        string libraryName)
     {
+        public string LibraryName { get; } = libraryName;
+
+        private readonly TypeToCSharpConverter _typeToCSharpConverter = typeToCSharpConverter;
+        private bool UseExplicitTypeFormat => csharpCodeWriterOptions.Value.TypeFormat is CSharpCodeWriterTypeFormat.Explicit;
+
+
         public string ConvertExpression(int indent, Expression expression, bool leadingIndent = true)
         {
             try
@@ -76,8 +81,6 @@ namespace Hl7.Cql.CodeGeneration.NET
                     """;
             }
         }
-
-        public string LibraryName { get; } = libraryName;
 
         private string ConvertDefinitionCallExpression(string leadingIndentString, DefinitionCallExpression dce)
         {
@@ -187,9 +190,9 @@ namespace Hl7.Cql.CodeGeneration.NET
                 {
                     null when type == typeof(object) => "null",
                     null                             => DefaultExpressionForType(),
-                    Type t                           => $"typeof({typeToCSharpConverter.ToCSharp(t)})",
+                    Type t                           => $"typeof({_typeToCSharpConverter.ToCSharp(t)})",
                     Uri u                            => $"new Uri(\"{u}\")",
-                    string s                         => SymbolDisplay.FormatLiteral(s, true),
+                    string s                         => QuoteString(s),
                     _                                => FormattableString.Invariant($"{value}")
                 };
             }
@@ -206,6 +209,8 @@ namespace Hl7.Cql.CodeGeneration.NET
                 return "default";
             }
         }
+
+        private string QuoteString(string s) => SymbolDisplay.FormatLiteral(s, true);
 
         private static string ConvertParameterExpression(string leadingIndentString, ParameterExpression pe)
         {
@@ -230,7 +235,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 { Object: not null } => $"{Parenthesize(ConvertExpression(indent, call.Object, false))}.",
                 { Method.IsStatic: true } ext when ext.Method.IsExtensionMethod() =>
                         $"{Parenthesize(ConvertExpression(indent, call.Arguments[0], false))}.",
-                { Method.IsStatic: true } => $"{typeToCSharpConverter.ToCSharp(call.Method.DeclaringType!)}.",
+                { Method.IsStatic: true } => $"{_typeToCSharpConverter.ToCSharp(call.Method.DeclaringType!)}.",
                 _                         => throw new InvalidOperationException("Calls should be either static or have a non-null object.")
             };
 
@@ -271,7 +276,7 @@ namespace Hl7.Cql.CodeGeneration.NET
         private string ConvertDefaultExpression(string leadingIndentString, DefaultExpression de)
         {
             var isNullableType = !de.Type.IsValueType || Nullable.GetUnderlyingType(de.Type) is not null;
-            var defaultExpression = isNullableType ? "null" : $"default({typeToCSharpConverter.ToCSharp(de.Type)})";
+            var defaultExpression = isNullableType ? "null" : $"default({_typeToCSharpConverter.ToCSharp(de.Type)})";
             return $"{leadingIndentString}{defaultExpression}";
         }
 
@@ -280,7 +285,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             if (typeBinary.NodeType == ExpressionType.TypeIs)
             {
                 var left = ConvertExpression(indent, typeBinary.Expression, false);
-                var type = typeToCSharpConverter.ToCSharp(typeBinary.TypeOperand);
+                var type = _typeToCSharpConverter.ToCSharp(typeBinary.TypeOperand);
                 var @is = $"{left} is {type}";
                 return @is;
             }
@@ -302,7 +307,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             conditionalSb.Append(CultureInfo.InvariantCulture, $"{IndentString(indent + 1)}: {ifFalse})");
 
             if (ce.IfTrue.Type != ce.Type || ce.IfFalse.Type != ce.Type)
-                return $"(({typeToCSharpConverter.ToCSharp(ce.Type)}){conditionalSb})";
+                return $"(({_typeToCSharpConverter.ToCSharp(ce.Type)}){conditionalSb})";
             else
                 return conditionalSb.ToString();
         }
@@ -352,7 +357,7 @@ namespace Hl7.Cql.CodeGeneration.NET
 
         private string ConvertMemberInitExpression(int indent, string leadingIndentString, MemberInitExpression memberInit)
         {
-            if (typeToCSharpConverter.ShouldUseTupleType(memberInit.Type))
+            if (_typeToCSharpConverter.ShouldUseTupleType(memberInit.Type))
             {
                 var memberAssignmentsByMemberName = memberInit.Bindings
                                            .Cast<MemberAssignment>()
@@ -360,7 +365,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                                                ma => ma.Member.Name,
                                                ma => ConvertExpression(0, ma.Expression, false));
 
-                var memberValues = typeToCSharpConverter
+                var memberValues = _typeToCSharpConverter
                                    .GetTupleProperties(memberInit.Type)
                                    .Select(p => memberAssignmentsByMemberName.GetValueOrDefault(p.Name, "default"))
                                    .ToArray();
@@ -371,7 +376,7 @@ namespace Hl7.Cql.CodeGeneration.NET
 
             var memberInitSb = new StringBuilder();
             memberInitSb.Append(leadingIndentString);
-            var typeName = typeToCSharpConverter.ToCSharp(memberInit.Type);
+            var typeName = _typeToCSharpConverter.ToCSharp(memberInit.Type);
 #pragma warning disable CA1305 // Specify IFormatProvider
             memberInitSb.AppendLine($"new {typeName}");
 #pragma warning restore CA1305 // Specify IFormatProvider
@@ -427,7 +432,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                     {
                         var newArraySb = new StringBuilder();
                         newArraySb.Append(leadingIndentString);
-                        var arrayType = typeToCSharpConverter.ToCSharp(newArray.Type.GetElementType()!);
+                        var arrayType = _typeToCSharpConverter.ToCSharp(newArray.Type.GetElementType()!);
                         var size = ConvertExpression(0, newArray.Expressions[0], false);
 #pragma warning disable CA1305 // Specify IFormatProvider
                         newArraySb.AppendLine("[]");
@@ -445,15 +450,15 @@ namespace Hl7.Cql.CodeGeneration.NET
             var arguments = @new.Arguments.Select(a => ConvertExpression(0, a));
             var argString = string.Join(", ", arguments);
             var newSb = new StringBuilder();
-            newSb.Append(CultureInfo.InvariantCulture, $"{leadingIndentString}new {typeToCSharpConverter.ToCSharp(@new.Type)}");
+            newSb.Append(CultureInfo.InvariantCulture, $"{leadingIndentString}new {_typeToCSharpConverter.ToCSharp(@new.Type)}");
             newSb.Append(CultureInfo.InvariantCulture, $"({argString})");
             return newSb.ToString();
         }
 
         private string ConvertMemberExpression(string leadingIndentString, MemberExpression me)
         {
-            var nullProp = typeToCSharpConverter.GetMemberAccessNullabilityOperator(me.Expression?.Type);
-            var @object = me.Expression is not null ? ConvertExpression(0, me.Expression) : typeToCSharpConverter.ToCSharp(me.Member.DeclaringType!);
+            var nullProp = _typeToCSharpConverter.GetMemberAccessNullabilityOperator(me.Expression?.Type);
+            var @object = me.Expression is not null ? ConvertExpression(0, me.Expression) : _typeToCSharpConverter.ToCSharp(me.Member.DeclaringType!);
             var memberName = EscapeKeywords(me.Member.Name);
             var nullCoalesce = $"{@object}{nullProp}.{memberName}";
             return $"{leadingIndentString}{nullCoalesce}";
@@ -465,7 +470,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             var lambdaSb = new StringBuilder();
             lambdaSb.Append(leadingIndentString);
 
-            var lambdaParameters = $"({string.Join(", ", lambda.Parameters.Select(p => $"{typeToCSharpConverter.ToCSharp(p.Type)} {EscapeKeywords(p.Name!)}"))})";
+            var lambdaParameters = $"({string.Join(", ", lambda.Parameters.Select(p => $"{_typeToCSharpConverter.ToCSharp(p.Type)} {EscapeKeywords(p.Name!)}"))})";
             lambdaSb.Append(lambdaParameters);
 
             if (lambda.Body is BlockExpression)
@@ -492,7 +497,7 @@ namespace Hl7.Cql.CodeGeneration.NET
         {
             var funcSb = new StringBuilder();
             funcSb.Append(leadingIndentString);
-            funcSb.Append(typeToCSharpConverter.ToCSharp(function.ReturnType) + " ");
+            funcSb.Append(_typeToCSharpConverter.ToCSharp(function.ReturnType) + " ");
             funcSb.Append(name);
 
             var lambda = ConvertLambdaExpression(indent, "", function, functionMode: true);
@@ -506,7 +511,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             var funcSb = new StringBuilder();
 
             funcSb.Append(indent, specifiers + " ");
-            funcSb.Append(typeToCSharpConverter.ToCSharp(function.ReturnType) + " ");
+            funcSb.Append(_typeToCSharpConverter.ToCSharp(function.ReturnType) + " ");
             funcSb.Append(name);
 
             var lambda = ConvertLambdaExpression(indent, "", function, functionMode: true);
@@ -560,7 +565,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 case ExpressionType.TypeAs:
                     {
                         var operand = ConvertExpression(indent, strippedUnary.Operand, false);
-                        var typeName = typeToCSharpConverter.ToCSharp(strippedUnary.Type);
+                        var typeName = _typeToCSharpConverter.ToCSharp(strippedUnary.Type);
                         var code = strippedUnary.NodeType == ExpressionType.TypeAs ?
                             $"{leadingIndentString}{Parenthesize($"{operand} as {typeName}")}" :
                             $"{leadingIndentString}{Parenthesize($"({typeName}){operand}")}";
@@ -597,7 +602,7 @@ namespace Hl7.Cql.CodeGeneration.NET
 
                 string typeDeclaration = "var";
                 if (UseExplicitTypeFormat || rightCode is "null" or "default")
-                    typeDeclaration = typeToCSharpConverter.ToCSharp(left.Type);
+                    typeDeclaration = _typeToCSharpConverter.ToCSharp(left.Type);
 
                 var assignment = $"{leadingIndentString}{typeDeclaration} {ParamName(parameter)} = {rightCode}";
                 return assignment;
@@ -614,8 +619,6 @@ namespace Hl7.Cql.CodeGeneration.NET
                 return binaryString;
             }
         }
-
-        private bool UseExplicitTypeFormat => csharpCodeWriterOptions.Value.TypeFormat is CSharpCodeWriterTypeFormat.Explicit;
 
         private static string BinaryOperatorFor(ExpressionType nodeType) => nodeType switch
         {
@@ -660,7 +663,7 @@ namespace Hl7.Cql.CodeGeneration.NET
         {
             if (method.IsGenericMethod)
             {
-                var genericArgs = string.Join(", ", method.GetGenericArguments().Select(type => typeToCSharpConverter.ToCSharp(type)));
+                var genericArgs = string.Join(", ", method.GetGenericArguments().Select(type => _typeToCSharpConverter.ToCSharp(type)));
                 return $"{method.Name}<{genericArgs}>";
             }
             else
@@ -682,4 +685,3 @@ namespace Hl7.Cql.CodeGeneration.NET
         }
     }
 }
-

--- a/Cql/CoreTests/AnnotationTagsTest.cs
+++ b/Cql/CoreTests/AnnotationTagsTest.cs
@@ -1,0 +1,39 @@
+﻿using System.Linq;
+using System.Reflection;
+using FluentAssertions;
+using Hl7.Cql.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static System.Reflection.BindingFlags;
+
+namespace CoreTests;
+
+[TestClass]
+public class AnnotationTagsTest
+{
+    [TestMethod]
+    public void TestAttributesWithQuotes()
+    {
+        // Temporary replacement test for TagsTest.Tags_Containing_Quotes_Must_Be_Escaped_In_CSharp
+        // This test will be removed once the original test is implemented.
+        // Also remove RR23.cql from Input\ELM\Hl7, then regenerate the ELM, then C# code.
+
+        var methodInfo = typeof(RR23_1_0_0).GetMethod(nameof(RR23_1_0_0.Injury_due_to_falling_rock_within_measurement_period), Public|Instance)!;
+        methodInfo.Should().NotBeNull("Method not found.");
+
+        CqlTagAttribute[] attribute = (CqlTagAttribute[])methodInfo.GetCustomAttributes<CqlTagAttribute>();
+
+        (from a in attribute
+         let name = a.Name
+         orderby name
+         let value = a.Value
+         select value)
+            .Should()
+            .BeEquivalentTo(new[]
+            {
+                "akin to Condition?code:in=http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock&onset-date=sa[Period-start]&onset-date=eb[Period-end]",
+                "\"code\",\"onset.ofType(DateTime)\",\"subject.ofType(Patient)\"]",
+                "Condition.code http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock",
+                "Conditions of type 'Injury due to falling rock' within the measurement period",
+            });
+    }
+}

--- a/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.3.0")]
+[CqlLibrary("RR23", "1.0.0")]
+public class RR23_1_0_0
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Injury_due_to_falling_rock;
+    internal Lazy<CqlValueSet> __Roadrunners_Syndrome_Indicators;
+    internal Lazy<CqlCode> __Tiny_Umbrella;
+    internal Lazy<CqlCode> __entered_in_error;
+    internal Lazy<CqlCode[]> __ACME_Product_Catalog;
+    internal Lazy<CqlCode[]> __ConditionVerificationStatusCodes;
+    internal Lazy<object> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<int?> __Injury_due_to_falling_rock_within_measurement_period;
+
+    #endregion
+    public RR23_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_1 = new FHIRHelpers_4_0_1(context);
+
+        __Injury_due_to_falling_rock = new Lazy<CqlValueSet>(this.Injury_due_to_falling_rock_Value);
+        __Roadrunners_Syndrome_Indicators = new Lazy<CqlValueSet>(this.Roadrunners_Syndrome_Indicators_Value);
+        __Tiny_Umbrella = new Lazy<CqlCode>(this.Tiny_Umbrella_Value);
+        __entered_in_error = new Lazy<CqlCode>(this.entered_in_error_Value);
+        __ACME_Product_Catalog = new Lazy<CqlCode[]>(this.ACME_Product_Catalog_Value);
+        __ConditionVerificationStatusCodes = new Lazy<CqlCode[]>(this.ConditionVerificationStatusCodes_Value);
+        __Measurement_Period = new Lazy<object>(this.Measurement_Period_Value);
+        __Patient = new Lazy<Patient>(this.Patient_Value);
+        __Injury_due_to_falling_rock_within_measurement_period = new Lazy<int?>(this.Injury_due_to_falling_rock_within_measurement_period_Value);
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_1 FHIRHelpers_4_0_1 { get; }
+
+    #endregion
+
+	private CqlValueSet Injury_due_to_falling_rock_Value() => 
+		new CqlValueSet("http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock", default);
+
+    [CqlDeclaration("Injury due to falling rock")]
+    [CqlValueSet("http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock")]
+	public CqlValueSet Injury_due_to_falling_rock() => 
+		__Injury_due_to_falling_rock.Value;
+
+	private CqlValueSet Roadrunners_Syndrome_Indicators_Value() => 
+		new CqlValueSet("http://moh.alpha.alp/ValueSet/DiagnosisRoadrunnerSyndrome", default);
+
+    [CqlDeclaration("Roadrunners Syndrome Indicators")]
+    [CqlValueSet("http://moh.alpha.alp/ValueSet/DiagnosisRoadrunnerSyndrome")]
+	public CqlValueSet Roadrunners_Syndrome_Indicators() => 
+		__Roadrunners_Syndrome_Indicators.Value;
+
+	private CqlCode Tiny_Umbrella_Value() => 
+		new CqlCode("U707", "http://acme.org/product-catalog", default, default);
+
+    [CqlDeclaration("Tiny Umbrella")]
+	public CqlCode Tiny_Umbrella() => 
+		__Tiny_Umbrella.Value;
+
+	private CqlCode entered_in_error_Value() => 
+		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default);
+
+    [CqlDeclaration("entered-in-error")]
+	public CqlCode entered_in_error() => 
+		__entered_in_error.Value;
+
+	private CqlCode[] ACME_Product_Catalog_Value()
+	{
+		CqlCode[] a_ = [
+			new CqlCode("U707", "http://acme.org/product-catalog", default, default),
+		];
+
+		return a_;
+	}
+
+    [CqlDeclaration("ACME Product Catalog")]
+	public CqlCode[] ACME_Product_Catalog() => 
+		__ACME_Product_Catalog.Value;
+
+	private CqlCode[] ConditionVerificationStatusCodes_Value()
+	{
+		CqlCode[] a_ = [
+			new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", default, default),
+		];
+
+		return a_;
+	}
+
+    [CqlDeclaration("ConditionVerificationStatusCodes")]
+	public CqlCode[] ConditionVerificationStatusCodes() => 
+		__ConditionVerificationStatusCodes.Value;
+
+	private object Measurement_Period_Value()
+	{
+		CqlDate a_ = context.Operators.Date(2023, 1, 1);
+		CqlDate b_ = context.Operators.Date(2023, 12, 31);
+		CqlInterval<CqlDate> c_ = context.Operators.Interval(a_, b_, true, true);
+		object d_ = context.ResolveParameter("RR23-1.0.0", "Measurement Period", c_);
+
+		return d_;
+	}
+
+    [CqlDeclaration("Measurement Period")]
+	public object Measurement_Period() => 
+		__Measurement_Period.Value;
+
+	private Patient Patient_Value()
+	{
+		IEnumerable<Patient> a_ = context.Operators.RetrieveByValueSet<Patient>(default, default);
+		Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+		return b_;
+	}
+
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient.Value;
+
+	private int? Injury_due_to_falling_rock_within_measurement_period_Value() => 
+		1;
+
+    [CqlDeclaration("Injury due to falling rock within measurement period")]
+    [CqlTag("description", "Conditions of type 'Injury due to falling rock' within the measurement period")]
+    [CqlTag("fhirquery", "akin to Condition?code:in=http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock&onset-date=sa[Period-start]&onset-date=eb[Period-end]")]
+    [CqlTag("datarequirement", "\"code\",\"onset.ofType(DateTime)\",\"subject.ofType(Patient)\"]")]
+    [CqlTag("coderequirement", "Condition.code http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock")]
+	public int? Injury_due_to_falling_rock_within_measurement_period() => 
+		__Injury_due_to_falling_rock_within_measurement_period.Value;
+
+}

--- a/Cql/CoreTests/CqlBooleanTest.cs
+++ b/Cql/CoreTests/CqlBooleanTest.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace CoreTests;
 
 [TestClass]
-internal class CqlBooleanTest
+public class CqlBooleanTest
 {
     [TestMethod]
     public void SomethingTrueEqualsTrue_ShouldBeTrue()

--- a/Cql/CoreTests/Input/ELM/HL7/RR23.cql
+++ b/Cql/CoreTests/Input/ELM/HL7/RR23.cql
@@ -1,0 +1,37 @@
+library RR23 version '1.0.0'
+
+/*
+@publisher: MOH Alpha
+@description: Library used to validate guidance related to Roadrunners Syndrome
+*/
+
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1'
+
+codesystem "ACME Product Catalog": 'http://acme.org/product-catalog'
+codesystem "ConditionVerificationStatusCodes": 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+
+valueset "Injury due to falling rock": 'http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock'
+valueset "Roadrunners Syndrome Indicators": 'http://moh.alpha.alp/ValueSet/DiagnosisRoadrunnerSyndrome'
+
+code "Tiny Umbrella": 'U707' from "ACME Product Catalog" display 'ACME Tiny Umbrella'
+code "entered-in-error": 'entered-in-error' from ConditionVerificationStatusCodes
+
+/*
+@parameter: in
+*/
+parameter "Measurement Period" default Interval[@2023-01-01, @2023-12-31]
+
+context Patient
+
+/*
+@description: Conditions of type 'Injury due to falling rock' within the measurement period
+@fhirquery: akin to Condition?code:in=http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock&onset-date=sa[Period-start]&onset-date=eb[Period-end]
+@datarequirement: Condition http://hl7.org/fhir/StructureDefinition/Encounter ["code","onset.ofType(DateTime)","subject.ofType(Patient)"]
+@coderequirement: Condition.code http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock
+*/
+define "Injury due to falling rock within measurement period": 1
+
+
+
+

--- a/Cql/CoreTests/Input/ELM/HL7/RR23.json
+++ b/Cql/CoreTests/Input/ELM/HL7/RR23.json
@@ -1,0 +1,228 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "3.1.0",
+         "translatorOptions" : "EnableLocators,EnableResultTypes",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "RR23",
+         "version" : "1.0.0"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "locator" : "8:1-8:26",
+            "localIdentifier" : "FHIR",
+            "uri" : "http://hl7.org/fhir",
+            "version" : "4.0.1",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "t" : [ {
+                  "name" : "publisher",
+                  "value" : "MOH Alpha"
+               }, {
+                  "name" : "description",
+                  "value" : "Library used to validate guidance related to Roadrunners Syndrome"
+               } ]
+            } ]
+         } ]
+      },
+      "includes" : {
+         "def" : [ {
+            "locator" : "9:1-9:35",
+            "localIdentifier" : "FHIRHelpers",
+            "path" : "FHIRHelpers",
+            "version" : "4.0.1"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "locator" : "23:1-23:73",
+            "name" : "Measurement Period",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "t" : [ {
+                  "name" : "parameter",
+                  "value" : "in"
+               } ]
+            } ],
+            "resultTypeSpecifier" : {
+               "type" : "IntervalTypeSpecifier",
+               "pointType" : {
+                  "name" : "{urn:hl7-org:elm-types:r1}Date",
+                  "type" : "NamedTypeSpecifier"
+               }
+            },
+            "default" : {
+               "locator" : "23:40-23:73",
+               "lowClosed" : true,
+               "highClosed" : true,
+               "type" : "Interval",
+               "resultTypeSpecifier" : {
+                  "type" : "IntervalTypeSpecifier",
+                  "pointType" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}Date",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               },
+               "low" : {
+                  "locator" : "23:49-23:59",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
+                  "type" : "Date",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2023",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "1",
+                     "type" : "Literal"
+                  }
+               },
+               "high" : {
+                  "locator" : "23:62-23:72",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}Date",
+                  "type" : "Date",
+                  "year" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "2023",
+                     "type" : "Literal"
+                  },
+                  "month" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "12",
+                     "type" : "Literal"
+                  },
+                  "day" : {
+                     "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+                     "value" : "31",
+                     "type" : "Literal"
+                  }
+               }
+            }
+         } ]
+      },
+      "codeSystems" : {
+         "def" : [ {
+            "locator" : "11:1-11:68",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "ACME Product Catalog",
+            "id" : "http://acme.org/product-catalog",
+            "accessLevel" : "Public"
+         }, {
+            "locator" : "12:1-12:107",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+            "name" : "ConditionVerificationStatusCodes",
+            "id" : "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+            "accessLevel" : "Public"
+         } ]
+      },
+      "valueSets" : {
+         "def" : [ {
+            "locator" : "14:1-14:102",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Injury due to falling rock",
+            "id" : "http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock",
+            "accessLevel" : "Public"
+         }, {
+            "locator" : "15:1-15:103",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "Roadrunners Syndrome Indicators",
+            "id" : "http://moh.alpha.alp/ValueSet/DiagnosisRoadrunnerSyndrome",
+            "accessLevel" : "Public"
+         } ]
+      },
+      "codes" : {
+         "def" : [ {
+            "locator" : "17:1-17:85",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+            "name" : "Tiny Umbrella",
+            "id" : "U707",
+            "display" : "ACME Tiny Umbrella",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "locator" : "17:35-17:56",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+               "name" : "ACME Product Catalog"
+            }
+         }, {
+            "locator" : "18:1-18:81",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+            "name" : "entered-in-error",
+            "id" : "entered-in-error",
+            "accessLevel" : "Public",
+            "codeSystem" : {
+               "locator" : "18:50-18:81",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}CodeSystem",
+               "name" : "ConditionVerificationStatusCodes"
+            }
+         } ]
+      },
+      "contexts" : {
+         "def" : [ {
+            "locator" : "25:1-25:15",
+            "name" : "Patient"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "25:1-25:15",
+            "name" : "Patient",
+            "context" : "Patient",
+            "expression" : {
+               "type" : "SingletonFrom",
+               "operand" : {
+                  "locator" : "25:1-25:15",
+                  "dataType" : "{http://hl7.org/fhir}Patient",
+                  "templateId" : "http://hl7.org/fhir/StructureDefinition/Patient",
+                  "type" : "Retrieve"
+               }
+            }
+         }, {
+            "locator" : "33:1-33:64",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+            "name" : "Injury due to falling rock within measurement period",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "annotation" : [ {
+               "type" : "Annotation",
+               "t" : [ {
+                  "name" : "description",
+                  "value" : "Conditions of type 'Injury due to falling rock' within the measurement period"
+               }, {
+                  "name" : "fhirquery",
+                  "value" : "akin to Condition?code:in=http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock&onset-date=sa[Period-start]&onset-date=eb[Period-end]"
+               }, {
+                  "name" : "datarequirement",
+                  "value" : "\"code\",\"onset.ofType(DateTime)\",\"subject.ofType(Patient)\"]"
+               }, {
+                  "name" : "coderequirement",
+                  "value" : "Condition.code http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock"
+               } ]
+            } ],
+            "expression" : {
+               "locator" : "33:64",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Integer",
+               "valueType" : "{urn:hl7-org:elm-types:r1}Integer",
+               "value" : "1",
+               "type" : "Literal"
+            }
+         } ]
+      }
+   }
+}
+

--- a/Cql/CqlToElmTests/TagsTest.cs
+++ b/Cql/CqlToElmTests/TagsTest.cs
@@ -13,7 +13,7 @@ public class TagsTest : Base
 #pragma warning restore IDE0060 // Remove unused parameter
 
     [TestMethod]
-    [Ignore("The C# CQL-to-ELM does not support capturing annotation tags yet. Once that is ready, this test must be completed. It will be moved to CoreTests for the time being.")]
+    [Ignore("The C# CQL-to-ELM does not support capturing annotation tags yet. Once that is ready, this test must be completed. It will be moved to CoreTests.AnnotationTagsTest.TestAttributesWithQuotes for the time being.")]
     public void Tags_Containing_Quotes_Must_Be_Escaped_In_CSharp()
     {
         var lib = MakeLibrary("""

--- a/Cql/CqlToElmTests/TagsTest.cs
+++ b/Cql/CqlToElmTests/TagsTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Hl7.Cql.CqlToElm.Test;
+
+[TestClass]
+public class TagsTest : Base
+{
+    [ClassInitialize]
+#pragma warning disable IDE0060 // Remove unused parameter
+    public static void Initialize(TestContext context) => ClassInitialize();
+#pragma warning restore IDE0060 // Remove unused parameter
+
+    [TestMethod]
+    [Ignore("The C# CQL-to-ELM does not support capturing annotation tags yet. Once that is ready, this test must be completed. It will be moved to CoreTests for the time being.")]
+    public void Tags_Containing_Quotes_Must_Be_Escaped_In_CSharp()
+    {
+        var lib = MakeLibrary("""
+            library Tags version '1.0.0'
+
+            /*
+            @publisher: MOH Alpha
+            @description: Library used to validate guidance related to Roadrunners Syndrome
+            */
+
+            using FHIR version '4.0.1'
+
+            valueset "Injury due to falling rock": 'http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock'
+
+            /*
+            @parameter: in
+            */
+            parameter "Measurement Period" default Interval[@2023-01-01, @2023-12-31]
+
+            context Patient
+
+            /*
+            @description: Conditions of type 'Injury due to falling rock' within the measurement period
+            @fhirquery: akin to Condition?code:in=http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock&onset-date=sa[Period-start]&onset-date=eb[Period-end]
+            @datarequirement: Condition http://hl7.org/fhir/StructureDefinition/Encounter ["code","onset.ofType(DateTime)","subject.ofType(Patient)"]
+            @coderequirement: Condition.code http://moh.alpha.alp/ValueSet/DiagnosisInjuryDueToFallingRock
+            */
+            define "Injury due to falling rock within measurement period":
+                [Condition: "Injury due to falling rock"] C
+                   where (C.onset.value as DateTime) during "Measurement Period"
+
+            """);
+
+        const string tagsLibraryName = "Tags-1.0.0";
+
+        LibrarySetDefinitions librarySetDefinitions = BuildLibrarySetDefinitions(lib);
+        librarySetDefinitions.Definitions.TryGetTags(
+            tagsLibraryName,
+            "Injury due to falling rock within measurement period",
+            Type.EmptyTypes,
+            out var tags)
+                             .Should().BeTrue("No tags found.");
+
+        LibrarySetCSharp librarySetCSharp = GenerateCSharp(librarySetDefinitions);
+        librarySetCSharp.CSharpCodeByLibraryName.TryGetValue(
+                            tagsLibraryName,
+                            out var cSharp)
+                        .Should()
+                        .BeTrue($"Expected C# code for {tagsLibraryName}");
+
+        // Complete this test, by checking that the attributes are correctly escaped in the C# code.
+        // See C# screenshot in PR https://github.com/FirelyTeam/firely-cql-sdk/pull/535
+        // The syntax tree can be processed by Roslyn
+    }
+
+}

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -10,7 +10,7 @@
     },
     "PackageCLI (Measures.Authoring)": {
       "commandName": "Project",
-      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(CqlSolutionDir)/Demo/Measures.Authoring/Elm\" --cql \"$(CqlSolutionDir)/Demo/Measures.Authoring/input/ql\" --fhir \"$(CqlSolutionDir)/Demo/Measures.Authoring/Resources\" --cs \"$(CqlSolutionDir)/Demo/Measures.Authoring/CSharp\" --cs-typeformat explicit --f true"
+      "commandLineArgs": "--override-utc-date-time \"1970-01-01T00:00:00.000Z\" --canonical-root-url \"https://fire.ly/fhir/\" --elm \"$(CqlSolutionDir)/Demo/Measures.Authoring/Elm\" --cql \"$(CqlSolutionDir)/Demo/Measures.Authoring/input/cql\" --fhir \"$(CqlSolutionDir)/Demo/Measures.Authoring/Resources\" --cs \"$(CqlSolutionDir)/Demo/Measures.Authoring/CSharp\" --cs-typeformat explicit --f true"
     },
     "PackageCLI (Ncqa.DQIC\\BuildArtifacts)": {
       "commandName": "Project",


### PR DESCRIPTION
Work for #533 
Escape strings when writing out c# literals.

e.g. before
![image](https://github.com/user-attachments/assets/af31c9f1-dbc3-4bf0-9219-cc4f7f604450)

after
![image](https://github.com/user-attachments/assets/96ac2813-e614-41e5-9948-2371f3893739)
