### PR TITLE
573 Remove obsoleted commandline argument --cs-typeformat

### DIFF
--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.Validator.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.Validator.cs
@@ -13,13 +13,7 @@ partial class CSharpCodeWriterOptions
 {
     internal partial class Validator : IValidateOptions<CSharpCodeWriterOptions>
     {
-        public ValidateOptionsResult Validate(string? name, CSharpCodeWriterOptions options)
-        {
-            if (options.TypeFormat == CSharpCodeWriterTypeFormat.Var)
-                return ValidateOptionsResult.Fail(
-                    $"The 'var' type format is not supported until later. Please only use 'explicit' for now until then. CLI argument is '{CSharpCodeWriterOptions.ArgNameTypeFormat}'.");
-
-            return ValidateOptionsResult.Success;
-        }
+        public ValidateOptionsResult Validate(string? name, CSharpCodeWriterOptions options) =>
+            ValidateOptionsResult.Success;
     }
 }

--- a/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
+++ b/Cql/CodeGeneration.NET/CSharpCodeWriterOptions.cs
@@ -29,13 +29,6 @@ public partial class CSharpCodeWriterOptions
     /// </summary>
     public DirectoryInfo? OutDirectory { get; set; }
 
-    internal const string ArgNameTypeFormat = "--cs-typeformat";
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to prefer 'var' over explicit types.
-    /// </summary>
-    public CSharpCodeWriterTypeFormat TypeFormat { get; set; }
-
     /// <summary>
     /// Binds the configuration values to the <see cref="CSharpCodeWriterOptions"/> object.
     /// </summary>
@@ -55,20 +48,4 @@ public partial class CSharpCodeWriterOptions
             return string.IsNullOrWhiteSpace(path) ? null : new DirectoryInfo(Path.GetFullPath(path));
         }
     }
-}
-
-/// <summary>
-/// How to format types in C# output
-/// </summary>
-public enum CSharpCodeWriterTypeFormat
-{
-    /// <summary>
-    /// Use 'var' over explicit types.
-    /// </summary>
-    Var = 1,
-
-    /// <summary>
-    /// Use explicit types.
-    /// </summary>
-    Explicit = 2
 }

--- a/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
+++ b/Cql/CodeGeneration.NET/CSharpLibrarySetToStreamsWriter.cs
@@ -33,18 +33,15 @@ namespace Hl7.Cql.CodeGeneration.NET
     internal class CSharpLibrarySetToStreamsWriter
     {
         private readonly ILogger<CSharpLibrarySetToStreamsWriter> _logger;
-        private readonly IOptions<CSharpCodeWriterOptions> _options;
         private readonly TypeToCSharpConverter _typeToCSharpConverter;
 
         public CSharpLibrarySetToStreamsWriter(
             ILogger<CSharpLibrarySetToStreamsWriter> logger,
-            IOptions<CSharpCodeWriterOptions> options,
             TypeResolver typeResolver,
             TypeToCSharpConverter typeToCSharpConverter)
         {
             _logger = logger;
             _typeToCSharpConverter = typeToCSharpConverter;
-            _options = options;
             _contextAccessModifier = AccessModifier.Internal;
             _definesAccessModifier = AccessModifier.Internal;
             _usings = BuildUsings(typeResolver);
@@ -399,14 +396,10 @@ namespace Hl7.Cql.CodeGeneration.NET
 
             var vng = new VariableNameGenerator(Enumerable.Empty<string>(), postfix: "_");
 
-            var simplifyNullConditionalMemberExpression = _options.Value.TypeFormat == CSharpCodeWriterTypeFormat.Var;
             var visitedBody = Transform(
                 overload.Body,
                 new RedundantCastsTransformer(),
-                new SimplifyExpressionsVisitor()
-                {
-                    SimplifyNullConditionalMemberExpression = simplifyNullConditionalMemberExpression
-                },
+                new SimplifyExpressionsVisitor(),
                 new RenameVariablesVisitor(vng),
                 new LocalVariableDeduper(_typeToCSharpConverter)
             );
@@ -463,7 +456,7 @@ namespace Hl7.Cql.CodeGeneration.NET
         }
 
         private ExpressionToCSharpConverter NewExpressionToCSharpConverter(string libraryName) =>
-            new(_options, _typeToCSharpConverter, libraryName);
+            new(_typeToCSharpConverter, libraryName);
 
         private void WriteTags(TextWriter writer, int indentLevel, ILookup<string, string>? tags)
         {

--- a/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
@@ -16,22 +16,17 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
-using System.Text.RegularExpressions;
 using Hl7.Cql.Abstractions.Infrastructure;
-using Microsoft.Extensions.Options;
 
 namespace Hl7.Cql.CodeGeneration.NET
 {
     internal class ExpressionToCSharpConverter(
-        IOptions<CSharpCodeWriterOptions> csharpCodeWriterOptions,
         TypeToCSharpConverter typeToCSharpConverter,
         string libraryName)
     {
         public string LibraryName { get; } = libraryName;
 
         private readonly TypeToCSharpConverter _typeToCSharpConverter = typeToCSharpConverter;
-        private bool UseExplicitTypeFormat => csharpCodeWriterOptions.Value.TypeFormat is CSharpCodeWriterTypeFormat.Explicit;
-
 
         public string ConvertExpression(int indent, Expression expression, bool leadingIndent = true)
         {
@@ -602,7 +597,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                 var rightCode = ConvertExpression(indent, right, false);
 
                 string typeDeclaration = "var";
-                if (UseExplicitTypeFormat || rightCode is "null" or "default")
+                if (rightCode is "null" or "default")
                     typeDeclaration = _typeToCSharpConverter.ToCSharp(left.Type);
 
                 var assignment = $"{leadingIndentString}{typeDeclaration} {ParamName(parameter)} = {rightCode}";

--- a/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionToCSharpConverter.cs
@@ -595,11 +595,7 @@ namespace Hl7.Cql.CodeGeneration.NET
                     return ConvertLocalFunctionDefinition(indent, leadingIndentString, le, parameter.Name!);
 
                 var rightCode = ConvertExpression(indent, right, false);
-
-                string typeDeclaration = "var";
-                if (rightCode is "null" or "default")
-                    typeDeclaration = _typeToCSharpConverter.ToCSharp(left.Type);
-
+                var typeDeclaration = _typeToCSharpConverter.ToCSharp(left.Type);
                 var assignment = $"{leadingIndentString}{typeDeclaration} {ParamName(parameter)} = {rightCode}";
                 return assignment;
             }

--- a/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
@@ -7,10 +7,5 @@ Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.CSharpCodeWriterOptions() -> void
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.get -> System.IO.DirectoryInfo?
 Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.OutDirectory.set -> void
-Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.TypeFormat.get -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
-Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.TypeFormat.set -> void
-Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
-Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Explicit = 2 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
-Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat.Var = 1 -> Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterTypeFormat
 static Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.AssemblyDataWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void
 static Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions.BindConfig(Hl7.Cql.CodeGeneration.NET.CSharpCodeWriterOptions! opt, Microsoft.Extensions.Configuration.IConfiguration! config) -> void

--- a/Cql/CodeGeneration.NET/Visitors/SimplifyExpressionsVisitor.cs
+++ b/Cql/CodeGeneration.NET/Visitors/SimplifyExpressionsVisitor.cs
@@ -61,8 +61,6 @@ namespace Hl7.Cql.CodeGeneration.NET.Visitors
             return DoVisit(node);
         }
 
-        public bool SimplifyNullConditionalMemberExpression { get; init; }
-
         private Expression DoVisit(Expression node)
         {
             // This visit will, by default, call `simplify()` on every
@@ -79,9 +77,6 @@ namespace Hl7.Cql.CodeGeneration.NET.Visitors
                 MemberExpression or
                 ElmAsExpression or
                 DefaultExpression
-                => base.Visit(node),
-
-                NullConditionalMemberExpression when SimplifyNullConditionalMemberExpression
                 => base.Visit(node),
 
                 // These expressions require special handling
@@ -275,9 +270,6 @@ namespace Hl7.Cql.CodeGeneration.NET.Visitors
             }
         }
 
-        private SimplifyExpressionsVisitor Clone() => new()
-        {
-            SimplifyNullConditionalMemberExpression = SimplifyNullConditionalMemberExpression
-        };
+        private SimplifyExpressionsVisitor Clone() => new();
     }
 }

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
 	.FindParentDirectoryContaining("*.sln")!;
 
-CSharpCodeWriterTypeFormat csTypeFormat = CSharpCodeWriterTypeFormat.Explicit;
 (string subDir, string measureSubDir)[] iteration = [
 	("Demo", "Measures.Demo"),
 	("CMS", "Measures.CMS")
@@ -27,7 +26,6 @@ foreach ((string librarySetSubDir, string measuresSubDir) in iteration)
 					 --fhir "{solutionDir}/LibrarySets/{librarySetSubDir}/Resources"
 					 --dll "{solutionDir}/LibrarySets/{librarySetSubDir}/Assemblies"
 					 --cs "{solutionDir}/Demo/{measuresSubDir}/CSharp"
-					 --cs-typeformat {csTypeFormat}
 					 --log-debug true
 					 {(first ? "" : "--log-dont-clear true")}
 					 """.Replace("\n", " "),

--- a/Cql/PackagerCLI/DependencyInjection/PackagerCliCommandLineSwitchConfigurationExtensions.cs
+++ b/Cql/PackagerCLI/DependencyInjection/PackagerCliCommandLineSwitchConfigurationExtensions.cs
@@ -36,7 +36,6 @@ internal static class PackagerCliCommandLineSwitchConfigurationExtensions
             [CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl] = PackageSection + nameof(CqlToResourcePackagingOptions.CanonicalRootUrl),
 
             [CSharpCodeWriterOptions.ArgNameOutDirectory] = CSharpCodeWriterSection + nameof(CSharpCodeWriterOptions.OutDirectory),
-            [CSharpCodeWriterOptions.ArgNameTypeFormat] = CSharpCodeWriterSection + nameof(CSharpCodeWriterOptions.TypeFormat),
 
             [AssemblyDataWriterOptions.ArgNameOutDirectory] = AssemblyDataWriterSection + nameof(CSharpCodeWriterOptions.OutDirectory),
 

--- a/Cql/PackagerCLI/OptionsConsoleDumper.cs
+++ b/Cql/PackagerCLI/OptionsConsoleDumper.cs
@@ -53,7 +53,6 @@ internal class OptionsConsoleDumper
             ArgFor("Fhir, OutDirectory", _fhirResourceWriterOptions.OutDirectory),
             ArgFor("Fhir, OverrideDate", _fhirResourceWriterOptions.OverrideDate),
             ArgFor("CSharp, OutDirectory", _csharpCodeWriterOptions.OutDirectory),
-            ArgFor("CSharp, TypeFormat", _csharpCodeWriterOptions.TypeFormat),
         }.Where(t => t.value is not null)
         .ToArray();
 

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -73,7 +73,6 @@ public class Program
                      {CqlToResourcePackagingOptions.ArgNameCqlDirectory,-26} {"<directory>",-19} Required: CQL root directory
                      {Optional(FhirResourceWriterOptions.ArgNameOutDirectory),-26} {"<directory>",-19} Resource directory
                      {Optional(CSharpCodeWriterOptions.ArgNameOutDirectory),-26} {"<directory>",-19} C# output directory
-                     {Optional(CSharpCodeWriterOptions.ArgNameTypeFormat),-26} {"<var|explicit>",-19} Whether to use var (default) or explicit types in the C# output
                      {Optional(AssemblyDataWriterOptions.ArgNameOutDirectory),-26}{"<directory>",-19} DLL output directory
                      {Optional(CqlToResourcePackagingOptions.ArgNameLogDebugEnabled),-26} {"<true|false>",-19} Enable debug logging or not (default)
                      {Optional(CqlToResourcePackagingOptions.ArgNameCanonicalRootUrl),-26} {"<url>",-19} The root url used for the resource canonical


### PR DESCRIPTION
Work for #573 
Remove the commandline argument for switching between var and explicit type