### PR TITLE
Build NuGet when pushing spikes

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -23,6 +23,7 @@ trigger:
     - develop-2.0*
     - release*
     - refs/tags/v*
+    - spike*
 
 stages:
 - stage: build


### PR DESCRIPTION
Allows developers to experiment with spikes resulting in NuGet packages, so they can be used in client/server software after pulling the PR into a spike build.