### PR TITLE
build: Fix case for Elm/Elm.csproj references

### DIFF
--- a/Cql/CoreTests/CoreTests.csproj
+++ b/Cql/CoreTests/CoreTests.csproj
@@ -35,7 +35,7 @@
 		<ProjectReference Include="..\Cql.Model\Cql.Model.csproj" />
 		<ProjectReference Include="..\Cql.Packaging\Cql.Packaging.csproj" />
 		<ProjectReference Include="..\Cql.Runtime\Cql.Runtime.csproj" />
-		<ProjectReference Include="..\ELM\ELM.csproj" />
+		<ProjectReference Include="..\Elm\Elm.csproj" />
 		<ProjectReference Include="..\Iso8601\Iso8601.csproj" />
 	</ItemGroup>
 

--- a/Cql/Cql.Compiler/Cql.Compiler.csproj
+++ b/Cql/Cql.Compiler/Cql.Compiler.csproj
@@ -20,7 +20,7 @@
 		<ProjectReference Include="..\Cql.Operators\Cql.Operators.csproj" />
 		<ProjectReference Include="..\Cql.ValueSets\Cql.ValueSets.csproj" />
 		<ProjectReference Include="..\Cql.Runtime\Cql.Runtime.csproj" />
-		<ProjectReference Include="..\ELM\ELM.csproj" />
+		<ProjectReference Include="..\Elm\Elm.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes #566 

Fixing wrong case when referencing Elm/Elm.csproj in CoreTests.csproj and in Cql.Compiler.csproj as this causes issues on case sensitive filesystems like Linux. 
