### PR TITLE
 Performance update for 1.0 

### DIFF
--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -66,6 +66,9 @@ namespace Hl7.Cql.CodeGeneration.NET
             var sb = new StringBuilder();
             sb.Append(leadingIndentString);
 
+            //var target = dce.LibraryName == LibraryName ? "this" :
+            //    VariableNameGenerator.NormalizeIdentifier(dce.LibraryName);
+
             var target = dce.LibraryName == LibraryName ? "this" : $"{VariableNameGenerator.NormalizeIdentifier(dce.LibraryName)}.Instance";
             var csFunctionName = VariableNameGenerator.NormalizeIdentifier(dce.DefinitionName);
 
@@ -78,6 +81,9 @@ namespace Hl7.Cql.CodeGeneration.NET
         {
             var sb = new StringBuilder();
             sb.Append(leadingIndentString);
+
+            //var target = fce.LibraryName == LibraryName ? "this" :
+            //    VariableNameGenerator.NormalizeIdentifier(fce.LibraryName);
 
             var target = fce.LibraryName == LibraryName ? "this" : $"{VariableNameGenerator.NormalizeIdentifier(fce.LibraryName)}.Instance";
             var csFunctionName = VariableNameGenerator.NormalizeIdentifier(fce.FunctionName);

--- a/Cql/CodeGeneration.NET/ExpressionConverter.cs
+++ b/Cql/CodeGeneration.NET/ExpressionConverter.cs
@@ -22,9 +22,10 @@ namespace Hl7.Cql.CodeGeneration.NET
 {
     internal class ExpressionConverter
     {
-        public ExpressionConverter(string libraryName)
+        public ExpressionConverter(string libraryName, IList<string> contextLibraries)
         {
             LibraryName = libraryName;
+            ContextLibraries = contextLibraries;
         }
 
         public string ConvertExpression(int indent, Expression expression, bool leadingIndent = true)
@@ -60,19 +61,28 @@ namespace Hl7.Cql.CodeGeneration.NET
         private static readonly ObjectIDGenerator gen = new();
 
         public string LibraryName { get; }
+        public IList<string> ContextLibraries { get; }
 
         private string convertDefinitionCallExpression(int indent, string leadingIndentString, DefinitionCallExpression dce)
         {
             var sb = new StringBuilder();
             sb.Append(leadingIndentString);
 
-            //var target = dce.LibraryName == LibraryName ? "this" :
-            //    VariableNameGenerator.NormalizeIdentifier(dce.LibraryName);
+            var target = dce.LibraryName == LibraryName ? "this"
+                : ContextLibraries.Contains(dce.LibraryName)
+                    ? VariableNameGenerator.NormalizeIdentifier(dce.LibraryName)
+                    : $"{VariableNameGenerator.NormalizeIdentifier(dce.LibraryName)}.Instance";
 
-            var target = dce.LibraryName == LibraryName ? "this" : $"{VariableNameGenerator.NormalizeIdentifier(dce.LibraryName)}.Instance";
             var csFunctionName = VariableNameGenerator.NormalizeIdentifier(dce.DefinitionName);
 
-            sb.Append(CultureInfo.InvariantCulture, $"{target}.{csFunctionName}(context)");
+            if (ContextLibraries.Contains(dce.LibraryName))
+            {
+                sb.Append(CultureInfo.InvariantCulture, $"{target}.{csFunctionName}()");
+            }
+            else
+            {
+                sb.Append(CultureInfo.InvariantCulture, $"{target}.{csFunctionName}(context)");
+            }
 
             return sb.ToString();
         }
@@ -82,14 +92,27 @@ namespace Hl7.Cql.CodeGeneration.NET
             var sb = new StringBuilder();
             sb.Append(leadingIndentString);
 
+            var target = fce.LibraryName == LibraryName ? "this"
+                : ContextLibraries.Contains(fce.LibraryName)
+                    ? VariableNameGenerator.NormalizeIdentifier(fce.LibraryName)
+                    : $"{VariableNameGenerator.NormalizeIdentifier(fce.LibraryName)}.Instance";
+
             //var target = fce.LibraryName == LibraryName ? "this" :
             //    VariableNameGenerator.NormalizeIdentifier(fce.LibraryName);
 
-            var target = fce.LibraryName == LibraryName ? "this" : $"{VariableNameGenerator.NormalizeIdentifier(fce.LibraryName)}.Instance";
             var csFunctionName = VariableNameGenerator.NormalizeIdentifier(fce.FunctionName);
 
             sb.Append(CultureInfo.InvariantCulture, $"{target}.{csFunctionName}");
-            sb.Append(convertArguments(indent, fce.Arguments));
+
+            if (ContextLibraries.Contains(fce.LibraryName))
+            {
+                sb.Append(convertArguments(indent, fce.Arguments.Skip(1)));
+            }
+            else
+            {
+                sb.Append(convertArguments(indent, fce.Arguments));
+            }
+            
 
             return sb.ToString();
         }
@@ -416,14 +439,14 @@ namespace Hl7.Cql.CodeGeneration.NET
         }
 
 
-        private string convertLambdaExpression(int indent, string leadingIndentString, LambdaExpression lambda, bool functionMode = false)
+        private string convertLambdaExpression(int indent, string leadingIndentString, LambdaExpression lambda, bool functionMode = false, bool addContext = false)
         {
             var lambdaSb = new StringBuilder();
             lambdaSb.Append(leadingIndentString);
 
             var parameters = lambda.Parameters.Select(p => $"{PrettyTypeName(p.Type)} {escapeKeywords(p.Name!)}").ToList();
             // inserts the context parameter in the start of the lambda expression
-            if (indent == 1)
+            if (indent == 1 && addContext)
                 parameters.Insert(0, "CqlContext context");
 
             var lambdaParameters = $"({string.Join(", ", parameters)})";
@@ -456,13 +479,13 @@ namespace Hl7.Cql.CodeGeneration.NET
             funcSb.Append(PrettyTypeName(function.ReturnType) + " ");
             funcSb.Append(name);
 
-            var lambda = convertLambdaExpression(indent, "", function, functionMode: true);
+            var lambda = convertLambdaExpression(indent, "", function, functionMode: true, addContext: false);
             funcSb.Append(lambda);
 
             return funcSb.ToString();
         }
 
-        public string ConvertTopLevelFunctionDefinition(int indent, LambdaExpression function, string name, string specifiers)
+        public string ConvertTopLevelFunctionDefinition(int indent, LambdaExpression function, string name, string specifiers, bool addContext)
         {
             var funcSb = new StringBuilder();
 
@@ -470,7 +493,7 @@ namespace Hl7.Cql.CodeGeneration.NET
             funcSb.Append(PrettyTypeName(function.ReturnType) + " ");
             funcSb.Append(name);
 
-            var lambda = convertLambdaExpression(indent, "", function, functionMode: true);
+            var lambda = convertLambdaExpression(indent, "", function, functionMode: true, addContext);
             funcSb.Append(lambda);
 
             if (function.Body is not BlockExpression)

--- a/Demo/Measures/AdultOutpatientEncountersFHIR4-2.2.000.cs
+++ b/Demo/Measures/AdultOutpatientEncountersFHIR4-2.2.000.cs
@@ -14,43 +14,95 @@ using Task = Hl7.Fhir.Model.Task;
 public class AdultOutpatientEncountersFHIR4_2_2_000
 {
 
-    public static AdultOutpatientEncountersFHIR4_2_2_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+
+    #endregion
+    public AdultOutpatientEncountersFHIR4_2_2_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value(context));
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
-	public CqlValueSet Annual_Wellness_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit?.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
-	public CqlValueSet Home_Healthcare_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("AdultOutpatientEncountersFHIR4-2.2.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -58,29 +110,32 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 		return b_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters")]
-	public IEnumerable<Encounter> Qualifying_Encounters(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Office_Visit(context);
+		var a_ = this.Office_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Annual_Wellness_Visit(context);
+		var c_ = this.Annual_Wellness_Visit();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up(context);
+		var f_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up(context);
+		var h_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Home_Healthcare_Services(context);
+		var l_ = this.Home_Healthcare_Services();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
 		var n_ = context.Operators.ListUnion<Encounter>(k_, m_);
 		bool? o_(Encounter ValidEncounter)
 		{
 			var q_ = context.Operators.Convert<string>(ValidEncounter?.StatusElement);
 			var r_ = context.Operators.Equal(q_, "finished");
-			var s_ = this.Measurement_Period(context);
-			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (ValidEncounter?.Period as object));
+			var s_ = this.Measurement_Period();
+			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ValidEncounter?.Period as object));
 			var u_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(s_, t_, null);
 			var v_ = context.Operators.And(r_, u_);
 
@@ -90,5 +145,9 @@ public class AdultOutpatientEncountersFHIR4_2_2_000
 
 		return p_;
 	}
+
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters?.Value;
 
 }

--- a/Demo/Measures/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.cs
+++ b/Demo/Measures/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.cs
@@ -14,83 +14,199 @@ using Task = Hl7.Fhir.Model.Task;
 public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 {
 
-    public static AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Inpatient;
+    internal Lazy<CqlValueSet> __Advanced_Illness;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Dementia_Medications;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Frailty_Device;
+    internal Lazy<CqlValueSet> __Frailty_Diagnosis;
+    internal Lazy<CqlValueSet> __Frailty_Encounter;
+    internal Lazy<CqlValueSet> __Frailty_Symptom;
+    internal Lazy<CqlValueSet> __Nonacute_Inpatient;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Outpatient;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<MedicationRequest>> __Dementia_Medications_In_Year_Before_or_During_Measurement_Period;
+    internal Lazy<IEnumerable<CqlInterval<CqlDateTime>>> __Long_Term_Care_Periods_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Outpatient_Encounters_with_Advanced_Illness;
+    internal Lazy<IEnumerable<Encounter>> __Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service;
+    internal Lazy<IEnumerable<CqlInterval<CqlDateTime>>> __Long_Term_Care_Overlapping_Periods;
+    internal Lazy<IEnumerable<CqlInterval<CqlDateTime>>> __Long_Term_Care_Adjacent_Periods;
+    internal Lazy<int?> __Max_Long_Term_Care_Period_Length;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounter_with_Advanced_Illness;
+    internal Lazy<bool?> __Has_Criteria_Indicating_Frailty;
+    internal Lazy<bool?> __Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80;
+    internal Lazy<bool?> __Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80;
+    internal Lazy<bool?> __Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days;
+
+    #endregion
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+
+        __Acute_Inpatient = new Lazy<CqlValueSet>(this.Acute_Inpatient_Value(context));
+        __Advanced_Illness = new Lazy<CqlValueSet>(this.Advanced_Illness_Value(context));
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value(context));
+        __Dementia_Medications = new Lazy<CqlValueSet>(this.Dementia_Medications_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Frailty_Device = new Lazy<CqlValueSet>(this.Frailty_Device_Value(context));
+        __Frailty_Diagnosis = new Lazy<CqlValueSet>(this.Frailty_Diagnosis_Value(context));
+        __Frailty_Encounter = new Lazy<CqlValueSet>(this.Frailty_Encounter_Value(context));
+        __Frailty_Symptom = new Lazy<CqlValueSet>(this.Frailty_Symptom_Value(context));
+        __Nonacute_Inpatient = new Lazy<CqlValueSet>(this.Nonacute_Inpatient_Value(context));
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value(context));
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value(context));
+        __Outpatient = new Lazy<CqlValueSet>(this.Outpatient_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Dementia_Medications_In_Year_Before_or_During_Measurement_Period = new Lazy<IEnumerable<MedicationRequest>>(this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value(context));
+        __Long_Term_Care_Periods_During_Measurement_Period = new Lazy<IEnumerable<CqlInterval<CqlDateTime>>>(this.Long_Term_Care_Periods_During_Measurement_Period_Value(context));
+        __Outpatient_Encounters_with_Advanced_Illness = new Lazy<IEnumerable<Encounter>>(this.Outpatient_Encounters_with_Advanced_Illness_Value(context));
+        __Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service = new Lazy<IEnumerable<Encounter>>(this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service_Value(context));
+        __Long_Term_Care_Overlapping_Periods = new Lazy<IEnumerable<CqlInterval<CqlDateTime>>>(this.Long_Term_Care_Overlapping_Periods_Value(context));
+        __Long_Term_Care_Adjacent_Periods = new Lazy<IEnumerable<CqlInterval<CqlDateTime>>>(this.Long_Term_Care_Adjacent_Periods_Value(context));
+        __Max_Long_Term_Care_Period_Length = new Lazy<int?>(this.Max_Long_Term_Care_Period_Length_Value(context));
+        __Inpatient_Encounter_with_Advanced_Illness = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounter_with_Advanced_Illness_Value(context));
+        __Has_Criteria_Indicating_Frailty = new Lazy<bool?>(this.Has_Criteria_Indicating_Frailty_Value(context));
+        __Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80 = new Lazy<bool?>(this.Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80_Value(context));
+        __Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80 = new Lazy<bool?>(this.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80_Value(context));
+        __Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days = new Lazy<bool?>(this.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
-	public CqlValueSet Acute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+	public CqlValueSet Acute_Inpatient() => 
+		__Acute_Inpatient?.Value;
+
+	private CqlValueSet Advanced_Illness_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
-	public CqlValueSet Advanced_Illness(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+	public CqlValueSet Advanced_Illness() => 
+		__Advanced_Illness?.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
-	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility?.Value;
+
+	private CqlValueSet Dementia_Medications_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
-	public CqlValueSet Dementia_Medications(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+	public CqlValueSet Dementia_Medications() => 
+		__Dementia_Medications?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1010", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Frailty_Device_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
-	public CqlValueSet Frailty_Device(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+	public CqlValueSet Frailty_Device() => 
+		__Frailty_Device?.Value;
+
+	private CqlValueSet Frailty_Diagnosis_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
-	public CqlValueSet Frailty_Diagnosis(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+	public CqlValueSet Frailty_Diagnosis() => 
+		__Frailty_Diagnosis?.Value;
+
+	private CqlValueSet Frailty_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
-	public CqlValueSet Frailty_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+	public CqlValueSet Frailty_Encounter() => 
+		__Frailty_Encounter?.Value;
+
+	private CqlValueSet Frailty_Symptom_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
-	public CqlValueSet Frailty_Symptom(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+	public CqlValueSet Frailty_Symptom() => 
+		__Frailty_Symptom?.Value;
+
+	private CqlValueSet Nonacute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
-	public CqlValueSet Nonacute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+	public CqlValueSet Nonacute_Inpatient() => 
+		__Nonacute_Inpatient?.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
-	public CqlValueSet Nursing_Facility_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit?.Value;
+
+	private CqlValueSet Observation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
-	public CqlValueSet Observation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+	public CqlValueSet Observation() => 
+		__Observation?.Value;
+
+	private CqlValueSet Outpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
-	public CqlValueSet Outpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+	public CqlValueSet Outpatient() => 
+		__Outpatient?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -98,10 +214,13 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return b_;
 	}
 
-    [CqlDeclaration("Dementia Medications In Year Before or During Measurement Period")]
-	public IEnumerable<MedicationRequest> Dementia_Medications_In_Year_Before_or_During_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<MedicationRequest> Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Dementia_Medications(context);
+		var a_ = this.Dementia_Medications();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
@@ -112,8 +231,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			var j_ = context.Operators.Convert<string>(DementiaMed?.IntentElement);
 			var k_ = context.Operators.Equal(j_, "order");
 			var l_ = context.Operators.And(i_, k_);
-			var m_ = CumulativeMedicationDurationFHIR4_1_0_000.Instance.MedicationPeriod(context, (DementiaMed as object));
-			var n_ = this.Measurement_Period(context);
+			var m_ = CumulativeMedicationDurationFHIR4_1_0_000.MedicationPeriod((DementiaMed as object));
+			var n_ = this.Measurement_Period();
 			var o_ = context.Operators.Start(n_);
 			var p_ = context.Operators.Quantity(1m, "year");
 			var q_ = context.Operators.Subtract(o_, p_);
@@ -129,20 +248,23 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return g_;
 	}
 
-    [CqlDeclaration("Long Term Care Periods During Measurement Period")]
-	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Periods_During_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Dementia Medications In Year Before or During Measurement Period")]
+	public IEnumerable<MedicationRequest> Dementia_Medications_In_Year_Before_or_During_Measurement_Period() => 
+		__Dementia_Medications_In_Year_Before_or_During_Measurement_Period?.Value;
+
+	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Periods_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+		var a_ = this.Care_Services_in_Long_Term_Residential_Facility();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Nursing_Facility_Visit(context);
+		var c_ = this.Nursing_Facility_Visit();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
 		bool? f_(Encounter LongTermFacilityEncounter)
 		{
 			var j_ = context.Operators.Convert<string>(LongTermFacilityEncounter?.StatusElement);
 			var k_ = context.Operators.Equal(j_, "finished");
-			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (LongTermFacilityEncounter?.Period as object));
-			var m_ = this.Measurement_Period(context);
+			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((LongTermFacilityEncounter?.Period as object));
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.Overlaps(l_, m_, null);
 			var o_ = context.Operators.And(k_, n_);
 
@@ -151,8 +273,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var g_ = context.Operators.WhereOrNull<Encounter>(e_, f_);
 		CqlInterval<CqlDateTime> h_(Encounter LongTermFacilityEncounter)
 		{
-			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (LongTermFacilityEncounter?.Period as object));
-			var q_ = this.Measurement_Period(context);
+			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((LongTermFacilityEncounter?.Period as object));
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.IntervalIntersectsInterval<CqlDateTime>(p_, q_);
 
 			return r_;
@@ -162,17 +284,20 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return i_;
 	}
 
-    [CqlDeclaration("Outpatient Encounters with Advanced Illness")]
-	public IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Long Term Care Periods During Measurement Period")]
+	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Periods_During_Measurement_Period() => 
+		__Long_Term_Care_Periods_During_Measurement_Period?.Value;
+
+	private IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness_Value(CqlContext context)
 	{
-		var a_ = this.Outpatient(context);
+		var a_ = this.Outpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Observation(context);
+		var c_ = this.Observation();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Emergency_Department_Visit(context);
+		var f_ = this.Emergency_Department_Visit();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Nonacute_Inpatient(context);
+		var h_ = this.Nonacute_Inpatient();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
@@ -186,15 +311,15 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var m_ = context.Operators.WhereOrNull<Encounter>(k_, l_);
 		IEnumerable<Encounter> n_(Encounter OutpatientEncounter)
 		{
-			var r_ = this.Advanced_Illness(context);
+			var r_ = this.Advanced_Illness();
 			var s_ = context.Operators.RetrieveByValueSet<Condition>(r_, null);
 			bool? t_(Condition AdvancedIllnessDiagnosis)
 			{
-				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.EncounterDiagnosis(context, OutpatientEncounter);
+				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(OutpatientEncounter);
 				var y_ = context.Operators.InList<Condition>(AdvancedIllnessDiagnosis, x_);
-				var z_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (OutpatientEncounter?.Period as object));
+				var z_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((OutpatientEncounter?.Period as object));
 				var aa_ = context.Operators.Start(z_);
-				var ab_ = this.Measurement_Period(context);
+				var ab_ = this.Measurement_Period();
 				var ac_ = context.Operators.End(ab_);
 				var ad_ = context.Operators.Quantity(2m, "years");
 				var ae_ = context.Operators.Subtract(ac_, ad_);
@@ -220,13 +345,16 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return o_;
 	}
 
-    [CqlDeclaration("Two Outpatient Encounters with Advanced Illness on Different Dates of Service")]
-	public IEnumerable<Encounter> Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service(CqlContext context)
+    [CqlDeclaration("Outpatient Encounters with Advanced Illness")]
+	public IEnumerable<Encounter> Outpatient_Encounters_with_Advanced_Illness() => 
+		__Outpatient_Encounters_with_Advanced_Illness?.Value;
+
+	private IEnumerable<Encounter> Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service_Value(CqlContext context)
 	{
-		var a_ = this.Outpatient_Encounters_with_Advanced_Illness(context);
+		var a_ = this.Outpatient_Encounters_with_Advanced_Illness();
 		IEnumerable<Encounter> b_(Encounter _OutpatientEncounter1)
 		{
-			var i_ = this.Outpatient_Encounters_with_Advanced_Illness(context);
+			var i_ = this.Outpatient_Encounters_with_Advanced_Illness();
 
 			return i_;
 		};
@@ -243,9 +371,9 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var d_ = context.Operators.SelectManyResultsOrNull<Encounter, Encounter, Tuples.Tuple_EYKUVMTUWTABihhEAdHIGbSFe>(a_, b_, c_);
 		bool? e_(Tuples.Tuple_EYKUVMTUWTABihhEAdHIGbSFe tuple_eykuvmtuwtabihheadhigbsfe)
 		{
-			var k_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, tuple_eykuvmtuwtabihheadhigbsfe.OutpatientEncounter2?.Period);
+			var k_ = FHIRHelpers_4_0_001.ToInterval(tuple_eykuvmtuwtabihheadhigbsfe.OutpatientEncounter2?.Period);
 			var l_ = context.Operators.End(k_);
-			var m_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, tuple_eykuvmtuwtabihheadhigbsfe.OutpatientEncounter1?.Period);
+			var m_ = FHIRHelpers_4_0_001.ToInterval(tuple_eykuvmtuwtabihheadhigbsfe.OutpatientEncounter1?.Period);
 			var n_ = context.Operators.End(m_);
 			var o_ = context.Operators.Quantity(1m, "day");
 			var p_ = context.Operators.Add(n_, o_);
@@ -261,22 +389,28 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return h_;
 	}
 
-    [CqlDeclaration("Long Term Care Overlapping Periods")]
-	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods(CqlContext context)
+    [CqlDeclaration("Two Outpatient Encounters with Advanced Illness on Different Dates of Service")]
+	public IEnumerable<Encounter> Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service() => 
+		__Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service?.Value;
+
+	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods_Value(CqlContext context)
 	{
-		var a_ = this.Long_Term_Care_Periods_During_Measurement_Period(context);
+		var a_ = this.Long_Term_Care_Periods_During_Measurement_Period();
 		var b_ = context.Operators.Collapse(a_, null);
 
 		return b_;
 	}
 
-    [CqlDeclaration("Long Term Care Adjacent Periods")]
-	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Adjacent_Periods(CqlContext context)
+    [CqlDeclaration("Long Term Care Overlapping Periods")]
+	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods() => 
+		__Long_Term_Care_Overlapping_Periods?.Value;
+
+	private IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Adjacent_Periods_Value(CqlContext context)
 	{
-		var a_ = this.Long_Term_Care_Overlapping_Periods(context);
+		var a_ = this.Long_Term_Care_Overlapping_Periods();
 		IEnumerable<CqlInterval<CqlDateTime>> b_(CqlInterval<CqlDateTime> _LTCPeriod1)
 		{
-			var i_ = this.Long_Term_Care_Overlapping_Periods(context);
+			var i_ = this.Long_Term_Care_Overlapping_Periods();
 
 			return i_;
 		};
@@ -319,11 +453,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return h_;
 	}
 
-    [CqlDeclaration("Max Long Term Care Period Length")]
-	public int? Max_Long_Term_Care_Period_Length(CqlContext context)
+    [CqlDeclaration("Long Term Care Adjacent Periods")]
+	public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Adjacent_Periods() => 
+		__Long_Term_Care_Adjacent_Periods?.Value;
+
+	private int? Max_Long_Term_Care_Period_Length_Value(CqlContext context)
 	{
-		var a_ = this.Long_Term_Care_Overlapping_Periods(context);
-		var b_ = this.Long_Term_Care_Adjacent_Periods(context);
+		var a_ = this.Long_Term_Care_Overlapping_Periods();
+		var b_ = this.Long_Term_Care_Adjacent_Periods();
 		var c_ = context.Operators.ListUnion<CqlInterval<CqlDateTime>>(a_, b_);
 		var d_ = context.Operators.Collapse(c_, null);
 		int? e_(CqlInterval<CqlDateTime> LTCPeriods)
@@ -340,10 +477,13 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return g_;
 	}
 
-    [CqlDeclaration("Inpatient Encounter with Advanced Illness")]
-	public IEnumerable<Encounter> Inpatient_Encounter_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Max Long Term Care Period Length")]
+	public int? Max_Long_Term_Care_Period_Length() => 
+		__Max_Long_Term_Care_Period_Length?.Value;
+
+	private IEnumerable<Encounter> Inpatient_Encounter_with_Advanced_Illness_Value(CqlContext context)
 	{
-		var a_ = this.Acute_Inpatient(context);
+		var a_ = this.Acute_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter AcuteInpatient)
 		{
@@ -355,15 +495,15 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
-			var i_ = this.Advanced_Illness(context);
+			var i_ = this.Advanced_Illness();
 			var j_ = context.Operators.RetrieveByValueSet<Condition>(i_, null);
 			bool? k_(Condition AdvancedIllnessDiagnosis)
 			{
-				var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.EncounterDiagnosis(context, InpatientEncounter);
+				var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.EncounterDiagnosis(InpatientEncounter);
 				var p_ = context.Operators.InList<Condition>(AdvancedIllnessDiagnosis, o_);
-				var q_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (InpatientEncounter?.Period as object));
+				var q_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((InpatientEncounter?.Period as object));
 				var r_ = context.Operators.Start(q_);
-				var s_ = this.Measurement_Period(context);
+				var s_ = this.Measurement_Period();
 				var t_ = context.Operators.End(s_);
 				var u_ = context.Operators.Quantity(2m, "years");
 				var v_ = context.Operators.Subtract(t_, u_);
@@ -389,10 +529,13 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return f_;
 	}
 
-    [CqlDeclaration("Has Criteria Indicating Frailty")]
-	public bool? Has_Criteria_Indicating_Frailty(CqlContext context)
+    [CqlDeclaration("Inpatient Encounter with Advanced Illness")]
+	public IEnumerable<Encounter> Inpatient_Encounter_with_Advanced_Illness() => 
+		__Inpatient_Encounter_with_Advanced_Illness?.Value;
+
+	private bool? Has_Criteria_Indicating_Frailty_Value(CqlContext context)
 	{
-		var a_ = this.Frailty_Device(context);
+		var a_ = this.Frailty_Device();
 		var b_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<DeviceRequest>(a_, null);
 		var e_ = context.Operators.ListUnion<DeviceRequest>(b_, d_);
@@ -409,8 +552,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 			var aj_ = context.Operators.Convert<string>(FrailtyDeviceOrder?.IntentElement);
 			var ak_ = context.Operators.Equal(aj_, "order");
 			var al_ = context.Operators.And(ai_, ak_);
-			var am_ = this.Measurement_Period(context);
-			var an_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (FrailtyDeviceOrder?.AuthoredOnElement as object));
+			var am_ = this.Measurement_Period();
+			var an_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((FrailtyDeviceOrder?.AuthoredOnElement as object));
 			var ao_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(am_, an_, null);
 			var ap_ = context.Operators.And(al_, ao_);
 
@@ -429,8 +572,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				"corrected",
 			};
 			var as_ = context.Operators.InList<string>(aq_, (ar_ as IEnumerable<string>));
-			var at_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FrailtyDeviceApplied?.Effective);
-			var au_ = this.Measurement_Period(context);
+			var at_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FrailtyDeviceApplied?.Effective);
+			var au_ = this.Measurement_Period();
 			var av_ = context.Operators.Overlaps(at_, au_, null);
 			var aw_ = context.Operators.And(as_, av_);
 
@@ -439,12 +582,12 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var l_ = context.Operators.WhereOrNull<Observation>(j_, k_);
 		var m_ = context.Operators.ExistsInList<Observation>(l_);
 		var n_ = context.Operators.Or(h_, m_);
-		var o_ = this.Frailty_Diagnosis(context);
+		var o_ = this.Frailty_Diagnosis();
 		var p_ = context.Operators.RetrieveByValueSet<Condition>(o_, null);
 		bool? q_(Condition FrailtyDiagnosis)
 		{
-			var ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, FrailtyDiagnosis);
-			var ay_ = this.Measurement_Period(context);
+			var ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(FrailtyDiagnosis);
+			var ay_ = this.Measurement_Period();
 			var az_ = context.Operators.Overlaps(ax_, ay_, null);
 
 			return az_;
@@ -452,14 +595,14 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var r_ = context.Operators.WhereOrNull<Condition>(p_, q_);
 		var s_ = context.Operators.ExistsInList<Condition>(r_);
 		var t_ = context.Operators.Or(n_, s_);
-		var u_ = this.Frailty_Encounter(context);
+		var u_ = this.Frailty_Encounter();
 		var v_ = context.Operators.RetrieveByValueSet<Encounter>(u_, null);
 		bool? w_(Encounter FrailtyEncounter)
 		{
 			var ba_ = context.Operators.Convert<string>(FrailtyEncounter?.StatusElement);
 			var bb_ = context.Operators.Equal(ba_, "finished");
-			var bc_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (FrailtyEncounter?.Period as object));
-			var bd_ = this.Measurement_Period(context);
+			var bc_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((FrailtyEncounter?.Period as object));
+			var bd_ = this.Measurement_Period();
 			var be_ = context.Operators.Overlaps(bc_, bd_, null);
 			var bf_ = context.Operators.And(bb_, be_);
 
@@ -468,7 +611,7 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		var x_ = context.Operators.WhereOrNull<Encounter>(v_, w_);
 		var y_ = context.Operators.ExistsInList<Encounter>(x_);
 		var z_ = context.Operators.Or(t_, y_);
-		var aa_ = this.Frailty_Symptom(context);
+		var aa_ = this.Frailty_Symptom();
 		var ab_ = context.Operators.RetrieveByValueSet<Observation>(aa_, null);
 		bool? ac_(Observation FrailtySymptom)
 		{
@@ -481,8 +624,8 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 				"corrected",
 			};
 			var bi_ = context.Operators.InList<string>(bg_, (bh_ as IEnumerable<string>));
-			var bj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FrailtySymptom?.Effective);
-			var bk_ = this.Measurement_Period(context);
+			var bj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FrailtySymptom?.Effective);
+			var bk_ = this.Measurement_Period();
 			var bl_ = context.Operators.Overlaps(bj_, bk_, null);
 			var bm_ = context.Operators.And(bi_, bl_);
 
@@ -495,25 +638,28 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return af_;
 	}
 
-    [CqlDeclaration("Advanced Illness and Frailty Exclusion Including Over Age 80")]
-	public bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80(CqlContext context)
+    [CqlDeclaration("Has Criteria Indicating Frailty")]
+	public bool? Has_Criteria_Indicating_Frailty() => 
+		__Has_Criteria_Indicating_Frailty?.Value;
+
+	private bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.Interval((int?)65, (int?)79, true, true);
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
-		var i_ = this.Has_Criteria_Indicating_Frailty(context);
+		var i_ = this.Has_Criteria_Indicating_Frailty();
 		var j_ = context.Operators.And(h_, i_);
-		var k_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service(context);
+		var k_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
 		var l_ = context.Operators.ExistsInList<Encounter>(k_);
-		var m_ = this.Inpatient_Encounter_with_Advanced_Illness(context);
+		var m_ = this.Inpatient_Encounter_with_Advanced_Illness();
 		var n_ = context.Operators.ExistsInList<Encounter>(m_);
 		var o_ = context.Operators.Or(l_, n_);
-		var p_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period(context);
+		var p_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period();
 		var q_ = context.Operators.ExistsInList<MedicationRequest>(p_);
 		var r_ = context.Operators.Or(o_, q_);
 		var s_ = context.Operators.And(j_, r_);
@@ -528,24 +674,27 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return ac_;
 	}
 
-    [CqlDeclaration("Advanced Illness and Frailty Exclusion Not Including Over Age 80")]
-	public bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(CqlContext context)
+    [CqlDeclaration("Advanced Illness and Frailty Exclusion Including Over Age 80")]
+	public bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80() => 
+		__Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80?.Value;
+
+	private bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.GreaterOrEqual(f_, (int?)65);
-		var h_ = this.Has_Criteria_Indicating_Frailty(context);
+		var h_ = this.Has_Criteria_Indicating_Frailty();
 		var i_ = context.Operators.And(g_, h_);
-		var j_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service(context);
+		var j_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service();
 		var k_ = context.Operators.ExistsInList<Encounter>(j_);
-		var l_ = this.Inpatient_Encounter_with_Advanced_Illness(context);
+		var l_ = this.Inpatient_Encounter_with_Advanced_Illness();
 		var m_ = context.Operators.ExistsInList<Encounter>(l_);
 		var n_ = context.Operators.Or(k_, m_);
-		var o_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period(context);
+		var o_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period();
 		var p_ = context.Operators.ExistsInList<MedicationRequest>(o_);
 		var q_ = context.Operators.Or(n_, p_);
 		var r_ = context.Operators.And(i_, q_);
@@ -553,13 +702,20 @@ public class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000
 		return r_;
 	}
 
-    [CqlDeclaration("Has Long Term Care Periods Longer Than 90 Consecutive Days")]
-	public bool? Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(CqlContext context)
+    [CqlDeclaration("Advanced Illness and Frailty Exclusion Not Including Over Age 80")]
+	public bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80() => 
+		__Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80?.Value;
+
+	private bool? Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days_Value(CqlContext context)
 	{
-		var a_ = this.Max_Long_Term_Care_Period_Length(context);
+		var a_ = this.Max_Long_Term_Care_Period_Length();
 		var b_ = context.Operators.Greater(a_, (int?)90);
 
 		return b_;
 	}
+
+    [CqlDeclaration("Has Long Term Care Periods Longer Than 90 Consecutive Days")]
+	public bool? Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days() => 
+		__Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days?.Value;
 
 }

--- a/Demo/Measures/BCSEHEDISMY2022-1.0.0.cs
+++ b/Demo/Measures/BCSEHEDISMY2022-1.0.0.cs
@@ -14,93 +14,233 @@ using Task = Hl7.Fhir.Model.Task;
 public class BCSEHEDISMY2022_1_0_0
 {
 
-    public static BCSEHEDISMY2022_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Absence_of_Left_Breast;
+    internal Lazy<CqlValueSet> __Absence_of_Right_Breast;
+    internal Lazy<CqlValueSet> __Bilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __Bilateral_Modifier;
+    internal Lazy<CqlValueSet> __Clinical_Bilateral_Modifier;
+    internal Lazy<CqlValueSet> __Clinical_Left_Modifier;
+    internal Lazy<CqlValueSet> __Clinical_Right_Modifier;
+    internal Lazy<CqlValueSet> __Clinical_Unilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __History_of_Bilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __Left_Modifier;
+    internal Lazy<CqlValueSet> __Mammography;
+    internal Lazy<CqlValueSet> __Right_Modifier;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Left;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Right;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<CqlDateTime> __October_1_Two_Years_Prior_to_the_Measurement_Period;
+    internal Lazy<CqlInterval<CqlDateTime>> __Participation_Period;
+    internal Lazy<IEnumerable<Coverage>> __Member_Coverage;
+    internal Lazy<bool?> __Enrolled_During_Participation_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Right_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Right_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Left_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Left_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Bilateral_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Bilateral_Mastectomy_Procedure;
+    internal Lazy<bool?> __Mastectomy_Exclusion;
+    internal Lazy<bool?> __Exclusions;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public BCSEHEDISMY2022_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAHealthPlanEnrollment_1_0_0 = new NCQAHealthPlanEnrollment_1_0_0(context);
+        NCQAStatus_1_0_0 = new NCQAStatus_1_0_0(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQAHospice_1_0_0 = new NCQAHospice_1_0_0(context);
+        NCQAAdvancedIllnessandFrailty_1_0_0 = new NCQAAdvancedIllnessandFrailty_1_0_0(context);
+        NCQAPalliativeCare_1_0_0 = new NCQAPalliativeCare_1_0_0(context);
+
+        __Absence_of_Left_Breast = new Lazy<CqlValueSet>(this.Absence_of_Left_Breast_Value(context));
+        __Absence_of_Right_Breast = new Lazy<CqlValueSet>(this.Absence_of_Right_Breast_Value(context));
+        __Bilateral_Mastectomy = new Lazy<CqlValueSet>(this.Bilateral_Mastectomy_Value(context));
+        __Bilateral_Modifier = new Lazy<CqlValueSet>(this.Bilateral_Modifier_Value(context));
+        __Clinical_Bilateral_Modifier = new Lazy<CqlValueSet>(this.Clinical_Bilateral_Modifier_Value(context));
+        __Clinical_Left_Modifier = new Lazy<CqlValueSet>(this.Clinical_Left_Modifier_Value(context));
+        __Clinical_Right_Modifier = new Lazy<CqlValueSet>(this.Clinical_Right_Modifier_Value(context));
+        __Clinical_Unilateral_Mastectomy = new Lazy<CqlValueSet>(this.Clinical_Unilateral_Mastectomy_Value(context));
+        __History_of_Bilateral_Mastectomy = new Lazy<CqlValueSet>(this.History_of_Bilateral_Mastectomy_Value(context));
+        __Left_Modifier = new Lazy<CqlValueSet>(this.Left_Modifier_Value(context));
+        __Mammography = new Lazy<CqlValueSet>(this.Mammography_Value(context));
+        __Right_Modifier = new Lazy<CqlValueSet>(this.Right_Modifier_Value(context));
+        __Unilateral_Mastectomy = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Value(context));
+        __Unilateral_Mastectomy_Left = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Left_Value(context));
+        __Unilateral_Mastectomy_Right = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Right_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __October_1_Two_Years_Prior_to_the_Measurement_Period = new Lazy<CqlDateTime>(this.October_1_Two_Years_Prior_to_the_Measurement_Period_Value(context));
+        __Participation_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Participation_Period_Value(context));
+        __Member_Coverage = new Lazy<IEnumerable<Coverage>>(this.Member_Coverage_Value(context));
+        __Enrolled_During_Participation_Period = new Lazy<bool?>(this.Enrolled_During_Participation_Period_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Right_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Right_Mastectomy_Diagnosis_Value(context));
+        __Right_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Right_Mastectomy_Procedure_Value(context));
+        __Left_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Left_Mastectomy_Diagnosis_Value(context));
+        __Left_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Left_Mastectomy_Procedure_Value(context));
+        __Bilateral_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Bilateral_Mastectomy_Diagnosis_Value(context));
+        __Bilateral_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Bilateral_Mastectomy_Procedure_Value(context));
+        __Mastectomy_Exclusion = new Lazy<bool?>(this.Mastectomy_Exclusion_Value(context));
+        __Exclusions = new Lazy<bool?>(this.Exclusions_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAHealthPlanEnrollment_1_0_0 NCQAHealthPlanEnrollment_1_0_0 { get; }
+    public NCQAStatus_1_0_0 NCQAStatus_1_0_0 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQAHospice_1_0_0 NCQAHospice_1_0_0 { get; }
+    public NCQAAdvancedIllnessandFrailty_1_0_0 NCQAAdvancedIllnessandFrailty_1_0_0 { get; }
+    public NCQAPalliativeCare_1_0_0 NCQAPalliativeCare_1_0_0 { get; }
+
+    #endregion
+
+	private CqlValueSet Absence_of_Left_Breast_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", null);
 
     [CqlDeclaration("Absence of Left Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329")]
-	public CqlValueSet Absence_of_Left_Breast(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1329", null);
+	public CqlValueSet Absence_of_Left_Breast() => 
+		__Absence_of_Left_Breast?.Value;
+
+	private CqlValueSet Absence_of_Right_Breast_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", null);
 
     [CqlDeclaration("Absence of Right Breast")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330")]
-	public CqlValueSet Absence_of_Right_Breast(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1330", null);
+	public CqlValueSet Absence_of_Right_Breast() => 
+		__Absence_of_Right_Breast?.Value;
+
+	private CqlValueSet Bilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", null);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042")]
-	public CqlValueSet Bilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1042", null);
+	public CqlValueSet Bilateral_Mastectomy() => 
+		__Bilateral_Mastectomy?.Value;
+
+	private CqlValueSet Bilateral_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", null);
 
     [CqlDeclaration("Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043")]
-	public CqlValueSet Bilateral_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1043", null);
+	public CqlValueSet Bilateral_Modifier() => 
+		__Bilateral_Modifier?.Value;
+
+	private CqlValueSet Clinical_Bilateral_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", null);
 
     [CqlDeclaration("Clinical Bilateral Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951")]
-	public CqlValueSet Clinical_Bilateral_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1951", null);
+	public CqlValueSet Clinical_Bilateral_Modifier() => 
+		__Clinical_Bilateral_Modifier?.Value;
+
+	private CqlValueSet Clinical_Left_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", null);
 
     [CqlDeclaration("Clinical Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949")]
-	public CqlValueSet Clinical_Left_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1949", null);
+	public CqlValueSet Clinical_Left_Modifier() => 
+		__Clinical_Left_Modifier?.Value;
+
+	private CqlValueSet Clinical_Right_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", null);
 
     [CqlDeclaration("Clinical Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950")]
-	public CqlValueSet Clinical_Right_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1950", null);
+	public CqlValueSet Clinical_Right_Modifier() => 
+		__Clinical_Right_Modifier?.Value;
+
+	private CqlValueSet Clinical_Unilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", null);
 
     [CqlDeclaration("Clinical Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948")]
-	public CqlValueSet Clinical_Unilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1948", null);
+	public CqlValueSet Clinical_Unilateral_Mastectomy() => 
+		__Clinical_Unilateral_Mastectomy?.Value;
+
+	private CqlValueSet History_of_Bilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", null);
 
     [CqlDeclaration("History of Bilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331")]
-	public CqlValueSet History_of_Bilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1331", null);
+	public CqlValueSet History_of_Bilateral_Mastectomy() => 
+		__History_of_Bilateral_Mastectomy?.Value;
+
+	private CqlValueSet Left_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", null);
 
     [CqlDeclaration("Left Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148")]
-	public CqlValueSet Left_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1148", null);
+	public CqlValueSet Left_Modifier() => 
+		__Left_Modifier?.Value;
+
+	private CqlValueSet Mammography_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", null);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168")]
-	public CqlValueSet Mammography(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1168", null);
+	public CqlValueSet Mammography() => 
+		__Mammography?.Value;
+
+	private CqlValueSet Right_Modifier_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", null);
 
     [CqlDeclaration("Right Modifier")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230")]
-	public CqlValueSet Right_Modifier(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1230", null);
+	public CqlValueSet Right_Modifier() => 
+		__Right_Modifier?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", null);
 
     [CqlDeclaration("Unilateral Mastectomy")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256")]
-	public CqlValueSet Unilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1256", null);
+	public CqlValueSet Unilateral_Mastectomy() => 
+		__Unilateral_Mastectomy?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Left_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", null);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334")]
-	public CqlValueSet Unilateral_Mastectomy_Left(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1334", null);
+	public CqlValueSet Unilateral_Mastectomy_Left() => 
+		__Unilateral_Mastectomy_Left?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Right_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", null);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335")]
-	public CqlValueSet Unilateral_Mastectomy_Right(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1335", null);
+	public CqlValueSet Unilateral_Mastectomy_Right() => 
+		__Unilateral_Mastectomy_Right?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("BCSEHEDISMY2022-1.0.0", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -108,10 +248,13 @@ public class BCSEHEDISMY2022_1_0_0
 		return b_;
 	}
 
-    [CqlDeclaration("October 1 Two Years Prior to the Measurement Period")]
-	public CqlDateTime October_1_Two_Years_Prior_to_the_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private CqlDateTime October_1_Two_Years_Prior_to_the_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Measurement_Period(context);
+		var a_ = this.Measurement_Period();
 		var b_ = context.Operators.Start(a_);
 		var c_ = context.Operators.ComponentFrom(b_, "year");
 		var d_ = context.Operators.Subtract(c_, (int?)2);
@@ -121,25 +264,31 @@ public class BCSEHEDISMY2022_1_0_0
 		return f_;
 	}
 
-    [CqlDeclaration("Participation Period")]
-	public CqlInterval<CqlDateTime> Participation_Period(CqlContext context)
+    [CqlDeclaration("October 1 Two Years Prior to the Measurement Period")]
+	public CqlDateTime October_1_Two_Years_Prior_to_the_Measurement_Period() => 
+		__October_1_Two_Years_Prior_to_the_Measurement_Period?.Value;
+
+	private CqlInterval<CqlDateTime> Participation_Period_Value(CqlContext context)
 	{
-		var a_ = this.October_1_Two_Years_Prior_to_the_Measurement_Period(context);
-		var b_ = this.Measurement_Period(context);
+		var a_ = this.October_1_Two_Years_Prior_to_the_Measurement_Period();
+		var b_ = this.Measurement_Period();
 		var c_ = context.Operators.End(b_);
 		var d_ = context.Operators.Interval(a_, c_, true, true);
 
 		return d_;
 	}
 
-    [CqlDeclaration("Member Coverage")]
-	public IEnumerable<Coverage> Member_Coverage(CqlContext context)
+    [CqlDeclaration("Participation Period")]
+	public CqlInterval<CqlDateTime> Participation_Period() => 
+		__Participation_Period?.Value;
+
+	private IEnumerable<Coverage> Member_Coverage_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Coverage>(null, null);
 		bool? b_(Coverage C)
 		{
-			var d_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (C?.Period as object));
-			var e_ = this.Participation_Period(context);
+			var d_ = NCQAFHIRBase_1_0_0.Normalize_Interval((C?.Period as object));
+			var e_ = this.Participation_Period();
 			var f_ = context.Operators.Overlaps(d_, e_, null);
 
 			return f_;
@@ -149,21 +298,24 @@ public class BCSEHEDISMY2022_1_0_0
 		return c_;
 	}
 
-    [CqlDeclaration("Enrolled During Participation Period")]
-	public bool? Enrolled_During_Participation_Period(CqlContext context)
+    [CqlDeclaration("Member Coverage")]
+	public IEnumerable<Coverage> Member_Coverage() => 
+		__Member_Coverage?.Value;
+
+	private bool? Enrolled_During_Participation_Period_Value(CqlContext context)
 	{
-		var a_ = this.Member_Coverage(context);
-		var b_ = this.Measurement_Period(context);
+		var a_ = this.Member_Coverage();
+		var b_ = this.Measurement_Period();
 		var c_ = context.Operators.End(b_);
 		var d_ = context.Operators.DateFrom(c_);
-		var e_ = this.October_1_Two_Years_Prior_to_the_Measurement_Period(context);
+		var e_ = this.October_1_Two_Years_Prior_to_the_Measurement_Period();
 		var f_ = context.Operators.DateFrom(e_);
 		var h_ = context.Operators.End(b_);
 		var i_ = context.Operators.DateFrom(h_);
 		var j_ = context.Operators.Quantity(2m, "years");
 		var k_ = context.Operators.Subtract(i_, j_);
 		var l_ = context.Operators.Interval(f_, k_, true, true);
-		var m_ = NCQAHealthPlanEnrollment_1_0_0.Instance.Health_Plan_Enrollment_Criteria(context, a_, d_, l_, (int?)0);
+		var m_ = NCQAHealthPlanEnrollment_1_0_0.Health_Plan_Enrollment_Criteria(a_, d_, l_, (int?)0);
 		var p_ = context.Operators.End(b_);
 		var q_ = context.Operators.DateFrom(p_);
 		var s_ = context.Operators.Start(b_);
@@ -174,7 +326,7 @@ public class BCSEHEDISMY2022_1_0_0
 		var y_ = context.Operators.DateFrom(x_);
 		var aa_ = context.Operators.Subtract(y_, u_);
 		var ab_ = context.Operators.Interval(v_, aa_, true, true);
-		var ac_ = NCQAHealthPlanEnrollment_1_0_0.Instance.Health_Plan_Enrollment_Criteria(context, a_, q_, ab_, (int?)45);
+		var ac_ = NCQAHealthPlanEnrollment_1_0_0.Health_Plan_Enrollment_Criteria(a_, q_, ab_, (int?)45);
 		var ad_ = context.Operators.And(m_, ac_);
 		var ag_ = context.Operators.End(b_);
 		var ah_ = context.Operators.DateFrom(ag_);
@@ -183,18 +335,21 @@ public class BCSEHEDISMY2022_1_0_0
 		var am_ = context.Operators.End(b_);
 		var an_ = context.Operators.DateFrom(am_);
 		var ao_ = context.Operators.Interval(ak_, an_, true, true);
-		var ap_ = NCQAHealthPlanEnrollment_1_0_0.Instance.Health_Plan_Enrollment_Criteria(context, a_, ah_, ao_, (int?)45);
+		var ap_ = NCQAHealthPlanEnrollment_1_0_0.Health_Plan_Enrollment_Criteria(a_, ah_, ao_, (int?)45);
 		var aq_ = context.Operators.And(ad_, ap_);
 
 		return aq_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Enrolled During Participation Period")]
+	public bool? Enrolled_During_Participation_Period() => 
+		__Enrolled_During_Participation_Period?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.End(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -202,31 +357,37 @@ public class BCSEHEDISMY2022_1_0_0
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
 		var j_ = context.Operators.EnumEqualsString(a_?.GenderElement?.Value, "female");
 		var k_ = context.Operators.And(h_, j_);
-		var l_ = this.Enrolled_During_Participation_Period(context);
+		var l_ = this.Enrolled_During_Participation_Period();
 		var m_ = context.Operators.And(k_, l_);
 
 		return m_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Right_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Absence_of_Right_Breast(context);
+		var a_ = this.Absence_of_Right_Breast();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Active_Condition(context, b_);
+		var c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition RightMastectomyDiagnosis)
 		{
-			var f_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, RightMastectomyDiagnosis);
+			var f_ = NCQAFHIRBase_1_0_0.Prevalence_Period(RightMastectomyDiagnosis);
 			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period(context);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.SameOrBefore(g_, i_, null);
 
@@ -237,44 +398,47 @@ public class BCSEHEDISMY2022_1_0_0
 		return e_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Procedure")]
-	public IEnumerable<Procedure> Right_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Right_Mastectomy_Diagnosis() => 
+		__Right_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Right(context);
+		var a_ = this.Unilateral_Mastectomy_Right();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, b_);
-		var d_ = this.Unilateral_Mastectomy(context);
+		var c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
+		var d_ = this.Unilateral_Mastectomy();
 		var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
-		var f_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, e_);
+		var f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
 			CqlConcept r_(CodeableConcept X)
 			{
-				var v_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var v_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return v_;
 			};
 			var s_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), r_);
-			var t_ = this.Right_Modifier(context);
+			var t_ = this.Right_Modifier();
 			var u_ = context.Operators.ConceptsInValueSet(s_, t_);
 
 			return u_;
 		};
 		var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
 		var i_ = context.Operators.ListUnion<Procedure>(c_, h_);
-		var j_ = this.Clinical_Unilateral_Mastectomy(context);
+		var j_ = this.Clinical_Unilateral_Mastectomy();
 		var k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
-		var l_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, k_);
+		var l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
 			CqlConcept w_(CodeableConcept X)
 			{
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var aa_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return aa_;
 			};
 			var x_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((ClinicalUnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), w_);
-			var y_ = this.Clinical_Right_Modifier(context);
+			var y_ = this.Clinical_Right_Modifier();
 			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
 
 			return z_;
@@ -283,9 +447,9 @@ public class BCSEHEDISMY2022_1_0_0
 		var o_ = context.Operators.ListUnion<Procedure>(i_, n_);
 		bool? p_(Procedure RightMastectomyProcedure)
 		{
-			var ab_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, RightMastectomyProcedure?.Performed);
+			var ab_ = NCQAFHIRBase_1_0_0.Normalize_Interval(RightMastectomyProcedure?.Performed);
 			var ac_ = context.Operators.End(ab_);
-			var ad_ = this.Measurement_Period(context);
+			var ad_ = this.Measurement_Period();
 			var ae_ = context.Operators.End(ad_);
 			var af_ = context.Operators.SameOrBefore(ac_, ae_, null);
 
@@ -296,17 +460,20 @@ public class BCSEHEDISMY2022_1_0_0
 		return q_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Left_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Procedure")]
+	public IEnumerable<Procedure> Right_Mastectomy_Procedure() => 
+		__Right_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Absence_of_Left_Breast(context);
+		var a_ = this.Absence_of_Left_Breast();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Active_Condition(context, b_);
+		var c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition LeftMastectomyDiagnosis)
 		{
-			var f_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, LeftMastectomyDiagnosis);
+			var f_ = NCQAFHIRBase_1_0_0.Prevalence_Period(LeftMastectomyDiagnosis);
 			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period(context);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.SameOrBefore(g_, i_, null);
 
@@ -317,44 +484,47 @@ public class BCSEHEDISMY2022_1_0_0
 		return e_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Procedure")]
-	public IEnumerable<Procedure> Left_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Left_Mastectomy_Diagnosis() => 
+		__Left_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Left(context);
+		var a_ = this.Unilateral_Mastectomy_Left();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, b_);
-		var d_ = this.Unilateral_Mastectomy(context);
+		var c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
+		var d_ = this.Unilateral_Mastectomy();
 		var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
-		var f_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, e_);
+		var f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
 			CqlConcept r_(CodeableConcept X)
 			{
-				var v_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var v_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return v_;
 			};
 			var s_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), r_);
-			var t_ = this.Left_Modifier(context);
+			var t_ = this.Left_Modifier();
 			var u_ = context.Operators.ConceptsInValueSet(s_, t_);
 
 			return u_;
 		};
 		var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
 		var i_ = context.Operators.ListUnion<Procedure>(c_, h_);
-		var j_ = this.Clinical_Unilateral_Mastectomy(context);
+		var j_ = this.Clinical_Unilateral_Mastectomy();
 		var k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
-		var l_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, k_);
+		var l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
 			CqlConcept w_(CodeableConcept X)
 			{
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var aa_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return aa_;
 			};
 			var x_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((ClinicalUnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), w_);
-			var y_ = this.Clinical_Left_Modifier(context);
+			var y_ = this.Clinical_Left_Modifier();
 			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
 
 			return z_;
@@ -363,9 +533,9 @@ public class BCSEHEDISMY2022_1_0_0
 		var o_ = context.Operators.ListUnion<Procedure>(i_, n_);
 		bool? p_(Procedure LeftMastectomyProcedure)
 		{
-			var ab_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, LeftMastectomyProcedure?.Performed);
+			var ab_ = NCQAFHIRBase_1_0_0.Normalize_Interval(LeftMastectomyProcedure?.Performed);
 			var ac_ = context.Operators.End(ab_);
-			var ad_ = this.Measurement_Period(context);
+			var ad_ = this.Measurement_Period();
 			var ae_ = context.Operators.End(ad_);
 			var af_ = context.Operators.SameOrBefore(ac_, ae_, null);
 
@@ -376,17 +546,20 @@ public class BCSEHEDISMY2022_1_0_0
 		return q_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Procedure")]
+	public IEnumerable<Procedure> Left_Mastectomy_Procedure() => 
+		__Left_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.History_of_Bilateral_Mastectomy(context);
+		var a_ = this.History_of_Bilateral_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Active_Condition(context, b_);
+		var c_ = NCQAStatus_1_0_0.Active_Condition(b_);
 		bool? d_(Condition BilateralMastectomyHistory)
 		{
-			var f_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, BilateralMastectomyHistory);
+			var f_ = NCQAFHIRBase_1_0_0.Prevalence_Period(BilateralMastectomyHistory);
 			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period(context);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.SameOrBefore(g_, i_, null);
 
@@ -397,44 +570,47 @@ public class BCSEHEDISMY2022_1_0_0
 		return e_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Procedure")]
-	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis() => 
+		__Bilateral_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Bilateral_Mastectomy(context);
+		var a_ = this.Bilateral_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, b_);
-		var d_ = this.Unilateral_Mastectomy(context);
+		var c_ = NCQAStatus_1_0_0.Completed_Procedure(b_);
+		var d_ = this.Unilateral_Mastectomy();
 		var e_ = context.Operators.RetrieveByValueSet<Procedure>(d_, null);
-		var f_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, e_);
+		var f_ = NCQAStatus_1_0_0.Completed_Procedure(e_);
 		bool? g_(Procedure UnilateralMastectomyProcedure)
 		{
 			CqlConcept r_(CodeableConcept X)
 			{
-				var v_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var v_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return v_;
 			};
 			var s_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), r_);
-			var t_ = this.Bilateral_Modifier(context);
+			var t_ = this.Bilateral_Modifier();
 			var u_ = context.Operators.ConceptsInValueSet(s_, t_);
 
 			return u_;
 		};
 		var h_ = context.Operators.WhereOrNull<Procedure>(f_, g_);
 		var i_ = context.Operators.ListUnion<Procedure>(c_, h_);
-		var j_ = this.Clinical_Unilateral_Mastectomy(context);
+		var j_ = this.Clinical_Unilateral_Mastectomy();
 		var k_ = context.Operators.RetrieveByValueSet<Procedure>(j_, null);
-		var l_ = NCQAStatus_1_0_0.Instance.Completed_Procedure(context, k_);
+		var l_ = NCQAStatus_1_0_0.Completed_Procedure(k_);
 		bool? m_(Procedure ClinicalUnilateralMastectomyProcedure)
 		{
 			CqlConcept w_(CodeableConcept X)
 			{
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var aa_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return aa_;
 			};
 			var x_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((ClinicalUnilateralMastectomyProcedure?.BodySite as IEnumerable<CodeableConcept>), w_);
-			var y_ = this.Clinical_Bilateral_Modifier(context);
+			var y_ = this.Clinical_Bilateral_Modifier();
 			var z_ = context.Operators.ConceptsInValueSet(x_, y_);
 
 			return z_;
@@ -443,9 +619,9 @@ public class BCSEHEDISMY2022_1_0_0
 		var o_ = context.Operators.ListUnion<Procedure>(i_, n_);
 		bool? p_(Procedure BilateralMastectomyPerformed)
 		{
-			var ab_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, BilateralMastectomyPerformed?.Performed);
+			var ab_ = NCQAFHIRBase_1_0_0.Normalize_Interval(BilateralMastectomyPerformed?.Performed);
 			var ac_ = context.Operators.End(ab_);
-			var ad_ = this.Measurement_Period(context);
+			var ad_ = this.Measurement_Period();
 			var ae_ = context.Operators.End(ad_);
 			var af_ = context.Operators.SameOrBefore(ac_, ae_, null);
 
@@ -456,55 +632,64 @@ public class BCSEHEDISMY2022_1_0_0
 		return q_;
 	}
 
-    [CqlDeclaration("Mastectomy Exclusion")]
-	public bool? Mastectomy_Exclusion(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Procedure")]
+	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure() => 
+		__Bilateral_Mastectomy_Procedure?.Value;
+
+	private bool? Mastectomy_Exclusion_Value(CqlContext context)
 	{
-		var a_ = this.Right_Mastectomy_Diagnosis(context);
+		var a_ = this.Right_Mastectomy_Diagnosis();
 		var b_ = context.Operators.ExistsInList<Condition>(a_);
-		var c_ = this.Right_Mastectomy_Procedure(context);
+		var c_ = this.Right_Mastectomy_Procedure();
 		var d_ = context.Operators.ExistsInList<Procedure>(c_);
 		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Left_Mastectomy_Diagnosis(context);
+		var f_ = this.Left_Mastectomy_Diagnosis();
 		var g_ = context.Operators.ExistsInList<Condition>(f_);
-		var h_ = this.Left_Mastectomy_Procedure(context);
+		var h_ = this.Left_Mastectomy_Procedure();
 		var i_ = context.Operators.ExistsInList<Procedure>(h_);
 		var j_ = context.Operators.Or(g_, i_);
 		var k_ = context.Operators.And(e_, j_);
-		var l_ = this.Bilateral_Mastectomy_Diagnosis(context);
+		var l_ = this.Bilateral_Mastectomy_Diagnosis();
 		var m_ = context.Operators.ExistsInList<Condition>(l_);
 		var n_ = context.Operators.Or(k_, m_);
-		var o_ = this.Bilateral_Mastectomy_Procedure(context);
+		var o_ = this.Bilateral_Mastectomy_Procedure();
 		var p_ = context.Operators.ExistsInList<Procedure>(o_);
 		var q_ = context.Operators.Or(n_, p_);
 
 		return q_;
 	}
 
-    [CqlDeclaration("Exclusions")]
-	public bool? Exclusions(CqlContext context)
+    [CqlDeclaration("Mastectomy Exclusion")]
+	public bool? Mastectomy_Exclusion() => 
+		__Mastectomy_Exclusion?.Value;
+
+	private bool? Exclusions_Value(CqlContext context)
 	{
-		var a_ = NCQAHospice_1_0_0.Instance.Hospice_Intervention_or_Encounter(context);
-		var b_ = this.Mastectomy_Exclusion(context);
+		var a_ = NCQAHospice_1_0_0.Hospice_Intervention_or_Encounter();
+		var b_ = this.Mastectomy_Exclusion();
 		var c_ = context.Operators.Or(a_, b_);
-		var d_ = NCQAAdvancedIllnessandFrailty_1_0_0.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var d_ = NCQAAdvancedIllnessandFrailty_1_0_0.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Measurement_Period(context);
-		var g_ = NCQAPalliativeCare_1_0_0.Instance.Palliative_Care_Overlapping_Period(context, f_);
+		var f_ = this.Measurement_Period();
+		var g_ = NCQAPalliativeCare_1_0_0.Palliative_Care_Overlapping_Period(f_);
 		var h_ = context.Operators.Or(e_, g_);
 
 		return h_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Exclusions")]
+	public bool? Exclusions() => 
+		__Exclusions?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Mammogram)
 		{
-			var f_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var f_ = NCQAFHIRBase_1_0_0.Normalize_Interval(Mammogram?.Effective);
 			var g_ = context.Operators.End(f_);
-			var h_ = this.Participation_Period(context);
+			var h_ = this.Participation_Period();
 			var i_ = context.Operators.ElementInInterval<CqlDateTime>(g_, h_, null);
 
 			return i_;
@@ -514,5 +699,9 @@ public class BCSEHEDISMY2022_1_0_0
 
 		return e_;
 	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
 
 }

--- a/Demo/Measures/BreastCancerScreeningsFHIR-0.0.009.cs
+++ b/Demo/Measures/BreastCancerScreeningsFHIR-0.0.009.cs
@@ -14,70 +14,206 @@ using Task = Hl7.Fhir.Model.Task;
 public class BreastCancerScreeningsFHIR_0_0_009
 {
 
-    public static BreastCancerScreeningsFHIR_0_0_009 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Bilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __History_of_bilateral_mastectomy;
+    internal Lazy<CqlValueSet> __Left;
+    internal Lazy<CqlValueSet> __Mammography;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Right;
+    internal Lazy<CqlValueSet> __Status_Post_Left_Mastectomy;
+    internal Lazy<CqlValueSet> __Status_Post_Right_Mastectomy;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Left;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Right;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy__Unspecified_Laterality;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Telehealth_Services;
+    internal Lazy<int?> __Age_at_start_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Right_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Right_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Left_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Left_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Bilateral_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Bilateral_Mastectomy_Procedure;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Observation_with_status;
+    internal Lazy<bool?> __Diagnostic_Report_with_status;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Final_Numerator_Population;
+    internal Lazy<bool?> __Observation_without_appropriate_status;
+    internal Lazy<bool?> __Diagnostic_Report_without_appropriate_status;
+
+    #endregion
+    public BreastCancerScreeningsFHIR_0_0_009(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        AdultOutpatientEncountersFHIR4_2_2_000 = new AdultOutpatientEncountersFHIR4_2_2_000(context);
+        AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 = new AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+
+        __Bilateral_Mastectomy = new Lazy<CqlValueSet>(this.Bilateral_Mastectomy_Value(context));
+        __History_of_bilateral_mastectomy = new Lazy<CqlValueSet>(this.History_of_bilateral_mastectomy_Value(context));
+        __Left = new Lazy<CqlValueSet>(this.Left_Value(context));
+        __Mammography = new Lazy<CqlValueSet>(this.Mammography_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Right = new Lazy<CqlValueSet>(this.Right_Value(context));
+        __Status_Post_Left_Mastectomy = new Lazy<CqlValueSet>(this.Status_Post_Left_Mastectomy_Value(context));
+        __Status_Post_Right_Mastectomy = new Lazy<CqlValueSet>(this.Status_Post_Right_Mastectomy_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Unilateral_Mastectomy_Left = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Left_Value(context));
+        __Unilateral_Mastectomy_Right = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Right_Value(context));
+        __Unilateral_Mastectomy__Unspecified_Laterality = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy__Unspecified_Laterality_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Telehealth_Services = new Lazy<IEnumerable<Encounter>>(this.Telehealth_Services_Value(context));
+        __Age_at_start_of_Measurement_Period = new Lazy<int?>(this.Age_at_start_of_Measurement_Period_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Right_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Right_Mastectomy_Diagnosis_Value(context));
+        __Right_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Right_Mastectomy_Procedure_Value(context));
+        __Left_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Left_Mastectomy_Diagnosis_Value(context));
+        __Left_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Left_Mastectomy_Procedure_Value(context));
+        __Bilateral_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Bilateral_Mastectomy_Diagnosis_Value(context));
+        __Bilateral_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Bilateral_Mastectomy_Procedure_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Observation_with_status = new Lazy<bool?>(this.Observation_with_status_Value(context));
+        __Diagnostic_Report_with_status = new Lazy<bool?>(this.Diagnostic_Report_with_status_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Final_Numerator_Population = new Lazy<bool?>(this.Final_Numerator_Population_Value(context));
+        __Observation_without_appropriate_status = new Lazy<bool?>(this.Observation_without_appropriate_status_Value(context));
+        __Diagnostic_Report_without_appropriate_status = new Lazy<bool?>(this.Diagnostic_Report_without_appropriate_status_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public AdultOutpatientEncountersFHIR4_2_2_000 AdultOutpatientEncountersFHIR4_2_2_000 { get; }
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Bilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
-	public CqlValueSet Bilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
+	public CqlValueSet Bilateral_Mastectomy() => 
+		__Bilateral_Mastectomy?.Value;
+
+	private CqlValueSet History_of_bilateral_mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
-	public CqlValueSet History_of_bilateral_mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
+	public CqlValueSet History_of_bilateral_mastectomy() => 
+		__History_of_bilateral_mastectomy?.Value;
+
+	private CqlValueSet Left_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
-	public CqlValueSet Left(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
+	public CqlValueSet Left() => 
+		__Left?.Value;
+
+	private CqlValueSet Mammography_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
-	public CqlValueSet Mammography(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
+	public CqlValueSet Mammography() => 
+		__Mammography?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Right_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
-	public CqlValueSet Right(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
+	public CqlValueSet Right() => 
+		__Right?.Value;
+
+	private CqlValueSet Status_Post_Left_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
-	public CqlValueSet Status_Post_Left_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
+	public CqlValueSet Status_Post_Left_Mastectomy() => 
+		__Status_Post_Left_Mastectomy?.Value;
+
+	private CqlValueSet Status_Post_Right_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
-	public CqlValueSet Status_Post_Right_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
+	public CqlValueSet Status_Post_Right_Mastectomy() => 
+		__Status_Post_Right_Mastectomy?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Left_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
-	public CqlValueSet Unilateral_Mastectomy_Left(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
+	public CqlValueSet Unilateral_Mastectomy_Left() => 
+		__Unilateral_Mastectomy_Left?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Right_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
-	public CqlValueSet Unilateral_Mastectomy_Right(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
+	public CqlValueSet Unilateral_Mastectomy_Right() => 
+		__Unilateral_Mastectomy_Right?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
-	public CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
+	public CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality() => 
+		__Unilateral_Mastectomy__Unspecified_Laterality?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2021, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -88,8 +224,11 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -97,52 +236,67 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Telehealth Services")]
-	public IEnumerable<Encounter> Telehealth_Services(CqlContext context)
+	private IEnumerable<Encounter> Telehealth_Services_Value(CqlContext context)
 	{
-		var a_ = this.Online_Assessments(context);
+		var a_ = this.Online_Assessments();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Telephone_Visits(context);
+		var c_ = this.Telephone_Visits();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
 			var h_ = context.Operators.Convert<string>(TelehealthEncounter?.StatusElement);
 			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = this.Measurement_Period(context);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (TelehealthEncounter?.Period as object));
+			var j_ = this.Measurement_Period();
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((TelehealthEncounter?.Period as object));
 			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, k_, null);
 			var m_ = context.Operators.And(i_, l_);
 
@@ -153,12 +307,15 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return g_;
 	}
 
-    [CqlDeclaration("Age at start of Measurement Period")]
-	public int? Age_at_start_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Telehealth Services")]
+	public IEnumerable<Encounter> Telehealth_Services() => 
+		__Telehealth_Services?.Value;
+
+	private int? Age_at_start_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -166,12 +323,15 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return f_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Age at start of Measurement Period")]
+	public int? Age_at_start_of_Measurement_Period() => 
+		__Age_at_start_of_Measurement_Period?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -180,8 +340,8 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		var j_ = context.Operators.Convert<string>(a_?.GenderElement);
 		var k_ = context.Operators.Equal(j_, "female");
 		var l_ = context.Operators.And(h_, k_);
-		var m_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
-		var n_ = this.Telehealth_Services(context);
+		var m_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
+		var n_ = this.Telehealth_Services();
 		var o_ = context.Operators.ListUnion<Encounter>(m_, n_);
 		var p_ = context.Operators.ExistsInList<Encounter>(o_);
 		var q_ = context.Operators.And(l_, p_);
@@ -189,31 +349,37 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return q_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Right_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Status_Post_Right_Mastectomy(context);
+		var a_ = this.Status_Post_Right_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality(context);
+		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			CqlConcept j_(CodeableConcept X)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var n_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return n_;
 			};
 			var k_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyDiagnosis?.BodySite as IEnumerable<CodeableConcept>), j_);
-			var l_ = this.Right(context);
+			var l_ = this.Right();
 			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
 
 			return m_;
@@ -222,9 +388,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		var g_ = context.Operators.ListUnion<Condition>(b_, f_);
 		bool? h_(Condition RightMastectomy)
 		{
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, RightMastectomy);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(RightMastectomy);
 			var p_ = context.Operators.Start(o_);
-			var q_ = this.Measurement_Period(context);
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.End(q_);
 			var s_ = context.Operators.SameOrBefore(p_, r_, null);
 
@@ -235,18 +401,21 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return i_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Procedure")]
-	public IEnumerable<Procedure> Right_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Right_Mastectomy_Diagnosis() => 
+		__Right_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Right(context);
+		var a_ = this.Unilateral_Mastectomy_Right();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(UnilateralMastectomyRightPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, UnilateralMastectomyRightPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(UnilateralMastectomyRightPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -258,23 +427,26 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Left_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Procedure")]
+	public IEnumerable<Procedure> Right_Mastectomy_Procedure() => 
+		__Right_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Status_Post_Left_Mastectomy(context);
+		var a_ = this.Status_Post_Left_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality(context);
+		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			CqlConcept j_(CodeableConcept X)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var n_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return n_;
 			};
 			var k_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyDiagnosis?.BodySite as IEnumerable<CodeableConcept>), j_);
-			var l_ = this.Left(context);
+			var l_ = this.Left();
 			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
 
 			return m_;
@@ -283,9 +455,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		var g_ = context.Operators.ListUnion<Condition>(b_, f_);
 		bool? h_(Condition LeftMastectomy)
 		{
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, LeftMastectomy);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(LeftMastectomy);
 			var p_ = context.Operators.Start(o_);
-			var q_ = this.Measurement_Period(context);
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.End(q_);
 			var s_ = context.Operators.SameOrBefore(p_, r_, null);
 
@@ -296,18 +468,21 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return i_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Procedure")]
-	public IEnumerable<Procedure> Left_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Left_Mastectomy_Diagnosis() => 
+		__Left_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Left(context);
+		var a_ = this.Unilateral_Mastectomy_Left();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(UnilateralMastectomyLeftPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, UnilateralMastectomyLeftPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(UnilateralMastectomyLeftPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -319,16 +494,19 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Procedure")]
+	public IEnumerable<Procedure> Left_Mastectomy_Procedure() => 
+		__Left_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.History_of_bilateral_mastectomy(context);
+		var a_ = this.History_of_bilateral_mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, BilateralMastectomyHistory);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -339,18 +517,21 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Procedure")]
-	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis() => 
+		__Bilateral_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Bilateral_Mastectomy(context);
+		var a_ = this.Bilateral_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(BilateralMastectomyPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BilateralMastectomyPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BilateralMastectomyPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -362,50 +543,56 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Procedure")]
+	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure() => 
+		__Bilateral_Mastectomy_Procedure?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = this.Right_Mastectomy_Diagnosis(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = this.Right_Mastectomy_Diagnosis();
 		var c_ = context.Operators.ExistsInList<Condition>(b_);
-		var d_ = this.Right_Mastectomy_Procedure(context);
+		var d_ = this.Right_Mastectomy_Procedure();
 		var e_ = context.Operators.ExistsInList<Procedure>(d_);
 		var f_ = context.Operators.Or(c_, e_);
-		var g_ = this.Left_Mastectomy_Diagnosis(context);
+		var g_ = this.Left_Mastectomy_Diagnosis();
 		var h_ = context.Operators.ExistsInList<Condition>(g_);
-		var i_ = this.Left_Mastectomy_Procedure(context);
+		var i_ = this.Left_Mastectomy_Procedure();
 		var j_ = context.Operators.ExistsInList<Procedure>(i_);
 		var k_ = context.Operators.Or(h_, j_);
 		var l_ = context.Operators.And(f_, k_);
 		var m_ = context.Operators.Or(a_, l_);
-		var n_ = this.Bilateral_Mastectomy_Diagnosis(context);
+		var n_ = this.Bilateral_Mastectomy_Diagnosis();
 		var o_ = context.Operators.ExistsInList<Condition>(n_);
 		var p_ = context.Operators.Or(m_, o_);
-		var q_ = this.Bilateral_Mastectomy_Procedure(context);
+		var q_ = this.Bilateral_Mastectomy_Procedure();
 		var r_ = context.Operators.ExistsInList<Procedure>(q_);
 		var s_ = context.Operators.Or(p_, r_);
-		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var u_ = context.Operators.Or(s_, t_);
-		var v_ = this.Patient(context);
+		var v_ = this.Patient();
 		var w_ = context.Operators.Convert<CqlDate>(v_?.BirthDateElement?.Value);
-		var x_ = this.Measurement_Period(context);
+		var x_ = this.Measurement_Period();
 		var y_ = context.Operators.Start(x_);
 		var z_ = context.Operators.DateFrom(y_);
 		var aa_ = context.Operators.CalculateAgeAt(w_, z_, "year");
 		var ab_ = context.Operators.GreaterOrEqual(aa_, (int?)65);
-		var ac_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(context);
+		var ac_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		var ad_ = context.Operators.And(ab_, ac_);
 		var ae_ = context.Operators.Or(u_, ad_);
-		var af_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var af_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var ag_ = context.Operators.Or(ae_, af_);
 
 		return ag_;
 	}
 
-    [CqlDeclaration("Observation with status")]
-	public bool? Observation_with_status(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private bool? Observation_with_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Mammogram)
 		{
@@ -418,9 +605,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 				"appended",
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(27m, "months");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -440,10 +627,13 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Diagnostic Report with status")]
-	public bool? Diagnostic_Report_with_status(CqlContext context)
+    [CqlDeclaration("Observation with status")]
+	public bool? Observation_with_status() => 
+		__Observation_with_status?.Value;
+
+	private bool? Diagnostic_Report_with_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
 		bool? c_(DiagnosticReport Mammogram)
 		{
@@ -456,9 +646,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 				"appended",
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(27m, "months");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -478,35 +668,44 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Diagnostic Report with status")]
+	public bool? Diagnostic_Report_with_status() => 
+		__Diagnostic_Report_with_status?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Observation_with_status(context);
-		var b_ = this.Diagnostic_Report_with_status(context);
+		var a_ = this.Observation_with_status();
+		var b_ = this.Diagnostic_Report_with_status();
 		var c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
-    [CqlDeclaration("Final Numerator Population")]
-	public bool? Final_Numerator_Population(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
+	private bool? Final_Numerator_Population_Value(CqlContext context)
 	{
-		var a_ = this.Numerator(context);
-		var b_ = this.Initial_Population(context);
+		var a_ = this.Numerator();
+		var b_ = this.Initial_Population();
 		var c_ = context.Operators.And(a_, b_);
-		var d_ = this.Denominator(context);
+		var d_ = this.Denominator();
 		var e_ = context.Operators.And(c_, d_);
-		var f_ = this.Denominator_Exclusions(context);
+		var f_ = this.Denominator_Exclusions();
 		var g_ = context.Operators.Not(f_);
 		var h_ = context.Operators.And(e_, g_);
 
 		return h_;
 	}
 
-    [CqlDeclaration("Observation without appropriate status")]
-	public bool? Observation_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Final Numerator Population")]
+	public bool? Final_Numerator_Population() => 
+		__Final_Numerator_Population?.Value;
+
+	private bool? Observation_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Mammogram)
 		{
@@ -520,9 +719,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
 			var i_ = context.Operators.Not(h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period(context);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(27m, "months");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -542,10 +741,13 @@ public class BreastCancerScreeningsFHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Diagnostic Report without appropriate status")]
-	public bool? Diagnostic_Report_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Observation without appropriate status")]
+	public bool? Observation_without_appropriate_status() => 
+		__Observation_without_appropriate_status?.Value;
+
+	private bool? Diagnostic_Report_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
 		bool? c_(DiagnosticReport Mammogram)
 		{
@@ -559,9 +761,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
 			var i_ = context.Operators.Not(h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period(context);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(27m, "months");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -580,5 +782,9 @@ public class BreastCancerScreeningsFHIR_0_0_009
 
 		return e_;
 	}
+
+    [CqlDeclaration("Diagnostic Report without appropriate status")]
+	public bool? Diagnostic_Report_without_appropriate_status() => 
+		__Diagnostic_Report_without_appropriate_status?.Value;
 
 }

--- a/Demo/Measures/CervicalCancerScreeningFHIR-0.0.005.cs
+++ b/Demo/Measures/CervicalCancerScreeningFHIR-0.0.005.cs
@@ -14,64 +14,177 @@ using Task = Hl7.Fhir.Model.Task;
 public class CervicalCancerScreeningFHIR_0_0_005
 {
 
-    public static CervicalCancerScreeningFHIR_0_0_005 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Congenital_or_Acquired_Absence_of_Cervix;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __HPV_Test;
+    internal Lazy<CqlValueSet> __Hysterectomy_with_No_Residual_Cervix;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Pap_Test;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __laboratory;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<object>> __Absence_of_Cervix;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Observation>> __Cervical_Cytology_Within_3_Years;
+    internal Lazy<IEnumerable<Observation>> __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<IEnumerable<Observation>> __Cervical_Cytology_Within_3_Years__2_;
+    internal Lazy<IEnumerable<Observation>> __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2_;
+
+    #endregion
+    public CervicalCancerScreeningFHIR_0_0_005(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+
+        __Congenital_or_Acquired_Absence_of_Cervix = new Lazy<CqlValueSet>(this.Congenital_or_Acquired_Absence_of_Cervix_Value(context));
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value(context));
+        __HPV_Test = new Lazy<CqlValueSet>(this.HPV_Test_Value(context));
+        __Hysterectomy_with_No_Residual_Cervix = new Lazy<CqlValueSet>(this.Hysterectomy_with_No_Residual_Cervix_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Pap_Test = new Lazy<CqlValueSet>(this.Pap_Test_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __laboratory = new Lazy<CqlCode>(this.laboratory_Value(context));
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Absence_of_Cervix = new Lazy<IEnumerable<object>>(this.Absence_of_Cervix_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Cervical_Cytology_Within_3_Years = new Lazy<IEnumerable<Observation>>(this.Cervical_Cytology_Within_3_Years_Value(context));
+        __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older = new Lazy<IEnumerable<Observation>>(this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Cervical_Cytology_Within_3_Years__2_ = new Lazy<IEnumerable<Observation>>(this.Cervical_Cytology_Within_3_Years__2__Value(context));
+        __HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2_ = new Lazy<IEnumerable<Observation>>(this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2__Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Congenital_or_Acquired_Absence_of_Cervix_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
 
     [CqlDeclaration("Congenital or Acquired Absence of Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016")]
-	public CqlValueSet Congenital_or_Acquired_Absence_of_Cervix(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.111.12.1016", null);
+	public CqlValueSet Congenital_or_Acquired_Absence_of_Cervix() => 
+		__Congenital_or_Acquired_Absence_of_Cervix?.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
-	public CqlValueSet Home_Healthcare_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services?.Value;
+
+	private CqlValueSet HPV_Test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
 
     [CqlDeclaration("HPV Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059")]
-	public CqlValueSet HPV_Test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1059", null);
+	public CqlValueSet HPV_Test() => 
+		__HPV_Test?.Value;
+
+	private CqlValueSet Hysterectomy_with_No_Residual_Cervix_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
 
     [CqlDeclaration("Hysterectomy with No Residual Cervix")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014")]
-	public CqlValueSet Hysterectomy_with_No_Residual_Cervix(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014", null);
+	public CqlValueSet Hysterectomy_with_No_Residual_Cervix() => 
+		__Hysterectomy_with_No_Residual_Cervix?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Pap_Test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
 
     [CqlDeclaration("Pap Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017")]
-	public CqlValueSet Pap_Test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1017", null);
+	public CqlValueSet Pap_Test() => 
+		__Pap_Test?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
 
-    [CqlDeclaration("laboratory")]
-	public CqlCode laboratory(CqlContext context) => 
+	private CqlCode laboratory_Value(CqlContext context) => 
 		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
-    [CqlDeclaration("ObservationCategoryCodes")]
-	public CqlCode[] ObservationCategoryCodes(CqlContext context)
+    [CqlDeclaration("laboratory")]
+	public CqlCode laboratory() => 
+		__laboratory?.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -81,8 +194,11 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -93,8 +209,11 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -102,55 +221,70 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Qualifying Encounters")]
-	public IEnumerable<Encounter> Qualifying_Encounters(CqlContext context)
+	private IEnumerable<Encounter> Qualifying_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Office_Visit(context);
+		var a_ = this.Office_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up(context);
+		var c_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up(context);
+		var f_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Home_Healthcare_Services(context);
+		var h_ = this.Home_Healthcare_Services();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Telephone_Visits(context);
+		var l_ = this.Telephone_Visits();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Online_Assessments(context);
+		var n_ = this.Online_Assessments();
 		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
 		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
@@ -158,8 +292,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		{
 			var t_ = context.Operators.Convert<string>(ValidEncounter?.StatusElement);
 			var u_ = context.Operators.Equal(t_, "finished");
-			var v_ = this.Measurement_Period(context);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ValidEncounter?.Period);
+			var v_ = this.Measurement_Period();
+			var w_ = FHIRHelpers_4_0_001.ToInterval(ValidEncounter?.Period);
 			var x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(v_, w_, null);
 			var y_ = context.Operators.And(u_, x_);
 
@@ -170,12 +304,15 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return s_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -184,33 +321,39 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		var j_ = context.Operators.Convert<string>(a_?.GenderElement);
 		var k_ = context.Operators.Equal(j_, "female");
 		var l_ = context.Operators.And(h_, k_);
-		var m_ = this.Qualifying_Encounters(context);
+		var m_ = this.Qualifying_Encounters();
 		var n_ = context.Operators.ExistsInList<Encounter>(m_);
 		var o_ = context.Operators.And(l_, n_);
 
 		return o_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Absence of Cervix")]
-	public IEnumerable<object> Absence_of_Cervix(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<object> Absence_of_Cervix_Value(CqlContext context)
 	{
-		var a_ = this.Hysterectomy_with_No_Residual_Cervix(context);
+		var a_ = this.Hysterectomy_with_No_Residual_Cervix();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure NoCervixProcedure)
 		{
 			var j_ = context.Operators.Convert<string>(NoCervixProcedure?.StatusElement);
 			var k_ = context.Operators.Equal(j_, "completed");
-			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, NoCervixProcedure?.Performed);
+			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(NoCervixProcedure?.Performed);
 			var m_ = context.Operators.End(l_);
-			var n_ = this.Measurement_Period(context);
+			var n_ = this.Measurement_Period();
 			var o_ = context.Operators.End(n_);
 			var p_ = context.Operators.SameOrBefore(m_, o_, null);
 			var q_ = context.Operators.And(k_, p_);
@@ -218,13 +361,13 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			return q_;
 		};
 		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
-		var e_ = this.Congenital_or_Acquired_Absence_of_Cervix(context);
+		var e_ = this.Congenital_or_Acquired_Absence_of_Cervix();
 		var f_ = context.Operators.RetrieveByValueSet<Condition>(e_, null);
 		bool? g_(Condition NoCervixDiagnosis)
 		{
-			var r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, NoCervixDiagnosis);
+			var r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(NoCervixDiagnosis);
 			var s_ = context.Operators.Start(r_);
-			var t_ = this.Measurement_Period(context);
+			var t_ = this.Measurement_Period();
 			var u_ = context.Operators.End(t_);
 			var v_ = context.Operators.SameOrBefore(s_, u_, null);
 
@@ -236,23 +379,29 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return i_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Absence of Cervix")]
+	public IEnumerable<object> Absence_of_Cervix() => 
+		__Absence_of_Cervix?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = this.Absence_of_Cervix(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = this.Absence_of_Cervix();
 		var c_ = context.Operators.ExistsInList<object>(b_);
 		var d_ = context.Operators.Or(a_, c_);
-		var e_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var e_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var f_ = context.Operators.Or(d_, e_);
 
 		return f_;
 	}
 
-    [CqlDeclaration("Cervical Cytology Within 3 Years")]
-	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years_Value(CqlContext context)
 	{
-		var a_ = this.Pap_Test(context);
+		var a_ = this.Pap_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation CervicalCytology)
 		{
@@ -266,8 +415,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
 			bool? h_(CodeableConcept CervicalCytologyCategory)
 			{
-				var ab_ = this.laboratory(context);
-				var ac_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, CervicalCytologyCategory);
+				var ab_ = this.laboratory();
+				var ac_ = FHIRHelpers_4_0_001.ToConcept(CervicalCytologyCategory);
 				var ad_ = context.Operators.CodeInList(ab_, (ac_?.codes as IEnumerable<CqlCode>));
 
 				return ad_;
@@ -275,8 +424,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			var i_ = context.Operators.WhereOrNull<CodeableConcept>((CervicalCytology?.Category as IEnumerable<CodeableConcept>), h_);
 			var j_ = context.Operators.ExistsInList<CodeableConcept>(i_);
 			var k_ = context.Operators.And(g_, j_);
-			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, CervicalCytology?.Effective);
-			var m_ = this.Measurement_Period(context);
+			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(CervicalCytology?.Effective);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.End(m_);
 			var o_ = context.Operators.Quantity(3m, "years");
 			var p_ = context.Operators.Subtract(n_, o_);
@@ -297,10 +446,13 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return d_;
 	}
 
-    [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older")]
-	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older(CqlContext context)
+    [CqlDeclaration("Cervical Cytology Within 3 Years")]
+	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years() => 
+		__Cervical_Cytology_Within_3_Years?.Value;
+
+	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older_Value(CqlContext context)
 	{
-		var a_ = this.HPV_Test(context);
+		var a_ = this.HPV_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation HPVTest)
 		{
@@ -314,8 +466,8 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
 			bool? h_(CodeableConcept HPVTestCategory)
 			{
-				var aj_ = this.laboratory(context);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, HPVTestCategory);
+				var aj_ = this.laboratory();
+				var ak_ = FHIRHelpers_4_0_001.ToConcept(HPVTestCategory);
 				var al_ = context.Operators.CodeInList(aj_, (ak_?.codes as IEnumerable<CqlCode>));
 
 				return al_;
@@ -323,16 +475,16 @@ public class CervicalCancerScreeningFHIR_0_0_005
 			var i_ = context.Operators.WhereOrNull<CodeableConcept>((HPVTest?.Category as IEnumerable<CodeableConcept>), h_);
 			var j_ = context.Operators.ExistsInList<CodeableConcept>(i_);
 			var k_ = context.Operators.And(g_, j_);
-			var l_ = this.Patient(context);
+			var l_ = this.Patient();
 			var m_ = context.Operators.Convert<CqlDate>(l_?.BirthDateElement?.Value);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, HPVTest?.Effective);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(HPVTest?.Effective);
 			var o_ = context.Operators.Start(n_);
 			var p_ = context.Operators.DateFrom(o_);
 			var q_ = context.Operators.CalculateAgeAt(m_, p_, "year");
 			var r_ = context.Operators.GreaterOrEqual(q_, (int?)30);
 			var s_ = context.Operators.And(k_, r_);
-			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, HPVTest?.Effective);
-			var u_ = this.Measurement_Period(context);
+			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(HPVTest?.Effective);
+			var u_ = this.Measurement_Period();
 			var v_ = context.Operators.End(u_);
 			var w_ = context.Operators.Quantity(5m, "years");
 			var x_ = context.Operators.Subtract(v_, w_);
@@ -353,20 +505,27 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return d_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older")]
+	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older() => 
+		__HPV_Test_Within_5_Years_for_Women_Age_30_and_Older?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Cervical_Cytology_Within_3_Years(context);
+		var a_ = this.Cervical_Cytology_Within_3_Years();
 		var b_ = context.Operators.ExistsInList<Observation>(a_);
-		var c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older(context);
+		var c_ = this.HPV_Test_Within_5_Years_for_Women_Age_30_and_Older();
 		var d_ = context.Operators.ExistsInList<Observation>(c_);
 		var e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
 
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
     [CqlDeclaration("isComplete")]
-	public bool? isComplete(CqlContext context, Observation observation)
+	public bool? isComplete(Observation observation)
 	{
 		var a_ = context.Operators.Convert<string>(observation?.StatusElement);
 		var b_ = new string[]
@@ -381,12 +540,12 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	}
 
     [CqlDeclaration("isLaboratoryTest")]
-	public bool? isLaboratoryTest(CqlContext context, Observation observation)
+	public bool? isLaboratoryTest(Observation observation)
 	{
 		bool? a_(CodeableConcept category)
 		{
-			var d_ = this.laboratory(context);
-			var e_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, category);
+			var d_ = this.laboratory();
+			var e_ = FHIRHelpers_4_0_001.ToConcept(category);
 			var f_ = context.Operators.CodeInList(d_, (e_?.codes as IEnumerable<CqlCode>));
 
 			return f_;
@@ -398,25 +557,24 @@ public class CervicalCancerScreeningFHIR_0_0_005
 	}
 
     [CqlDeclaration("latest")]
-	public CqlDateTime latest(CqlContext context, object choice)
+	public CqlDateTime latest(object choice)
 	{
-		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, choice);
+		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(choice);
 
 		return a_;
 	}
 
-    [CqlDeclaration("Cervical Cytology Within 3 Years (2)")]
-	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years__2_(CqlContext context)
+	private IEnumerable<Observation> Cervical_Cytology_Within_3_Years__2__Value(CqlContext context)
 	{
-		var a_ = this.Pap_Test(context);
+		var a_ = this.Pap_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation CervicalCytology)
 		{
-			var e_ = this.isComplete(context, CervicalCytology);
-			var f_ = this.isLaboratoryTest(context, CervicalCytology);
+			var e_ = this.isComplete(CervicalCytology);
+			var f_ = this.isLaboratoryTest(CervicalCytology);
 			var g_ = context.Operators.And(e_, f_);
-			var h_ = this.latest(context, CervicalCytology?.Effective);
-			var i_ = this.Measurement_Period(context);
+			var h_ = this.latest(CervicalCytology?.Effective);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(3m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -437,34 +595,37 @@ public class CervicalCancerScreeningFHIR_0_0_005
 		return d_;
 	}
 
+    [CqlDeclaration("Cervical Cytology Within 3 Years (2)")]
+	public IEnumerable<Observation> Cervical_Cytology_Within_3_Years__2_() => 
+		__Cervical_Cytology_Within_3_Years__2_?.Value;
+
     [CqlDeclaration("toInterval")]
-	public CqlInterval<CqlDateTime> toInterval(CqlContext context, object choice)
+	public CqlInterval<CqlDateTime> toInterval(object choice)
 	{
-		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, choice);
+		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(choice);
 
 		return a_;
 	}
 
-    [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older (2)")]
-	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2_(CqlContext context)
+	private IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2__Value(CqlContext context)
 	{
-		var a_ = this.HPV_Test(context);
+		var a_ = this.HPV_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation HPVTest)
 		{
-			var e_ = this.isComplete(context, HPVTest);
-			var f_ = this.isLaboratoryTest(context, HPVTest);
+			var e_ = this.isComplete(HPVTest);
+			var f_ = this.isLaboratoryTest(HPVTest);
 			var g_ = context.Operators.And(e_, f_);
-			var h_ = this.Patient(context);
+			var h_ = this.Patient();
 			var i_ = context.Operators.Convert<CqlDate>(h_?.BirthDateElement?.Value);
-			var j_ = this.toInterval(context, HPVTest?.Effective);
+			var j_ = this.toInterval(HPVTest?.Effective);
 			var k_ = context.Operators.Start(j_);
 			var l_ = context.Operators.DateFrom(k_);
 			var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 			var n_ = context.Operators.GreaterOrEqual(m_, (int?)30);
 			var o_ = context.Operators.And(g_, n_);
-			var p_ = this.latest(context, HPVTest?.Effective);
-			var q_ = this.Measurement_Period(context);
+			var p_ = this.latest(HPVTest?.Effective);
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.End(q_);
 			var s_ = context.Operators.Quantity(5m, "years");
 			var t_ = context.Operators.Subtract(r_, s_);
@@ -484,5 +645,9 @@ public class CervicalCancerScreeningFHIR_0_0_005
 
 		return d_;
 	}
+
+    [CqlDeclaration("HPV Test Within 5 Years for Women Age 30 and Older (2)")]
+	public IEnumerable<Observation> HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2_() => 
+		__HPV_Test_Within_5_Years_for_Women_Age_30_and_Older__2_?.Value;
 
 }

--- a/Demo/Measures/ColorectalCancerScreeningsFHIR-0.0.003.cs
+++ b/Demo/Measures/ColorectalCancerScreeningsFHIR-0.0.003.cs
@@ -14,169 +14,431 @@ using Task = Hl7.Fhir.Model.Task;
 public class ColorectalCancerScreeningsFHIR_0_0_003
 {
 
-    public static ColorectalCancerScreeningsFHIR_0_0_003 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Inpatient;
+    internal Lazy<CqlValueSet> __Advanced_Illness;
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Colonoscopy;
+    internal Lazy<CqlValueSet> __CT_Colonography;
+    internal Lazy<CqlValueSet> __Dementia_Medications;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Fecal_Occult_Blood_Test__FOBT_;
+    internal Lazy<CqlValueSet> __FIT_DNA;
+    internal Lazy<CqlValueSet> __Flexible_Sigmoidoscopy;
+    internal Lazy<CqlValueSet> __Frailty_Device;
+    internal Lazy<CqlValueSet> __Frailty_Diagnosis;
+    internal Lazy<CqlValueSet> __Frailty_Encounter;
+    internal Lazy<CqlValueSet> __Frailty_Symptom;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlValueSet> __Malignant_Neoplasm_of_Colon;
+    internal Lazy<CqlValueSet> __Nonacute_Inpatient;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Total_Colectomy;
+    internal Lazy<CqlValueSet> __Total_Colectomy_ICD9;
+    internal Lazy<CqlCode> __laboratory;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Telehealth_Services;
+    internal Lazy<int?> __Age_at_start_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Malignant_Neoplasm;
+    internal Lazy<IEnumerable<Procedure>> __Total_Colectomy_Performed;
+    internal Lazy<IEnumerable<Condition>> __Total_Colectomy_Condition;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>> __Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset;
+    internal Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>> __Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset;
+    internal Lazy<IEnumerable<CqlDateTime>> __CT_Colonography_Display_Date;
+    internal Lazy<IEnumerable<Observation>> __CT_Colonography_Performed;
+    internal Lazy<IEnumerable<Observation>> __CT_Colonography_Performed_without_appropriate_status;
+    internal Lazy<IEnumerable<CqlDateTime>> __Flexible_Sigmoidoscopy_Display_Date;
+    internal Lazy<IEnumerable<Procedure>> __Flexible_Sigmoidoscopy_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Flexible_Sigmoidoscopy_Performed_without_appropriate_status;
+    internal Lazy<IEnumerable<CqlDateTime>> __Colonoscopy_Display_Date;
+    internal Lazy<IEnumerable<Procedure>> __Colonoscopy_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Colonoscopy_Performed_without_appropriate_status;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Final_Numerator_Population;
+
+    #endregion
+    public ColorectalCancerScreeningsFHIR_0_0_003(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        AdultOutpatientEncountersFHIR4_2_2_000 = new AdultOutpatientEncountersFHIR4_2_2_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+        AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 = new AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+
+        __Acute_Inpatient = new Lazy<CqlValueSet>(this.Acute_Inpatient_Value(context));
+        __Advanced_Illness = new Lazy<CqlValueSet>(this.Advanced_Illness_Value(context));
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value(context));
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value(context));
+        __Colonoscopy = new Lazy<CqlValueSet>(this.Colonoscopy_Value(context));
+        __CT_Colonography = new Lazy<CqlValueSet>(this.CT_Colonography_Value(context));
+        __Dementia_Medications = new Lazy<CqlValueSet>(this.Dementia_Medications_Value(context));
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(context));
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Fecal_Occult_Blood_Test__FOBT_ = new Lazy<CqlValueSet>(this.Fecal_Occult_Blood_Test__FOBT__Value(context));
+        __FIT_DNA = new Lazy<CqlValueSet>(this.FIT_DNA_Value(context));
+        __Flexible_Sigmoidoscopy = new Lazy<CqlValueSet>(this.Flexible_Sigmoidoscopy_Value(context));
+        __Frailty_Device = new Lazy<CqlValueSet>(this.Frailty_Device_Value(context));
+        __Frailty_Diagnosis = new Lazy<CqlValueSet>(this.Frailty_Diagnosis_Value(context));
+        __Frailty_Encounter = new Lazy<CqlValueSet>(this.Frailty_Encounter_Value(context));
+        __Frailty_Symptom = new Lazy<CqlValueSet>(this.Frailty_Symptom_Value(context));
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value(context));
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value(context));
+        __Malignant_Neoplasm_of_Colon = new Lazy<CqlValueSet>(this.Malignant_Neoplasm_of_Colon_Value(context));
+        __Nonacute_Inpatient = new Lazy<CqlValueSet>(this.Nonacute_Inpatient_Value(context));
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value(context));
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Outpatient = new Lazy<CqlValueSet>(this.Outpatient_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Total_Colectomy = new Lazy<CqlValueSet>(this.Total_Colectomy_Value(context));
+        __Total_Colectomy_ICD9 = new Lazy<CqlValueSet>(this.Total_Colectomy_ICD9_Value(context));
+        __laboratory = new Lazy<CqlCode>(this.laboratory_Value(context));
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Telehealth_Services = new Lazy<IEnumerable<Encounter>>(this.Telehealth_Services_Value(context));
+        __Age_at_start_of_Measurement_Period = new Lazy<int?>(this.Age_at_start_of_Measurement_Period_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Malignant_Neoplasm = new Lazy<IEnumerable<Condition>>(this.Malignant_Neoplasm_Value(context));
+        __Total_Colectomy_Performed = new Lazy<IEnumerable<Procedure>>(this.Total_Colectomy_Performed_Value(context));
+        __Total_Colectomy_Condition = new Lazy<IEnumerable<Condition>>(this.Total_Colectomy_Condition_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status = new Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>>(this.Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value(context));
+        __Fecal_Occult_Blood_Test_Performed = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_Value(context));
+        __Fecal_Occult_Blood_Test_Performed__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value(context));
+        __Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(context));
+        __Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status = new Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>>(this.Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(context));
+        __CT_Colonography_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.CT_Colonography_Display_Date_Value(context));
+        __CT_Colonography_Performed = new Lazy<IEnumerable<Observation>>(this.CT_Colonography_Performed_Value(context));
+        __CT_Colonography_Performed_without_appropriate_status = new Lazy<IEnumerable<Observation>>(this.CT_Colonography_Performed_without_appropriate_status_Value(context));
+        __Flexible_Sigmoidoscopy_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.Flexible_Sigmoidoscopy_Display_Date_Value(context));
+        __Flexible_Sigmoidoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Flexible_Sigmoidoscopy_Performed_Value(context));
+        __Flexible_Sigmoidoscopy_Performed_without_appropriate_status = new Lazy<IEnumerable<Procedure>>(this.Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value(context));
+        __Colonoscopy_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.Colonoscopy_Display_Date_Value(context));
+        __Colonoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Colonoscopy_Performed_Value(context));
+        __Colonoscopy_Performed_without_appropriate_status = new Lazy<IEnumerable<Procedure>>(this.Colonoscopy_Performed_without_appropriate_status_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Final_Numerator_Population = new Lazy<bool?>(this.Final_Numerator_Population_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public AdultOutpatientEncountersFHIR4_2_2_000 AdultOutpatientEncountersFHIR4_2_2_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
-	public CqlValueSet Acute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+	public CqlValueSet Acute_Inpatient() => 
+		__Acute_Inpatient?.Value;
+
+	private CqlValueSet Advanced_Illness_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
-	public CqlValueSet Advanced_Illness(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+	public CqlValueSet Advanced_Illness() => 
+		__Advanced_Illness?.Value;
+
+	private CqlValueSet Annual_Wellness_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
-	public CqlValueSet Annual_Wellness_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit?.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
-	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility?.Value;
+
+	private CqlValueSet Colonoscopy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
-	public CqlValueSet Colonoscopy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+	public CqlValueSet Colonoscopy() => 
+		__Colonoscopy?.Value;
+
+	private CqlValueSet CT_Colonography_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
-	public CqlValueSet CT_Colonography(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+	public CqlValueSet CT_Colonography() => 
+		__CT_Colonography?.Value;
+
+	private CqlValueSet Dementia_Medications_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
-	public CqlValueSet Dementia_Medications(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+	public CqlValueSet Dementia_Medications() => 
+		__Dementia_Medications?.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
-	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care?.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
-	public CqlValueSet Discharged_to_Home_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
-	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_() => 
+		__Fecal_Occult_Blood_Test__FOBT_?.Value;
+
+	private CqlValueSet FIT_DNA_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
-	public CqlValueSet FIT_DNA(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+	public CqlValueSet FIT_DNA() => 
+		__FIT_DNA?.Value;
+
+	private CqlValueSet Flexible_Sigmoidoscopy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
-	public CqlValueSet Flexible_Sigmoidoscopy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+	public CqlValueSet Flexible_Sigmoidoscopy() => 
+		__Flexible_Sigmoidoscopy?.Value;
+
+	private CqlValueSet Frailty_Device_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
-	public CqlValueSet Frailty_Device(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+	public CqlValueSet Frailty_Device() => 
+		__Frailty_Device?.Value;
+
+	private CqlValueSet Frailty_Diagnosis_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
-	public CqlValueSet Frailty_Diagnosis(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+	public CqlValueSet Frailty_Diagnosis() => 
+		__Frailty_Diagnosis?.Value;
+
+	private CqlValueSet Frailty_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
-	public CqlValueSet Frailty_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+	public CqlValueSet Frailty_Encounter() => 
+		__Frailty_Encounter?.Value;
+
+	private CqlValueSet Frailty_Symptom_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
-	public CqlValueSet Frailty_Symptom(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+	public CqlValueSet Frailty_Symptom() => 
+		__Frailty_Symptom?.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
-	public CqlValueSet Home_Healthcare_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services?.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
-	public CqlValueSet Hospice_care_ambulatory(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory?.Value;
+
+	private CqlValueSet Malignant_Neoplasm_of_Colon_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
-	public CqlValueSet Malignant_Neoplasm_of_Colon(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+	public CqlValueSet Malignant_Neoplasm_of_Colon() => 
+		__Malignant_Neoplasm_of_Colon?.Value;
+
+	private CqlValueSet Nonacute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
-	public CqlValueSet Nonacute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+	public CqlValueSet Nonacute_Inpatient() => 
+		__Nonacute_Inpatient?.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
-	public CqlValueSet Nursing_Facility_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit?.Value;
+
+	private CqlValueSet Observation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
-	public CqlValueSet Observation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+	public CqlValueSet Observation() => 
+		__Observation?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Outpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
-	public CqlValueSet Outpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+	public CqlValueSet Outpatient() => 
+		__Outpatient?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
+
+	private CqlValueSet Total_Colectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
-	public CqlValueSet Total_Colectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+	public CqlValueSet Total_Colectomy() => 
+		__Total_Colectomy?.Value;
+
+	private CqlValueSet Total_Colectomy_ICD9_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
-	public CqlValueSet Total_Colectomy_ICD9(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
+	public CqlValueSet Total_Colectomy_ICD9() => 
+		__Total_Colectomy_ICD9?.Value;
 
-    [CqlDeclaration("laboratory")]
-	public CqlCode laboratory(CqlContext context) => 
+	private CqlCode laboratory_Value(CqlContext context) => 
 		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
-    [CqlDeclaration("ObservationCategoryCodes")]
-	public CqlCode[] ObservationCategoryCodes(CqlContext context)
+    [CqlDeclaration("laboratory")]
+	public CqlCode laboratory() => 
+		__laboratory?.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -186,8 +448,11 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2021, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -198,8 +463,11 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -207,52 +475,67 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Telehealth Services")]
-	public IEnumerable<Encounter> Telehealth_Services(CqlContext context)
+	private IEnumerable<Encounter> Telehealth_Services_Value(CqlContext context)
 	{
-		var a_ = this.Online_Assessments(context);
+		var a_ = this.Online_Assessments();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Telephone_Visits(context);
+		var c_ = this.Telephone_Visits();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
 			var h_ = context.Operators.Convert<string>(TelehealthEncounter?.StatusElement);
 			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = this.Measurement_Period(context);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (TelehealthEncounter?.Period as object));
+			var j_ = this.Measurement_Period();
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((TelehealthEncounter?.Period as object));
 			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, k_, null);
 			var m_ = context.Operators.And(i_, l_);
 
@@ -263,12 +546,15 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return g_;
 	}
 
-    [CqlDeclaration("Age at start of Measurement Period")]
-	public int? Age_at_start_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Telehealth Services")]
+	public IEnumerable<Encounter> Telehealth_Services() => 
+		__Telehealth_Services?.Value;
+
+	private int? Age_at_start_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -276,19 +562,22 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Age at start of Measurement Period")]
+	public int? Age_at_start_of_Measurement_Period() => 
+		__Age_at_start_of_Measurement_Period?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.Interval((int?)51, (int?)75, true, false);
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
-		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
-		var j_ = this.Telehealth_Services(context);
+		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
+		var j_ = this.Telehealth_Services();
 		var k_ = context.Operators.ListUnion<Encounter>(i_, j_);
 		var l_ = context.Operators.ExistsInList<Encounter>(k_);
 		var m_ = context.Operators.And(h_, l_);
@@ -296,24 +585,30 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return m_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Malignant Neoplasm")]
-	public IEnumerable<Condition> Malignant_Neoplasm(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Condition> Malignant_Neoplasm_Value(CqlContext context)
 	{
-		var a_ = this.Malignant_Neoplasm_of_Colon(context);
+		var a_ = this.Malignant_Neoplasm_of_Colon();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ColorectalCancer)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ColorectalCancer);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -324,18 +619,21 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Total Colectomy Performed")]
-	public IEnumerable<Procedure> Total_Colectomy_Performed(CqlContext context)
+    [CqlDeclaration("Malignant Neoplasm")]
+	public IEnumerable<Condition> Malignant_Neoplasm() => 
+		__Malignant_Neoplasm?.Value;
+
+	private IEnumerable<Procedure> Total_Colectomy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Total_Colectomy(context);
+		var a_ = this.Total_Colectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colectomy)
 		{
 			var e_ = context.Operators.Convert<string>(Colectomy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colectomy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colectomy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -347,16 +645,19 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Total Colectomy Condition")]
-	public IEnumerable<Condition> Total_Colectomy_Condition(CqlContext context)
+    [CqlDeclaration("Total Colectomy Performed")]
+	public IEnumerable<Procedure> Total_Colectomy_Performed() => 
+		__Total_Colectomy_Performed?.Value;
+
+	private IEnumerable<Condition> Total_Colectomy_Condition_Value(CqlContext context)
 	{
-		var a_ = this.Total_Colectomy_ICD9(context);
+		var a_ = this.Total_Colectomy_ICD9();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ColectomyDx)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ColectomyDx);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -367,46 +668,52 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Total Colectomy Condition")]
+	public IEnumerable<Condition> Total_Colectomy_Condition() => 
+		__Total_Colectomy_Condition?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = this.Malignant_Neoplasm(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = this.Malignant_Neoplasm();
 		var c_ = context.Operators.ExistsInList<Condition>(b_);
 		var d_ = context.Operators.Or(a_, c_);
-		var e_ = this.Total_Colectomy_Performed(context);
+		var e_ = this.Total_Colectomy_Performed();
 		var f_ = context.Operators.ExistsInList<Procedure>(e_);
 		var g_ = context.Operators.Or(d_, f_);
-		var h_ = this.Total_Colectomy_Condition(context);
+		var h_ = this.Total_Colectomy_Condition();
 		var i_ = context.Operators.ExistsInList<Condition>(h_);
 		var j_ = context.Operators.Or(g_, i_);
-		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var l_ = context.Operators.Or(j_, k_);
-		var m_ = this.Patient(context);
+		var m_ = this.Patient();
 		var n_ = context.Operators.Convert<CqlDate>(m_?.BirthDateElement?.Value);
-		var o_ = this.Measurement_Period(context);
+		var o_ = this.Measurement_Period();
 		var p_ = context.Operators.Start(o_);
 		var q_ = context.Operators.DateFrom(p_);
 		var r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
 		var s_ = context.Operators.GreaterOrEqual(r_, (int?)65);
-		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(context);
+		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		var u_ = context.Operators.And(s_, t_);
 		var v_ = context.Operators.Or(l_, u_);
-		var w_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var w_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var x_ = context.Operators.Or(v_, w_);
 
 		return x_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Display Date, Result, Category, Status")]
-	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var h_ = this.Measurement_Period(context);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.Start(h_);
 			var j_ = context.Operators.Quantity(1m, "year");
 			var k_ = context.Operators.Subtract(i_, j_);
@@ -419,7 +726,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW e_(Observation FecalOccult)
 		{
-			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
+			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
 			var q_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(FecalOccult?.Value, "coding");
 			bool? r_(Coding @this)
 			{
@@ -477,10 +784,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Display Date, Result, Category, Status")]
+	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status() => 
+		__Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -527,8 +837,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, o_, null);
 			var q_ = context.Operators.And(m_, p_);
 
@@ -539,10 +849,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed() => 
+		__Fecal_Occult_Blood_Test_Performed?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -589,8 +902,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, o_, "day");
 			var q_ = context.Operators.And(m_, p_);
 
@@ -601,10 +914,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate category, ignore status, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -643,8 +959,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var g_ = context.Operators.ExistsInList<CodeableConcept>(f_);
 			var h_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var i_ = context.Operators.And(g_, h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var k_ = this.Measurement_Period(context);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, "day");
 			var m_ = context.Operators.And(i_, l_);
 
@@ -655,10 +971,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate status, ignore category, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate category, ignore status, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -673,8 +992,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var h_ = context.Operators.Not(g_);
 			var i_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var j_ = context.Operators.And(h_, i_);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var l_ = this.Measurement_Period(context);
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, "day");
 			var n_ = context.Operators.And(j_, m_);
 
@@ -685,15 +1004,18 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Display Date, Result, Category, Status")]
-	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate status, ignore category, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset?.Value;
+
+	private IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var h_ = this.Measurement_Period(context);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.Quantity(4m, "years");
 			var k_ = context.Operators.Subtract(i_, j_);
@@ -709,7 +1031,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW e_(Observation FitDNA)
 		{
-			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
+			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
 			var u_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(FitDNA?.Value, "coding");
 			bool? v_(Coding @this)
 			{
@@ -767,10 +1089,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Display Date, Result, Category, Status")]
+	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status() => 
+		__Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -817,8 +1142,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.End(o_);
 			var q_ = context.Operators.Quantity(3m, "years");
 			var r_ = context.Operators.Subtract(p_, q_);
@@ -837,10 +1162,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed() => 
+		__Fecal_Immunochemical_Test_DNA_Performed?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -887,8 +1215,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.End(o_);
 			var q_ = context.Operators.Quantity(3m, "years");
 			var r_ = context.Operators.Subtract(p_, q_);
@@ -907,10 +1235,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate category, ignore status, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -949,8 +1280,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var g_ = context.Operators.ExistsInList<CodeableConcept>(f_);
 			var h_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var i_ = context.Operators.And(g_, h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var k_ = this.Measurement_Period(context);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(3m, "years");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -969,10 +1300,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate status, ignore category, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate category, ignore status, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -987,8 +1321,8 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			var h_ = context.Operators.Not(g_);
 			var i_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var j_ = context.Operators.And(h_, i_);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var l_ = this.Measurement_Period(context);
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(3m, "years");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -1007,16 +1341,19 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("CT Colonography Display Date")]
-	public IEnumerable<CqlDateTime> CT_Colonography_Display_Date(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate status, ignore category, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset?.Value;
+
+	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(6m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1032,7 +1369,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		CqlDateTime e_(Observation Colonography)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, Colonography?.Effective);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(Colonography?.Effective);
 
 			return u_;
 		};
@@ -1041,10 +1378,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("CT Colonography Performed")]
-	public IEnumerable<Observation> CT_Colonography_Performed(CqlContext context)
+    [CqlDeclaration("CT Colonography Display Date")]
+	public IEnumerable<CqlDateTime> CT_Colonography_Display_Date() => 
+		__CT_Colonography_Display_Date?.Value;
+
+	private IEnumerable<Observation> CT_Colonography_Performed_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
@@ -1057,9 +1397,9 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 				"appended",
 			};
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(5m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1078,10 +1418,13 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("CT Colonography Performed without appropriate status")]
-	public IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("CT Colonography Performed")]
+	public IEnumerable<Observation> CT_Colonography_Performed() => 
+		__CT_Colonography_Performed?.Value;
+
+	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
@@ -1095,9 +1438,9 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 			};
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
 			var h_ = context.Operators.Not(g_);
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(5m, "years");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -1116,16 +1459,19 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Display Date")]
-	public IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date(CqlContext context)
+    [CqlDeclaration("CT Colonography Performed without appropriate status")]
+	public IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status() => 
+		__CT_Colonography_Performed_without_appropriate_status?.Value;
+
+	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(6m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1141,7 +1487,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
 		CqlDateTime e_(Procedure FlexibleSigmoidoscopy)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FlexibleSigmoidoscopy?.Performed);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FlexibleSigmoidoscopy?.Performed);
 
 			return u_;
 		};
@@ -1150,18 +1496,21 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
-	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Display Date")]
+	public IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date() => 
+		__Flexible_Sigmoidoscopy_Display_Date?.Value;
+
+	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(FlexibleSigmoidoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(5m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1180,19 +1529,22 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Performed without appropriate status")]
-	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
+	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed() => 
+		__Flexible_Sigmoidoscopy_Performed?.Value;
+
+	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(FlexibleSigmoidoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
 			var g_ = context.Operators.Not(f_);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(5m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1211,16 +1563,19 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Colonoscopy Display Date")]
-	public IEnumerable<CqlDateTime> Colonoscopy_Display_Date(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Performed without appropriate status")]
+	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status() => 
+		__Flexible_Sigmoidoscopy_Performed_without_appropriate_status?.Value;
+
+	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(11m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1236,7 +1591,7 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
 		CqlDateTime e_(Procedure Colonoscopy)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, Colonoscopy?.Performed);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(Colonoscopy?.Performed);
 
 			return u_;
 		};
@@ -1245,18 +1600,21 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Colonoscopy Performed")]
-	public IEnumerable<Procedure> Colonoscopy_Performed(CqlContext context)
+    [CqlDeclaration("Colonoscopy Display Date")]
+	public IEnumerable<CqlDateTime> Colonoscopy_Display_Date() => 
+		__Colonoscopy_Display_Date?.Value;
+
+	private IEnumerable<Procedure> Colonoscopy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(Colonoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(10m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1275,19 +1633,22 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Colonoscopy Performed without appropriate status")]
-	public IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Colonoscopy Performed")]
+	public IEnumerable<Procedure> Colonoscopy_Performed() => 
+		__Colonoscopy_Performed?.Value;
+
+	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(Colonoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
 			var g_ = context.Operators.Not(f_);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(10m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1306,40 +1667,50 @@ public class ColorectalCancerScreeningsFHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Colonoscopy Performed without appropriate status")]
+	public IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status() => 
+		__Colonoscopy_Performed_without_appropriate_status?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy_Performed(context);
+		var a_ = this.Colonoscopy_Performed();
 		var b_ = context.Operators.ExistsInList<Procedure>(a_);
-		var c_ = this.Fecal_Occult_Blood_Test_Performed(context);
+		var c_ = this.Fecal_Occult_Blood_Test_Performed();
 		var d_ = context.Operators.ExistsInList<Observation>(c_);
 		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Flexible_Sigmoidoscopy_Performed(context);
+		var f_ = this.Flexible_Sigmoidoscopy_Performed();
 		var g_ = context.Operators.ExistsInList<Procedure>(f_);
 		var h_ = context.Operators.Or(e_, g_);
-		var i_ = this.Fecal_Immunochemical_Test_DNA_Performed(context);
+		var i_ = this.Fecal_Immunochemical_Test_DNA_Performed();
 		var j_ = context.Operators.ExistsInList<Observation>(i_);
 		var k_ = context.Operators.Or(h_, j_);
-		var l_ = this.CT_Colonography_Performed(context);
+		var l_ = this.CT_Colonography_Performed();
 		var m_ = context.Operators.ExistsInList<Observation>(l_);
 		var n_ = context.Operators.Or(k_, m_);
 
 		return n_;
 	}
 
-    [CqlDeclaration("Final Numerator Population")]
-	public bool? Final_Numerator_Population(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
+	private bool? Final_Numerator_Population_Value(CqlContext context)
 	{
-		var a_ = this.Numerator(context);
-		var b_ = this.Initial_Population(context);
+		var a_ = this.Numerator();
+		var b_ = this.Initial_Population();
 		var c_ = context.Operators.And(a_, b_);
-		var d_ = this.Denominator(context);
+		var d_ = this.Denominator();
 		var e_ = context.Operators.And(c_, d_);
-		var f_ = this.Denominator_Exclusions(context);
+		var f_ = this.Denominator_Exclusions();
 		var g_ = context.Operators.Not(f_);
 		var h_ = context.Operators.And(e_, g_);
 
 		return h_;
 	}
+
+    [CqlDeclaration("Final Numerator Population")]
+	public bool? Final_Numerator_Population() => 
+		__Final_Numerator_Population?.Value;
 
 }

--- a/Demo/Measures/CumulativeMedicationDurationFHIR4-1.0.000.cs
+++ b/Demo/Measures/CumulativeMedicationDurationFHIR4-1.0.000.cs
@@ -14,114 +14,268 @@ using Task = Hl7.Fhir.Model.Task;
 public class CumulativeMedicationDurationFHIR4_1_0_000
 {
 
-    public static CumulativeMedicationDurationFHIR4_1_0_000 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("AC")]
-	public CqlCode AC(CqlContext context) => 
+    #region Cached values
+
+    internal Lazy<CqlCode> __AC;
+    internal Lazy<CqlCode> __ACD;
+    internal Lazy<CqlCode> __ACM;
+    internal Lazy<CqlCode> __ACV;
+    internal Lazy<CqlCode> __AFT;
+    internal Lazy<CqlCode> __AFT_early;
+    internal Lazy<CqlCode> __AFT_late;
+    internal Lazy<CqlCode> __C;
+    internal Lazy<CqlCode> __CD;
+    internal Lazy<CqlCode> __CM;
+    internal Lazy<CqlCode> __CV;
+    internal Lazy<CqlCode> __EVE;
+    internal Lazy<CqlCode> __EVE_early;
+    internal Lazy<CqlCode> __EVE_late;
+    internal Lazy<CqlCode> __HS;
+    internal Lazy<CqlCode> __MORN;
+    internal Lazy<CqlCode> __MORN_early;
+    internal Lazy<CqlCode> __MORN_late;
+    internal Lazy<CqlCode> __NIGHT;
+    internal Lazy<CqlCode> __NOON;
+    internal Lazy<CqlCode> __PC;
+    internal Lazy<CqlCode> __PCD;
+    internal Lazy<CqlCode> __PCM;
+    internal Lazy<CqlCode> __PCV;
+    internal Lazy<CqlCode> __PHS;
+    internal Lazy<CqlCode> __WAKE;
+    internal Lazy<CqlCode[]> __V3TimingEvent;
+    internal Lazy<CqlCode[]> __EventTiming;
+    internal Lazy<string> __ErrorLevel;
+    internal Lazy<Patient> __Patient;
+
+    #endregion
+    public CumulativeMedicationDurationFHIR4_1_0_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __AC = new Lazy<CqlCode>(this.AC_Value(context));
+        __ACD = new Lazy<CqlCode>(this.ACD_Value(context));
+        __ACM = new Lazy<CqlCode>(this.ACM_Value(context));
+        __ACV = new Lazy<CqlCode>(this.ACV_Value(context));
+        __AFT = new Lazy<CqlCode>(this.AFT_Value(context));
+        __AFT_early = new Lazy<CqlCode>(this.AFT_early_Value(context));
+        __AFT_late = new Lazy<CqlCode>(this.AFT_late_Value(context));
+        __C = new Lazy<CqlCode>(this.C_Value(context));
+        __CD = new Lazy<CqlCode>(this.CD_Value(context));
+        __CM = new Lazy<CqlCode>(this.CM_Value(context));
+        __CV = new Lazy<CqlCode>(this.CV_Value(context));
+        __EVE = new Lazy<CqlCode>(this.EVE_Value(context));
+        __EVE_early = new Lazy<CqlCode>(this.EVE_early_Value(context));
+        __EVE_late = new Lazy<CqlCode>(this.EVE_late_Value(context));
+        __HS = new Lazy<CqlCode>(this.HS_Value(context));
+        __MORN = new Lazy<CqlCode>(this.MORN_Value(context));
+        __MORN_early = new Lazy<CqlCode>(this.MORN_early_Value(context));
+        __MORN_late = new Lazy<CqlCode>(this.MORN_late_Value(context));
+        __NIGHT = new Lazy<CqlCode>(this.NIGHT_Value(context));
+        __NOON = new Lazy<CqlCode>(this.NOON_Value(context));
+        __PC = new Lazy<CqlCode>(this.PC_Value(context));
+        __PCD = new Lazy<CqlCode>(this.PCD_Value(context));
+        __PCM = new Lazy<CqlCode>(this.PCM_Value(context));
+        __PCV = new Lazy<CqlCode>(this.PCV_Value(context));
+        __PHS = new Lazy<CqlCode>(this.PHS_Value(context));
+        __WAKE = new Lazy<CqlCode>(this.WAKE_Value(context));
+        __V3TimingEvent = new Lazy<CqlCode[]>(this.V3TimingEvent_Value(context));
+        __EventTiming = new Lazy<CqlCode[]>(this.EventTiming_Value(context));
+        __ErrorLevel = new Lazy<string>(this.ErrorLevel_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlCode AC_Value(CqlContext context) => 
 		new CqlCode("AC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("ACD")]
-	public CqlCode ACD(CqlContext context) => 
+    [CqlDeclaration("AC")]
+	public CqlCode AC() => 
+		__AC?.Value;
+
+	private CqlCode ACD_Value(CqlContext context) => 
 		new CqlCode("ACD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("ACM")]
-	public CqlCode ACM(CqlContext context) => 
+    [CqlDeclaration("ACD")]
+	public CqlCode ACD() => 
+		__ACD?.Value;
+
+	private CqlCode ACM_Value(CqlContext context) => 
 		new CqlCode("ACM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("ACV")]
-	public CqlCode ACV(CqlContext context) => 
+    [CqlDeclaration("ACM")]
+	public CqlCode ACM() => 
+		__ACM?.Value;
+
+	private CqlCode ACV_Value(CqlContext context) => 
 		new CqlCode("ACV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("AFT")]
-	public CqlCode AFT(CqlContext context) => 
+    [CqlDeclaration("ACV")]
+	public CqlCode ACV() => 
+		__ACV?.Value;
+
+	private CqlCode AFT_Value(CqlContext context) => 
 		new CqlCode("AFT", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("AFT.early")]
-	public CqlCode AFT_early(CqlContext context) => 
+    [CqlDeclaration("AFT")]
+	public CqlCode AFT() => 
+		__AFT?.Value;
+
+	private CqlCode AFT_early_Value(CqlContext context) => 
 		new CqlCode("AFT.early", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("AFT.late")]
-	public CqlCode AFT_late(CqlContext context) => 
+    [CqlDeclaration("AFT.early")]
+	public CqlCode AFT_early() => 
+		__AFT_early?.Value;
+
+	private CqlCode AFT_late_Value(CqlContext context) => 
 		new CqlCode("AFT.late", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("C")]
-	public CqlCode C(CqlContext context) => 
+    [CqlDeclaration("AFT.late")]
+	public CqlCode AFT_late() => 
+		__AFT_late?.Value;
+
+	private CqlCode C_Value(CqlContext context) => 
 		new CqlCode("C", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("CD")]
-	public CqlCode CD(CqlContext context) => 
+    [CqlDeclaration("C")]
+	public CqlCode C() => 
+		__C?.Value;
+
+	private CqlCode CD_Value(CqlContext context) => 
 		new CqlCode("CD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("CM")]
-	public CqlCode CM(CqlContext context) => 
+    [CqlDeclaration("CD")]
+	public CqlCode CD() => 
+		__CD?.Value;
+
+	private CqlCode CM_Value(CqlContext context) => 
 		new CqlCode("CM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("CV")]
-	public CqlCode CV(CqlContext context) => 
+    [CqlDeclaration("CM")]
+	public CqlCode CM() => 
+		__CM?.Value;
+
+	private CqlCode CV_Value(CqlContext context) => 
 		new CqlCode("CV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("EVE")]
-	public CqlCode EVE(CqlContext context) => 
+    [CqlDeclaration("CV")]
+	public CqlCode CV() => 
+		__CV?.Value;
+
+	private CqlCode EVE_Value(CqlContext context) => 
 		new CqlCode("EVE", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("EVE.early")]
-	public CqlCode EVE_early(CqlContext context) => 
+    [CqlDeclaration("EVE")]
+	public CqlCode EVE() => 
+		__EVE?.Value;
+
+	private CqlCode EVE_early_Value(CqlContext context) => 
 		new CqlCode("EVE.early", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("EVE.late")]
-	public CqlCode EVE_late(CqlContext context) => 
+    [CqlDeclaration("EVE.early")]
+	public CqlCode EVE_early() => 
+		__EVE_early?.Value;
+
+	private CqlCode EVE_late_Value(CqlContext context) => 
 		new CqlCode("EVE.late", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("HS")]
-	public CqlCode HS(CqlContext context) => 
+    [CqlDeclaration("EVE.late")]
+	public CqlCode EVE_late() => 
+		__EVE_late?.Value;
+
+	private CqlCode HS_Value(CqlContext context) => 
 		new CqlCode("HS", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("MORN")]
-	public CqlCode MORN(CqlContext context) => 
+    [CqlDeclaration("HS")]
+	public CqlCode HS() => 
+		__HS?.Value;
+
+	private CqlCode MORN_Value(CqlContext context) => 
 		new CqlCode("MORN", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("MORN.early")]
-	public CqlCode MORN_early(CqlContext context) => 
+    [CqlDeclaration("MORN")]
+	public CqlCode MORN() => 
+		__MORN?.Value;
+
+	private CqlCode MORN_early_Value(CqlContext context) => 
 		new CqlCode("MORN.early", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("MORN.late")]
-	public CqlCode MORN_late(CqlContext context) => 
+    [CqlDeclaration("MORN.early")]
+	public CqlCode MORN_early() => 
+		__MORN_early?.Value;
+
+	private CqlCode MORN_late_Value(CqlContext context) => 
 		new CqlCode("MORN.late", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("NIGHT")]
-	public CqlCode NIGHT(CqlContext context) => 
+    [CqlDeclaration("MORN.late")]
+	public CqlCode MORN_late() => 
+		__MORN_late?.Value;
+
+	private CqlCode NIGHT_Value(CqlContext context) => 
 		new CqlCode("NIGHT", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("NOON")]
-	public CqlCode NOON(CqlContext context) => 
+    [CqlDeclaration("NIGHT")]
+	public CqlCode NIGHT() => 
+		__NIGHT?.Value;
+
+	private CqlCode NOON_Value(CqlContext context) => 
 		new CqlCode("NOON", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("PC")]
-	public CqlCode PC(CqlContext context) => 
+    [CqlDeclaration("NOON")]
+	public CqlCode NOON() => 
+		__NOON?.Value;
+
+	private CqlCode PC_Value(CqlContext context) => 
 		new CqlCode("PC", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("PCD")]
-	public CqlCode PCD(CqlContext context) => 
+    [CqlDeclaration("PC")]
+	public CqlCode PC() => 
+		__PC?.Value;
+
+	private CqlCode PCD_Value(CqlContext context) => 
 		new CqlCode("PCD", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("PCM")]
-	public CqlCode PCM(CqlContext context) => 
+    [CqlDeclaration("PCD")]
+	public CqlCode PCD() => 
+		__PCD?.Value;
+
+	private CqlCode PCM_Value(CqlContext context) => 
 		new CqlCode("PCM", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("PCV")]
-	public CqlCode PCV(CqlContext context) => 
+    [CqlDeclaration("PCM")]
+	public CqlCode PCM() => 
+		__PCM?.Value;
+
+	private CqlCode PCV_Value(CqlContext context) => 
 		new CqlCode("PCV", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("PHS")]
-	public CqlCode PHS(CqlContext context) => 
+    [CqlDeclaration("PCV")]
+	public CqlCode PCV() => 
+		__PCV?.Value;
+
+	private CqlCode PHS_Value(CqlContext context) => 
 		new CqlCode("PHS", "http://hl7.org/fhir/event-timing", null, null);
 
-    [CqlDeclaration("WAKE")]
-	public CqlCode WAKE(CqlContext context) => 
+    [CqlDeclaration("PHS")]
+	public CqlCode PHS() => 
+		__PHS?.Value;
+
+	private CqlCode WAKE_Value(CqlContext context) => 
 		new CqlCode("WAKE", "http://terminology.hl7.org/CodeSystem/v3-TimingEvent", null, null);
 
-    [CqlDeclaration("V3TimingEvent")]
-	public CqlCode[] V3TimingEvent(CqlContext context)
+    [CqlDeclaration("WAKE")]
+	public CqlCode WAKE() => 
+		__WAKE?.Value;
+
+	private CqlCode[] V3TimingEvent_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -144,8 +298,11 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		return a_;
 	}
 
-    [CqlDeclaration("EventTiming")]
-	public CqlCode[] EventTiming(CqlContext context)
+    [CqlDeclaration("V3TimingEvent")]
+	public CqlCode[] V3TimingEvent() => 
+		__V3TimingEvent?.Value;
+
+	private CqlCode[] EventTiming_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -166,16 +323,22 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		return a_;
 	}
 
-    [CqlDeclaration("ErrorLevel")]
-	public string ErrorLevel(CqlContext context)
+    [CqlDeclaration("EventTiming")]
+	public CqlCode[] EventTiming() => 
+		__EventTiming?.Value;
+
+	private string ErrorLevel_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("CumulativeMedicationDurationFHIR4-1.0.000", "ErrorLevel", "Warning");
 
 		return (string)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("ErrorLevel")]
+	public string ErrorLevel() => 
+		__ErrorLevel?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -183,8 +346,12 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("ToDaily")]
-	public decimal? ToDaily(CqlContext context, int? frequency, CqlQuantity period)
+	public decimal? ToDaily(int? frequency, CqlQuantity period)
 	{
 		decimal? a_()
 		{
@@ -406,7 +573,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 			}
 			else
 			{
-				var dl_ = this.ErrorLevel(context);
+				var dl_ = this.ErrorLevel();
 				var dm_ = context.Operators.Concatenate("Unknown unit ", (period?.unit ?? ""));
 				var dn_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownUnit", dl_, dm_);
 
@@ -418,17 +585,17 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("ToDaily")]
-	public decimal? ToDaily(CqlContext context, CqlCode frequency)
+	public decimal? ToDaily(CqlCode frequency)
 	{
 		decimal? a_()
 		{
-			if ((context.Operators.Equal(frequency, this.C(context)) ?? false))
+			if ((context.Operators.Equal(frequency, this.C()) ?? false))
 			{
 				return (decimal?)3.0m;
 			}
 			else
 			{
-				var b_ = this.ErrorLevel(context);
+				var b_ = this.ErrorLevel();
 				var c_ = context.Operators.Concatenate("Unknown frequency code ", (frequency?.code ?? ""));
 				var d_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownFrequencyCode", b_, c_);
 
@@ -440,7 +607,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("MedicationRequestPeriod")]
-	public CqlInterval<CqlDateTime> MedicationRequestPeriod(CqlContext context, MedicationRequest Request)
+	public CqlInterval<CqlDateTime> MedicationRequestPeriod(MedicationRequest Request)
 	{
 		var a_ = new MedicationRequest[]
 		{
@@ -450,15 +617,15 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		{
 			CqlInterval<CqlDateTime> e_()
 			{
-				if ((context.Operators.Not(context.Operators.Or((bool?)(context.Operators.End(FHIRHelpers_4_0_001.Instance.ToInterval(context, ((((context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>)))?.Timing)?.Repeat)?.Bounds as Period))) is null), context.Operators.Equal(context.Operators.End(FHIRHelpers_4_0_001.Instance.ToInterval(context, ((((context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>)))?.Timing)?.Repeat)?.Bounds as Period))), context.Operators.Maximum<CqlDateTime>()))) ?? false))
+				if ((context.Operators.Not(context.Operators.Or((bool?)(context.Operators.End(FHIRHelpers_4_0_001.ToInterval(((((context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>)))?.Timing)?.Repeat)?.Bounds as Period))) is null), context.Operators.Equal(context.Operators.End(FHIRHelpers_4_0_001.ToInterval(((((context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>)))?.Timing)?.Repeat)?.Bounds as Period))), context.Operators.Maximum<CqlDateTime>()))) ?? false))
 				{
 					var f_ = context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>));
-					var g_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (f_?.Timing?.Repeat?.Bounds as Period));
+					var g_ = FHIRHelpers_4_0_001.ToInterval((f_?.Timing?.Repeat?.Bounds as Period));
 					var h_ = context.Operators.Start(g_);
-					var i_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, R?.DispenseRequest?.ValidityPeriod);
+					var i_ = FHIRHelpers_4_0_001.ToInterval(R?.DispenseRequest?.ValidityPeriod);
 					var j_ = context.Operators.Start(i_);
-					var k_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, R?.AuthoredOnElement);
-					var m_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (f_?.Timing?.Repeat?.Bounds as Period));
+					var k_ = FHIRHelpers_4_0_001.ToDateTime(R?.AuthoredOnElement);
+					var m_ = FHIRHelpers_4_0_001.ToInterval((f_?.Timing?.Repeat?.Bounds as Period));
 					var n_ = context.Operators.End(m_);
 					var o_ = context.Operators.Interval(((h_ ?? j_) ?? k_), n_, true, true);
 
@@ -467,34 +634,34 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 				else
 				{
 					var p_ = context.Operators.SingleOrNull<Dosage>((R?.DosageInstruction as IEnumerable<Dosage>));
-					var q_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (p_?.Timing?.Repeat?.Bounds as Period));
+					var q_ = FHIRHelpers_4_0_001.ToInterval((p_?.Timing?.Repeat?.Bounds as Period));
 					var r_ = context.Operators.Start(q_);
-					var s_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, R?.DispenseRequest?.ValidityPeriod);
+					var s_ = FHIRHelpers_4_0_001.ToInterval(R?.DispenseRequest?.ValidityPeriod);
 					var t_ = context.Operators.Start(s_);
-					var u_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, R?.AuthoredOnElement);
-					var w_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (p_?.Timing?.Repeat?.Bounds as Period));
+					var u_ = FHIRHelpers_4_0_001.ToDateTime(R?.AuthoredOnElement);
+					var w_ = FHIRHelpers_4_0_001.ToInterval((p_?.Timing?.Repeat?.Bounds as Period));
 					var x_ = context.Operators.Start(w_);
 					var z_ = context.Operators.Start(s_);
-					var ab_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, R?.DispenseRequest?.ExpectedSupplyDuration);
-					var ac_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, R?.DispenseRequest?.Quantity);
+					var ab_ = FHIRHelpers_4_0_001.ToQuantity(R?.DispenseRequest?.ExpectedSupplyDuration);
+					var ac_ = FHIRHelpers_4_0_001.ToQuantity(R?.DispenseRequest?.Quantity);
 					var ae_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((p_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
-					var af_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (ae_?.Dose as Range));
+					var af_ = FHIRHelpers_4_0_001.ToInterval((ae_?.Dose as Range));
 					var ag_ = context.Operators.End(af_);
 					var ai_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((p_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
-					var aj_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (ai_?.Dose as Quantity));
+					var aj_ = FHIRHelpers_4_0_001.ToQuantity((ai_?.Dose as Quantity));
 					var al_ = context.Operators.Convert<Integer>(p_?.Timing?.Repeat?.FrequencyMaxElement);
 					var an_ = context.Operators.Convert<Integer>(p_?.Timing?.Repeat?.FrequencyElement);
-					var ao_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, (al_ ?? an_));
-					var aq_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, p_?.Timing?.Repeat?.PeriodElement);
+					var ao_ = FHIRHelpers_4_0_001.ToInteger((al_ ?? an_));
+					var aq_ = FHIRHelpers_4_0_001.ToDecimal(p_?.Timing?.Repeat?.PeriodElement);
 					var as_ = context.Operators.Convert<string>(p_?.Timing?.Repeat?.PeriodUnitElement?.Value);
-					var at_ = this.ToDaily(context, ao_, new CqlQuantity(aq_, as_));
+					var at_ = this.ToDaily(ao_, new CqlQuantity(aq_, as_));
 					var av_ = context.Operators.CountOrNull<Time>((p_?.Timing?.Repeat?.TimeOfDayElement as IEnumerable<Time>));
 					var aw_ = context.Operators.ConvertIntegerToDecimal(av_);
 					var ax_ = context.Operators.ConvertDecimalToQuantity(((at_ ?? aw_) ?? (decimal?)1.0m));
 					var ay_ = context.Operators.Multiply((ag_ ?? aj_), ax_);
 					var az_ = context.Operators.Divide(ac_, ay_);
 					var ba_ = context.Operators.Convert<Integer>(R?.DispenseRequest?.NumberOfRepeatsAllowedElement);
-					var bb_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, ba_);
+					var bb_ = FHIRHelpers_4_0_001.ToInteger(ba_);
 					var bc_ = context.Operators.Add((int?)1, (bb_ ?? (int?)0));
 					var bd_ = context.Operators.ConvertIntegerToQuantity(bc_);
 					var be_ = context.Operators.Multiply((ab_ ?? az_), bd_);
@@ -514,7 +681,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("MedicationDispensePeriod")]
-	public CqlInterval<CqlDateTime> MedicationDispensePeriod(CqlContext context, MedicationDispense Dispense)
+	public CqlInterval<CqlDateTime> MedicationDispensePeriod(MedicationDispense Dispense)
 	{
 		var a_ = new MedicationDispense[]
 		{
@@ -522,21 +689,21 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		};
 		CqlInterval<CqlDateTime> b_(MedicationDispense D)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (D?.WhenHandedOverElement ?? D?.WhenPreparedElement));
-			var g_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, D?.DaysSupply);
-			var h_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, D?.Quantity);
+			var e_ = FHIRHelpers_4_0_001.ToDateTime((D?.WhenHandedOverElement ?? D?.WhenPreparedElement));
+			var g_ = FHIRHelpers_4_0_001.ToQuantity(D?.DaysSupply);
+			var h_ = FHIRHelpers_4_0_001.ToQuantity(D?.Quantity);
 			var i_ = context.Operators.SingleOrNull<Dosage>((D?.DosageInstruction as IEnumerable<Dosage>));
 			var j_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((i_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
-			var k_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (j_?.Dose as Range));
+			var k_ = FHIRHelpers_4_0_001.ToInterval((j_?.Dose as Range));
 			var l_ = context.Operators.End(k_);
 			var n_ = context.Operators.SingleOrNull<Dosage.DoseAndRateComponent>((i_?.DoseAndRate as IEnumerable<Dosage.DoseAndRateComponent>));
-			var o_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (n_?.Dose as Quantity));
+			var o_ = FHIRHelpers_4_0_001.ToQuantity((n_?.Dose as Quantity));
 			var q_ = context.Operators.Convert<Integer>(i_?.Timing?.Repeat?.FrequencyMaxElement);
 			var s_ = context.Operators.Convert<Integer>(i_?.Timing?.Repeat?.FrequencyElement);
-			var t_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, (q_ ?? s_));
-			var v_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, i_?.Timing?.Repeat?.PeriodElement);
+			var t_ = FHIRHelpers_4_0_001.ToInteger((q_ ?? s_));
+			var v_ = FHIRHelpers_4_0_001.ToDecimal(i_?.Timing?.Repeat?.PeriodElement);
 			var x_ = context.Operators.Convert<string>(i_?.Timing?.Repeat?.PeriodUnitElement?.Value);
-			var y_ = this.ToDaily(context, t_, new CqlQuantity(v_, x_));
+			var y_ = this.ToDaily(t_, new CqlQuantity(v_, x_));
 			var aa_ = context.Operators.CountOrNull<Time>((i_?.Timing?.Repeat?.TimeOfDayElement as IEnumerable<Time>));
 			var ab_ = context.Operators.ConvertIntegerToDecimal(aa_);
 			var ac_ = context.Operators.ConvertDecimalToQuantity(((y_ ?? ab_) ?? (decimal?)1.0m));
@@ -554,7 +721,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("TherapeuticDuration")]
-	public CqlQuantity TherapeuticDuration(CqlContext context, CqlConcept medication)
+	public CqlQuantity TherapeuticDuration(CqlConcept medication)
 	{
 		var a_ = context.Operators.Quantity(14m, "days");
 
@@ -562,7 +729,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("MedicationAdministrationPeriod")]
-	public CqlInterval<CqlDateTime> MedicationAdministrationPeriod(CqlContext context, MedicationAdministration Administration)
+	public CqlInterval<CqlDateTime> MedicationAdministrationPeriod(MedicationAdministration Administration)
 	{
 		var a_ = new MedicationAdministration[]
 		{
@@ -572,13 +739,13 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		{
 			CqlInterval<CqlDateTime> e_()
 			{
-				if ((context.Operators.And(context.Operators.Not((bool?)(context.Operators.Start(FHIRHelpers_4_0_001.Instance.ToInterval(context, (Administration?.Effective as Period))) is null)), context.Operators.Not((bool?)(this.TherapeuticDuration(context, FHIRHelpers_4_0_001.Instance.ToConcept(context, (Administration?.Medication as CodeableConcept))) is null))) ?? false))
+				if ((context.Operators.And(context.Operators.Not((bool?)(context.Operators.Start(FHIRHelpers_4_0_001.ToInterval((Administration?.Effective as Period))) is null)), context.Operators.Not((bool?)(this.TherapeuticDuration(FHIRHelpers_4_0_001.ToConcept((Administration?.Medication as CodeableConcept))) is null))) ?? false))
 				{
-					var f_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (Administration?.Effective as Period));
+					var f_ = FHIRHelpers_4_0_001.ToInterval((Administration?.Effective as Period));
 					var g_ = context.Operators.Start(f_);
 					var i_ = context.Operators.Start(f_);
-					var j_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, (Administration?.Medication as CodeableConcept));
-					var k_ = this.TherapeuticDuration(context, j_);
+					var j_ = FHIRHelpers_4_0_001.ToConcept((Administration?.Medication as CodeableConcept));
+					var k_ = this.TherapeuticDuration(j_);
 					var l_ = context.Operators.Add(i_, k_);
 					var m_ = context.Operators.Interval(g_, l_, true, true);
 
@@ -601,7 +768,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("CumulativeDuration")]
-	public int? CumulativeDuration(CqlContext context, IEnumerable<CqlInterval<CqlDateTime>> Intervals)
+	public int? CumulativeDuration(IEnumerable<CqlInterval<CqlDateTime>> Intervals)
 	{
 		var a_ = context.Operators.Collapse(Intervals, "day");
 		int? b_(CqlInterval<CqlDateTime> X)
@@ -619,7 +786,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("RolloutIntervals")]
-	public IEnumerable<CqlInterval<CqlDateTime>> RolloutIntervals(CqlContext context, IEnumerable<CqlInterval<CqlDateTime>> intervals)
+	public IEnumerable<CqlInterval<CqlDateTime>> RolloutIntervals(IEnumerable<CqlInterval<CqlDateTime>> intervals)
 	{
 		IEnumerable<CqlInterval<CqlDateTime>> a_ = null;
 		IEnumerable<CqlInterval<CqlDateTime>> b_(IEnumerable<CqlInterval<CqlDateTime>> R, CqlInterval<CqlDateTime> I)
@@ -673,25 +840,25 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("MedicationPeriod")]
-	public CqlInterval<CqlDateTime> MedicationPeriod(CqlContext context, object medication)
+	public CqlInterval<CqlDateTime> MedicationPeriod(object medication)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (medication is MedicationRequest)
 			{
-				var b_ = this.MedicationRequestPeriod(context, (medication as MedicationRequest));
+				var b_ = this.MedicationRequestPeriod((medication as MedicationRequest));
 
 				return b_;
 			}
 			else if (medication is MedicationDispense)
 			{
-				var c_ = this.MedicationDispensePeriod(context, (medication as MedicationDispense));
+				var c_ = this.MedicationDispensePeriod((medication as MedicationDispense));
 
 				return c_;
 			}
 			else if (medication is MedicationAdministration)
 			{
-				var d_ = this.MedicationAdministrationPeriod(context, (medication as MedicationAdministration));
+				var d_ = this.MedicationAdministrationPeriod((medication as MedicationAdministration));
 
 				return d_;
 			}
@@ -707,7 +874,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 	}
 
     [CqlDeclaration("CumulativeMedicationDuration")]
-	public int? CumulativeMedicationDuration(CqlContext context, IEnumerable<object> Medications)
+	public int? CumulativeMedicationDuration(IEnumerable<object> Medications)
 	{
 		bool? a_(object M)
 		{
@@ -718,7 +885,7 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		var b_ = context.Operators.WhereOrNull<object>(Medications, a_);
 		CqlInterval<CqlDateTime> c_(object M)
 		{
-			var m_ = this.MedicationPeriod(context, M);
+			var m_ = this.MedicationPeriod(M);
 
 			return m_;
 		};
@@ -734,14 +901,14 @@ public class CumulativeMedicationDurationFHIR4_1_0_000
 		var f_ = context.Operators.WhereOrNull<object>(Medications, e_);
 		CqlInterval<CqlDateTime> g_(object M)
 		{
-			var q_ = this.MedicationPeriod(context, M);
+			var q_ = this.MedicationPeriod(M);
 
 			return q_;
 		};
 		var h_ = context.Operators.SelectOrNull<object, CqlInterval<CqlDateTime>>(f_, g_);
-		var i_ = this.RolloutIntervals(context, h_);
+		var i_ = this.RolloutIntervals(h_);
 		var j_ = context.Operators.ListUnion<CqlInterval<CqlDateTime>>(d_, i_);
-		var k_ = this.CumulativeDuration(context, j_);
+		var k_ = this.CumulativeDuration(j_);
 
 		return k_;
 	}

--- a/Demo/Measures/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.cs
+++ b/Demo/Measures/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.cs
@@ -14,93 +14,247 @@ using Task = Hl7.Fhir.Model.Task;
 public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 {
 
-    public static DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Diabetic_Retinopathy;
+    internal Lazy<CqlValueSet> __Level_of_Severity_of_Retinopathy_Findings;
+    internal Lazy<CqlValueSet> __Macular_Edema_Findings_Present;
+    internal Lazy<CqlValueSet> __Macular_Exam;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Ophthalmological_Services;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Patient_Reason;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode> __Healthcare_professional__occupation_;
+    internal Lazy<CqlCode> __Macular_edema_absent__situation_;
+    internal Lazy<CqlCode> __Medical_practitioner__occupation_;
+    internal Lazy<CqlCode> __Ophthalmologist__occupation_;
+    internal Lazy<CqlCode> __Optometrist__occupation_;
+    internal Lazy<CqlCode> __Physician__occupation_;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Diabetic_Retinopathy_Encounter;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema;
+    internal Lazy<IEnumerable<Communication>> __Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<IEnumerable<Observation>> __Macular_Exam_Performed;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Communication>> __Level_of_Severity_of_Retinopathy_Findings_Communicated;
+    internal Lazy<IEnumerable<Communication>> __Macular_Edema_Absence_Communicated;
+    internal Lazy<IEnumerable<Communication>> __Macular_Edema_Presence_Communicated;
+    internal Lazy<bool?> __Results_of_Dilated_Macular_or_Fundus_Exam_Communicated;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value(context));
+        __Diabetic_Retinopathy = new Lazy<CqlValueSet>(this.Diabetic_Retinopathy_Value(context));
+        __Level_of_Severity_of_Retinopathy_Findings = new Lazy<CqlValueSet>(this.Level_of_Severity_of_Retinopathy_Findings_Value(context));
+        __Macular_Edema_Findings_Present = new Lazy<CqlValueSet>(this.Macular_Edema_Findings_Present_Value(context));
+        __Macular_Exam = new Lazy<CqlValueSet>(this.Macular_Exam_Value(context));
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value(context));
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Ophthalmological_Services = new Lazy<CqlValueSet>(this.Ophthalmological_Services_Value(context));
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value(context));
+        __Patient_Reason = new Lazy<CqlValueSet>(this.Patient_Reason_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __Healthcare_professional__occupation_ = new Lazy<CqlCode>(this.Healthcare_professional__occupation__Value(context));
+        __Macular_edema_absent__situation_ = new Lazy<CqlCode>(this.Macular_edema_absent__situation__Value(context));
+        __Medical_practitioner__occupation_ = new Lazy<CqlCode>(this.Medical_practitioner__occupation__Value(context));
+        __Ophthalmologist__occupation_ = new Lazy<CqlCode>(this.Ophthalmologist__occupation__Value(context));
+        __Optometrist__occupation_ = new Lazy<CqlCode>(this.Optometrist__occupation__Value(context));
+        __Physician__occupation_ = new Lazy<CqlCode>(this.Physician__occupation__Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Qualifying_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_During_Measurement_Period_Value(context));
+        __Diabetic_Retinopathy_Encounter = new Lazy<IEnumerable<Encounter>>(this.Diabetic_Retinopathy_Encounter_Value(context));
+        __Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value(context));
+        __Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value(context));
+        __Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema = new Lazy<IEnumerable<Communication>>(this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value(context));
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Macular_Exam_Performed = new Lazy<IEnumerable<Observation>>(this.Macular_Exam_Performed_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Level_of_Severity_of_Retinopathy_Findings_Communicated = new Lazy<IEnumerable<Communication>>(this.Level_of_Severity_of_Retinopathy_Findings_Communicated_Value(context));
+        __Macular_Edema_Absence_Communicated = new Lazy<IEnumerable<Communication>>(this.Macular_Edema_Absence_Communicated_Value(context));
+        __Macular_Edema_Presence_Communicated = new Lazy<IEnumerable<Communication>>(this.Macular_Edema_Presence_Communicated_Value(context));
+        __Results_of_Dilated_Macular_or_Fundus_Exam_Communicated = new Lazy<bool?>(this.Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
-	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility?.Value;
+
+	private CqlValueSet Diabetic_Retinopathy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
 
     [CqlDeclaration("Diabetic Retinopathy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327")]
-	public CqlValueSet Diabetic_Retinopathy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327", null);
+	public CqlValueSet Diabetic_Retinopathy() => 
+		__Diabetic_Retinopathy?.Value;
+
+	private CqlValueSet Level_of_Severity_of_Retinopathy_Findings_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
 
     [CqlDeclaration("Level of Severity of Retinopathy Findings")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283")]
-	public CqlValueSet Level_of_Severity_of_Retinopathy_Findings(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283", null);
+	public CqlValueSet Level_of_Severity_of_Retinopathy_Findings() => 
+		__Level_of_Severity_of_Retinopathy_Findings?.Value;
+
+	private CqlValueSet Macular_Edema_Findings_Present_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
 
     [CqlDeclaration("Macular Edema Findings Present")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320")]
-	public CqlValueSet Macular_Edema_Findings_Present(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320", null);
+	public CqlValueSet Macular_Edema_Findings_Present() => 
+		__Macular_Edema_Findings_Present?.Value;
+
+	private CqlValueSet Macular_Exam_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
 
     [CqlDeclaration("Macular Exam")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251")]
-	public CqlValueSet Macular_Exam(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251", null);
+	public CqlValueSet Macular_Exam() => 
+		__Macular_Exam?.Value;
+
+	private CqlValueSet Medical_Reason_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007")]
-	public CqlValueSet Medical_Reason(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason?.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
-	public CqlValueSet Nursing_Facility_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Ophthalmological_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
 
     [CqlDeclaration("Ophthalmological Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285")]
-	public CqlValueSet Ophthalmological_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285", null);
+	public CqlValueSet Ophthalmological_Services() => 
+		__Ophthalmological_Services?.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
-	public CqlValueSet Outpatient_Consultation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation?.Value;
+
+	private CqlValueSet Patient_Reason_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
 
     [CqlDeclaration("Patient Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008")]
-	public CqlValueSet Patient_Reason(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+	public CqlValueSet Patient_Reason() => 
+		__Patient_Reason?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Healthcare professional (occupation)")]
-	public CqlCode Healthcare_professional__occupation_(CqlContext context) => 
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode Healthcare_professional__occupation__Value(CqlContext context) => 
 		new CqlCode("223366009", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Macular edema absent (situation)")]
-	public CqlCode Macular_edema_absent__situation_(CqlContext context) => 
+    [CqlDeclaration("Healthcare professional (occupation)")]
+	public CqlCode Healthcare_professional__occupation_() => 
+		__Healthcare_professional__occupation_?.Value;
+
+	private CqlCode Macular_edema_absent__situation__Value(CqlContext context) => 
 		new CqlCode("428341000124108", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Medical practitioner (occupation)")]
-	public CqlCode Medical_practitioner__occupation_(CqlContext context) => 
+    [CqlDeclaration("Macular edema absent (situation)")]
+	public CqlCode Macular_edema_absent__situation_() => 
+		__Macular_edema_absent__situation_?.Value;
+
+	private CqlCode Medical_practitioner__occupation__Value(CqlContext context) => 
 		new CqlCode("158965000", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Ophthalmologist (occupation)")]
-	public CqlCode Ophthalmologist__occupation_(CqlContext context) => 
+    [CqlDeclaration("Medical practitioner (occupation)")]
+	public CqlCode Medical_practitioner__occupation_() => 
+		__Medical_practitioner__occupation_?.Value;
+
+	private CqlCode Ophthalmologist__occupation__Value(CqlContext context) => 
 		new CqlCode("422234006", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Optometrist (occupation)")]
-	public CqlCode Optometrist__occupation_(CqlContext context) => 
+    [CqlDeclaration("Ophthalmologist (occupation)")]
+	public CqlCode Ophthalmologist__occupation_() => 
+		__Ophthalmologist__occupation_?.Value;
+
+	private CqlCode Optometrist__occupation__Value(CqlContext context) => 
 		new CqlCode("28229004", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Physician (occupation)")]
-	public CqlCode Physician__occupation_(CqlContext context) => 
+    [CqlDeclaration("Optometrist (occupation)")]
+	public CqlCode Optometrist__occupation_() => 
+		__Optometrist__occupation_?.Value;
+
+	private CqlCode Physician__occupation__Value(CqlContext context) => 
 		new CqlCode("309343006", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Physician (occupation)")]
+	public CqlCode Physician__occupation_() => 
+		__Physician__occupation_?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -110,8 +264,11 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return a_;
 	}
 
-    [CqlDeclaration("SNOMEDCT")]
-	public CqlCode[] SNOMEDCT(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlCode[] SNOMEDCT_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -126,16 +283,22 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -143,59 +306,74 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Qualifying Encounter During Measurement Period")]
-	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+	private IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Office_Visit(context);
+		var a_ = this.Office_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Ophthalmological_Services(context);
+		var c_ = this.Ophthalmological_Services();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Outpatient_Consultation(context);
+		var f_ = this.Outpatient_Consultation();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+		var h_ = this.Care_Services_in_Long_Term_Residential_Facility();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Nursing_Facility_Visit(context);
+		var l_ = this.Nursing_Facility_Visit();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
 		var n_ = context.Operators.ListUnion<Encounter>(k_, m_);
 		bool? o_(Encounter QualifyingEncounter)
 		{
-			var q_ = this.Measurement_Period(context);
-			var r_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, QualifyingEncounter?.Period);
+			var q_ = this.Measurement_Period();
+			var r_ = FHIRHelpers_4_0_001.ToInterval(QualifyingEncounter?.Period);
 			var s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, r_, null);
 			var t_ = context.Operators.Convert<string>(QualifyingEncounter?.StatusElement);
 			var u_ = context.Operators.Equal(t_, "finished");
@@ -208,22 +386,25 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return p_;
 	}
 
-    [CqlDeclaration("Diabetic Retinopathy Encounter")]
-	public IEnumerable<Encounter> Diabetic_Retinopathy_Encounter(CqlContext context)
+    [CqlDeclaration("Qualifying Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period() => 
+		__Qualifying_Encounter_During_Measurement_Period?.Value;
+
+	private IEnumerable<Encounter> Diabetic_Retinopathy_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+		var a_ = this.Qualifying_Encounter_During_Measurement_Period();
 		IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
 		{
-			var d_ = this.Diabetic_Retinopathy(context);
+			var d_ = this.Diabetic_Retinopathy();
 			var e_ = context.Operators.RetrieveByValueSet<Condition>(d_, null);
 			bool? f_(Condition DiabeticRetinopathy)
 			{
-				var j_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, DiabeticRetinopathy?.ClinicalStatus);
-				var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.active(context);
+				var j_ = FHIRHelpers_4_0_001.ToConcept(DiabeticRetinopathy?.ClinicalStatus);
+				var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.active();
 				var l_ = context.Operators.ConvertCodeToConcept(k_);
 				var m_ = context.Operators.Equivalent(j_, l_);
-				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, DiabeticRetinopathy);
-				var o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ValidQualifyingEncounter?.Period);
+				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(DiabeticRetinopathy);
+				var o_ = FHIRHelpers_4_0_001.ToInterval(ValidQualifyingEncounter?.Period);
 				var p_ = context.Operators.Overlaps(n_, o_, null);
 				var q_ = context.Operators.And(m_, p_);
 
@@ -241,8 +422,12 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return c_;
 	}
 
+    [CqlDeclaration("Diabetic Retinopathy Encounter")]
+	public IEnumerable<Encounter> Diabetic_Retinopathy_Encounter() => 
+		__Diabetic_Retinopathy_Encounter?.Value;
+
     [CqlDeclaration("GetModifierExtensions")]
-	public IEnumerable<Extension> GetModifierExtensions(CqlContext context, DomainResource domainResource, string url)
+	public IEnumerable<Extension> GetModifierExtensions(DomainResource domainResource, string url)
 	{
 		bool? a_(Extension E)
 		{
@@ -262,28 +447,27 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	}
 
     [CqlDeclaration("GetModifierExtension")]
-	public Extension GetModifierExtension(CqlContext context, DomainResource domainResource, string url)
+	public Extension GetModifierExtension(DomainResource domainResource, string url)
 	{
-		var a_ = this.GetModifierExtensions(context, domainResource, url);
+		var a_ = this.GetModifierExtensions(domainResource, url);
 		var b_ = context.Operators.SingleOrNull<Extension>(a_);
 
 		return b_;
 	}
 
-    [CqlDeclaration("Medical or Patient Reason for Not Communicating Level of Severity of Retinopathy")]
-	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy(CqlContext context)
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy_Value(CqlContext context)
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings(context);
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
 		var b_ = typeof(Communication).GetProperty("ReasonCode");
 		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication LevelOfSeverityNotCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter(context);
+			var h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
-				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.GetExtension(context, LevelOfSeverityNotCommunicated, "qicore-recorded");
-				var o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (n_?.Value as Period));
+				var m_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension(LevelOfSeverityNotCommunicated, "qicore-recorded");
+				var o_ = FHIRHelpers_4_0_001.ToInterval((n_?.Value as Period));
 				var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, null);
 
 				return p_;
@@ -300,14 +484,14 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		{
 			var q_ = context.Operators.Convert<string>(LevelOfSeverityNotCommunicated?.StatusElement);
 			var r_ = context.Operators.Equal(q_, "not-done");
-			var s_ = this.GetModifierExtension(context, LevelOfSeverityNotCommunicated, "qicore-notDone");
-			var t_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, (s_?.Value as FhirBoolean));
+			var s_ = this.GetModifierExtension(LevelOfSeverityNotCommunicated, "qicore-notDone");
+			var t_ = FHIRHelpers_4_0_001.ToBoolean((s_?.Value as FhirBoolean));
 			var u_ = context.Operators.IsTrue(t_);
 			var v_ = context.Operators.And(r_, u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, LevelOfSeverityNotCommunicated?.StatusReason);
-			var x_ = this.Medical_Reason(context);
+			var w_ = FHIRHelpers_4_0_001.ToConcept(LevelOfSeverityNotCommunicated?.StatusReason);
+			var x_ = this.Medical_Reason();
 			var y_ = context.Operators.ConceptInValueSet(w_, x_);
-			var aa_ = this.Patient_Reason(context);
+			var aa_ = this.Patient_Reason();
 			var ab_ = context.Operators.ConceptInValueSet(w_, aa_);
 			var ac_ = context.Operators.Or(y_, ab_);
 			var ad_ = context.Operators.And(v_, ac_);
@@ -319,21 +503,24 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return g_;
 	}
 
-    [CqlDeclaration("Medical or Patient Reason for Not Communicating Absence of Macular Edema")]
-	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema(CqlContext context)
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Level of Severity of Retinopathy")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy?.Value;
+
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema_Value(CqlContext context)
 	{
-		var a_ = this.Macular_edema_absent__situation_(context);
+		var a_ = this.Macular_edema_absent__situation_();
 		var b_ = context.Operators.ToList<CqlCode>(a_);
 		var c_ = typeof(Communication).GetProperty("ReasonCode");
 		var d_ = context.Operators.RetrieveByCodes<Communication>(b_, c_);
 		IEnumerable<Communication> e_(Communication MacularEdemaAbsentNotCommunicated)
 		{
-			var i_ = this.Diabetic_Retinopathy_Encounter(context);
+			var i_ = this.Diabetic_Retinopathy_Encounter();
 			bool? j_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
-				var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.GetExtension(context, MacularEdemaAbsentNotCommunicated, "qicore-recorded");
-				var p_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (o_?.Value as Period));
+				var n_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension(MacularEdemaAbsentNotCommunicated, "qicore-recorded");
+				var p_ = FHIRHelpers_4_0_001.ToInterval((o_?.Value as Period));
 				var q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, p_, null);
 
 				return q_;
@@ -350,14 +537,14 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		{
 			var r_ = context.Operators.Convert<string>(MacularEdemaAbsentNotCommunicated?.StatusElement);
 			var s_ = context.Operators.Equal(r_, "not-done");
-			var t_ = this.GetModifierExtension(context, MacularEdemaAbsentNotCommunicated, "qicore-notDone");
-			var u_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, (t_?.Value as FhirBoolean));
+			var t_ = this.GetModifierExtension(MacularEdemaAbsentNotCommunicated, "qicore-notDone");
+			var u_ = FHIRHelpers_4_0_001.ToBoolean((t_?.Value as FhirBoolean));
 			var v_ = context.Operators.IsTrue(u_);
 			var w_ = context.Operators.And(s_, v_);
-			var x_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, MacularEdemaAbsentNotCommunicated?.StatusReason);
-			var y_ = this.Medical_Reason(context);
+			var x_ = FHIRHelpers_4_0_001.ToConcept(MacularEdemaAbsentNotCommunicated?.StatusReason);
+			var y_ = this.Medical_Reason();
 			var z_ = context.Operators.ConceptInValueSet(x_, y_);
-			var ab_ = this.Patient_Reason(context);
+			var ab_ = this.Patient_Reason();
 			var ac_ = context.Operators.ConceptInValueSet(x_, ab_);
 			var ad_ = context.Operators.Or(z_, ac_);
 			var ae_ = context.Operators.And(w_, ad_);
@@ -369,20 +556,23 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return h_;
 	}
 
-    [CqlDeclaration("Medical or Patient Reason for Not Communicating Presence of Macular Edema")]
-	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema(CqlContext context)
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Absence of Macular Edema")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema?.Value;
+
+	private IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema_Value(CqlContext context)
 	{
-		var a_ = this.Macular_Edema_Findings_Present(context);
+		var a_ = this.Macular_Edema_Findings_Present();
 		var b_ = typeof(Communication).GetProperty("ReasonCode");
 		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication MacularEdemaPresentNotCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter(context);
+			var h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
-				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.GetExtension(context, MacularEdemaPresentNotCommunicated, "qicore-recorded");
-				var o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (n_?.Value as Period));
+				var m_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetExtension(MacularEdemaPresentNotCommunicated, "qicore-recorded");
+				var o_ = FHIRHelpers_4_0_001.ToInterval((n_?.Value as Period));
 				var p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, null);
 
 				return p_;
@@ -399,14 +589,14 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		{
 			var q_ = context.Operators.Convert<string>(MacularEdemaPresentNotCommunicated?.StatusElement);
 			var r_ = context.Operators.Equal(q_, "not-done");
-			var s_ = this.GetModifierExtension(context, MacularEdemaPresentNotCommunicated, "qicore-notDone");
-			var t_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, (s_?.Value as FhirBoolean));
+			var s_ = this.GetModifierExtension(MacularEdemaPresentNotCommunicated, "qicore-notDone");
+			var t_ = FHIRHelpers_4_0_001.ToBoolean((s_?.Value as FhirBoolean));
 			var u_ = context.Operators.IsTrue(t_);
 			var v_ = context.Operators.And(r_, u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, MacularEdemaPresentNotCommunicated?.StatusReason);
-			var x_ = this.Medical_Reason(context);
+			var w_ = FHIRHelpers_4_0_001.ToConcept(MacularEdemaPresentNotCommunicated?.StatusReason);
+			var x_ = this.Medical_Reason();
 			var y_ = context.Operators.ConceptInValueSet(w_, x_);
-			var aa_ = this.Patient_Reason(context);
+			var aa_ = this.Patient_Reason();
 			var ab_ = context.Operators.ConceptInValueSet(w_, aa_);
 			var ac_ = context.Operators.Or(y_, ab_);
 			var ad_ = context.Operators.And(v_, ac_);
@@ -418,49 +608,58 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return g_;
 	}
 
-    [CqlDeclaration("Denominator Exceptions")]
-	public bool? Denominator_Exceptions(CqlContext context)
+    [CqlDeclaration("Medical or Patient Reason for Not Communicating Presence of Macular Edema")]
+	public IEnumerable<Communication> Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema() => 
+		__Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema?.Value;
+
+	private bool? Denominator_Exceptions_Value(CqlContext context)
 	{
-		var a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy(context);
+		var a_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Level_of_Severity_of_Retinopathy();
 		var b_ = context.Operators.ExistsInList<Communication>(a_);
-		var c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema(context);
+		var c_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Absence_of_Macular_Edema();
 		var d_ = context.Operators.ExistsInList<Communication>(c_);
 		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema(context);
+		var f_ = this.Medical_or_Patient_Reason_for_Not_Communicating_Presence_of_Macular_Edema();
 		var g_ = context.Operators.ExistsInList<Communication>(f_);
 		var h_ = context.Operators.Or(e_, g_);
 
 		return h_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.ConvertStringToDateTime(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.CalculateAgeAt(b_, d_, "year");
 		var f_ = context.Operators.GreaterOrEqual(e_, (int?)18);
-		var g_ = this.Diabetic_Retinopathy_Encounter(context);
+		var g_ = this.Diabetic_Retinopathy_Encounter();
 		var h_ = context.Operators.ExistsInList<Encounter>(g_);
 		var i_ = context.Operators.And(f_, h_);
 
 		return i_;
 	}
 
-    [CqlDeclaration("Macular Exam Performed")]
-	public IEnumerable<Observation> Macular_Exam_Performed(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private IEnumerable<Observation> Macular_Exam_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Macular_Exam(context);
+		var a_ = this.Macular_Exam();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		IEnumerable<Observation> c_(Observation MacularExam)
 		{
-			var g_ = this.Diabetic_Retinopathy_Encounter(context);
+			var g_ = this.Diabetic_Retinopathy_Encounter();
 			bool? h_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
-				var m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, MacularExam?.Effective);
+				var l_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
+				var m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(MacularExam?.Effective);
 				var n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, m_, null);
 
 				return n_;
@@ -493,30 +692,36 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return f_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Macular Exam Performed")]
+	public IEnumerable<Observation> Macular_Exam_Performed() => 
+		__Macular_Exam_Performed?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
-		var b_ = this.Macular_Exam_Performed(context);
+		var a_ = this.Initial_Population();
+		var b_ = this.Macular_Exam_Performed();
 		var c_ = context.Operators.ExistsInList<Observation>(b_);
 		var d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
-    [CqlDeclaration("Level of Severity of Retinopathy Findings Communicated")]
-	public IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated_Value(CqlContext context)
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings(context);
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings();
 		var b_ = typeof(Communication).GetProperty("ReasonCode");
 		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication LevelOfSeverityCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter(context);
+			var h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, LevelOfSeverityCommunicated?.SentElement);
-				var n_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
+				var m_ = FHIRHelpers_4_0_001.ToDateTime(LevelOfSeverityCommunicated?.SentElement);
+				var n_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
 				var o_ = context.Operators.Start(n_);
 				var p_ = context.Operators.After(m_, o_, null);
 
@@ -542,20 +747,23 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return g_;
 	}
 
-    [CqlDeclaration("Macular Edema Absence Communicated")]
-	public IEnumerable<Communication> Macular_Edema_Absence_Communicated(CqlContext context)
+    [CqlDeclaration("Level of Severity of Retinopathy Findings Communicated")]
+	public IEnumerable<Communication> Level_of_Severity_of_Retinopathy_Findings_Communicated() => 
+		__Level_of_Severity_of_Retinopathy_Findings_Communicated?.Value;
+
+	private IEnumerable<Communication> Macular_Edema_Absence_Communicated_Value(CqlContext context)
 	{
-		var a_ = this.Macular_edema_absent__situation_(context);
+		var a_ = this.Macular_edema_absent__situation_();
 		var b_ = context.Operators.ToList<CqlCode>(a_);
 		var c_ = typeof(Communication).GetProperty("ReasonCode");
 		var d_ = context.Operators.RetrieveByCodes<Communication>(b_, c_);
 		IEnumerable<Communication> e_(Communication MacularEdemaAbsentCommunicated)
 		{
-			var i_ = this.Diabetic_Retinopathy_Encounter(context);
+			var i_ = this.Diabetic_Retinopathy_Encounter();
 			bool? j_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, MacularEdemaAbsentCommunicated?.SentElement);
-				var o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
+				var n_ = FHIRHelpers_4_0_001.ToDateTime(MacularEdemaAbsentCommunicated?.SentElement);
+				var o_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
 				var p_ = context.Operators.Start(o_);
 				var q_ = context.Operators.After(n_, p_, null);
 
@@ -581,19 +789,22 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return h_;
 	}
 
-    [CqlDeclaration("Macular Edema Presence Communicated")]
-	public IEnumerable<Communication> Macular_Edema_Presence_Communicated(CqlContext context)
+    [CqlDeclaration("Macular Edema Absence Communicated")]
+	public IEnumerable<Communication> Macular_Edema_Absence_Communicated() => 
+		__Macular_Edema_Absence_Communicated?.Value;
+
+	private IEnumerable<Communication> Macular_Edema_Presence_Communicated_Value(CqlContext context)
 	{
-		var a_ = this.Macular_Edema_Findings_Present(context);
+		var a_ = this.Macular_Edema_Findings_Present();
 		var b_ = typeof(Communication).GetProperty("ReasonCode");
 		var c_ = context.Operators.RetrieveByValueSet<Communication>(a_, b_);
 		IEnumerable<Communication> d_(Communication MacularEdemaPresentCommunicated)
 		{
-			var h_ = this.Diabetic_Retinopathy_Encounter(context);
+			var h_ = this.Diabetic_Retinopathy_Encounter();
 			bool? i_(Encounter EncounterDiabeticRetinopathy)
 			{
-				var m_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, MacularEdemaPresentCommunicated?.SentElement);
-				var n_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterDiabeticRetinopathy?.Period);
+				var m_ = FHIRHelpers_4_0_001.ToDateTime(MacularEdemaPresentCommunicated?.SentElement);
+				var n_ = FHIRHelpers_4_0_001.ToInterval(EncounterDiabeticRetinopathy?.Period);
 				var o_ = context.Operators.Start(n_);
 				var p_ = context.Operators.After(m_, o_, null);
 
@@ -619,14 +830,35 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 		return g_;
 	}
 
-    [CqlDeclaration("Results of Dilated Macular or Fundus Exam Communicated")]
-	public bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated(CqlContext context)
+    [CqlDeclaration("Macular Edema Presence Communicated")]
+	public IEnumerable<Communication> Macular_Edema_Presence_Communicated() => 
+		__Macular_Edema_Presence_Communicated?.Value;
+
+	private bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated_Value(CqlContext context)
 	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated(context);
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
 		var b_ = context.Operators.ExistsInList<Communication>(a_);
-		var c_ = this.Macular_Edema_Absence_Communicated(context);
+		var c_ = this.Macular_Edema_Absence_Communicated();
 		var d_ = context.Operators.ExistsInList<Communication>(c_);
-		var e_ = this.Macular_Edema_Presence_Communicated(context);
+		var e_ = this.Macular_Edema_Presence_Communicated();
+		var f_ = context.Operators.ExistsInList<Communication>(e_);
+		var g_ = context.Operators.Or(d_, f_);
+		var h_ = context.Operators.And(b_, g_);
+
+		return h_;
+	}
+
+    [CqlDeclaration("Results of Dilated Macular or Fundus Exam Communicated")]
+	public bool? Results_of_Dilated_Macular_or_Fundus_Exam_Communicated() => 
+		__Results_of_Dilated_Macular_or_Fundus_Exam_Communicated?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
+	{
+		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated();
+		var b_ = context.Operators.ExistsInList<Communication>(a_);
+		var c_ = this.Macular_Edema_Absence_Communicated();
+		var d_ = context.Operators.ExistsInList<Communication>(c_);
+		var e_ = this.Macular_Edema_Presence_Communicated();
 		var f_ = context.Operators.ExistsInList<Communication>(e_);
 		var g_ = context.Operators.Or(d_, f_);
 		var h_ = context.Operators.And(b_, g_);
@@ -635,18 +867,7 @@ public class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004
 	}
 
     [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
-	{
-		var a_ = this.Level_of_Severity_of_Retinopathy_Findings_Communicated(context);
-		var b_ = context.Operators.ExistsInList<Communication>(a_);
-		var c_ = this.Macular_Edema_Absence_Communicated(context);
-		var d_ = context.Operators.ExistsInList<Communication>(c_);
-		var e_ = this.Macular_Edema_Presence_Communicated(context);
-		var f_ = context.Operators.ExistsInList<Communication>(e_);
-		var g_ = context.Operators.Or(d_, f_);
-		var h_ = context.Operators.And(b_, g_);
-
-		return h_;
-	}
+	public bool? Numerator() => 
+		__Numerator?.Value;
 
 }

--- a/Demo/Measures/DevDays-2023.0.0.cs
+++ b/Demo/Measures/DevDays-2023.0.0.cs
@@ -14,18 +14,58 @@ using Task = Hl7.Fhir.Model.Task;
 public class DevDays_2023_0_0
 {
 
-    public static DevDays_2023_0_0 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("Sucked into jet engine")]
-	public CqlCode Sucked_into_jet_engine(CqlContext context) => 
+    #region Cached values
+
+    internal Lazy<CqlCode> __Sucked_into_jet_engine;
+    internal Lazy<CqlCode> __Sucked_into_jet_engine__subsequent_encounter;
+    internal Lazy<CqlCode[]> __ICD10;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Condition>> __Jet_engine_conditions;
+    internal Lazy<IEnumerable<Condition>> __Subsequent_encounters;
+    internal Lazy<bool?> __Initial_population;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public DevDays_2023_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Sucked_into_jet_engine = new Lazy<CqlCode>(this.Sucked_into_jet_engine_Value(context));
+        __Sucked_into_jet_engine__subsequent_encounter = new Lazy<CqlCode>(this.Sucked_into_jet_engine__subsequent_encounter_Value(context));
+        __ICD10 = new Lazy<CqlCode[]>(this.ICD10_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Jet_engine_conditions = new Lazy<IEnumerable<Condition>>(this.Jet_engine_conditions_Value(context));
+        __Subsequent_encounters = new Lazy<IEnumerable<Condition>>(this.Subsequent_encounters_Value(context));
+        __Initial_population = new Lazy<bool?>(this.Initial_population_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlCode Sucked_into_jet_engine_Value(CqlContext context) => 
 		new CqlCode("V97.33", "http://hl7.org/fhir/sid/icd-10", null, null);
 
-    [CqlDeclaration("Sucked into jet engine, subsequent encounter")]
-	public CqlCode Sucked_into_jet_engine__subsequent_encounter(CqlContext context) => 
+    [CqlDeclaration("Sucked into jet engine")]
+	public CqlCode Sucked_into_jet_engine() => 
+		__Sucked_into_jet_engine?.Value;
+
+	private CqlCode Sucked_into_jet_engine__subsequent_encounter_Value(CqlContext context) => 
 		new CqlCode("V97.33XD", "http://hl7.org/fhir/sid/icd-10", null, null);
 
-    [CqlDeclaration("ICD10")]
-	public CqlCode[] ICD10(CqlContext context)
+    [CqlDeclaration("Sucked into jet engine, subsequent encounter")]
+	public CqlCode Sucked_into_jet_engine__subsequent_encounter() => 
+		__Sucked_into_jet_engine__subsequent_encounter?.Value;
+
+	private CqlCode[] ICD10_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -36,16 +76,22 @@ public class DevDays_2023_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ICD10")]
+	public CqlCode[] ICD10() => 
+		__ICD10?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("DevDays-2023.0.0", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -53,24 +99,58 @@ public class DevDays_2023_0_0
 		return b_;
 	}
 
-    [CqlDeclaration("Jet engine conditions")]
-	public IEnumerable<Condition> Jet_engine_conditions(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Condition> Jet_engine_conditions_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition c)
 		{
 			bool? d_(Coding coding)
 			{
-				var k_ = FHIRHelpers_4_0_001.Instance.ToCode(context, coding);
-				var l_ = this.Sucked_into_jet_engine(context);
+				var k_ = FHIRHelpers_4_0_001.ToCode(coding);
+				var l_ = this.Sucked_into_jet_engine();
 				var m_ = context.Operators.Equivalent(k_, l_);
 
 				return m_;
 			};
 			var e_ = context.Operators.WhereOrNull<Coding>((c?.Code?.Coding as IEnumerable<Coding>), d_);
 			var f_ = context.Operators.ExistsInList<Coding>(e_);
-			var g_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (c?.Onset as FhirDateTime));
-			var h_ = this.Measurement_Period(context);
+			var g_ = FHIRHelpers_4_0_001.ToDateTime((c?.Onset as FhirDateTime));
+			var h_ = this.Measurement_Period();
+			var i_ = context.Operators.ElementInInterval<CqlDateTime>(g_, h_, null);
+			var j_ = context.Operators.And(f_, i_);
+
+			return j_;
+		};
+		var c_ = context.Operators.WhereOrNull<Condition>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Jet engine conditions")]
+	public IEnumerable<Condition> Jet_engine_conditions() => 
+		__Jet_engine_conditions?.Value;
+
+	private IEnumerable<Condition> Subsequent_encounters_Value(CqlContext context)
+	{
+		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
+		bool? b_(Condition c)
+		{
+			bool? d_(Coding coding)
+			{
+				var k_ = FHIRHelpers_4_0_001.ToCode(coding);
+				var l_ = this.Sucked_into_jet_engine__subsequent_encounter();
+				var m_ = context.Operators.Equivalent(k_, l_);
+
+				return m_;
+			};
+			var e_ = context.Operators.WhereOrNull<Coding>((c?.Code?.Coding as IEnumerable<Coding>), d_);
+			var f_ = context.Operators.ExistsInList<Coding>(e_);
+			var g_ = FHIRHelpers_4_0_001.ToDateTime((c?.Onset as FhirDateTime));
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.ElementInInterval<CqlDateTime>(g_, h_, null);
 			var j_ = context.Operators.And(f_, i_);
 
@@ -82,49 +162,31 @@ public class DevDays_2023_0_0
 	}
 
     [CqlDeclaration("Subsequent encounters")]
-	public IEnumerable<Condition> Subsequent_encounters(CqlContext context)
+	public IEnumerable<Condition> Subsequent_encounters() => 
+		__Subsequent_encounters?.Value;
+
+	private bool? Initial_population_Value(CqlContext context)
 	{
-		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
-		bool? b_(Condition c)
-		{
-			bool? d_(Coding coding)
-			{
-				var k_ = FHIRHelpers_4_0_001.Instance.ToCode(context, coding);
-				var l_ = this.Sucked_into_jet_engine__subsequent_encounter(context);
-				var m_ = context.Operators.Equivalent(k_, l_);
+		var a_ = this.Jet_engine_conditions();
+		var b_ = context.Operators.ExistsInList<Condition>(a_);
 
-				return m_;
-			};
-			var e_ = context.Operators.WhereOrNull<Coding>((c?.Code?.Coding as IEnumerable<Coding>), d_);
-			var f_ = context.Operators.ExistsInList<Coding>(e_);
-			var g_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (c?.Onset as FhirDateTime));
-			var h_ = this.Measurement_Period(context);
-			var i_ = context.Operators.ElementInInterval<CqlDateTime>(g_, h_, null);
-			var j_ = context.Operators.And(f_, i_);
-
-			return j_;
-		};
-		var c_ = context.Operators.WhereOrNull<Condition>(a_, b_);
-
-		return c_;
+		return b_;
 	}
 
     [CqlDeclaration("Initial population")]
-	public bool? Initial_population(CqlContext context)
+	public bool? Initial_population() => 
+		__Initial_population?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Jet_engine_conditions(context);
+		var a_ = this.Subsequent_encounters();
 		var b_ = context.Operators.ExistsInList<Condition>(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
-	{
-		var a_ = this.Subsequent_encounters(context);
-		var b_ = context.Operators.ExistsInList<Condition>(a_);
-
-		return b_;
-	}
+	public bool? Numerator() => 
+		__Numerator?.Value;
 
 }

--- a/Demo/Measures/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.cs
+++ b/Demo/Measures/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.cs
@@ -14,74 +14,201 @@ using Task = Hl7.Fhir.Model.Task;
 public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 {
 
-    public static DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __HbA1c_Laboratory_Test;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Telehealth_Services;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<Observation> __Most_Recent_HbA1c;
+    internal Lazy<bool?> __Has_Most_Recent_HbA1c_Without_Result;
+    internal Lazy<bool?> __Has_Most_Recent_Elevated_HbA1c;
+    internal Lazy<bool?> __Has_No_Record_Of_HbA1c;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+
+    #endregion
+    public DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+        AdultOutpatientEncountersFHIR4_2_2_000 = new AdultOutpatientEncountersFHIR4_2_2_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+        AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 = new AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value(context));
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value(context));
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(context));
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __HbA1c_Laboratory_Test = new Lazy<CqlValueSet>(this.HbA1c_Laboratory_Test_Value(context));
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value(context));
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Telehealth_Services = new Lazy<IEnumerable<Encounter>>(this.Telehealth_Services_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Most_Recent_HbA1c = new Lazy<Observation>(this.Most_Recent_HbA1c_Value(context));
+        __Has_Most_Recent_HbA1c_Without_Result = new Lazy<bool?>(this.Has_Most_Recent_HbA1c_Without_Result_Value(context));
+        __Has_Most_Recent_Elevated_HbA1c = new Lazy<bool?>(this.Has_Most_Recent_Elevated_HbA1c_Value(context));
+        __Has_No_Record_Of_HbA1c = new Lazy<bool?>(this.Has_No_Record_Of_HbA1c_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+    public AdultOutpatientEncountersFHIR4_2_2_000 AdultOutpatientEncountersFHIR4_2_2_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
-	public CqlValueSet Annual_Wellness_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit?.Value;
+
+	private CqlValueSet Diabetes_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
-	public CqlValueSet Diabetes(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+	public CqlValueSet Diabetes() => 
+		__Diabetes?.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
-	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care?.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
-	public CqlValueSet Discharged_to_Home_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet HbA1c_Laboratory_Test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
 
     [CqlDeclaration("HbA1c Laboratory Test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013")]
-	public CqlValueSet HbA1c_Laboratory_Test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1013", null);
+	public CqlValueSet HbA1c_Laboratory_Test() => 
+		__HbA1c_Laboratory_Test?.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
-	public CqlValueSet Home_Healthcare_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services?.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
-	public CqlValueSet Hospice_care_ambulatory(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -91,16 +218,22 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -108,49 +241,64 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Telehealth Services")]
-	public IEnumerable<Encounter> Telehealth_Services(CqlContext context)
+	private IEnumerable<Encounter> Telehealth_Services_Value(CqlContext context)
 	{
-		var a_ = this.Telephone_Visits(context);
+		var a_ = this.Telephone_Visits();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter TelehealthEncounter)
 		{
 			var e_ = context.Operators.Convert<string>(TelehealthEncounter?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "finished");
-			var g_ = this.Measurement_Period(context);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (TelehealthEncounter?.Period as object));
+			var g_ = this.Measurement_Period();
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((TelehealthEncounter?.Period as object));
 			var i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(g_, h_, null);
 			var j_ = context.Operators.And(f_, i_);
 
@@ -161,28 +309,31 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return d_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Telehealth Services")]
+	public IEnumerable<Encounter> Telehealth_Services() => 
+		__Telehealth_Services?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.Interval((int?)18, (int?)75, true, false);
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
-		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
-		var j_ = this.Telehealth_Services(context);
+		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
+		var j_ = this.Telehealth_Services();
 		var k_ = context.Operators.ListUnion<Encounter>(i_, j_);
 		var l_ = context.Operators.ExistsInList<Encounter>(k_);
 		var m_ = context.Operators.And(h_, l_);
-		var n_ = this.Diabetes(context);
+		var n_ = this.Diabetes();
 		var o_ = context.Operators.RetrieveByValueSet<Condition>(n_, null);
 		bool? p_(Condition Diabetes)
 		{
-			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Diabetes);
-			var u_ = this.Measurement_Period(context);
+			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
+			var u_ = this.Measurement_Period();
 			var v_ = context.Operators.Overlaps(t_, u_, null);
 
 			return v_;
@@ -194,18 +345,24 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return s_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Most Recent HbA1c")]
-	public Observation Most_Recent_HbA1c(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private Observation Most_Recent_HbA1c_Value(CqlContext context)
 	{
-		var a_ = this.HbA1c_Laboratory_Test(context);
+		var a_ = this.HbA1c_Laboratory_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation RecentHbA1c)
 		{
@@ -217,8 +374,8 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 				"corrected",
 			};
 			var j_ = context.Operators.InList<string>(h_, (i_ as IEnumerable<string>));
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, RecentHbA1c?.Effective);
-			var l_ = this.Measurement_Period(context);
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(RecentHbA1c?.Effective);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
 			var n_ = context.Operators.And(j_, m_);
 
@@ -227,7 +384,7 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		object e_(Observation @this)
 		{
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 			var p_ = context.Operators.Start(o_);
 
 			return p_;
@@ -238,31 +395,40 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return g_;
 	}
 
-    [CqlDeclaration("Has Most Recent HbA1c Without Result")]
-	public bool? Has_Most_Recent_HbA1c_Without_Result(CqlContext context)
+    [CqlDeclaration("Most Recent HbA1c")]
+	public Observation Most_Recent_HbA1c() => 
+		__Most_Recent_HbA1c?.Value;
+
+	private bool? Has_Most_Recent_HbA1c_Without_Result_Value(CqlContext context)
 	{
-		var a_ = this.Most_Recent_HbA1c(context);
+		var a_ = this.Most_Recent_HbA1c();
 		var b_ = context.Operators.Not((bool?)(a_ is null));
 		var d_ = context.Operators.And(b_, (bool?)(a_?.Value is null));
 
 		return d_;
 	}
 
-    [CqlDeclaration("Has Most Recent Elevated HbA1c")]
-	public bool? Has_Most_Recent_Elevated_HbA1c(CqlContext context)
+    [CqlDeclaration("Has Most Recent HbA1c Without Result")]
+	public bool? Has_Most_Recent_HbA1c_Without_Result() => 
+		__Has_Most_Recent_HbA1c_Without_Result?.Value;
+
+	private bool? Has_Most_Recent_Elevated_HbA1c_Value(CqlContext context)
 	{
-		var a_ = this.Most_Recent_HbA1c(context);
-		var b_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (a_?.Value as Quantity));
+		var a_ = this.Most_Recent_HbA1c();
+		var b_ = FHIRHelpers_4_0_001.ToQuantity((a_?.Value as Quantity));
 		var c_ = context.Operators.Quantity(9m, "%");
 		var d_ = context.Operators.Greater(b_, c_);
 
 		return d_;
 	}
 
-    [CqlDeclaration("Has No Record Of HbA1c")]
-	public bool? Has_No_Record_Of_HbA1c(CqlContext context)
+    [CqlDeclaration("Has Most Recent Elevated HbA1c")]
+	public bool? Has_Most_Recent_Elevated_HbA1c() => 
+		__Has_Most_Recent_Elevated_HbA1c?.Value;
+
+	private bool? Has_No_Record_Of_HbA1c_Value(CqlContext context)
 	{
-		var a_ = this.HbA1c_Laboratory_Test(context);
+		var a_ = this.HbA1c_Laboratory_Test();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation NoHbA1c)
 		{
@@ -274,8 +440,8 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 				"corrected",
 			};
 			var i_ = context.Operators.InList<string>(g_, (h_ as IEnumerable<string>));
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, NoHbA1c?.Effective);
-			var k_ = this.Measurement_Period(context);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(NoHbA1c?.Effective);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, null);
 			var m_ = context.Operators.And(i_, l_);
 
@@ -288,38 +454,48 @@ public class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015
 		return f_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Has No Record Of HbA1c")]
+	public bool? Has_No_Record_Of_HbA1c() => 
+		__Has_No_Record_Of_HbA1c?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Has_Most_Recent_HbA1c_Without_Result(context);
-		var b_ = this.Has_Most_Recent_Elevated_HbA1c(context);
+		var a_ = this.Has_Most_Recent_HbA1c_Without_Result();
+		var b_ = this.Has_Most_Recent_Elevated_HbA1c();
 		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_No_Record_Of_HbA1c(context);
+		var d_ = this.Has_No_Record_Of_HbA1c();
 		var e_ = context.Operators.Or(c_, d_);
 
 		return e_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Patient(context);
+		var d_ = this.Patient();
 		var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
-		var f_ = this.Measurement_Period(context);
+		var f_ = this.Measurement_Period();
 		var g_ = context.Operators.Start(f_);
 		var h_ = context.Operators.DateFrom(g_);
 		var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
 		var j_ = context.Operators.GreaterOrEqual(i_, (int?)65);
-		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(context);
+		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		var l_ = context.Operators.And(j_, k_);
 		var m_ = context.Operators.Or(c_, l_);
-		var n_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var n_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var o_ = context.Operators.Or(m_, n_);
 
 		return o_;
 	}
+
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
 
 }

--- a/Demo/Measures/DischargedonAntithromboticTherapyFHIR-0.0.010.cs
+++ b/Demo/Measures/DischargedonAntithromboticTherapyFHIR-0.0.010.cs
@@ -14,88 +14,215 @@ using Task = Hl7.Fhir.Model.Task;
 public class DischargedonAntithromboticTherapyFHIR_0_0_010
 {
 
-    public static DischargedonAntithromboticTherapyFHIR_0_0_010 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Antithrombotic_Therapy;
+    internal Lazy<CqlValueSet> __Comfort_Measures;
+    internal Lazy<CqlValueSet> __Discharge_To_Acute_Care_Facility;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Hemorrhagic_Stroke;
+    internal Lazy<CqlValueSet> __Ischemic_Stroke;
+    internal Lazy<CqlValueSet> __Left_Against_Medical_Advice;
+    internal Lazy<CqlValueSet> __Medical_Reason;
+    internal Lazy<CqlValueSet> __Non_Elective_Inpatient_Encounter;
+    internal Lazy<CqlValueSet> __Patient_Expired;
+    internal Lazy<CqlValueSet> __Patient_Refusal;
+    internal Lazy<CqlValueSet> __Pharmacological_Contraindications_For_Antithrombotic_Therapy;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<MedicationRequest>> __Antithrombotic_Not_Given_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_With_No_Antithrombotic_At_Discharge;
+    internal Lazy<IEnumerable<MedicationRequest>> __Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exceptions;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<MedicationRequest>> __Antithrombotic_Therapy_at_Discharge;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public DischargedonAntithromboticTherapyFHIR_0_0_010(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        TJCOverallFHIR_1_8_000 = new TJCOverallFHIR_1_8_000(context);
+
+        __Antithrombotic_Therapy = new Lazy<CqlValueSet>(this.Antithrombotic_Therapy_Value(context));
+        __Comfort_Measures = new Lazy<CqlValueSet>(this.Comfort_Measures_Value(context));
+        __Discharge_To_Acute_Care_Facility = new Lazy<CqlValueSet>(this.Discharge_To_Acute_Care_Facility_Value(context));
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(context));
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Hemorrhagic_Stroke = new Lazy<CqlValueSet>(this.Hemorrhagic_Stroke_Value(context));
+        __Ischemic_Stroke = new Lazy<CqlValueSet>(this.Ischemic_Stroke_Value(context));
+        __Left_Against_Medical_Advice = new Lazy<CqlValueSet>(this.Left_Against_Medical_Advice_Value(context));
+        __Medical_Reason = new Lazy<CqlValueSet>(this.Medical_Reason_Value(context));
+        __Non_Elective_Inpatient_Encounter = new Lazy<CqlValueSet>(this.Non_Elective_Inpatient_Encounter_Value(context));
+        __Patient_Expired = new Lazy<CqlValueSet>(this.Patient_Expired_Value(context));
+        __Patient_Refusal = new Lazy<CqlValueSet>(this.Patient_Refusal_Value(context));
+        __Pharmacological_Contraindications_For_Antithrombotic_Therapy = new Lazy<CqlValueSet>(this.Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value(context));
+        __Antithrombotic_Not_Given_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Antithrombotic_Not_Given_at_Discharge_Value(context));
+        __Encounter_With_No_Antithrombotic_At_Discharge = new Lazy<IEnumerable<Encounter>>(this.Encounter_With_No_Antithrombotic_At_Discharge_Value(context));
+        __Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value(context));
+        __Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<Encounter>>(this.Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value(context));
+        __Denominator_Exceptions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exceptions_Value(context));
+        __Denominator_Exclusions = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusions_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Antithrombotic_Therapy_at_Discharge = new Lazy<IEnumerable<MedicationRequest>>(this.Antithrombotic_Therapy_at_Discharge_Value(context));
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public TJCOverallFHIR_1_8_000 TJCOverallFHIR_1_8_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Antithrombotic_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", null);
 
     [CqlDeclaration("Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201")]
-	public CqlValueSet Antithrombotic_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.201", null);
+	public CqlValueSet Antithrombotic_Therapy() => 
+		__Antithrombotic_Therapy?.Value;
+
+	private CqlValueSet Comfort_Measures_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
-	public CqlValueSet Comfort_Measures(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
+	public CqlValueSet Comfort_Measures() => 
+		__Comfort_Measures?.Value;
+
+	private CqlValueSet Discharge_To_Acute_Care_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
-	public CqlValueSet Discharge_To_Acute_Care_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
+		__Discharge_To_Acute_Care_Facility?.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
-	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care?.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
-	public CqlValueSet Discharged_to_Home_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Hemorrhagic_Stroke_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
-	public CqlValueSet Hemorrhagic_Stroke(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
+	public CqlValueSet Hemorrhagic_Stroke() => 
+		__Hemorrhagic_Stroke?.Value;
+
+	private CqlValueSet Ischemic_Stroke_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
-	public CqlValueSet Ischemic_Stroke(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
+	public CqlValueSet Ischemic_Stroke() => 
+		__Ischemic_Stroke?.Value;
+
+	private CqlValueSet Left_Against_Medical_Advice_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
-	public CqlValueSet Left_Against_Medical_Advice(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+	public CqlValueSet Left_Against_Medical_Advice() => 
+		__Left_Against_Medical_Advice?.Value;
+
+	private CqlValueSet Medical_Reason_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
 
     [CqlDeclaration("Medical Reason")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473")]
-	public CqlValueSet Medical_Reason(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.473", null);
+	public CqlValueSet Medical_Reason() => 
+		__Medical_Reason?.Value;
+
+	private CqlValueSet Non_Elective_Inpatient_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
 
     [CqlDeclaration("Non-Elective Inpatient Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
-	public CqlValueSet Non_Elective_Inpatient_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
+	public CqlValueSet Non_Elective_Inpatient_Encounter() => 
+		__Non_Elective_Inpatient_Encounter?.Value;
+
+	private CqlValueSet Patient_Expired_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
-	public CqlValueSet Patient_Expired(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+	public CqlValueSet Patient_Expired() => 
+		__Patient_Expired?.Value;
+
+	private CqlValueSet Patient_Refusal_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
 
     [CqlDeclaration("Patient Refusal")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93")]
-	public CqlValueSet Patient_Refusal(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.93", null);
+	public CqlValueSet Patient_Refusal() => 
+		__Patient_Refusal?.Value;
+
+	private CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
 
     [CqlDeclaration("Pharmacological Contraindications For Antithrombotic Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52")]
-	public CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.52", null);
+	public CqlValueSet Pharmacological_Contraindications_For_Antithrombotic_Therapy() => 
+		__Pharmacological_Contraindications_For_Antithrombotic_Therapy?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.0.010", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -103,50 +230,56 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return b_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public IEnumerable<Encounter> Denominator(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Encounter> Denominator_Value(CqlContext context)
 	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Ischemic_Stroke_Encounter(context);
+		var a_ = TJCOverallFHIR_1_8_000.Ischemic_Stroke_Encounter();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Antithrombotic Not Given at Discharge")]
-	public IEnumerable<MedicationRequest> Antithrombotic_Not_Given_at_Discharge(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<MedicationRequest> Antithrombotic_Not_Given_at_Discharge_Value(CqlContext context)
 	{
-		var a_ = this.Antithrombotic_Therapy(context);
+		var a_ = this.Antithrombotic_Therapy();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		bool? c_(MedicationRequest NoAntithromboticDischarge)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, NoAntithromboticDischarge?.DoNotPerformElement);
+			var e_ = FHIRHelpers_4_0_001.ToBoolean(NoAntithromboticDischarge?.DoNotPerformElement);
 			var f_ = context.Operators.IsTrue(e_);
 			CqlConcept g_(CodeableConcept X)
 			{
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var ab_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return ab_;
 			};
 			var h_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((NoAntithromboticDischarge?.ReasonCode as IEnumerable<CodeableConcept>), g_);
-			var i_ = this.Medical_Reason(context);
+			var i_ = this.Medical_Reason();
 			var j_ = context.Operators.ConceptsInValueSet(h_, i_);
 			CqlConcept k_(CodeableConcept X)
 			{
-				var ac_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var ac_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return ac_;
 			};
 			var l_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((NoAntithromboticDischarge?.ReasonCode as IEnumerable<CodeableConcept>), k_);
-			var m_ = this.Patient_Refusal(context);
+			var m_ = this.Patient_Refusal();
 			var n_ = context.Operators.ConceptsInValueSet(l_, m_);
 			var o_ = context.Operators.Or(j_, n_);
 			var p_ = context.Operators.And(f_, o_);
 			bool? q_(CodeableConcept C)
 			{
-				var ad_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, C);
-				var ae_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Community(context);
+				var ad_ = FHIRHelpers_4_0_001.ToConcept(C);
+				var ae_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Community();
 				var af_ = context.Operators.ConvertCodeToConcept(ae_);
 				var ag_ = context.Operators.Equivalent(ad_, af_);
-				var ai_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Discharge(context);
+				var ai_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Discharge();
 				var aj_ = context.Operators.ConvertCodeToConcept(ai_);
 				var ak_ = context.Operators.Equivalent(ad_, aj_);
 				var al_ = context.Operators.Or(ag_, ak_);
@@ -175,17 +308,20 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return d_;
 	}
 
-    [CqlDeclaration("Encounter With No Antithrombotic At Discharge")]
-	public IEnumerable<Encounter> Encounter_With_No_Antithrombotic_At_Discharge(CqlContext context)
+    [CqlDeclaration("Antithrombotic Not Given at Discharge")]
+	public IEnumerable<MedicationRequest> Antithrombotic_Not_Given_at_Discharge() => 
+		__Antithrombotic_Not_Given_at_Discharge?.Value;
+
+	private IEnumerable<Encounter> Encounter_With_No_Antithrombotic_At_Discharge_Value(CqlContext context)
 	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Ischemic_Stroke_Encounter(context);
+		var a_ = TJCOverallFHIR_1_8_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Antithrombotic_Not_Given_at_Discharge(context);
+			var d_ = this.Antithrombotic_Not_Given_at_Discharge();
 			bool? e_(MedicationRequest NoDischargeAntithrombotic)
 			{
-				var i_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, NoDischargeAntithrombotic?.AuthoredOnElement);
-				var j_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, IschemicStrokeEncounter?.Period);
+				var i_ = FHIRHelpers_4_0_001.ToDateTime(NoDischargeAntithrombotic?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_0_001.ToInterval(IschemicStrokeEncounter?.Period);
 				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, null);
 
 				return k_;
@@ -202,23 +338,26 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return c_;
 	}
 
-    [CqlDeclaration("Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
-	public IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge(CqlContext context)
+    [CqlDeclaration("Encounter With No Antithrombotic At Discharge")]
+	public IEnumerable<Encounter> Encounter_With_No_Antithrombotic_At_Discharge() => 
+		__Encounter_With_No_Antithrombotic_At_Discharge?.Value;
+
+	private IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value(CqlContext context)
 	{
-		var a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy(context);
+		var a_ = this.Pharmacological_Contraindications_For_Antithrombotic_Therapy();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		bool? c_(MedicationRequest Pharmacological)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, Pharmacological?.DoNotPerformElement);
+			var e_ = FHIRHelpers_4_0_001.ToBoolean(Pharmacological?.DoNotPerformElement);
 			var f_ = context.Operators.IsTrue(e_);
 			var g_ = context.Operators.Not(f_);
 			bool? h_(CodeableConcept C)
 			{
-				var s_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, C);
-				var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Community(context);
+				var s_ = FHIRHelpers_4_0_001.ToConcept(C);
+				var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Community();
 				var u_ = context.Operators.ConvertCodeToConcept(t_);
 				var v_ = context.Operators.Equivalent(s_, u_);
-				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Discharge(context);
+				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Discharge();
 				var y_ = context.Operators.ConvertCodeToConcept(x_);
 				var z_ = context.Operators.Equivalent(s_, y_);
 				var aa_ = context.Operators.Or(v_, z_);
@@ -247,17 +386,20 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return d_;
 	}
 
-    [CqlDeclaration("Encounter With Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
-	public IEnumerable<Encounter> Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge(CqlContext context)
+    [CqlDeclaration("Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
+	public IEnumerable<MedicationRequest> Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
+		__Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge?.Value;
+
+	private IEnumerable<Encounter> Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge_Value(CqlContext context)
 	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Ischemic_Stroke_Encounter(context);
+		var a_ = TJCOverallFHIR_1_8_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge(context);
+			var d_ = this.Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
 			bool? e_(MedicationRequest DischargePharmacological)
 			{
-				var i_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, DischargePharmacological?.AuthoredOnElement);
-				var j_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, IschemicStrokeEncounter?.Period);
+				var i_ = FHIRHelpers_4_0_001.ToDateTime(DischargePharmacological?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_0_001.ToInterval(IschemicStrokeEncounter?.Period);
 				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, null);
 
 				return k_;
@@ -274,51 +416,63 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return c_;
 	}
 
-    [CqlDeclaration("Denominator Exceptions")]
-	public IEnumerable<Encounter> Denominator_Exceptions(CqlContext context)
+    [CqlDeclaration("Encounter With Pharmacological Contraindications for Antithrombotic Therapy at Discharge")]
+	public IEnumerable<Encounter> Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge() => 
+		__Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge?.Value;
+
+	private IEnumerable<Encounter> Denominator_Exceptions_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_With_No_Antithrombotic_At_Discharge(context);
-		var b_ = this.Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge(context);
+		var a_ = this.Encounter_With_No_Antithrombotic_At_Discharge();
+		var b_ = this.Encounter_With_Pharmacological_Contraindications_for_Antithrombotic_Therapy_at_Discharge();
+		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+
+		return c_;
+	}
+
+    [CqlDeclaration("Denominator Exceptions")]
+	public IEnumerable<Encounter> Denominator_Exceptions() => 
+		__Denominator_Exceptions?.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusions_Value(CqlContext context)
+	{
+		var a_ = TJCOverallFHIR_1_8_000.Ischemic_Stroke_Encounters_with_Discharge_Disposition();
+		var b_ = TJCOverallFHIR_1_8_000.Encounter_with_Comfort_Measures_during_Hospitalization();
 		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
 
 		return c_;
 	}
 
     [CqlDeclaration("Denominator Exclusions")]
-	public IEnumerable<Encounter> Denominator_Exclusions(CqlContext context)
-	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Ischemic_Stroke_Encounters_with_Discharge_Disposition(context);
-		var b_ = TJCOverallFHIR_1_8_000.Instance.Encounter_with_Comfort_Measures_during_Hospitalization(context);
-		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
+	public IEnumerable<Encounter> Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
 
-		return c_;
-	}
-
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Encounter_with_Principal_Diagnosis_and_Age(context);
+		var a_ = TJCOverallFHIR_1_8_000.Encounter_with_Principal_Diagnosis_and_Age();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Antithrombotic Therapy at Discharge")]
-	public IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge_Value(CqlContext context)
 	{
-		var a_ = this.Antithrombotic_Therapy(context);
+		var a_ = this.Antithrombotic_Therapy();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		bool? c_(MedicationRequest Antithrombotic)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToBoolean(context, Antithrombotic?.DoNotPerformElement);
+			var e_ = FHIRHelpers_4_0_001.ToBoolean(Antithrombotic?.DoNotPerformElement);
 			var f_ = context.Operators.IsTrue(e_);
 			var g_ = context.Operators.Not(f_);
 			bool? h_(CodeableConcept C)
 			{
-				var s_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, C);
-				var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Community(context);
+				var s_ = FHIRHelpers_4_0_001.ToConcept(C);
+				var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Community();
 				var u_ = context.Operators.ConvertCodeToConcept(t_);
 				var v_ = context.Operators.Equivalent(s_, u_);
-				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Discharge(context);
+				var x_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Discharge();
 				var y_ = context.Operators.ConvertCodeToConcept(x_);
 				var z_ = context.Operators.Equivalent(s_, y_);
 				var aa_ = context.Operators.Or(v_, z_);
@@ -347,17 +501,20 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return d_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public IEnumerable<Encounter> Numerator(CqlContext context)
+    [CqlDeclaration("Antithrombotic Therapy at Discharge")]
+	public IEnumerable<MedicationRequest> Antithrombotic_Therapy_at_Discharge() => 
+		__Antithrombotic_Therapy_at_Discharge?.Value;
+
+	private IEnumerable<Encounter> Numerator_Value(CqlContext context)
 	{
-		var a_ = TJCOverallFHIR_1_8_000.Instance.Ischemic_Stroke_Encounter(context);
+		var a_ = TJCOverallFHIR_1_8_000.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Antithrombotic_Therapy_at_Discharge(context);
+			var d_ = this.Antithrombotic_Therapy_at_Discharge();
 			bool? e_(MedicationRequest DischargeAntithrombotic)
 			{
-				var i_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, DischargeAntithrombotic?.AuthoredOnElement);
-				var j_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, IschemicStrokeEncounter?.Period);
+				var i_ = FHIRHelpers_4_0_001.ToDateTime(DischargeAntithrombotic?.AuthoredOnElement);
+				var j_ = FHIRHelpers_4_0_001.ToInterval(IschemicStrokeEncounter?.Period);
 				var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, null);
 
 				return k_;
@@ -374,36 +531,52 @@ public class DischargedonAntithromboticTherapyFHIR_0_0_010
 		return c_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
-
-		return a_;
-	}
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
 }

--- a/Demo/Measures/Exam125FHIR-0.0.009.cs
+++ b/Demo/Measures/Exam125FHIR-0.0.009.cs
@@ -14,70 +14,206 @@ using Task = Hl7.Fhir.Model.Task;
 public class Exam125FHIR_0_0_009
 {
 
-    public static Exam125FHIR_0_0_009 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Bilateral_Mastectomy;
+    internal Lazy<CqlValueSet> __History_of_bilateral_mastectomy;
+    internal Lazy<CqlValueSet> __Left;
+    internal Lazy<CqlValueSet> __Mammography;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Right;
+    internal Lazy<CqlValueSet> __Status_Post_Left_Mastectomy;
+    internal Lazy<CqlValueSet> __Status_Post_Right_Mastectomy;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Left;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy_Right;
+    internal Lazy<CqlValueSet> __Unilateral_Mastectomy__Unspecified_Laterality;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Telehealth_Services;
+    internal Lazy<int?> __Age_at_start_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Right_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Right_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Left_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Left_Mastectomy_Procedure;
+    internal Lazy<IEnumerable<Condition>> __Bilateral_Mastectomy_Diagnosis;
+    internal Lazy<IEnumerable<Procedure>> __Bilateral_Mastectomy_Procedure;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Observation_with_status;
+    internal Lazy<bool?> __Diagnostic_Report_with_status;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Final_Numerator_Population;
+    internal Lazy<bool?> __Observation_without_appropriate_status;
+    internal Lazy<bool?> __Diagnostic_Report_without_appropriate_status;
+
+    #endregion
+    public Exam125FHIR_0_0_009(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        AdultOutpatientEncountersFHIR4_2_2_000 = new AdultOutpatientEncountersFHIR4_2_2_000(context);
+        AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 = new AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+
+        __Bilateral_Mastectomy = new Lazy<CqlValueSet>(this.Bilateral_Mastectomy_Value(context));
+        __History_of_bilateral_mastectomy = new Lazy<CqlValueSet>(this.History_of_bilateral_mastectomy_Value(context));
+        __Left = new Lazy<CqlValueSet>(this.Left_Value(context));
+        __Mammography = new Lazy<CqlValueSet>(this.Mammography_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Right = new Lazy<CqlValueSet>(this.Right_Value(context));
+        __Status_Post_Left_Mastectomy = new Lazy<CqlValueSet>(this.Status_Post_Left_Mastectomy_Value(context));
+        __Status_Post_Right_Mastectomy = new Lazy<CqlValueSet>(this.Status_Post_Right_Mastectomy_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Unilateral_Mastectomy_Left = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Left_Value(context));
+        __Unilateral_Mastectomy_Right = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy_Right_Value(context));
+        __Unilateral_Mastectomy__Unspecified_Laterality = new Lazy<CqlValueSet>(this.Unilateral_Mastectomy__Unspecified_Laterality_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Telehealth_Services = new Lazy<IEnumerable<Encounter>>(this.Telehealth_Services_Value(context));
+        __Age_at_start_of_Measurement_Period = new Lazy<int?>(this.Age_at_start_of_Measurement_Period_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Right_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Right_Mastectomy_Diagnosis_Value(context));
+        __Right_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Right_Mastectomy_Procedure_Value(context));
+        __Left_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Left_Mastectomy_Diagnosis_Value(context));
+        __Left_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Left_Mastectomy_Procedure_Value(context));
+        __Bilateral_Mastectomy_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Bilateral_Mastectomy_Diagnosis_Value(context));
+        __Bilateral_Mastectomy_Procedure = new Lazy<IEnumerable<Procedure>>(this.Bilateral_Mastectomy_Procedure_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Observation_with_status = new Lazy<bool?>(this.Observation_with_status_Value(context));
+        __Diagnostic_Report_with_status = new Lazy<bool?>(this.Diagnostic_Report_with_status_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Final_Numerator_Population = new Lazy<bool?>(this.Final_Numerator_Population_Value(context));
+        __Observation_without_appropriate_status = new Lazy<bool?>(this.Observation_without_appropriate_status_Value(context));
+        __Diagnostic_Report_without_appropriate_status = new Lazy<bool?>(this.Diagnostic_Report_without_appropriate_status_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public AdultOutpatientEncountersFHIR4_2_2_000 AdultOutpatientEncountersFHIR4_2_2_000 { get; }
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Bilateral_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
 
     [CqlDeclaration("Bilateral Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005")]
-	public CqlValueSet Bilateral_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1005", null);
+	public CqlValueSet Bilateral_Mastectomy() => 
+		__Bilateral_Mastectomy?.Value;
+
+	private CqlValueSet History_of_bilateral_mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
 
     [CqlDeclaration("History of bilateral mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068")]
-	public CqlValueSet History_of_bilateral_mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1068", null);
+	public CqlValueSet History_of_bilateral_mastectomy() => 
+		__History_of_bilateral_mastectomy?.Value;
+
+	private CqlValueSet Left_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
 
     [CqlDeclaration("Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036")]
-	public CqlValueSet Left(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1036", null);
+	public CqlValueSet Left() => 
+		__Left?.Value;
+
+	private CqlValueSet Mammography_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
 
     [CqlDeclaration("Mammography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047")]
-	public CqlValueSet Mammography(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.11.1047", null);
+	public CqlValueSet Mammography() => 
+		__Mammography?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Right_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
 
     [CqlDeclaration("Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035")]
-	public CqlValueSet Right(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.122.12.1035", null);
+	public CqlValueSet Right() => 
+		__Right?.Value;
+
+	private CqlValueSet Status_Post_Left_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
 
     [CqlDeclaration("Status Post Left Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069")]
-	public CqlValueSet Status_Post_Left_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1069", null);
+	public CqlValueSet Status_Post_Left_Mastectomy() => 
+		__Status_Post_Left_Mastectomy?.Value;
+
+	private CqlValueSet Status_Post_Right_Mastectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
 
     [CqlDeclaration("Status Post Right Mastectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070")]
-	public CqlValueSet Status_Post_Right_Mastectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1070", null);
+	public CqlValueSet Status_Post_Right_Mastectomy() => 
+		__Status_Post_Right_Mastectomy?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Left_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
 
     [CqlDeclaration("Unilateral Mastectomy Left")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133")]
-	public CqlValueSet Unilateral_Mastectomy_Left(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1133", null);
+	public CqlValueSet Unilateral_Mastectomy_Left() => 
+		__Unilateral_Mastectomy_Left?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy_Right_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
 
     [CqlDeclaration("Unilateral Mastectomy Right")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134")]
-	public CqlValueSet Unilateral_Mastectomy_Right(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1134", null);
+	public CqlValueSet Unilateral_Mastectomy_Right() => 
+		__Unilateral_Mastectomy_Right?.Value;
+
+	private CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
 
     [CqlDeclaration("Unilateral Mastectomy, Unspecified Laterality")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071")]
-	public CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1071", null);
+	public CqlValueSet Unilateral_Mastectomy__Unspecified_Laterality() => 
+		__Unilateral_Mastectomy__Unspecified_Laterality?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2021, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -88,8 +224,11 @@ public class Exam125FHIR_0_0_009
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -97,52 +236,67 @@ public class Exam125FHIR_0_0_009
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Telehealth Services")]
-	public IEnumerable<Encounter> Telehealth_Services(CqlContext context)
+	private IEnumerable<Encounter> Telehealth_Services_Value(CqlContext context)
 	{
-		var a_ = this.Online_Assessments(context);
+		var a_ = this.Online_Assessments();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Telephone_Visits(context);
+		var c_ = this.Telephone_Visits();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
 			var h_ = context.Operators.Convert<string>(TelehealthEncounter?.StatusElement);
 			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = this.Measurement_Period(context);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (TelehealthEncounter?.Period as object));
+			var j_ = this.Measurement_Period();
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((TelehealthEncounter?.Period as object));
 			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, k_, null);
 			var m_ = context.Operators.And(i_, l_);
 
@@ -153,12 +307,15 @@ public class Exam125FHIR_0_0_009
 		return g_;
 	}
 
-    [CqlDeclaration("Age at start of Measurement Period")]
-	public int? Age_at_start_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Telehealth Services")]
+	public IEnumerable<Encounter> Telehealth_Services() => 
+		__Telehealth_Services?.Value;
+
+	private int? Age_at_start_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -166,12 +323,15 @@ public class Exam125FHIR_0_0_009
 		return f_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Age at start of Measurement Period")]
+	public int? Age_at_start_of_Measurement_Period() => 
+		__Age_at_start_of_Measurement_Period?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -180,8 +340,8 @@ public class Exam125FHIR_0_0_009
 		var j_ = context.Operators.Convert<string>(a_?.GenderElement);
 		var k_ = context.Operators.Equal(j_, "female");
 		var l_ = context.Operators.And(h_, k_);
-		var m_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
-		var n_ = this.Telehealth_Services(context);
+		var m_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
+		var n_ = this.Telehealth_Services();
 		var o_ = context.Operators.ListUnion<Encounter>(m_, n_);
 		var p_ = context.Operators.ExistsInList<Encounter>(o_);
 		var q_ = context.Operators.And(l_, p_);
@@ -189,31 +349,37 @@ public class Exam125FHIR_0_0_009
 		return q_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Right_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Condition> Right_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Status_Post_Right_Mastectomy(context);
+		var a_ = this.Status_Post_Right_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality(context);
+		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			CqlConcept j_(CodeableConcept X)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var n_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return n_;
 			};
 			var k_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyDiagnosis?.BodySite as IEnumerable<CodeableConcept>), j_);
-			var l_ = this.Right(context);
+			var l_ = this.Right();
 			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
 
 			return m_;
@@ -222,9 +388,9 @@ public class Exam125FHIR_0_0_009
 		var g_ = context.Operators.ListUnion<Condition>(b_, f_);
 		bool? h_(Condition RightMastectomy)
 		{
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, RightMastectomy);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(RightMastectomy);
 			var p_ = context.Operators.Start(o_);
-			var q_ = this.Measurement_Period(context);
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.End(q_);
 			var s_ = context.Operators.SameOrBefore(p_, r_, null);
 
@@ -235,18 +401,21 @@ public class Exam125FHIR_0_0_009
 		return i_;
 	}
 
-    [CqlDeclaration("Right Mastectomy Procedure")]
-	public IEnumerable<Procedure> Right_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Right_Mastectomy_Diagnosis() => 
+		__Right_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Right_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Right(context);
+		var a_ = this.Unilateral_Mastectomy_Right();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure UnilateralMastectomyRightPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(UnilateralMastectomyRightPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, UnilateralMastectomyRightPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(UnilateralMastectomyRightPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -258,23 +427,26 @@ public class Exam125FHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Left_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Right Mastectomy Procedure")]
+	public IEnumerable<Procedure> Right_Mastectomy_Procedure() => 
+		__Right_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Left_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Status_Post_Left_Mastectomy(context);
+		var a_ = this.Status_Post_Left_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality(context);
+		var c_ = this.Unilateral_Mastectomy__Unspecified_Laterality();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		bool? e_(Condition UnilateralMastectomyDiagnosis)
 		{
 			CqlConcept j_(CodeableConcept X)
 			{
-				var n_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var n_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return n_;
 			};
 			var k_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((UnilateralMastectomyDiagnosis?.BodySite as IEnumerable<CodeableConcept>), j_);
-			var l_ = this.Left(context);
+			var l_ = this.Left();
 			var m_ = context.Operators.ConceptsInValueSet(k_, l_);
 
 			return m_;
@@ -283,9 +455,9 @@ public class Exam125FHIR_0_0_009
 		var g_ = context.Operators.ListUnion<Condition>(b_, f_);
 		bool? h_(Condition LeftMastectomy)
 		{
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, LeftMastectomy);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(LeftMastectomy);
 			var p_ = context.Operators.Start(o_);
-			var q_ = this.Measurement_Period(context);
+			var q_ = this.Measurement_Period();
 			var r_ = context.Operators.End(q_);
 			var s_ = context.Operators.SameOrBefore(p_, r_, null);
 
@@ -296,18 +468,21 @@ public class Exam125FHIR_0_0_009
 		return i_;
 	}
 
-    [CqlDeclaration("Left Mastectomy Procedure")]
-	public IEnumerable<Procedure> Left_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Left_Mastectomy_Diagnosis() => 
+		__Left_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Left_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Unilateral_Mastectomy_Left(context);
+		var a_ = this.Unilateral_Mastectomy_Left();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure UnilateralMastectomyLeftPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(UnilateralMastectomyLeftPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, UnilateralMastectomyLeftPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(UnilateralMastectomyLeftPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -319,16 +494,19 @@ public class Exam125FHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
-	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis(CqlContext context)
+    [CqlDeclaration("Left Mastectomy Procedure")]
+	public IEnumerable<Procedure> Left_Mastectomy_Procedure() => 
+		__Left_Mastectomy_Procedure?.Value;
+
+	private IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.History_of_bilateral_mastectomy(context);
+		var a_ = this.History_of_bilateral_mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition BilateralMastectomyHistory)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, BilateralMastectomyHistory);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(BilateralMastectomyHistory);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -339,18 +517,21 @@ public class Exam125FHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Bilateral Mastectomy Procedure")]
-	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Diagnosis")]
+	public IEnumerable<Condition> Bilateral_Mastectomy_Diagnosis() => 
+		__Bilateral_Mastectomy_Diagnosis?.Value;
+
+	private IEnumerable<Procedure> Bilateral_Mastectomy_Procedure_Value(CqlContext context)
 	{
-		var a_ = this.Bilateral_Mastectomy(context);
+		var a_ = this.Bilateral_Mastectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure BilateralMastectomyPerformed)
 		{
 			var e_ = context.Operators.Convert<string>(BilateralMastectomyPerformed?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BilateralMastectomyPerformed?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BilateralMastectomyPerformed?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -362,50 +543,56 @@ public class Exam125FHIR_0_0_009
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Bilateral Mastectomy Procedure")]
+	public IEnumerable<Procedure> Bilateral_Mastectomy_Procedure() => 
+		__Bilateral_Mastectomy_Procedure?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = this.Right_Mastectomy_Diagnosis(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = this.Right_Mastectomy_Diagnosis();
 		var c_ = context.Operators.ExistsInList<Condition>(b_);
-		var d_ = this.Right_Mastectomy_Procedure(context);
+		var d_ = this.Right_Mastectomy_Procedure();
 		var e_ = context.Operators.ExistsInList<Procedure>(d_);
 		var f_ = context.Operators.Or(c_, e_);
-		var g_ = this.Left_Mastectomy_Diagnosis(context);
+		var g_ = this.Left_Mastectomy_Diagnosis();
 		var h_ = context.Operators.ExistsInList<Condition>(g_);
-		var i_ = this.Left_Mastectomy_Procedure(context);
+		var i_ = this.Left_Mastectomy_Procedure();
 		var j_ = context.Operators.ExistsInList<Procedure>(i_);
 		var k_ = context.Operators.Or(h_, j_);
 		var l_ = context.Operators.And(f_, k_);
 		var m_ = context.Operators.Or(a_, l_);
-		var n_ = this.Bilateral_Mastectomy_Diagnosis(context);
+		var n_ = this.Bilateral_Mastectomy_Diagnosis();
 		var o_ = context.Operators.ExistsInList<Condition>(n_);
 		var p_ = context.Operators.Or(m_, o_);
-		var q_ = this.Bilateral_Mastectomy_Procedure(context);
+		var q_ = this.Bilateral_Mastectomy_Procedure();
 		var r_ = context.Operators.ExistsInList<Procedure>(q_);
 		var s_ = context.Operators.Or(p_, r_);
-		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var u_ = context.Operators.Or(s_, t_);
-		var v_ = this.Patient(context);
+		var v_ = this.Patient();
 		var w_ = context.Operators.Convert<CqlDate>(v_?.BirthDateElement?.Value);
-		var x_ = this.Measurement_Period(context);
+		var x_ = this.Measurement_Period();
 		var y_ = context.Operators.Start(x_);
 		var z_ = context.Operators.DateFrom(y_);
 		var aa_ = context.Operators.CalculateAgeAt(w_, z_, "year");
 		var ab_ = context.Operators.GreaterOrEqual(aa_, (int?)65);
-		var ac_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(context);
+		var ac_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		var ad_ = context.Operators.And(ab_, ac_);
 		var ae_ = context.Operators.Or(u_, ad_);
-		var af_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var af_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var ag_ = context.Operators.Or(ae_, af_);
 
 		return ag_;
 	}
 
-    [CqlDeclaration("Observation with status")]
-	public bool? Observation_with_status(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private bool? Observation_with_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Mammogram)
 		{
@@ -418,9 +605,9 @@ public class Exam125FHIR_0_0_009
 				"appended",
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(27m, "months");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -440,10 +627,13 @@ public class Exam125FHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Diagnostic Report with status")]
-	public bool? Diagnostic_Report_with_status(CqlContext context)
+    [CqlDeclaration("Observation with status")]
+	public bool? Observation_with_status() => 
+		__Observation_with_status?.Value;
+
+	private bool? Diagnostic_Report_with_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
 		bool? c_(DiagnosticReport Mammogram)
 		{
@@ -456,9 +646,9 @@ public class Exam125FHIR_0_0_009
 				"appended",
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(27m, "months");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -478,35 +668,44 @@ public class Exam125FHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Diagnostic Report with status")]
+	public bool? Diagnostic_Report_with_status() => 
+		__Diagnostic_Report_with_status?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Observation_with_status(context);
-		var b_ = this.Diagnostic_Report_with_status(context);
+		var a_ = this.Observation_with_status();
+		var b_ = this.Diagnostic_Report_with_status();
 		var c_ = context.Operators.Or(a_, b_);
 
 		return c_;
 	}
 
-    [CqlDeclaration("Final Numerator Population")]
-	public bool? Final_Numerator_Population(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
+	private bool? Final_Numerator_Population_Value(CqlContext context)
 	{
-		var a_ = this.Numerator(context);
-		var b_ = this.Initial_Population(context);
+		var a_ = this.Numerator();
+		var b_ = this.Initial_Population();
 		var c_ = context.Operators.And(a_, b_);
-		var d_ = this.Denominator(context);
+		var d_ = this.Denominator();
 		var e_ = context.Operators.And(c_, d_);
-		var f_ = this.Denominator_Exclusions(context);
+		var f_ = this.Denominator_Exclusions();
 		var g_ = context.Operators.Not(f_);
 		var h_ = context.Operators.And(e_, g_);
 
 		return h_;
 	}
 
-    [CqlDeclaration("Observation without appropriate status")]
-	public bool? Observation_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Final Numerator Population")]
+	public bool? Final_Numerator_Population() => 
+		__Final_Numerator_Population?.Value;
+
+	private bool? Observation_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Mammogram)
 		{
@@ -520,9 +719,9 @@ public class Exam125FHIR_0_0_009
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
 			var i_ = context.Operators.Not(h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period(context);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(27m, "months");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -542,10 +741,13 @@ public class Exam125FHIR_0_0_009
 		return e_;
 	}
 
-    [CqlDeclaration("Diagnostic Report without appropriate status")]
-	public bool? Diagnostic_Report_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Observation without appropriate status")]
+	public bool? Observation_without_appropriate_status() => 
+		__Observation_without_appropriate_status?.Value;
+
+	private bool? Diagnostic_Report_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Mammography(context);
+		var a_ = this.Mammography();
 		var b_ = context.Operators.RetrieveByValueSet<DiagnosticReport>(a_, null);
 		bool? c_(DiagnosticReport Mammogram)
 		{
@@ -559,9 +761,9 @@ public class Exam125FHIR_0_0_009
 			};
 			var h_ = context.Operators.InList<string>(f_, (g_ as IEnumerable<string>));
 			var i_ = context.Operators.Not(h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Mammogram?.Effective);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Mammogram?.Effective);
 			var k_ = context.Operators.End(j_);
-			var l_ = this.Measurement_Period(context);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(27m, "months");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -580,5 +782,9 @@ public class Exam125FHIR_0_0_009
 
 		return e_;
 	}
+
+    [CqlDeclaration("Diagnostic Report without appropriate status")]
+	public bool? Diagnostic_Report_without_appropriate_status() => 
+		__Diagnostic_Report_without_appropriate_status?.Value;
 
 }

--- a/Demo/Measures/Exam130FHIR-0.0.003.cs
+++ b/Demo/Measures/Exam130FHIR-0.0.003.cs
@@ -14,169 +14,431 @@ using Task = Hl7.Fhir.Model.Task;
 public class Exam130FHIR_0_0_003
 {
 
-    public static Exam130FHIR_0_0_003 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Inpatient;
+    internal Lazy<CqlValueSet> __Advanced_Illness;
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Care_Services_in_Long_Term_Residential_Facility;
+    internal Lazy<CqlValueSet> __Colonoscopy;
+    internal Lazy<CqlValueSet> __CT_Colonography;
+    internal Lazy<CqlValueSet> __Dementia_Medications;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Fecal_Occult_Blood_Test__FOBT_;
+    internal Lazy<CqlValueSet> __FIT_DNA;
+    internal Lazy<CqlValueSet> __Flexible_Sigmoidoscopy;
+    internal Lazy<CqlValueSet> __Frailty_Device;
+    internal Lazy<CqlValueSet> __Frailty_Diagnosis;
+    internal Lazy<CqlValueSet> __Frailty_Encounter;
+    internal Lazy<CqlValueSet> __Frailty_Symptom;
+    internal Lazy<CqlValueSet> __Home_Healthcare_Services;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlValueSet> __Malignant_Neoplasm_of_Colon;
+    internal Lazy<CqlValueSet> __Nonacute_Inpatient;
+    internal Lazy<CqlValueSet> __Nursing_Facility_Visit;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlValueSet> __Total_Colectomy;
+    internal Lazy<CqlValueSet> __Total_Colectomy_ICD9;
+    internal Lazy<CqlCode> __laboratory;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Telehealth_Services;
+    internal Lazy<int?> __Age_at_start_of_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<IEnumerable<Condition>> __Malignant_Neoplasm;
+    internal Lazy<IEnumerable<Procedure>> __Total_Colectomy_Performed;
+    internal Lazy<IEnumerable<Condition>> __Total_Colectomy_Condition;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>> __Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset;
+    internal Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>> __Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset;
+    internal Lazy<IEnumerable<Observation>> __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset;
+    internal Lazy<IEnumerable<CqlDateTime>> __CT_Colonography_Display_Date;
+    internal Lazy<IEnumerable<Observation>> __CT_Colonography_Performed;
+    internal Lazy<IEnumerable<Observation>> __CT_Colonography_Performed_without_appropriate_status;
+    internal Lazy<IEnumerable<CqlDateTime>> __Flexible_Sigmoidoscopy_Display_Date;
+    internal Lazy<IEnumerable<Procedure>> __Flexible_Sigmoidoscopy_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Flexible_Sigmoidoscopy_Performed_without_appropriate_status;
+    internal Lazy<IEnumerable<CqlDateTime>> __Colonoscopy_Display_Date;
+    internal Lazy<IEnumerable<Procedure>> __Colonoscopy_Performed;
+    internal Lazy<IEnumerable<Procedure>> __Colonoscopy_Performed_without_appropriate_status;
+    internal Lazy<bool?> __Numerator;
+    internal Lazy<bool?> __Final_Numerator_Population;
+
+    #endregion
+    public Exam130FHIR_0_0_003(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        AdultOutpatientEncountersFHIR4_2_2_000 = new AdultOutpatientEncountersFHIR4_2_2_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+        AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 = new AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000(context);
+        PalliativeCareFHIR_0_6_000 = new PalliativeCareFHIR_0_6_000(context);
+        CumulativeMedicationDurationFHIR4_1_0_000 = new CumulativeMedicationDurationFHIR4_1_0_000(context);
+
+        __Acute_Inpatient = new Lazy<CqlValueSet>(this.Acute_Inpatient_Value(context));
+        __Advanced_Illness = new Lazy<CqlValueSet>(this.Advanced_Illness_Value(context));
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value(context));
+        __Care_Services_in_Long_Term_Residential_Facility = new Lazy<CqlValueSet>(this.Care_Services_in_Long_Term_Residential_Facility_Value(context));
+        __Colonoscopy = new Lazy<CqlValueSet>(this.Colonoscopy_Value(context));
+        __CT_Colonography = new Lazy<CqlValueSet>(this.CT_Colonography_Value(context));
+        __Dementia_Medications = new Lazy<CqlValueSet>(this.Dementia_Medications_Value(context));
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(context));
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Fecal_Occult_Blood_Test__FOBT_ = new Lazy<CqlValueSet>(this.Fecal_Occult_Blood_Test__FOBT__Value(context));
+        __FIT_DNA = new Lazy<CqlValueSet>(this.FIT_DNA_Value(context));
+        __Flexible_Sigmoidoscopy = new Lazy<CqlValueSet>(this.Flexible_Sigmoidoscopy_Value(context));
+        __Frailty_Device = new Lazy<CqlValueSet>(this.Frailty_Device_Value(context));
+        __Frailty_Diagnosis = new Lazy<CqlValueSet>(this.Frailty_Diagnosis_Value(context));
+        __Frailty_Encounter = new Lazy<CqlValueSet>(this.Frailty_Encounter_Value(context));
+        __Frailty_Symptom = new Lazy<CqlValueSet>(this.Frailty_Symptom_Value(context));
+        __Home_Healthcare_Services = new Lazy<CqlValueSet>(this.Home_Healthcare_Services_Value(context));
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value(context));
+        __Malignant_Neoplasm_of_Colon = new Lazy<CqlValueSet>(this.Malignant_Neoplasm_of_Colon_Value(context));
+        __Nonacute_Inpatient = new Lazy<CqlValueSet>(this.Nonacute_Inpatient_Value(context));
+        __Nursing_Facility_Visit = new Lazy<CqlValueSet>(this.Nursing_Facility_Visit_Value(context));
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Outpatient = new Lazy<CqlValueSet>(this.Outpatient_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Total_Colectomy = new Lazy<CqlValueSet>(this.Total_Colectomy_Value(context));
+        __Total_Colectomy_ICD9 = new Lazy<CqlValueSet>(this.Total_Colectomy_ICD9_Value(context));
+        __laboratory = new Lazy<CqlCode>(this.laboratory_Value(context));
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Telehealth_Services = new Lazy<IEnumerable<Encounter>>(this.Telehealth_Services_Value(context));
+        __Age_at_start_of_Measurement_Period = new Lazy<int?>(this.Age_at_start_of_Measurement_Period_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Malignant_Neoplasm = new Lazy<IEnumerable<Condition>>(this.Malignant_Neoplasm_Value(context));
+        __Total_Colectomy_Performed = new Lazy<IEnumerable<Procedure>>(this.Total_Colectomy_Performed_Value(context));
+        __Total_Colectomy_Condition = new Lazy<IEnumerable<Condition>>(this.Total_Colectomy_Condition_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status = new Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>>(this.Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value(context));
+        __Fecal_Occult_Blood_Test_Performed = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_Value(context));
+        __Fecal_Occult_Blood_Test_Performed__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value(context));
+        __Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(context));
+        __Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status = new Lazy<IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW>>(this.Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(context));
+        __Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset = new Lazy<IEnumerable<Observation>>(this.Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(context));
+        __CT_Colonography_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.CT_Colonography_Display_Date_Value(context));
+        __CT_Colonography_Performed = new Lazy<IEnumerable<Observation>>(this.CT_Colonography_Performed_Value(context));
+        __CT_Colonography_Performed_without_appropriate_status = new Lazy<IEnumerable<Observation>>(this.CT_Colonography_Performed_without_appropriate_status_Value(context));
+        __Flexible_Sigmoidoscopy_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.Flexible_Sigmoidoscopy_Display_Date_Value(context));
+        __Flexible_Sigmoidoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Flexible_Sigmoidoscopy_Performed_Value(context));
+        __Flexible_Sigmoidoscopy_Performed_without_appropriate_status = new Lazy<IEnumerable<Procedure>>(this.Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value(context));
+        __Colonoscopy_Display_Date = new Lazy<IEnumerable<CqlDateTime>>(this.Colonoscopy_Display_Date_Value(context));
+        __Colonoscopy_Performed = new Lazy<IEnumerable<Procedure>>(this.Colonoscopy_Performed_Value(context));
+        __Colonoscopy_Performed_without_appropriate_status = new Lazy<IEnumerable<Procedure>>(this.Colonoscopy_Performed_without_appropriate_status_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+        __Final_Numerator_Population = new Lazy<bool?>(this.Final_Numerator_Population_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public AdultOutpatientEncountersFHIR4_2_2_000 AdultOutpatientEncountersFHIR4_2_2_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+    public AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 { get; }
+    public PalliativeCareFHIR_0_6_000 PalliativeCareFHIR_0_6_000 { get; }
+    public CumulativeMedicationDurationFHIR4_1_0_000 CumulativeMedicationDurationFHIR4_1_0_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083")]
-	public CqlValueSet Acute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1083", null);
+	public CqlValueSet Acute_Inpatient() => 
+		__Acute_Inpatient?.Value;
+
+	private CqlValueSet Advanced_Illness_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082")]
-	public CqlValueSet Advanced_Illness(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1082", null);
+	public CqlValueSet Advanced_Illness() => 
+		__Advanced_Illness?.Value;
+
+	private CqlValueSet Annual_Wellness_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
-	public CqlValueSet Annual_Wellness_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit?.Value;
+
+	private CqlValueSet Care_Services_in_Long_Term_Residential_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
 
     [CqlDeclaration("Care Services in Long-Term Residential Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014")]
-	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+	public CqlValueSet Care_Services_in_Long_Term_Residential_Facility() => 
+		__Care_Services_in_Long_Term_Residential_Facility?.Value;
+
+	private CqlValueSet Colonoscopy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
 
     [CqlDeclaration("Colonoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020")]
-	public CqlValueSet Colonoscopy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1020", null);
+	public CqlValueSet Colonoscopy() => 
+		__Colonoscopy?.Value;
+
+	private CqlValueSet CT_Colonography_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
 
     [CqlDeclaration("CT Colonography")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038")]
-	public CqlValueSet CT_Colonography(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1038", null);
+	public CqlValueSet CT_Colonography() => 
+		__CT_Colonography?.Value;
+
+	private CqlValueSet Dementia_Medications_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510")]
-	public CqlValueSet Dementia_Medications(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.196.12.1510", null);
+	public CqlValueSet Dementia_Medications() => 
+		__Dementia_Medications?.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
-	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care?.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
-	public CqlValueSet Discharged_to_Home_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Fecal_Occult_Blood_Test__FOBT__Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
 
     [CqlDeclaration("Fecal Occult Blood Test (FOBT)")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011")]
-	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1011", null);
+	public CqlValueSet Fecal_Occult_Blood_Test__FOBT_() => 
+		__Fecal_Occult_Blood_Test__FOBT_?.Value;
+
+	private CqlValueSet FIT_DNA_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
 
     [CqlDeclaration("FIT DNA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039")]
-	public CqlValueSet FIT_DNA(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1039", null);
+	public CqlValueSet FIT_DNA() => 
+		__FIT_DNA?.Value;
+
+	private CqlValueSet Flexible_Sigmoidoscopy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
 
     [CqlDeclaration("Flexible Sigmoidoscopy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010")]
-	public CqlValueSet Flexible_Sigmoidoscopy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1010", null);
+	public CqlValueSet Flexible_Sigmoidoscopy() => 
+		__Flexible_Sigmoidoscopy?.Value;
+
+	private CqlValueSet Frailty_Device_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300")]
-	public CqlValueSet Frailty_Device(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.118.12.1300", null);
+	public CqlValueSet Frailty_Device() => 
+		__Frailty_Device?.Value;
+
+	private CqlValueSet Frailty_Diagnosis_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074")]
-	public CqlValueSet Frailty_Diagnosis(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1074", null);
+	public CqlValueSet Frailty_Diagnosis() => 
+		__Frailty_Diagnosis?.Value;
+
+	private CqlValueSet Frailty_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088")]
-	public CqlValueSet Frailty_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1088", null);
+	public CqlValueSet Frailty_Encounter() => 
+		__Frailty_Encounter?.Value;
+
+	private CqlValueSet Frailty_Symptom_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075")]
-	public CqlValueSet Frailty_Symptom(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.113.12.1075", null);
+	public CqlValueSet Frailty_Symptom() => 
+		__Frailty_Symptom?.Value;
+
+	private CqlValueSet Home_Healthcare_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
 
     [CqlDeclaration("Home Healthcare Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016")]
-	public CqlValueSet Home_Healthcare_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+	public CqlValueSet Home_Healthcare_Services() => 
+		__Home_Healthcare_Services?.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
-	public CqlValueSet Hospice_care_ambulatory(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory?.Value;
+
+	private CqlValueSet Malignant_Neoplasm_of_Colon_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
 
     [CqlDeclaration("Malignant Neoplasm of Colon")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001")]
-	public CqlValueSet Malignant_Neoplasm_of_Colon(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.108.12.1001", null);
+	public CqlValueSet Malignant_Neoplasm_of_Colon() => 
+		__Malignant_Neoplasm_of_Colon?.Value;
+
+	private CqlValueSet Nonacute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084")]
-	public CqlValueSet Nonacute_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1084", null);
+	public CqlValueSet Nonacute_Inpatient() => 
+		__Nonacute_Inpatient?.Value;
+
+	private CqlValueSet Nursing_Facility_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
 
     [CqlDeclaration("Nursing Facility Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012")]
-	public CqlValueSet Nursing_Facility_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+	public CqlValueSet Nursing_Facility_Visit() => 
+		__Nursing_Facility_Visit?.Value;
+
+	private CqlValueSet Observation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086")]
-	public CqlValueSet Observation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1086", null);
+	public CqlValueSet Observation() => 
+		__Observation?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Outpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087")]
-	public CqlValueSet Outpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+	public CqlValueSet Outpatient() => 
+		__Outpatient?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
+
+	private CqlValueSet Total_Colectomy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
 
     [CqlDeclaration("Total Colectomy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019")]
-	public CqlValueSet Total_Colectomy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1019", null);
+	public CqlValueSet Total_Colectomy() => 
+		__Total_Colectomy?.Value;
+
+	private CqlValueSet Total_Colectomy_ICD9_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
 
     [CqlDeclaration("Total Colectomy ICD9")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136")]
-	public CqlValueSet Total_Colectomy_ICD9(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.11.1136", null);
+	public CqlValueSet Total_Colectomy_ICD9() => 
+		__Total_Colectomy_ICD9?.Value;
 
-    [CqlDeclaration("laboratory")]
-	public CqlCode laboratory(CqlContext context) => 
+	private CqlCode laboratory_Value(CqlContext context) => 
 		new CqlCode("laboratory", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
-    [CqlDeclaration("ObservationCategoryCodes")]
-	public CqlCode[] ObservationCategoryCodes(CqlContext context)
+    [CqlDeclaration("laboratory")]
+	public CqlCode laboratory() => 
+		__laboratory?.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -186,8 +448,11 @@ public class Exam130FHIR_0_0_003
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2021, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -198,8 +463,11 @@ public class Exam130FHIR_0_0_003
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -207,52 +475,67 @@ public class Exam130FHIR_0_0_003
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Telehealth Services")]
-	public IEnumerable<Encounter> Telehealth_Services(CqlContext context)
+	private IEnumerable<Encounter> Telehealth_Services_Value(CqlContext context)
 	{
-		var a_ = this.Online_Assessments(context);
+		var a_ = this.Online_Assessments();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Telephone_Visits(context);
+		var c_ = this.Telephone_Visits();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
 		bool? f_(Encounter TelehealthEncounter)
 		{
 			var h_ = context.Operators.Convert<string>(TelehealthEncounter?.StatusElement);
 			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = this.Measurement_Period(context);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (TelehealthEncounter?.Period as object));
+			var j_ = this.Measurement_Period();
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((TelehealthEncounter?.Period as object));
 			var l_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, k_, null);
 			var m_ = context.Operators.And(i_, l_);
 
@@ -263,12 +546,15 @@ public class Exam130FHIR_0_0_003
 		return g_;
 	}
 
-    [CqlDeclaration("Age at start of Measurement Period")]
-	public int? Age_at_start_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Telehealth Services")]
+	public IEnumerable<Encounter> Telehealth_Services() => 
+		__Telehealth_Services?.Value;
+
+	private int? Age_at_start_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -276,19 +562,22 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Age at start of Measurement Period")]
+	public int? Age_at_start_of_Measurement_Period() => 
+		__Age_at_start_of_Measurement_Period?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.Interval((int?)51, (int?)75, true, false);
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
-		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
-		var j_ = this.Telehealth_Services(context);
+		var i_ = AdultOutpatientEncountersFHIR4_2_2_000.Qualifying_Encounters();
+		var j_ = this.Telehealth_Services();
 		var k_ = context.Operators.ListUnion<Encounter>(i_, j_);
 		var l_ = context.Operators.ExistsInList<Encounter>(k_);
 		var m_ = context.Operators.And(h_, l_);
@@ -296,24 +585,30 @@ public class Exam130FHIR_0_0_003
 		return m_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Malignant Neoplasm")]
-	public IEnumerable<Condition> Malignant_Neoplasm(CqlContext context)
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Condition> Malignant_Neoplasm_Value(CqlContext context)
 	{
-		var a_ = this.Malignant_Neoplasm_of_Colon(context);
+		var a_ = this.Malignant_Neoplasm_of_Colon();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ColorectalCancer)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ColorectalCancer);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColorectalCancer);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -324,18 +619,21 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Total Colectomy Performed")]
-	public IEnumerable<Procedure> Total_Colectomy_Performed(CqlContext context)
+    [CqlDeclaration("Malignant Neoplasm")]
+	public IEnumerable<Condition> Malignant_Neoplasm() => 
+		__Malignant_Neoplasm?.Value;
+
+	private IEnumerable<Procedure> Total_Colectomy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Total_Colectomy(context);
+		var a_ = this.Total_Colectomy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colectomy)
 		{
 			var e_ = context.Operators.Convert<string>(Colectomy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colectomy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colectomy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.SameOrBefore(h_, j_, null);
 			var l_ = context.Operators.And(f_, k_);
@@ -347,16 +645,19 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Total Colectomy Condition")]
-	public IEnumerable<Condition> Total_Colectomy_Condition(CqlContext context)
+    [CqlDeclaration("Total Colectomy Performed")]
+	public IEnumerable<Procedure> Total_Colectomy_Performed() => 
+		__Total_Colectomy_Performed?.Value;
+
+	private IEnumerable<Condition> Total_Colectomy_Condition_Value(CqlContext context)
 	{
-		var a_ = this.Total_Colectomy_ICD9(context);
+		var a_ = this.Total_Colectomy_ICD9();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ColectomyDx)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ColectomyDx);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ColectomyDx);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.SameOrBefore(f_, h_, null);
 
@@ -367,46 +668,52 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Total Colectomy Condition")]
+	public IEnumerable<Condition> Total_Colectomy_Condition() => 
+		__Total_Colectomy_Condition?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
-		var b_ = this.Malignant_Neoplasm(context);
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
+		var b_ = this.Malignant_Neoplasm();
 		var c_ = context.Operators.ExistsInList<Condition>(b_);
 		var d_ = context.Operators.Or(a_, c_);
-		var e_ = this.Total_Colectomy_Performed(context);
+		var e_ = this.Total_Colectomy_Performed();
 		var f_ = context.Operators.ExistsInList<Procedure>(e_);
 		var g_ = context.Operators.Or(d_, f_);
-		var h_ = this.Total_Colectomy_Condition(context);
+		var h_ = this.Total_Colectomy_Condition();
 		var i_ = context.Operators.ExistsInList<Condition>(h_);
 		var j_ = context.Operators.Or(g_, i_);
-		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(context);
+		var k_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80();
 		var l_ = context.Operators.Or(j_, k_);
-		var m_ = this.Patient(context);
+		var m_ = this.Patient();
 		var n_ = context.Operators.Convert<CqlDate>(m_?.BirthDateElement?.Value);
-		var o_ = this.Measurement_Period(context);
+		var o_ = this.Measurement_Period();
 		var p_ = context.Operators.Start(o_);
 		var q_ = context.Operators.DateFrom(p_);
 		var r_ = context.Operators.CalculateAgeAt(n_, q_, "year");
 		var s_ = context.Operators.GreaterOrEqual(r_, (int?)65);
-		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Instance.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days(context);
+		var t_ = AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000.Has_Long_Term_Care_Periods_Longer_Than_90_Consecutive_Days();
 		var u_ = context.Operators.And(s_, t_);
 		var v_ = context.Operators.Or(l_, u_);
-		var w_ = PalliativeCareFHIR_0_6_000.Instance.Palliative_Care_in_the_Measurement_Period(context);
+		var w_ = PalliativeCareFHIR_0_6_000.Palliative_Care_in_the_Measurement_Period();
 		var x_ = context.Operators.Or(v_, w_);
 
 		return x_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Display Date, Result, Category, Status")]
-	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var h_ = this.Measurement_Period(context);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.Start(h_);
 			var j_ = context.Operators.Quantity(1m, "year");
 			var k_ = context.Operators.Subtract(i_, j_);
@@ -419,7 +726,7 @@ public class Exam130FHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW e_(Observation FecalOccult)
 		{
-			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
+			var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
 			var q_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(FecalOccult?.Value, "coding");
 			bool? r_(Coding @this)
 			{
@@ -477,10 +784,13 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Display Date, Result, Category, Status")]
+	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status() => 
+		__Fecal_Occult_Blood_Test_Display_Date__Result__Category__Status?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -527,8 +837,8 @@ public class Exam130FHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, o_, null);
 			var q_ = context.Operators.And(m_, p_);
 
@@ -539,10 +849,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed() => 
+		__Fecal_Occult_Blood_Test_Performed?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -589,8 +902,8 @@ public class Exam130FHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.ElementInInterval<CqlDateTime>(n_, o_, "day");
 			var q_ = context.Operators.And(m_, p_);
 
@@ -601,10 +914,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate category, ignore status, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -643,8 +959,8 @@ public class Exam130FHIR_0_0_003
 			var g_ = context.Operators.ExistsInList<CodeableConcept>(f_);
 			var h_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var i_ = context.Operators.And(g_, h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var k_ = this.Measurement_Period(context);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, "day");
 			var m_ = context.Operators.And(i_, l_);
 
@@ -655,10 +971,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate status, ignore category, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate category, ignore status, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed_without_appropriate_category__ignore_status__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.Fecal_Occult_Blood_Test__FOBT_(context);
+		var a_ = this.Fecal_Occult_Blood_Test__FOBT_();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FecalOccult)
 		{
@@ -673,8 +992,8 @@ public class Exam130FHIR_0_0_003
 			var h_ = context.Operators.Not(g_);
 			var i_ = context.Operators.Not((bool?)(FecalOccult?.Value is null));
 			var j_ = context.Operators.And(h_, i_);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FecalOccult?.Effective);
-			var l_ = this.Measurement_Period(context);
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FecalOccult?.Effective);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, "day");
 			var n_ = context.Operators.And(j_, m_);
 
@@ -685,15 +1004,18 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Display Date, Result, Category, Status")]
-	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status(CqlContext context)
+    [CqlDeclaration("Fecal Occult Blood Test Performed without appropriate status, ignore category, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset() => 
+		__Fecal_Occult_Blood_Test_Performed_without_appropriate_status__ignore_category__day_of_TZoffset?.Value;
+
+	private IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var h_ = this.Measurement_Period(context);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.Quantity(4m, "years");
 			var k_ = context.Operators.Subtract(i_, j_);
@@ -709,7 +1031,7 @@ public class Exam130FHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW e_(Observation FitDNA)
 		{
-			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
+			var t_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
 			var u_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(FitDNA?.Value, "coding");
 			bool? v_(Coding @this)
 			{
@@ -767,10 +1089,13 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Display Date, Result, Category, Status")]
+	public IEnumerable<Tuples.Tuple_GHYDcaRJOeEdWbTSSCjjBhBFW> Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status() => 
+		__Fecal_Immunochemical_Test_DNA_Display_Date__Result__Category__Status?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -817,8 +1142,8 @@ public class Exam130FHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.End(o_);
 			var q_ = context.Operators.Quantity(3m, "years");
 			var r_ = context.Operators.Subtract(p_, q_);
@@ -837,10 +1162,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed() => 
+		__Fecal_Immunochemical_Test_DNA_Performed?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -887,8 +1215,8 @@ public class Exam130FHIR_0_0_003
 			var k_ = context.Operators.And(g_, j_);
 			var l_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var m_ = context.Operators.And(k_, l_);
-			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var o_ = this.Measurement_Period(context);
+			var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.End(o_);
 			var q_ = context.Operators.Quantity(3m, "years");
 			var r_ = context.Operators.Subtract(p_, q_);
@@ -907,10 +1235,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate category, ignore status, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -949,8 +1280,8 @@ public class Exam130FHIR_0_0_003
 			var g_ = context.Operators.ExistsInList<CodeableConcept>(f_);
 			var h_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var i_ = context.Operators.And(g_, h_);
-			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var k_ = this.Measurement_Period(context);
+			var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(3m, "years");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -969,10 +1300,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate status, ignore category, day of TZoffset")]
-	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate category, ignore status, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_category__ignore_status__day_of_TZoffset?.Value;
+
+	private IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset_Value(CqlContext context)
 	{
-		var a_ = this.FIT_DNA(context);
+		var a_ = this.FIT_DNA();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FitDNA)
 		{
@@ -987,8 +1321,8 @@ public class Exam130FHIR_0_0_003
 			var h_ = context.Operators.Not(g_);
 			var i_ = context.Operators.Not((bool?)(FitDNA?.Value is null));
 			var j_ = context.Operators.And(h_, i_);
-			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FitDNA?.Effective);
-			var l_ = this.Measurement_Period(context);
+			var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FitDNA?.Effective);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.End(l_);
 			var n_ = context.Operators.Quantity(3m, "years");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -1007,16 +1341,19 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("CT Colonography Display Date")]
-	public IEnumerable<CqlDateTime> CT_Colonography_Display_Date(CqlContext context)
+    [CqlDeclaration("Fecal Immunochemical Test DNA Performed without appropriate status, ignore category, day of TZoffset")]
+	public IEnumerable<Observation> Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset() => 
+		__Fecal_Immunochemical_Test_DNA_Performed_without_appropriate_status__ignore_category__day_of_TZoffset?.Value;
+
+	private IEnumerable<CqlDateTime> CT_Colonography_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(6m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1032,7 +1369,7 @@ public class Exam130FHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		CqlDateTime e_(Observation Colonography)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, Colonography?.Effective);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(Colonography?.Effective);
 
 			return u_;
 		};
@@ -1041,10 +1378,13 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("CT Colonography Performed")]
-	public IEnumerable<Observation> CT_Colonography_Performed(CqlContext context)
+    [CqlDeclaration("CT Colonography Display Date")]
+	public IEnumerable<CqlDateTime> CT_Colonography_Display_Date() => 
+		__CT_Colonography_Display_Date?.Value;
+
+	private IEnumerable<Observation> CT_Colonography_Performed_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
@@ -1057,9 +1397,9 @@ public class Exam130FHIR_0_0_003
 				"appended",
 			};
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(5m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1078,10 +1418,13 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("CT Colonography Performed without appropriate status")]
-	public IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("CT Colonography Performed")]
+	public IEnumerable<Observation> CT_Colonography_Performed() => 
+		__CT_Colonography_Performed?.Value;
+
+	private IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.CT_Colonography(context);
+		var a_ = this.CT_Colonography();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation Colonography)
 		{
@@ -1095,9 +1438,9 @@ public class Exam130FHIR_0_0_003
 			};
 			var g_ = context.Operators.InList<string>(e_, (f_ as IEnumerable<string>));
 			var h_ = context.Operators.Not(g_);
-			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonography?.Effective);
+			var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonography?.Effective);
 			var j_ = context.Operators.End(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.End(k_);
 			var m_ = context.Operators.Quantity(5m, "years");
 			var n_ = context.Operators.Subtract(l_, m_);
@@ -1116,16 +1459,19 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Display Date")]
-	public IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date(CqlContext context)
+    [CqlDeclaration("CT Colonography Performed without appropriate status")]
+	public IEnumerable<Observation> CT_Colonography_Performed_without_appropriate_status() => 
+		__CT_Colonography_Performed_without_appropriate_status?.Value;
+
+	private IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(6m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1141,7 +1487,7 @@ public class Exam130FHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
 		CqlDateTime e_(Procedure FlexibleSigmoidoscopy)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, FlexibleSigmoidoscopy?.Performed);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(FlexibleSigmoidoscopy?.Performed);
 
 			return u_;
 		};
@@ -1150,18 +1496,21 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
-	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Display Date")]
+	public IEnumerable<CqlDateTime> Flexible_Sigmoidoscopy_Display_Date() => 
+		__Flexible_Sigmoidoscopy_Display_Date?.Value;
+
+	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(FlexibleSigmoidoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(5m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1180,19 +1529,22 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Flexible Sigmoidoscopy Performed without appropriate status")]
-	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Performed")]
+	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed() => 
+		__Flexible_Sigmoidoscopy_Performed?.Value;
+
+	private IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Flexible_Sigmoidoscopy(context);
+		var a_ = this.Flexible_Sigmoidoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FlexibleSigmoidoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(FlexibleSigmoidoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
 			var g_ = context.Operators.Not(f_);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FlexibleSigmoidoscopy?.Performed);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FlexibleSigmoidoscopy?.Performed);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(5m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1211,16 +1563,19 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Colonoscopy Display Date")]
-	public IEnumerable<CqlDateTime> Colonoscopy_Display_Date(CqlContext context)
+    [CqlDeclaration("Flexible Sigmoidoscopy Performed without appropriate status")]
+	public IEnumerable<Procedure> Flexible_Sigmoidoscopy_Performed_without_appropriate_status() => 
+		__Flexible_Sigmoidoscopy_Performed_without_appropriate_status?.Value;
+
+	private IEnumerable<CqlDateTime> Colonoscopy_Display_Date_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(11m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1236,7 +1591,7 @@ public class Exam130FHIR_0_0_003
 		var d_ = context.Operators.WhereOrNull<Procedure>(b_, c_);
 		CqlDateTime e_(Procedure Colonoscopy)
 		{
-			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, Colonoscopy?.Performed);
+			var u_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Latest(Colonoscopy?.Performed);
 
 			return u_;
 		};
@@ -1245,18 +1600,21 @@ public class Exam130FHIR_0_0_003
 		return f_;
 	}
 
-    [CqlDeclaration("Colonoscopy Performed")]
-	public IEnumerable<Procedure> Colonoscopy_Performed(CqlContext context)
+    [CqlDeclaration("Colonoscopy Display Date")]
+	public IEnumerable<CqlDateTime> Colonoscopy_Display_Date() => 
+		__Colonoscopy_Display_Date?.Value;
+
+	private IEnumerable<Procedure> Colonoscopy_Performed_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(Colonoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.End(i_);
 			var k_ = context.Operators.Quantity(10m, "years");
 			var l_ = context.Operators.Subtract(j_, k_);
@@ -1275,19 +1633,22 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Colonoscopy Performed without appropriate status")]
-	public IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status(CqlContext context)
+    [CqlDeclaration("Colonoscopy Performed")]
+	public IEnumerable<Procedure> Colonoscopy_Performed() => 
+		__Colonoscopy_Performed?.Value;
+
+	private IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy(context);
+		var a_ = this.Colonoscopy();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure Colonoscopy)
 		{
 			var e_ = context.Operators.Convert<string>(Colonoscopy?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "completed");
 			var g_ = context.Operators.Not(f_);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Colonoscopy?.Performed);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Colonoscopy?.Performed);
 			var i_ = context.Operators.End(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Quantity(10m, "years");
 			var m_ = context.Operators.Subtract(k_, l_);
@@ -1306,40 +1667,50 @@ public class Exam130FHIR_0_0_003
 		return d_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Colonoscopy Performed without appropriate status")]
+	public IEnumerable<Procedure> Colonoscopy_Performed_without_appropriate_status() => 
+		__Colonoscopy_Performed_without_appropriate_status?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Colonoscopy_Performed(context);
+		var a_ = this.Colonoscopy_Performed();
 		var b_ = context.Operators.ExistsInList<Procedure>(a_);
-		var c_ = this.Fecal_Occult_Blood_Test_Performed(context);
+		var c_ = this.Fecal_Occult_Blood_Test_Performed();
 		var d_ = context.Operators.ExistsInList<Observation>(c_);
 		var e_ = context.Operators.Or(b_, d_);
-		var f_ = this.Flexible_Sigmoidoscopy_Performed(context);
+		var f_ = this.Flexible_Sigmoidoscopy_Performed();
 		var g_ = context.Operators.ExistsInList<Procedure>(f_);
 		var h_ = context.Operators.Or(e_, g_);
-		var i_ = this.Fecal_Immunochemical_Test_DNA_Performed(context);
+		var i_ = this.Fecal_Immunochemical_Test_DNA_Performed();
 		var j_ = context.Operators.ExistsInList<Observation>(i_);
 		var k_ = context.Operators.Or(h_, j_);
-		var l_ = this.CT_Colonography_Performed(context);
+		var l_ = this.CT_Colonography_Performed();
 		var m_ = context.Operators.ExistsInList<Observation>(l_);
 		var n_ = context.Operators.Or(k_, m_);
 
 		return n_;
 	}
 
-    [CqlDeclaration("Final Numerator Population")]
-	public bool? Final_Numerator_Population(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
+
+	private bool? Final_Numerator_Population_Value(CqlContext context)
 	{
-		var a_ = this.Numerator(context);
-		var b_ = this.Initial_Population(context);
+		var a_ = this.Numerator();
+		var b_ = this.Initial_Population();
 		var c_ = context.Operators.And(a_, b_);
-		var d_ = this.Denominator(context);
+		var d_ = this.Denominator();
 		var e_ = context.Operators.And(c_, d_);
-		var f_ = this.Denominator_Exclusions(context);
+		var f_ = this.Denominator_Exclusions();
 		var g_ = context.Operators.Not(f_);
 		var h_ = context.Operators.And(e_, g_);
 
 		return h_;
 	}
+
+    [CqlDeclaration("Final Numerator Population")]
+	public bool? Final_Numerator_Population() => 
+		__Final_Numerator_Population?.Value;
 
 }

--- a/Demo/Measures/FHIR347-0.1.021.cs
+++ b/Demo/Measures/FHIR347-0.1.021.cs
@@ -14,189 +14,453 @@ using Task = Hl7.Fhir.Model.Task;
 public class FHIR347_0_1_021
 {
 
-    public static FHIR347_0_1_021 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Annual_Wellness_Visit;
+    internal Lazy<CqlValueSet> __Atherosclerosis_and_Peripheral_Arterial_Disease;
+    internal Lazy<CqlValueSet> __Breastfeeding;
+    internal Lazy<CqlValueSet> __CABG_Surgeries;
+    internal Lazy<CqlValueSet> __CABG__PCI_Procedure;
+    internal Lazy<CqlValueSet> __Carotid_Intervention;
+    internal Lazy<CqlValueSet> __Cerebrovascular_Disease__Stroke__TIA;
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __End_Stage_Renal_Disease;
+    internal Lazy<CqlValueSet> __Hepatitis_A;
+    internal Lazy<CqlValueSet> __Hepatitis_B;
+    internal Lazy<CqlValueSet> __High_Intensity_Statin_Therapy;
+    internal Lazy<CqlValueSet> __Hospice_Care_Ambulatory;
+    internal Lazy<CqlValueSet> __Hypercholesterolemia;
+    internal Lazy<CqlValueSet> __Ischemic_Heart_Disease_or_Other_Related_Diagnoses;
+    internal Lazy<CqlValueSet> __LDL_Cholesterol;
+    internal Lazy<CqlValueSet> __Liver_Disease;
+    internal Lazy<CqlValueSet> __Low_Intensity_Statin_Therapy;
+    internal Lazy<CqlValueSet> __Moderate_Intensity_Statin_Therapy;
+    internal Lazy<CqlValueSet> __Myocardial_Infarction;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Outpatient_Consultation;
+    internal Lazy<CqlValueSet> __Outpatient_Encounters_for_Preventive_Care;
+    internal Lazy<CqlValueSet> __Palliative_Care_Encounter;
+    internal Lazy<CqlValueSet> __Palliative_or_Hospice_Care;
+    internal Lazy<CqlValueSet> __PCI;
+    internal Lazy<CqlValueSet> __Pregnancy_or_Other_Related_Diagnoses;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Other;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Individual_Counseling;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Rhabdomyolysis;
+    internal Lazy<CqlValueSet> __Stable_and_Unstable_Angina;
+    internal Lazy<CqlValueSet> __Statin_Allergen;
+    internal Lazy<CqlValueSet> __Statin_Associated_Muscle_Symptoms;
+    internal Lazy<CqlCode> __Encounter_for_palliative_care;
+    internal Lazy<CqlCode[]> __ICD10CM;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<object>> __ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_during_Measurement_Period;
+    internal Lazy<bool?> __Initial_Population_1;
+    internal Lazy<bool?> __Denominator_1;
+    internal Lazy<bool?> __Patients_Age_20_or_Older_at_Start_of_Measurement_Period;
+    internal Lazy<IEnumerable<Observation>> __LDL_Result_Greater_Than_or_Equal_To_190;
+    internal Lazy<IEnumerable<Condition>> __Hypercholesterolemia_Diagnosis;
+    internal Lazy<bool?> __Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD;
+    internal Lazy<bool?> __Initial_Population_2;
+    internal Lazy<bool?> __Denominator_2;
+    internal Lazy<bool?> __Has_Diabetes_Diagnosis;
+    internal Lazy<bool?> __Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia;
+    internal Lazy<bool?> __Initial_Population_3;
+    internal Lazy<bool?> __Denominator_3;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<bool?> __Has_Allergy_to_Statin;
+    internal Lazy<bool?> __Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care;
+    internal Lazy<bool?> __Has_Hepatitis_or_Liver_Disease_Diagnosis;
+    internal Lazy<bool?> __Has_Statin_Associated_Muscle_Symptoms;
+    internal Lazy<bool?> __Has_ESRD_Diagnosis;
+    internal Lazy<bool?> __Has_Adverse_Reaction_to_Statin;
+    internal Lazy<bool?> __Denominator_Exceptions;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<IEnumerable<MedicationRequest>> __Statin_Therapy_Ordered_during_Measurement_Period;
+    internal Lazy<IEnumerable<MedicationRequest>> __Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public FHIR347_0_1_021(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __Annual_Wellness_Visit = new Lazy<CqlValueSet>(this.Annual_Wellness_Visit_Value(context));
+        __Atherosclerosis_and_Peripheral_Arterial_Disease = new Lazy<CqlValueSet>(this.Atherosclerosis_and_Peripheral_Arterial_Disease_Value(context));
+        __Breastfeeding = new Lazy<CqlValueSet>(this.Breastfeeding_Value(context));
+        __CABG_Surgeries = new Lazy<CqlValueSet>(this.CABG_Surgeries_Value(context));
+        __CABG__PCI_Procedure = new Lazy<CqlValueSet>(this.CABG__PCI_Procedure_Value(context));
+        __Carotid_Intervention = new Lazy<CqlValueSet>(this.Carotid_Intervention_Value(context));
+        __Cerebrovascular_Disease__Stroke__TIA = new Lazy<CqlValueSet>(this.Cerebrovascular_Disease__Stroke__TIA_Value(context));
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value(context));
+        __End_Stage_Renal_Disease = new Lazy<CqlValueSet>(this.End_Stage_Renal_Disease_Value(context));
+        __Hepatitis_A = new Lazy<CqlValueSet>(this.Hepatitis_A_Value(context));
+        __Hepatitis_B = new Lazy<CqlValueSet>(this.Hepatitis_B_Value(context));
+        __High_Intensity_Statin_Therapy = new Lazy<CqlValueSet>(this.High_Intensity_Statin_Therapy_Value(context));
+        __Hospice_Care_Ambulatory = new Lazy<CqlValueSet>(this.Hospice_Care_Ambulatory_Value(context));
+        __Hypercholesterolemia = new Lazy<CqlValueSet>(this.Hypercholesterolemia_Value(context));
+        __Ischemic_Heart_Disease_or_Other_Related_Diagnoses = new Lazy<CqlValueSet>(this.Ischemic_Heart_Disease_or_Other_Related_Diagnoses_Value(context));
+        __LDL_Cholesterol = new Lazy<CqlValueSet>(this.LDL_Cholesterol_Value(context));
+        __Liver_Disease = new Lazy<CqlValueSet>(this.Liver_Disease_Value(context));
+        __Low_Intensity_Statin_Therapy = new Lazy<CqlValueSet>(this.Low_Intensity_Statin_Therapy_Value(context));
+        __Moderate_Intensity_Statin_Therapy = new Lazy<CqlValueSet>(this.Moderate_Intensity_Statin_Therapy_Value(context));
+        __Myocardial_Infarction = new Lazy<CqlValueSet>(this.Myocardial_Infarction_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Outpatient_Consultation = new Lazy<CqlValueSet>(this.Outpatient_Consultation_Value(context));
+        __Outpatient_Encounters_for_Preventive_Care = new Lazy<CqlValueSet>(this.Outpatient_Encounters_for_Preventive_Care_Value(context));
+        __Palliative_Care_Encounter = new Lazy<CqlValueSet>(this.Palliative_Care_Encounter_Value(context));
+        __Palliative_or_Hospice_Care = new Lazy<CqlValueSet>(this.Palliative_or_Hospice_Care_Value(context));
+        __PCI = new Lazy<CqlValueSet>(this.PCI_Value(context));
+        __Pregnancy_or_Other_Related_Diagnoses = new Lazy<CqlValueSet>(this.Pregnancy_or_Other_Related_Diagnoses_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services___Other = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Other_Value(context));
+        __Preventive_Care_Services_Individual_Counseling = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Individual_Counseling_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Rhabdomyolysis = new Lazy<CqlValueSet>(this.Rhabdomyolysis_Value(context));
+        __Stable_and_Unstable_Angina = new Lazy<CqlValueSet>(this.Stable_and_Unstable_Angina_Value(context));
+        __Statin_Allergen = new Lazy<CqlValueSet>(this.Statin_Allergen_Value(context));
+        __Statin_Associated_Muscle_Symptoms = new Lazy<CqlValueSet>(this.Statin_Associated_Muscle_Symptoms_Value(context));
+        __Encounter_for_palliative_care = new Lazy<CqlCode>(this.Encounter_for_palliative_care_Value(context));
+        __ICD10CM = new Lazy<CqlCode[]>(this.ICD10CM_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period = new Lazy<IEnumerable<object>>(this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period_Value(context));
+        __Qualifying_Encounter_during_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_during_Measurement_Period_Value(context));
+        __Initial_Population_1 = new Lazy<bool?>(this.Initial_Population_1_Value(context));
+        __Denominator_1 = new Lazy<bool?>(this.Denominator_1_Value(context));
+        __Patients_Age_20_or_Older_at_Start_of_Measurement_Period = new Lazy<bool?>(this.Patients_Age_20_or_Older_at_Start_of_Measurement_Period_Value(context));
+        __LDL_Result_Greater_Than_or_Equal_To_190 = new Lazy<IEnumerable<Observation>>(this.LDL_Result_Greater_Than_or_Equal_To_190_Value(context));
+        __Hypercholesterolemia_Diagnosis = new Lazy<IEnumerable<Condition>>(this.Hypercholesterolemia_Diagnosis_Value(context));
+        __Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD = new Lazy<bool?>(this.Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD_Value(context));
+        __Initial_Population_2 = new Lazy<bool?>(this.Initial_Population_2_Value(context));
+        __Denominator_2 = new Lazy<bool?>(this.Denominator_2_Value(context));
+        __Has_Diabetes_Diagnosis = new Lazy<bool?>(this.Has_Diabetes_Diagnosis_Value(context));
+        __Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia = new Lazy<bool?>(this.Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia_Value(context));
+        __Initial_Population_3 = new Lazy<bool?>(this.Initial_Population_3_Value(context));
+        __Denominator_3 = new Lazy<bool?>(this.Denominator_3_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Has_Allergy_to_Statin = new Lazy<bool?>(this.Has_Allergy_to_Statin_Value(context));
+        __Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care = new Lazy<bool?>(this.Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care_Value(context));
+        __Has_Hepatitis_or_Liver_Disease_Diagnosis = new Lazy<bool?>(this.Has_Hepatitis_or_Liver_Disease_Diagnosis_Value(context));
+        __Has_Statin_Associated_Muscle_Symptoms = new Lazy<bool?>(this.Has_Statin_Associated_Muscle_Symptoms_Value(context));
+        __Has_ESRD_Diagnosis = new Lazy<bool?>(this.Has_ESRD_Diagnosis_Value(context));
+        __Has_Adverse_Reaction_to_Statin = new Lazy<bool?>(this.Has_Adverse_Reaction_to_Statin_Value(context));
+        __Denominator_Exceptions = new Lazy<bool?>(this.Denominator_Exceptions_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Statin_Therapy_Ordered_during_Measurement_Period = new Lazy<IEnumerable<MedicationRequest>>(this.Statin_Therapy_Ordered_during_Measurement_Period_Value(context));
+        __Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period = new Lazy<IEnumerable<MedicationRequest>>(this.Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Annual_Wellness_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
 
     [CqlDeclaration("Annual Wellness Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240")]
-	public CqlValueSet Annual_Wellness_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240", null);
+	public CqlValueSet Annual_Wellness_Visit() => 
+		__Annual_Wellness_Visit?.Value;
+
+	private CqlValueSet Atherosclerosis_and_Peripheral_Arterial_Disease_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", null);
 
     [CqlDeclaration("Atherosclerosis and Peripheral Arterial Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21")]
-	public CqlValueSet Atherosclerosis_and_Peripheral_Arterial_Disease(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21", null);
+	public CqlValueSet Atherosclerosis_and_Peripheral_Arterial_Disease() => 
+		__Atherosclerosis_and_Peripheral_Arterial_Disease?.Value;
+
+	private CqlValueSet Breastfeeding_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", null);
 
     [CqlDeclaration("Breastfeeding")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73")]
-	public CqlValueSet Breastfeeding(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73", null);
+	public CqlValueSet Breastfeeding() => 
+		__Breastfeeding?.Value;
+
+	private CqlValueSet CABG_Surgeries_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", null);
 
     [CqlDeclaration("CABG Surgeries")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694")]
-	public CqlValueSet CABG_Surgeries(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.694", null);
+	public CqlValueSet CABG_Surgeries() => 
+		__CABG_Surgeries?.Value;
+
+	private CqlValueSet CABG__PCI_Procedure_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", null);
 
     [CqlDeclaration("CABG, PCI Procedure")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566")]
-	public CqlValueSet CABG__PCI_Procedure(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1138.566", null);
+	public CqlValueSet CABG__PCI_Procedure() => 
+		__CABG__PCI_Procedure?.Value;
+
+	private CqlValueSet Carotid_Intervention_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", null);
 
     [CqlDeclaration("Carotid Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204")]
-	public CqlValueSet Carotid_Intervention(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.204", null);
+	public CqlValueSet Carotid_Intervention() => 
+		__Carotid_Intervention?.Value;
+
+	private CqlValueSet Cerebrovascular_Disease__Stroke__TIA_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", null);
 
     [CqlDeclaration("Cerebrovascular Disease, Stroke, TIA")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44")]
-	public CqlValueSet Cerebrovascular_Disease__Stroke__TIA(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.44", null);
+	public CqlValueSet Cerebrovascular_Disease__Stroke__TIA() => 
+		__Cerebrovascular_Disease__Stroke__TIA?.Value;
+
+	private CqlValueSet Diabetes_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
-	public CqlValueSet Diabetes(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+	public CqlValueSet Diabetes() => 
+		__Diabetes?.Value;
+
+	private CqlValueSet End_Stage_Renal_Disease_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
 
     [CqlDeclaration("End Stage Renal Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353")]
-	public CqlValueSet End_Stage_Renal_Disease(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353", null);
+	public CqlValueSet End_Stage_Renal_Disease() => 
+		__End_Stage_Renal_Disease?.Value;
+
+	private CqlValueSet Hepatitis_A_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
 
     [CqlDeclaration("Hepatitis A")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024")]
-	public CqlValueSet Hepatitis_A(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.110.12.1024", null);
+	public CqlValueSet Hepatitis_A() => 
+		__Hepatitis_A?.Value;
+
+	private CqlValueSet Hepatitis_B_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", null);
 
     [CqlDeclaration("Hepatitis B")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269")]
-	public CqlValueSet Hepatitis_B(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.269", null);
+	public CqlValueSet Hepatitis_B() => 
+		__Hepatitis_B?.Value;
+
+	private CqlValueSet High_Intensity_Statin_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", null);
 
     [CqlDeclaration("High Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572")]
-	public CqlValueSet High_Intensity_Statin_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1572", null);
+	public CqlValueSet High_Intensity_Statin_Therapy() => 
+		__High_Intensity_Statin_Therapy?.Value;
+
+	private CqlValueSet Hospice_Care_Ambulatory_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
 
     [CqlDeclaration("Hospice Care Ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584")]
-	public CqlValueSet Hospice_Care_Ambulatory(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1584", null);
+	public CqlValueSet Hospice_Care_Ambulatory() => 
+		__Hospice_Care_Ambulatory?.Value;
+
+	private CqlValueSet Hypercholesterolemia_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", null);
 
     [CqlDeclaration("Hypercholesterolemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100")]
-	public CqlValueSet Hypercholesterolemia(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.100", null);
+	public CqlValueSet Hypercholesterolemia() => 
+		__Hypercholesterolemia?.Value;
+
+	private CqlValueSet Ischemic_Heart_Disease_or_Other_Related_Diagnoses_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", null);
 
     [CqlDeclaration("Ischemic Heart Disease or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46")]
-	public CqlValueSet Ischemic_Heart_Disease_or_Other_Related_Diagnoses(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.46", null);
+	public CqlValueSet Ischemic_Heart_Disease_or_Other_Related_Diagnoses() => 
+		__Ischemic_Heart_Disease_or_Other_Related_Diagnoses?.Value;
+
+	private CqlValueSet LDL_Cholesterol_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", null);
 
     [CqlDeclaration("LDL Cholesterol")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573")]
-	public CqlValueSet LDL_Cholesterol(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1573", null);
+	public CqlValueSet LDL_Cholesterol() => 
+		__LDL_Cholesterol?.Value;
+
+	private CqlValueSet Liver_Disease_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", null);
 
     [CqlDeclaration("Liver Disease")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42")]
-	public CqlValueSet Liver_Disease(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.42", null);
+	public CqlValueSet Liver_Disease() => 
+		__Liver_Disease?.Value;
+
+	private CqlValueSet Low_Intensity_Statin_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", null);
 
     [CqlDeclaration("Low Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574")]
-	public CqlValueSet Low_Intensity_Statin_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1574", null);
+	public CqlValueSet Low_Intensity_Statin_Therapy() => 
+		__Low_Intensity_Statin_Therapy?.Value;
+
+	private CqlValueSet Moderate_Intensity_Statin_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", null);
 
     [CqlDeclaration("Moderate Intensity Statin Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575")]
-	public CqlValueSet Moderate_Intensity_Statin_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1575", null);
+	public CqlValueSet Moderate_Intensity_Statin_Therapy() => 
+		__Moderate_Intensity_Statin_Therapy?.Value;
+
+	private CqlValueSet Myocardial_Infarction_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", null);
 
     [CqlDeclaration("Myocardial Infarction")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403")]
-	public CqlValueSet Myocardial_Infarction(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", null);
+	public CqlValueSet Myocardial_Infarction() => 
+		__Myocardial_Infarction?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Outpatient_Consultation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
 
     [CqlDeclaration("Outpatient Consultation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008")]
-	public CqlValueSet Outpatient_Consultation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+	public CqlValueSet Outpatient_Consultation() => 
+		__Outpatient_Consultation?.Value;
+
+	private CqlValueSet Outpatient_Encounters_for_Preventive_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", null);
 
     [CqlDeclaration("Outpatient Encounters for Preventive Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576")]
-	public CqlValueSet Outpatient_Encounters_for_Preventive_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1576", null);
+	public CqlValueSet Outpatient_Encounters_for_Preventive_Care() => 
+		__Outpatient_Encounters_for_Preventive_Care?.Value;
+
+	private CqlValueSet Palliative_Care_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", null);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575")]
-	public CqlValueSet Palliative_Care_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1575", null);
+	public CqlValueSet Palliative_Care_Encounter() => 
+		__Palliative_Care_Encounter?.Value;
+
+	private CqlValueSet Palliative_or_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
-	public CqlValueSet Palliative_or_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+	public CqlValueSet Palliative_or_Hospice_Care() => 
+		__Palliative_or_Hospice_Care?.Value;
+
+	private CqlValueSet PCI_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", null);
 
     [CqlDeclaration("PCI")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67")]
-	public CqlValueSet PCI(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.67", null);
+	public CqlValueSet PCI() => 
+		__PCI?.Value;
+
+	private CqlValueSet Pregnancy_or_Other_Related_Diagnoses_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", null);
 
     [CqlDeclaration("Pregnancy or Other Related Diagnoses")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623")]
-	public CqlValueSet Pregnancy_or_Other_Related_Diagnoses(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1623", null);
+	public CqlValueSet Pregnancy_or_Other_Related_Diagnoses() => 
+		__Pregnancy_or_Other_Related_Diagnoses?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Other_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
 
     [CqlDeclaration("Preventive Care Services - Other")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030")]
-	public CqlValueSet Preventive_Care_Services___Other(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1030", null);
+	public CqlValueSet Preventive_Care_Services___Other() => 
+		__Preventive_Care_Services___Other?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Individual_Counseling_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
 
     [CqlDeclaration("Preventive Care Services-Individual Counseling")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026")]
-	public CqlValueSet Preventive_Care_Services_Individual_Counseling(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1026", null);
+	public CqlValueSet Preventive_Care_Services_Individual_Counseling() => 
+		__Preventive_Care_Services_Individual_Counseling?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Rhabdomyolysis_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", null);
 
     [CqlDeclaration("Rhabdomyolysis")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102")]
-	public CqlValueSet Rhabdomyolysis(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.102", null);
+	public CqlValueSet Rhabdomyolysis() => 
+		__Rhabdomyolysis?.Value;
+
+	private CqlValueSet Stable_and_Unstable_Angina_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", null);
 
     [CqlDeclaration("Stable and Unstable Angina")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47")]
-	public CqlValueSet Stable_and_Unstable_Angina(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.47", null);
+	public CqlValueSet Stable_and_Unstable_Angina() => 
+		__Stable_and_Unstable_Angina?.Value;
+
+	private CqlValueSet Statin_Allergen_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", null);
 
     [CqlDeclaration("Statin Allergen")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42")]
-	public CqlValueSet Statin_Allergen(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.42", null);
+	public CqlValueSet Statin_Allergen() => 
+		__Statin_Allergen?.Value;
+
+	private CqlValueSet Statin_Associated_Muscle_Symptoms_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", null);
 
     [CqlDeclaration("Statin Associated Muscle Symptoms")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85")]
-	public CqlValueSet Statin_Associated_Muscle_Symptoms(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.85", null);
+	public CqlValueSet Statin_Associated_Muscle_Symptoms() => 
+		__Statin_Associated_Muscle_Symptoms?.Value;
 
-    [CqlDeclaration("Encounter for palliative care")]
-	public CqlCode Encounter_for_palliative_care(CqlContext context) => 
+	private CqlCode Encounter_for_palliative_care_Value(CqlContext context) => 
 		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
 
-    [CqlDeclaration("ICD10CM")]
-	public CqlCode[] ICD10CM(CqlContext context)
+    [CqlDeclaration("Encounter for palliative care")]
+	public CqlCode Encounter_for_palliative_care() => 
+		__Encounter_for_palliative_care?.Value;
+
+	private CqlCode[] ICD10CM_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -206,16 +470,22 @@ public class FHIR347_0_1_021
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ICD10CM")]
+	public CqlCode[] ICD10CM() => 
+		__ICD10CM?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("FHIR347-0.1.021", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -223,50 +493,53 @@ public class FHIR347_0_1_021
 		return b_;
 	}
 
-    [CqlDeclaration("ASCVD Diagnosis or Procedure before End of Measurement Period")]
-	public IEnumerable<object> ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<object> ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Myocardial_Infarction(context);
+		var a_ = this.Myocardial_Infarction();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Cerebrovascular_Disease__Stroke__TIA(context);
+		var c_ = this.Cerebrovascular_Disease__Stroke__TIA();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
-		var f_ = this.Atherosclerosis_and_Peripheral_Arterial_Disease(context);
+		var f_ = this.Atherosclerosis_and_Peripheral_Arterial_Disease();
 		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-		var h_ = this.Ischemic_Heart_Disease_or_Other_Related_Diagnoses(context);
+		var h_ = this.Ischemic_Heart_Disease_or_Other_Related_Diagnoses();
 		var i_ = context.Operators.RetrieveByValueSet<Condition>(h_, null);
 		var j_ = context.Operators.ListUnion<Condition>(g_, i_);
 		var k_ = context.Operators.ListUnion<Condition>(e_, j_);
-		var l_ = this.Stable_and_Unstable_Angina(context);
+		var l_ = this.Stable_and_Unstable_Angina();
 		var m_ = context.Operators.RetrieveByValueSet<Condition>(l_, null);
 		var n_ = context.Operators.ListUnion<Condition>(k_, m_);
 		bool? o_(Condition ASCVDDiagnosis)
 		{
-			var ae_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ASCVDDiagnosis);
+			var ae_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ASCVDDiagnosis);
 			var af_ = context.Operators.Start(ae_);
-			var ag_ = this.Measurement_Period(context);
+			var ag_ = this.Measurement_Period();
 			var ah_ = context.Operators.End(ag_);
 			var ai_ = context.Operators.Before(af_, ah_, null);
 
 			return ai_;
 		};
 		var p_ = context.Operators.WhereOrNull<Condition>(n_, o_);
-		var q_ = this.PCI(context);
+		var q_ = this.PCI();
 		var r_ = context.Operators.RetrieveByValueSet<Procedure>(q_, null);
-		var s_ = this.CABG_Surgeries(context);
+		var s_ = this.CABG_Surgeries();
 		var t_ = context.Operators.RetrieveByValueSet<Procedure>(s_, null);
 		var u_ = context.Operators.ListUnion<Procedure>(r_, t_);
-		var v_ = this.Carotid_Intervention(context);
+		var v_ = this.Carotid_Intervention();
 		var w_ = context.Operators.RetrieveByValueSet<Procedure>(v_, null);
-		var x_ = this.CABG__PCI_Procedure(context);
+		var x_ = this.CABG__PCI_Procedure();
 		var y_ = context.Operators.RetrieveByValueSet<Procedure>(x_, null);
 		var z_ = context.Operators.ListUnion<Procedure>(w_, y_);
 		var aa_ = context.Operators.ListUnion<Procedure>(u_, z_);
 		bool? ab_(Procedure ASCVDProcedure)
 		{
-			var aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ASCVDProcedure?.Performed);
+			var aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(ASCVDProcedure?.Performed);
 			var ak_ = context.Operators.Start(aj_);
-			var al_ = this.Measurement_Period(context);
+			var al_ = this.Measurement_Period();
 			var am_ = context.Operators.End(al_);
 			var an_ = context.Operators.Before(ak_, am_, null);
 			var ao_ = context.Operators.Convert<string>(ASCVDProcedure?.StatusElement);
@@ -281,36 +554,39 @@ public class FHIR347_0_1_021
 		return ad_;
 	}
 
-    [CqlDeclaration("Qualifying Encounter during Measurement Period")]
-	public IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period(CqlContext context)
+    [CqlDeclaration("ASCVD Diagnosis or Procedure before End of Measurement Period")]
+	public IEnumerable<object> ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period() => 
+		__ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Annual_Wellness_Visit(context);
+		var a_ = this.Annual_Wellness_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Office_Visit(context);
+		var c_ = this.Office_Visit();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Outpatient_Consultation(context);
+		var f_ = this.Outpatient_Consultation();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Outpatient_Encounters_for_Preventive_Care(context);
+		var h_ = this.Outpatient_Encounters_for_Preventive_Care();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up(context);
+		var l_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Preventive_Care_Services___Other(context);
+		var n_ = this.Preventive_Care_Services___Other();
 		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
 		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
-		var r_ = this.Preventive_Care_Services_Individual_Counseling(context);
+		var r_ = this.Preventive_Care_Services_Individual_Counseling();
 		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up(context);
+		var t_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
 		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
 		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
 		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
 		{
-			var z_ = this.Measurement_Period(context);
-			var aa_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ValidEncounter?.Period);
+			var z_ = this.Measurement_Period();
+			var aa_ = FHIRHelpers_4_0_001.ToInterval(ValidEncounter?.Period);
 			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, aa_, null);
 			var ac_ = context.Operators.Convert<string>(ValidEncounter?.StatusElement);
 			var ad_ = context.Operators.Equal(ac_, "finished");
@@ -323,32 +599,41 @@ public class FHIR347_0_1_021
 		return y_;
 	}
 
-    [CqlDeclaration("Initial Population 1")]
-	public bool? Initial_Population_1(CqlContext context)
+    [CqlDeclaration("Qualifying Encounter during Measurement Period")]
+	public IEnumerable<Encounter> Qualifying_Encounter_during_Measurement_Period() => 
+		__Qualifying_Encounter_during_Measurement_Period?.Value;
+
+	private bool? Initial_Population_1_Value(CqlContext context)
 	{
-		var a_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+		var a_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period();
 		var b_ = context.Operators.ExistsInList<object>(a_);
-		var c_ = this.Qualifying_Encounter_during_Measurement_Period(context);
+		var c_ = this.Qualifying_Encounter_during_Measurement_Period();
 		var d_ = context.Operators.ExistsInList<Encounter>(c_);
 		var e_ = context.Operators.And(b_, d_);
 
 		return e_;
 	}
 
-    [CqlDeclaration("Denominator 1")]
-	public bool? Denominator_1(CqlContext context)
+    [CqlDeclaration("Initial Population 1")]
+	public bool? Initial_Population_1() => 
+		__Initial_Population_1?.Value;
+
+	private bool? Denominator_1_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population_1(context);
+		var a_ = this.Initial_Population_1();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Patients Age 20 or Older at Start of Measurement Period")]
-	public bool? Patients_Age_20_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Denominator 1")]
+	public bool? Denominator_1() => 
+		__Denominator_1?.Value;
+
+	private bool? Patients_Age_20_or_Older_at_Start_of_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.ConvertStringToDateTime(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.CalculateAgeAt(b_, d_, "year");
 		var f_ = context.Operators.GreaterOrEqual(e_, (int?)20);
@@ -356,19 +641,22 @@ public class FHIR347_0_1_021
 		return f_;
 	}
 
-    [CqlDeclaration("LDL Result Greater Than or Equal To 190")]
-	public IEnumerable<Observation> LDL_Result_Greater_Than_or_Equal_To_190(CqlContext context)
+    [CqlDeclaration("Patients Age 20 or Older at Start of Measurement Period")]
+	public bool? Patients_Age_20_or_Older_at_Start_of_Measurement_Period() => 
+		__Patients_Age_20_or_Older_at_Start_of_Measurement_Period?.Value;
+
+	private IEnumerable<Observation> LDL_Result_Greater_Than_or_Equal_To_190_Value(CqlContext context)
 	{
-		var a_ = this.LDL_Cholesterol(context);
+		var a_ = this.LDL_Cholesterol();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation LDL)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (LDL?.Value as Quantity));
+			var e_ = FHIRHelpers_4_0_001.ToQuantity((LDL?.Value as Quantity));
 			var f_ = context.Operators.Quantity(190m, "mg/dL");
 			var g_ = context.Operators.GreaterOrEqual(e_, f_);
-			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, LDL?.Effective);
+			var h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(LDL?.Effective);
 			var i_ = context.Operators.Start(h_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.End(j_);
 			var l_ = context.Operators.Before(i_, k_, null);
 			var m_ = context.Operators.And(g_, l_);
@@ -390,16 +678,19 @@ public class FHIR347_0_1_021
 		return d_;
 	}
 
-    [CqlDeclaration("Hypercholesterolemia Diagnosis")]
-	public IEnumerable<Condition> Hypercholesterolemia_Diagnosis(CqlContext context)
+    [CqlDeclaration("LDL Result Greater Than or Equal To 190")]
+	public IEnumerable<Observation> LDL_Result_Greater_Than_or_Equal_To_190() => 
+		__LDL_Result_Greater_Than_or_Equal_To_190?.Value;
+
+	private IEnumerable<Condition> Hypercholesterolemia_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Hypercholesterolemia(context);
+		var a_ = this.Hypercholesterolemia();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Hypercholesterolemia)
 		{
-			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Hypercholesterolemia);
+			var e_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Hypercholesterolemia);
 			var f_ = context.Operators.Start(e_);
-			var g_ = this.Measurement_Period(context);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.End(g_);
 			var i_ = context.Operators.Before(f_, h_, null);
 
@@ -410,16 +701,19 @@ public class FHIR347_0_1_021
 		return d_;
 	}
 
-    [CqlDeclaration("Patients Age 20 Years and Older with LDL Cholesterol Result Greater than or Equal to 190 or Hypercholesterolemia without ASCVD")]
-	public bool? Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD(CqlContext context)
+    [CqlDeclaration("Hypercholesterolemia Diagnosis")]
+	public IEnumerable<Condition> Hypercholesterolemia_Diagnosis() => 
+		__Hypercholesterolemia_Diagnosis?.Value;
+
+	private bool? Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD_Value(CqlContext context)
 	{
-		var a_ = this.Patients_Age_20_or_Older_at_Start_of_Measurement_Period(context);
-		var b_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
-		var c_ = this.Hypercholesterolemia_Diagnosis(context);
+		var a_ = this.Patients_Age_20_or_Older_at_Start_of_Measurement_Period();
+		var b_ = this.LDL_Result_Greater_Than_or_Equal_To_190();
+		var c_ = this.Hypercholesterolemia_Diagnosis();
 		var d_ = context.Operators.ListUnion<object>((b_ as IEnumerable<object>), (c_ as IEnumerable<object>));
 		var e_ = context.Operators.ExistsInList<object>(d_);
 		var f_ = context.Operators.And(a_, e_);
-		var g_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+		var g_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period();
 		var h_ = context.Operators.ExistsInList<object>(g_);
 		var i_ = context.Operators.Not(h_);
 		var j_ = context.Operators.And(f_, i_);
@@ -427,34 +721,43 @@ public class FHIR347_0_1_021
 		return j_;
 	}
 
-    [CqlDeclaration("Initial Population 2")]
-	public bool? Initial_Population_2(CqlContext context)
+    [CqlDeclaration("Patients Age 20 Years and Older with LDL Cholesterol Result Greater than or Equal to 190 or Hypercholesterolemia without ASCVD")]
+	public bool? Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD() => 
+		__Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD?.Value;
+
+	private bool? Initial_Population_2_Value(CqlContext context)
 	{
-		var a_ = this.Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD(context);
-		var b_ = this.Qualifying_Encounter_during_Measurement_Period(context);
+		var a_ = this.Patients_Age_20_Years_and_Older_with_LDL_Cholesterol_Result_Greater_than_or_Equal_to_190_or_Hypercholesterolemia_without_ASCVD();
+		var b_ = this.Qualifying_Encounter_during_Measurement_Period();
 		var c_ = context.Operators.ExistsInList<Encounter>(b_);
 		var d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator 2")]
-	public bool? Denominator_2(CqlContext context)
+    [CqlDeclaration("Initial Population 2")]
+	public bool? Initial_Population_2() => 
+		__Initial_Population_2?.Value;
+
+	private bool? Denominator_2_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population_2(context);
+		var a_ = this.Initial_Population_2();
 
 		return a_;
 	}
 
-    [CqlDeclaration("Has Diabetes Diagnosis")]
-	public bool? Has_Diabetes_Diagnosis(CqlContext context)
+    [CqlDeclaration("Denominator 2")]
+	public bool? Denominator_2() => 
+		__Denominator_2?.Value;
+
+	private bool? Has_Diabetes_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Diabetes(context);
+		var a_ = this.Diabetes();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition Diabetes)
 		{
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Diabetes);
-			var g_ = this.Measurement_Period(context);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Diabetes);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.Overlaps(f_, g_, null);
 
 			return h_;
@@ -465,27 +768,30 @@ public class FHIR347_0_1_021
 		return e_;
 	}
 
-    [CqlDeclaration("Patients Age 40 to 75 Years with Diabetes without ASCVD or LDL Greater than 190 or Hypercholesterolemia")]
-	public bool? Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia(CqlContext context)
+    [CqlDeclaration("Has Diabetes Diagnosis")]
+	public bool? Has_Diabetes_Diagnosis() => 
+		__Has_Diabetes_Diagnosis?.Value;
+
+	private bool? Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.ConvertStringToDateTime(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.CalculateAgeAt(b_, d_, "year");
 		var f_ = context.Operators.Interval((int?)40, (int?)75, true, true);
 		var g_ = context.Operators.ElementInInterval<int?>(e_, f_, null);
-		var h_ = this.Has_Diabetes_Diagnosis(context);
+		var h_ = this.Has_Diabetes_Diagnosis();
 		var i_ = context.Operators.And(g_, h_);
-		var j_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
+		var j_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period();
 		var k_ = context.Operators.ExistsInList<object>(j_);
 		var l_ = context.Operators.Not(k_);
 		var m_ = context.Operators.And(i_, l_);
-		var n_ = this.LDL_Result_Greater_Than_or_Equal_To_190(context);
+		var n_ = this.LDL_Result_Greater_Than_or_Equal_To_190();
 		var o_ = context.Operators.ExistsInList<Observation>(n_);
 		var p_ = context.Operators.Not(o_);
 		var q_ = context.Operators.And(m_, p_);
-		var r_ = this.Hypercholesterolemia_Diagnosis(context);
+		var r_ = this.Hypercholesterolemia_Diagnosis();
 		var s_ = context.Operators.ExistsInList<Condition>(r_);
 		var t_ = context.Operators.Not(s_);
 		var u_ = context.Operators.And(q_, t_);
@@ -493,67 +799,88 @@ public class FHIR347_0_1_021
 		return u_;
 	}
 
-    [CqlDeclaration("Initial Population 3")]
-	public bool? Initial_Population_3(CqlContext context)
+    [CqlDeclaration("Patients Age 40 to 75 Years with Diabetes without ASCVD or LDL Greater than 190 or Hypercholesterolemia")]
+	public bool? Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia() => 
+		__Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia?.Value;
+
+	private bool? Initial_Population_3_Value(CqlContext context)
 	{
-		var a_ = this.Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia(context);
-		var b_ = this.Qualifying_Encounter_during_Measurement_Period(context);
+		var a_ = this.Patients_Age_40_to_75_Years_with_Diabetes_without_ASCVD_or_LDL_Greater_than_190_or_Hypercholesterolemia();
+		var b_ = this.Qualifying_Encounter_during_Measurement_Period();
 		var c_ = context.Operators.ExistsInList<Encounter>(b_);
 		var d_ = context.Operators.And(a_, c_);
 
 		return d_;
 	}
 
-    [CqlDeclaration("Denominator 3")]
-	public bool? Denominator_3(CqlContext context)
+    [CqlDeclaration("Initial Population 3")]
+	public bool? Initial_Population_3() => 
+		__Initial_Population_3?.Value;
+
+	private bool? Denominator_3_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population_3(context);
+		var a_ = this.Initial_Population_3();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator 3")]
+	public bool? Denominator_3() => 
+		__Denominator_3?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Has Allergy to Statin")]
-	public bool? Has_Allergy_to_Statin(CqlContext context)
+	private bool? Has_Allergy_to_Statin_Value(CqlContext context)
 	{
-		var a_ = this.Statin_Allergen(context);
+		var a_ = this.Statin_Allergen();
 		var b_ = context.Operators.RetrieveByValueSet<AllergyIntolerance>(a_, null);
 		bool? c_(AllergyIntolerance StatinAllergy)
 		{
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, StatinAllergy?.Onset);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(StatinAllergy?.Onset);
 			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period(context);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.Before(g_, i_, null);
 
@@ -565,18 +892,21 @@ public class FHIR347_0_1_021
 		return e_;
 	}
 
-    [CqlDeclaration("Has Order or Receiving Hospice Care or Palliative Care")]
-	public bool? Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care(CqlContext context)
+    [CqlDeclaration("Has Allergy to Statin")]
+	public bool? Has_Allergy_to_Statin() => 
+		__Has_Allergy_to_Statin?.Value;
+
+	private bool? Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care_Value(CqlContext context)
 	{
-		var a_ = this.Hospice_Care_Ambulatory(context);
+		var a_ = this.Hospice_Care_Ambulatory();
 		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
-		var c_ = this.Palliative_or_Hospice_Care(context);
+		var c_ = this.Palliative_or_Hospice_Care();
 		var d_ = context.Operators.RetrieveByValueSet<ServiceRequest>(c_, null);
 		var e_ = context.Operators.ListUnion<ServiceRequest>(b_, d_);
 		bool? f_(ServiceRequest PalliativeOrHospiceCareOrder)
 		{
-			var y_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, PalliativeOrHospiceCareOrder?.AuthoredOnElement);
-			var z_ = this.Measurement_Period(context);
+			var y_ = FHIRHelpers_4_0_001.ToDateTime(PalliativeOrHospiceCareOrder?.AuthoredOnElement);
+			var z_ = this.Measurement_Period();
 			var aa_ = context.Operators.End(z_);
 			var ab_ = context.Operators.SameOrBefore(y_, aa_, null);
 			var ac_ = context.Operators.Convert<string>(PalliativeOrHospiceCareOrder?.StatusElement);
@@ -601,9 +931,9 @@ public class FHIR347_0_1_021
 		var m_ = context.Operators.ListUnion<Procedure>(j_, l_);
 		bool? n_(Procedure PalliativeOrHospiceCarePerformed)
 		{
-			var aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, PalliativeOrHospiceCarePerformed?.Performed);
+			var aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(PalliativeOrHospiceCarePerformed?.Performed);
 			var ak_ = context.Operators.Start(aj_);
-			var al_ = this.Measurement_Period(context);
+			var al_ = this.Measurement_Period();
 			var am_ = context.Operators.End(al_);
 			var an_ = context.Operators.SameOrBefore(ak_, am_, null);
 			var ao_ = context.Operators.Convert<string>(PalliativeOrHospiceCarePerformed?.StatusElement);
@@ -615,14 +945,14 @@ public class FHIR347_0_1_021
 		var o_ = context.Operators.WhereOrNull<Procedure>(m_, n_);
 		var p_ = context.Operators.ExistsInList<Procedure>(o_);
 		var q_ = context.Operators.Or(h_, p_);
-		var r_ = this.Encounter_for_palliative_care(context);
+		var r_ = this.Encounter_for_palliative_care();
 		var s_ = context.Operators.ToList<CqlCode>(r_);
 		var t_ = context.Operators.RetrieveByCodes<Encounter>(s_, null);
 		bool? u_(Encounter PalliativeEncounter)
 		{
-			var ar_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, PalliativeEncounter?.Period);
+			var ar_ = FHIRHelpers_4_0_001.ToInterval(PalliativeEncounter?.Period);
 			var as_ = context.Operators.Start(ar_);
-			var at_ = this.Measurement_Period(context);
+			var at_ = this.Measurement_Period();
 			var au_ = context.Operators.End(at_);
 			var av_ = context.Operators.SameOrBefore(as_, au_, null);
 			var aw_ = context.Operators.Convert<string>(PalliativeEncounter?.StatusElement);
@@ -638,21 +968,24 @@ public class FHIR347_0_1_021
 		return x_;
 	}
 
-    [CqlDeclaration("Has Hepatitis or Liver Disease Diagnosis")]
-	public bool? Has_Hepatitis_or_Liver_Disease_Diagnosis(CqlContext context)
+    [CqlDeclaration("Has Order or Receiving Hospice Care or Palliative Care")]
+	public bool? Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care() => 
+		__Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care?.Value;
+
+	private bool? Has_Hepatitis_or_Liver_Disease_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Hepatitis_A(context);
+		var a_ = this.Hepatitis_A();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Hepatitis_B(context);
+		var c_ = this.Hepatitis_B();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
-		var f_ = this.Liver_Disease(context);
+		var f_ = this.Liver_Disease();
 		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 		var h_ = context.Operators.ListUnion<Condition>(e_, g_);
 		bool? i_(Condition HepatitisLiverDisease)
 		{
-			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, HepatitisLiverDisease);
-			var m_ = this.Measurement_Period(context);
+			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(HepatitisLiverDisease);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.Overlaps(l_, m_, null);
 
 			return n_;
@@ -663,16 +996,19 @@ public class FHIR347_0_1_021
 		return k_;
 	}
 
-    [CqlDeclaration("Has Statin Associated Muscle Symptoms")]
-	public bool? Has_Statin_Associated_Muscle_Symptoms(CqlContext context)
+    [CqlDeclaration("Has Hepatitis or Liver Disease Diagnosis")]
+	public bool? Has_Hepatitis_or_Liver_Disease_Diagnosis() => 
+		__Has_Hepatitis_or_Liver_Disease_Diagnosis?.Value;
+
+	private bool? Has_Statin_Associated_Muscle_Symptoms_Value(CqlContext context)
 	{
-		var a_ = this.Statin_Associated_Muscle_Symptoms(context);
+		var a_ = this.Statin_Associated_Muscle_Symptoms();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition StatinMuscleSymptom)
 		{
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, StatinMuscleSymptom);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(StatinMuscleSymptom);
 			var g_ = context.Operators.Start(f_);
-			var h_ = this.Measurement_Period(context);
+			var h_ = this.Measurement_Period();
 			var i_ = context.Operators.End(h_);
 			var j_ = context.Operators.Before(g_, i_, null);
 
@@ -684,15 +1020,18 @@ public class FHIR347_0_1_021
 		return e_;
 	}
 
-    [CqlDeclaration("Has ESRD Diagnosis")]
-	public bool? Has_ESRD_Diagnosis(CqlContext context)
+    [CqlDeclaration("Has Statin Associated Muscle Symptoms")]
+	public bool? Has_Statin_Associated_Muscle_Symptoms() => 
+		__Has_Statin_Associated_Muscle_Symptoms?.Value;
+
+	private bool? Has_ESRD_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.End_Stage_Renal_Disease(context);
+		var a_ = this.End_Stage_Renal_Disease();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
 		bool? c_(Condition ESRD)
 		{
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ESRD);
-			var g_ = this.Measurement_Period(context);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ESRD);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.Overlaps(f_, g_, null);
 
 			return h_;
@@ -703,15 +1042,18 @@ public class FHIR347_0_1_021
 		return e_;
 	}
 
-    [CqlDeclaration("Has Adverse Reaction to Statin")]
-	public bool? Has_Adverse_Reaction_to_Statin(CqlContext context)
+    [CqlDeclaration("Has ESRD Diagnosis")]
+	public bool? Has_ESRD_Diagnosis() => 
+		__Has_ESRD_Diagnosis?.Value;
+
+	private bool? Has_Adverse_Reaction_to_Statin_Value(CqlContext context)
 	{
-		var a_ = this.Statin_Allergen(context);
+		var a_ = this.Statin_Allergen();
 		var b_ = context.Operators.RetrieveByValueSet<AdverseEvent>(a_, null);
 		bool? c_(AdverseEvent StatinReaction)
 		{
-			var f_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, StatinReaction?.DateElement);
-			var g_ = this.Measurement_Period(context);
+			var f_ = FHIRHelpers_4_0_001.ToDateTime(StatinReaction?.DateElement);
+			var g_ = this.Measurement_Period();
 			var h_ = context.Operators.ElementInInterval<CqlDateTime>(f_, g_, null);
 
 			return h_;
@@ -722,39 +1064,45 @@ public class FHIR347_0_1_021
 		return e_;
 	}
 
-    [CqlDeclaration("Denominator Exceptions")]
-	public bool? Denominator_Exceptions(CqlContext context)
+    [CqlDeclaration("Has Adverse Reaction to Statin")]
+	public bool? Has_Adverse_Reaction_to_Statin() => 
+		__Has_Adverse_Reaction_to_Statin?.Value;
+
+	private bool? Denominator_Exceptions_Value(CqlContext context)
 	{
-		var a_ = this.Has_Allergy_to_Statin(context);
-		var b_ = this.Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care(context);
+		var a_ = this.Has_Allergy_to_Statin();
+		var b_ = this.Has_Order_or_Receiving_Hospice_Care_or_Palliative_Care();
 		var c_ = context.Operators.Or(a_, b_);
-		var d_ = this.Has_Hepatitis_or_Liver_Disease_Diagnosis(context);
+		var d_ = this.Has_Hepatitis_or_Liver_Disease_Diagnosis();
 		var e_ = context.Operators.Or(c_, d_);
-		var f_ = this.Has_Statin_Associated_Muscle_Symptoms(context);
+		var f_ = this.Has_Statin_Associated_Muscle_Symptoms();
 		var g_ = context.Operators.Or(e_, f_);
-		var h_ = this.Has_ESRD_Diagnosis(context);
+		var h_ = this.Has_ESRD_Diagnosis();
 		var i_ = context.Operators.Or(g_, h_);
-		var j_ = this.Has_Adverse_Reaction_to_Statin(context);
+		var j_ = this.Has_Adverse_Reaction_to_Statin();
 		var k_ = context.Operators.Or(i_, j_);
 
 		return k_;
 	}
 
-    [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
+    [CqlDeclaration("Denominator Exceptions")]
+	public bool? Denominator_Exceptions() => 
+		__Denominator_Exceptions?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
 	{
-		var a_ = this.Pregnancy_or_Other_Related_Diagnoses(context);
+		var a_ = this.Pregnancy_or_Other_Related_Diagnoses();
 		var b_ = context.Operators.RetrieveByValueSet<Condition>(a_, null);
-		var c_ = this.Breastfeeding(context);
+		var c_ = this.Breastfeeding();
 		var d_ = context.Operators.RetrieveByValueSet<Condition>(c_, null);
 		var e_ = context.Operators.ListUnion<Condition>(b_, d_);
-		var f_ = this.Rhabdomyolysis(context);
+		var f_ = this.Rhabdomyolysis();
 		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 		var h_ = context.Operators.ListUnion<Condition>(e_, g_);
 		bool? i_(Condition ExclusionDiagnosis)
 		{
-			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ExclusionDiagnosis);
-			var m_ = this.Measurement_Period(context);
+			var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(ExclusionDiagnosis);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.Overlaps(l_, m_, null);
 
 			return n_;
@@ -765,27 +1113,30 @@ public class FHIR347_0_1_021
 		return k_;
 	}
 
-    [CqlDeclaration("Statin Therapy Ordered during Measurement Period")]
-	public IEnumerable<MedicationRequest> Statin_Therapy_Ordered_during_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Denominator Exclusions")]
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
+
+	private IEnumerable<MedicationRequest> Statin_Therapy_Ordered_during_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Low_Intensity_Statin_Therapy(context);
+		var a_ = this.Low_Intensity_Statin_Therapy();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
-		var f_ = this.Moderate_Intensity_Statin_Therapy(context);
+		var f_ = this.Moderate_Intensity_Statin_Therapy();
 		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
 		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
 		var j_ = context.Operators.ListUnion<MedicationRequest>(g_, i_);
 		var k_ = context.Operators.ListUnion<MedicationRequest>(e_, j_);
-		var l_ = this.High_Intensity_Statin_Therapy(context);
+		var l_ = this.High_Intensity_Statin_Therapy();
 		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
 		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
 		var p_ = context.Operators.ListUnion<MedicationRequest>(m_, o_);
 		var q_ = context.Operators.ListUnion<MedicationRequest>(k_, p_);
 		bool? r_(MedicationRequest StatinOrdered)
 		{
-			var t_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, StatinOrdered?.AuthoredOnElement);
-			var u_ = this.Measurement_Period(context);
+			var t_ = FHIRHelpers_4_0_001.ToDateTime(StatinOrdered?.AuthoredOnElement);
+			var u_ = this.Measurement_Period();
 			var v_ = context.Operators.ElementInInterval<CqlDateTime>(t_, u_, null);
 			var w_ = context.Operators.Convert<string>(StatinOrdered?.StatusElement);
 			var x_ = new string[]
@@ -806,19 +1157,22 @@ public class FHIR347_0_1_021
 		return s_;
 	}
 
-    [CqlDeclaration("Prescribed Statin Therapy Any Time during Measurement Period")]
-	public IEnumerable<MedicationRequest> Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Statin Therapy Ordered during Measurement Period")]
+	public IEnumerable<MedicationRequest> Statin_Therapy_Ordered_during_Measurement_Period() => 
+		__Statin_Therapy_Ordered_during_Measurement_Period?.Value;
+
+	private IEnumerable<MedicationRequest> Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Low_Intensity_Statin_Therapy(context);
+		var a_ = this.Low_Intensity_Statin_Therapy();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<MedicationRequest>(a_, null);
 		var e_ = context.Operators.ListUnion<MedicationRequest>(b_, d_);
-		var f_ = this.Moderate_Intensity_Statin_Therapy(context);
+		var f_ = this.Moderate_Intensity_Statin_Therapy();
 		var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
 		var i_ = context.Operators.RetrieveByValueSet<MedicationRequest>(f_, null);
 		var j_ = context.Operators.ListUnion<MedicationRequest>(g_, i_);
 		var k_ = context.Operators.ListUnion<MedicationRequest>(e_, j_);
-		var l_ = this.High_Intensity_Statin_Therapy(context);
+		var l_ = this.High_Intensity_Statin_Therapy();
 		var m_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
 		var o_ = context.Operators.RetrieveByValueSet<MedicationRequest>(l_, null);
 		var p_ = context.Operators.ListUnion<MedicationRequest>(m_, o_);
@@ -852,8 +1206,8 @@ public class FHIR347_0_1_021
 						return null;
 					};
 				};
-				var ag_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, af_());
-				var ah_ = this.Measurement_Period(context);
+				var ag_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(af_());
+				var ah_ = this.Measurement_Period();
 				var ai_ = context.Operators.Overlaps(ag_, ah_, null);
 
 				return ai_;
@@ -876,16 +1230,23 @@ public class FHIR347_0_1_021
 		return s_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Prescribed Statin Therapy Any Time during Measurement Period")]
+	public IEnumerable<MedicationRequest> Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period() => 
+		__Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Statin_Therapy_Ordered_during_Measurement_Period(context);
+		var a_ = this.Statin_Therapy_Ordered_during_Measurement_Period();
 		var b_ = context.Operators.ExistsInList<MedicationRequest>(a_);
-		var c_ = this.Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period(context);
+		var c_ = this.Prescribed_Statin_Therapy_Any_Time_during_Measurement_Period();
 		var d_ = context.Operators.ExistsInList<MedicationRequest>(c_);
 		var e_ = context.Operators.Or(b_, d_);
 
 		return e_;
 	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
 
 }

--- a/Demo/Measures/FHIRHelpers-4.0.001.cs
+++ b/Demo/Measures/FHIRHelpers-4.0.001.cs
@@ -14,10 +14,26 @@ using Task = Hl7.Fhir.Model.Task;
 public class FHIRHelpers_4_0_001
 {
 
-    public static FHIRHelpers_4_0_001 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    #region Cached values
+
+    internal Lazy<Patient> __Patient;
+
+    #endregion
+    public FHIRHelpers_4_0_001(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+    }
+    #region Dependencies
+
+
+    #endregion
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -25,8 +41,12 @@ public class FHIRHelpers_4_0_001
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("ToInterval")]
-	public CqlInterval<CqlDateTime> ToInterval(CqlContext context, Period period)
+	public CqlInterval<CqlDateTime> ToInterval(Period period)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
@@ -50,7 +70,7 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToInterval")]
-	public CqlInterval<CqlQuantity> ToInterval(CqlContext context, Range range)
+	public CqlInterval<CqlQuantity> ToInterval(Range range)
 	{
 		CqlInterval<CqlQuantity> a_()
 		{
@@ -62,8 +82,8 @@ public class FHIRHelpers_4_0_001
 			}
 			else
 			{
-				var c_ = this.ToQuantity(context, range?.Low);
-				var d_ = this.ToQuantity(context, range?.High);
+				var c_ = this.ToQuantity(range?.Low);
+				var d_ = this.ToQuantity(range?.High);
 				var e_ = context.Operators.Interval(c_, d_, true, true);
 
 				return e_;
@@ -74,13 +94,13 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToQuantity")]
-	public CqlQuantity ToQuantity(CqlContext context, Quantity quantity) => 
+	public CqlQuantity ToQuantity(Quantity quantity) => 
 		((quantity is null)
 			? null
 			: (new CqlQuantity(quantity?.ValueElement?.Value, quantity?.UnitElement?.Value)));
 
     [CqlDeclaration("ToRatio")]
-	public CqlRatio ToRatio(CqlContext context, Ratio ratio)
+	public CqlRatio ToRatio(Ratio ratio)
 	{
 		CqlRatio a_()
 		{
@@ -90,8 +110,8 @@ public class FHIRHelpers_4_0_001
 			}
 			else
 			{
-				var b_ = this.ToQuantity(context, ratio?.Numerator);
-				var c_ = this.ToQuantity(context, ratio?.Denominator);
+				var b_ = this.ToQuantity(ratio?.Numerator);
+				var c_ = this.ToQuantity(ratio?.Denominator);
 
 				return new CqlRatio(b_, c_);
 			};
@@ -101,13 +121,13 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToCode")]
-	public CqlCode ToCode(CqlContext context, Coding coding) => 
+	public CqlCode ToCode(Coding coding) => 
 		((coding is null)
 			? null
 			: (new CqlCode(coding?.CodeElement?.Value, coding?.SystemElement?.Value, coding?.VersionElement?.Value, coding?.DisplayElement?.Value)));
 
     [CqlDeclaration("ToConcept")]
-	public CqlConcept ToConcept(CqlContext context, CodeableConcept concept)
+	public CqlConcept ToConcept(CodeableConcept concept)
 	{
 		CqlConcept a_()
 		{
@@ -119,7 +139,7 @@ public class FHIRHelpers_4_0_001
 			{
 				CqlCode b_(Coding C)
 				{
-					var d_ = this.ToCode(context, C);
+					var d_ = this.ToCode(C);
 
 					return d_;
 				};
@@ -133,859 +153,859 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToString")]
-	public Account.AccountStatus? ToString(CqlContext context, Code<Account.AccountStatus> value) => 
+	public Account.AccountStatus? ToString(Code<Account.AccountStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionCardinalityBehavior? ToString(CqlContext context, Code<ActionCardinalityBehavior> value) => 
+	public ActionCardinalityBehavior? ToString(Code<ActionCardinalityBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionConditionKind? ToString(CqlContext context, Code<ActionConditionKind> value) => 
+	public ActionConditionKind? ToString(Code<ActionConditionKind> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionGroupingBehavior? ToString(CqlContext context, Code<ActionGroupingBehavior> value) => 
+	public ActionGroupingBehavior? ToString(Code<ActionGroupingBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionParticipantType? ToString(CqlContext context, Code<ActionParticipantType> value) => 
+	public ActionParticipantType? ToString(Code<ActionParticipantType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionPrecheckBehavior? ToString(CqlContext context, Code<ActionPrecheckBehavior> value) => 
+	public ActionPrecheckBehavior? ToString(Code<ActionPrecheckBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionRelationshipType? ToString(CqlContext context, Code<ActionRelationshipType> value) => 
+	public ActionRelationshipType? ToString(Code<ActionRelationshipType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionRequiredBehavior? ToString(CqlContext context, Code<ActionRequiredBehavior> value) => 
+	public ActionRequiredBehavior? ToString(Code<ActionRequiredBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActionSelectionBehavior? ToString(CqlContext context, Code<ActionSelectionBehavior> value) => 
+	public ActionSelectionBehavior? ToString(Code<ActionSelectionBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ActivityDefinition.RequestResourceType? ToString(CqlContext context, Code<ActivityDefinition.RequestResourceType> value) => 
+	public ActivityDefinition.RequestResourceType? ToString(Code<ActivityDefinition.RequestResourceType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Address.AddressType? ToString(CqlContext context, Code<Address.AddressType> value) => 
+	public Address.AddressType? ToString(Code<Address.AddressType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Address.AddressUse? ToString(CqlContext context, Code<Address.AddressUse> value) => 
+	public Address.AddressUse? ToString(Code<Address.AddressUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AdministrativeGender? ToString(CqlContext context, Code<AdministrativeGender> value) => 
+	public AdministrativeGender? ToString(Code<AdministrativeGender> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AdverseEvent.AdverseEventActuality? ToString(CqlContext context, Code<AdverseEvent.AdverseEventActuality> value) => 
+	public AdverseEvent.AdverseEventActuality? ToString(Code<AdverseEvent.AdverseEventActuality> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ElementDefinition.AggregationMode? ToString(CqlContext context, Code<ElementDefinition.AggregationMode> value) => 
+	public ElementDefinition.AggregationMode? ToString(Code<ElementDefinition.AggregationMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AllergyIntolerance.AllergyIntoleranceCategory? ToString(CqlContext context, Code<AllergyIntolerance.AllergyIntoleranceCategory> value) => 
+	public AllergyIntolerance.AllergyIntoleranceCategory? ToString(Code<AllergyIntolerance.AllergyIntoleranceCategory> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AllergyIntolerance.AllergyIntoleranceCriticality? ToString(CqlContext context, Code<AllergyIntolerance.AllergyIntoleranceCriticality> value) => 
+	public AllergyIntolerance.AllergyIntoleranceCriticality? ToString(Code<AllergyIntolerance.AllergyIntoleranceCriticality> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AllergyIntolerance.AllergyIntoleranceSeverity? ToString(CqlContext context, Code<AllergyIntolerance.AllergyIntoleranceSeverity> value) => 
+	public AllergyIntolerance.AllergyIntoleranceSeverity? ToString(Code<AllergyIntolerance.AllergyIntoleranceSeverity> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AllergyIntolerance.AllergyIntoleranceType? ToString(CqlContext context, Code<AllergyIntolerance.AllergyIntoleranceType> value) => 
+	public AllergyIntolerance.AllergyIntoleranceType? ToString(Code<AllergyIntolerance.AllergyIntoleranceType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Appointment.AppointmentStatus? ToString(CqlContext context, Code<Appointment.AppointmentStatus> value) => 
+	public Appointment.AppointmentStatus? ToString(Code<Appointment.AppointmentStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestScript.AssertionDirectionType? ToString(CqlContext context, Code<TestScript.AssertionDirectionType> value) => 
+	public TestScript.AssertionDirectionType? ToString(Code<TestScript.AssertionDirectionType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestScript.AssertionOperatorType? ToString(CqlContext context, Code<TestScript.AssertionOperatorType> value) => 
+	public TestScript.AssertionOperatorType? ToString(Code<TestScript.AssertionOperatorType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestScript.AssertionResponseTypes? ToString(CqlContext context, Code<TestScript.AssertionResponseTypes> value) => 
+	public TestScript.AssertionResponseTypes? ToString(Code<TestScript.AssertionResponseTypes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AuditEvent.AuditEventAction? ToString(CqlContext context, Code<AuditEvent.AuditEventAction> value) => 
+	public AuditEvent.AuditEventAction? ToString(Code<AuditEvent.AuditEventAction> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AuditEvent.AuditEventAgentNetworkType? ToString(CqlContext context, Code<AuditEvent.AuditEventAgentNetworkType> value) => 
+	public AuditEvent.AuditEventAgentNetworkType? ToString(Code<AuditEvent.AuditEventAgentNetworkType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public AuditEvent.AuditEventOutcome? ToString(CqlContext context, Code<AuditEvent.AuditEventOutcome> value) => 
+	public AuditEvent.AuditEventOutcome? ToString(Code<AuditEvent.AuditEventOutcome> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public BindingStrength? ToString(CqlContext context, Code<BindingStrength> value) => 
+	public BindingStrength? ToString(Code<BindingStrength> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public BiologicallyDerivedProduct.BiologicallyDerivedProductCategory? ToString(CqlContext context, Code<BiologicallyDerivedProduct.BiologicallyDerivedProductCategory> value) => 
+	public BiologicallyDerivedProduct.BiologicallyDerivedProductCategory? ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductCategory> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public BiologicallyDerivedProduct.BiologicallyDerivedProductStatus? ToString(CqlContext context, Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStatus> value) => 
+	public BiologicallyDerivedProduct.BiologicallyDerivedProductStatus? ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale? ToString(CqlContext context, Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale> value) => 
+	public BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale? ToString(Code<BiologicallyDerivedProduct.BiologicallyDerivedProductStorageScale> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Bundle.BundleType? ToString(CqlContext context, Code<Bundle.BundleType> value) => 
+	public Bundle.BundleType? ToString(Code<Bundle.BundleType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatementKind? ToString(CqlContext context, Code<CapabilityStatementKind> value) => 
+	public CapabilityStatementKind? ToString(Code<CapabilityStatementKind> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CarePlan.CarePlanActivityKind? ToString(CqlContext context, Code<CarePlan.CarePlanActivityKind> value) => 
+	public CarePlan.CarePlanActivityKind? ToString(Code<CarePlan.CarePlanActivityKind> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CarePlan.CarePlanActivityStatus? ToString(CqlContext context, Code<CarePlan.CarePlanActivityStatus> value) => 
+	public CarePlan.CarePlanActivityStatus? ToString(Code<CarePlan.CarePlanActivityStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CarePlan.CarePlanIntent? ToString(CqlContext context, Code<CarePlan.CarePlanIntent> value) => 
+	public CarePlan.CarePlanIntent? ToString(Code<CarePlan.CarePlanIntent> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public RequestStatus? ToString(CqlContext context, Code<RequestStatus> value) => 
+	public RequestStatus? ToString(Code<RequestStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CareTeam.CareTeamStatus? ToString(CqlContext context, Code<CareTeam.CareTeamStatus> value) => 
+	public CareTeam.CareTeamStatus? ToString(Code<CareTeam.CareTeamStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CatalogEntry.CatalogEntryRelationType? ToString(CqlContext context, Code<CatalogEntry.CatalogEntryRelationType> value) => 
+	public CatalogEntry.CatalogEntryRelationType? ToString(Code<CatalogEntry.CatalogEntryRelationType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public InvoicePriceComponentType? ToString(CqlContext context, Code<InvoicePriceComponentType> value) => 
+	public InvoicePriceComponentType? ToString(Code<InvoicePriceComponentType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ChargeItem.ChargeItemStatus? ToString(CqlContext context, Code<ChargeItem.ChargeItemStatus> value) => 
+	public ChargeItem.ChargeItemStatus? ToString(Code<ChargeItem.ChargeItemStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FinancialResourceStatusCodes? ToString(CqlContext context, Code<FinancialResourceStatusCodes> value) => 
+	public FinancialResourceStatusCodes? ToString(Code<FinancialResourceStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ClinicalImpression.ClinicalImpressionStatus? ToString(CqlContext context, Code<ClinicalImpression.ClinicalImpressionStatus> value) => 
+	public ClinicalImpression.ClinicalImpressionStatus? ToString(Code<ClinicalImpression.ClinicalImpressionStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TerminologyCapabilities.CodeSearchSupport? ToString(CqlContext context, Code<TerminologyCapabilities.CodeSearchSupport> value) => 
+	public TerminologyCapabilities.CodeSearchSupport? ToString(Code<TerminologyCapabilities.CodeSearchSupport> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CodeSystemContentMode? ToString(CqlContext context, Code<CodeSystemContentMode> value) => 
+	public CodeSystemContentMode? ToString(Code<CodeSystemContentMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CodeSystem.CodeSystemHierarchyMeaning? ToString(CqlContext context, Code<CodeSystem.CodeSystemHierarchyMeaning> value) => 
+	public CodeSystem.CodeSystemHierarchyMeaning? ToString(Code<CodeSystem.CodeSystemHierarchyMeaning> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public RequestPriority? ToString(CqlContext context, Code<RequestPriority> value) => 
+	public RequestPriority? ToString(Code<RequestPriority> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public EventStatus? ToString(CqlContext context, Code<EventStatus> value) => 
+	public EventStatus? ToString(Code<EventStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CompartmentType? ToString(CqlContext context, Code<CompartmentType> value) => 
+	public CompartmentType? ToString(Code<CompartmentType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Composition.CompositionAttestationMode? ToString(CqlContext context, Code<Composition.CompositionAttestationMode> value) => 
+	public Composition.CompositionAttestationMode? ToString(Code<Composition.CompositionAttestationMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CompositionStatus? ToString(CqlContext context, Code<CompositionStatus> value) => 
+	public CompositionStatus? ToString(Code<CompositionStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ConceptMapEquivalence? ToString(CqlContext context, Code<ConceptMapEquivalence> value) => 
+	public ConceptMapEquivalence? ToString(Code<ConceptMapEquivalence> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ConceptMap.ConceptMapGroupUnmappedMode? ToString(CqlContext context, Code<ConceptMap.ConceptMapGroupUnmappedMode> value) => 
+	public ConceptMap.ConceptMapGroupUnmappedMode? ToString(Code<ConceptMap.ConceptMapGroupUnmappedMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.ConditionalDeleteStatus? ToString(CqlContext context, Code<CapabilityStatement.ConditionalDeleteStatus> value) => 
+	public CapabilityStatement.ConditionalDeleteStatus? ToString(Code<CapabilityStatement.ConditionalDeleteStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.ConditionalReadStatus? ToString(CqlContext context, Code<CapabilityStatement.ConditionalReadStatus> value) => 
+	public CapabilityStatement.ConditionalReadStatus? ToString(Code<CapabilityStatement.ConditionalReadStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Consent.ConsentDataMeaning? ToString(CqlContext context, Code<Consent.ConsentDataMeaning> value) => 
+	public Consent.ConsentDataMeaning? ToString(Code<Consent.ConsentDataMeaning> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Consent.ConsentProvisionType? ToString(CqlContext context, Code<Consent.ConsentProvisionType> value) => 
+	public Consent.ConsentProvisionType? ToString(Code<Consent.ConsentProvisionType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Consent.ConsentState? ToString(CqlContext context, Code<Consent.ConsentState> value) => 
+	public Consent.ConsentState? ToString(Code<Consent.ConsentState> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ConstraintSeverity? ToString(CqlContext context, Code<ConstraintSeverity> value) => 
+	public ConstraintSeverity? ToString(Code<ConstraintSeverity> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ContactPoint.ContactPointSystem? ToString(CqlContext context, Code<ContactPoint.ContactPointSystem> value) => 
+	public ContactPoint.ContactPointSystem? ToString(Code<ContactPoint.ContactPointSystem> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ContactPoint.ContactPointUse? ToString(CqlContext context, Code<ContactPoint.ContactPointUse> value) => 
+	public ContactPoint.ContactPointUse? ToString(Code<ContactPoint.ContactPointUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Contract.ContractResourcePublicationStatusCodes? ToString(CqlContext context, Code<Contract.ContractResourcePublicationStatusCodes> value) => 
+	public Contract.ContractResourcePublicationStatusCodes? ToString(Code<Contract.ContractResourcePublicationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Contract.ContractResourceStatusCodes? ToString(CqlContext context, Code<Contract.ContractResourceStatusCodes> value) => 
+	public Contract.ContractResourceStatusCodes? ToString(Code<Contract.ContractResourceStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Contributor.ContributorType? ToString(CqlContext context, Code<Contributor.ContributorType> value) => 
+	public Contributor.ContributorType? ToString(Code<Contributor.ContributorType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Money.Currencies? ToString(CqlContext context, Code<Money.Currencies> value) => 
+	public Money.Currencies? ToString(Code<Money.Currencies> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DaysOfWeek? ToString(CqlContext context, Code<DaysOfWeek> value) => 
+	public DaysOfWeek? ToString(Code<DaysOfWeek> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DetectedIssue.DetectedIssueSeverity? ToString(CqlContext context, Code<DetectedIssue.DetectedIssueSeverity> value) => 
+	public DetectedIssue.DetectedIssueSeverity? ToString(Code<DetectedIssue.DetectedIssueSeverity> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ObservationStatus? ToString(CqlContext context, Code<ObservationStatus> value) => 
+	public ObservationStatus? ToString(Code<ObservationStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceMetric.DeviceMetricCalibrationState? ToString(CqlContext context, Code<DeviceMetric.DeviceMetricCalibrationState> value) => 
+	public DeviceMetric.DeviceMetricCalibrationState? ToString(Code<DeviceMetric.DeviceMetricCalibrationState> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceMetric.DeviceMetricCalibrationType? ToString(CqlContext context, Code<DeviceMetric.DeviceMetricCalibrationType> value) => 
+	public DeviceMetric.DeviceMetricCalibrationType? ToString(Code<DeviceMetric.DeviceMetricCalibrationType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceMetric.DeviceMetricCategory? ToString(CqlContext context, Code<DeviceMetric.DeviceMetricCategory> value) => 
+	public DeviceMetric.DeviceMetricCategory? ToString(Code<DeviceMetric.DeviceMetricCategory> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceMetric.DeviceMetricColor? ToString(CqlContext context, Code<DeviceMetric.DeviceMetricColor> value) => 
+	public DeviceMetric.DeviceMetricColor? ToString(Code<DeviceMetric.DeviceMetricColor> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceMetric.DeviceMetricOperationalStatus? ToString(CqlContext context, Code<DeviceMetric.DeviceMetricOperationalStatus> value) => 
+	public DeviceMetric.DeviceMetricOperationalStatus? ToString(Code<DeviceMetric.DeviceMetricOperationalStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceNameType? ToString(CqlContext context, Code<DeviceNameType> value) => 
+	public DeviceNameType? ToString(Code<DeviceNameType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DeviceUseStatement.DeviceUseStatementStatus? ToString(CqlContext context, Code<DeviceUseStatement.DeviceUseStatementStatus> value) => 
+	public DeviceUseStatement.DeviceUseStatementStatus? ToString(Code<DeviceUseStatement.DeviceUseStatementStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DiagnosticReport.DiagnosticReportStatus? ToString(CqlContext context, Code<DiagnosticReport.DiagnosticReportStatus> value) => 
+	public DiagnosticReport.DiagnosticReportStatus? ToString(Code<DiagnosticReport.DiagnosticReportStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ElementDefinition.DiscriminatorType? ToString(CqlContext context, Code<ElementDefinition.DiscriminatorType> value) => 
+	public ElementDefinition.DiscriminatorType? ToString(Code<ElementDefinition.DiscriminatorType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Composition.V3ConfidentialityClassification? ToString(CqlContext context, Code<Composition.V3ConfidentialityClassification> value) => 
+	public Composition.V3ConfidentialityClassification? ToString(Code<Composition.V3ConfidentialityClassification> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.DocumentMode? ToString(CqlContext context, Code<CapabilityStatement.DocumentMode> value) => 
+	public CapabilityStatement.DocumentMode? ToString(Code<CapabilityStatement.DocumentMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DocumentReferenceStatus? ToString(CqlContext context, Code<DocumentReferenceStatus> value) => 
+	public DocumentReferenceStatus? ToString(Code<DocumentReferenceStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DocumentRelationshipType? ToString(CqlContext context, Code<DocumentRelationshipType> value) => 
+	public DocumentRelationshipType? ToString(Code<DocumentRelationshipType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CoverageEligibilityRequest.EligibilityRequestPurpose? ToString(CqlContext context, Code<CoverageEligibilityRequest.EligibilityRequestPurpose> value) => 
+	public CoverageEligibilityRequest.EligibilityRequestPurpose? ToString(Code<CoverageEligibilityRequest.EligibilityRequestPurpose> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CoverageEligibilityResponse.EligibilityResponsePurpose? ToString(CqlContext context, Code<CoverageEligibilityResponse.EligibilityResponsePurpose> value) => 
+	public CoverageEligibilityResponse.EligibilityResponsePurpose? ToString(Code<CoverageEligibilityResponse.EligibilityResponsePurpose> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Questionnaire.EnableWhenBehavior? ToString(CqlContext context, Code<Questionnaire.EnableWhenBehavior> value) => 
+	public Questionnaire.EnableWhenBehavior? ToString(Code<Questionnaire.EnableWhenBehavior> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Encounter.EncounterLocationStatus? ToString(CqlContext context, Code<Encounter.EncounterLocationStatus> value) => 
+	public Encounter.EncounterLocationStatus? ToString(Code<Encounter.EncounterLocationStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Encounter.EncounterStatus? ToString(CqlContext context, Code<Encounter.EncounterStatus> value) => 
+	public Encounter.EncounterStatus? ToString(Code<Encounter.EncounterStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Endpoint.EndpointStatus? ToString(CqlContext context, Code<Endpoint.EndpointStatus> value) => 
+	public Endpoint.EndpointStatus? ToString(Code<Endpoint.EndpointStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public EpisodeOfCare.EpisodeOfCareStatus? ToString(CqlContext context, Code<EpisodeOfCare.EpisodeOfCareStatus> value) => 
+	public EpisodeOfCare.EpisodeOfCareStatus? ToString(Code<EpisodeOfCare.EpisodeOfCareStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.EventCapabilityMode? ToString(CqlContext context, Code<CapabilityStatement.EventCapabilityMode> value) => 
+	public CapabilityStatement.EventCapabilityMode? ToString(Code<CapabilityStatement.EventCapabilityMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Timing.EventTiming? ToString(CqlContext context, Code<Timing.EventTiming> value) => 
+	public Timing.EventTiming? ToString(Code<Timing.EventTiming> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public VariableTypeCode? ToString(CqlContext context, Code<VariableTypeCode> value) => 
+	public VariableTypeCode? ToString(Code<VariableTypeCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ExampleScenario.ExampleScenarioActorType? ToString(CqlContext context, Code<ExampleScenario.ExampleScenarioActorType> value) => 
+	public ExampleScenario.ExampleScenarioActorType? ToString(Code<ExampleScenario.ExampleScenarioActorType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ExplanationOfBenefit.ExplanationOfBenefitStatus? ToString(CqlContext context, Code<ExplanationOfBenefit.ExplanationOfBenefitStatus> value) => 
+	public ExplanationOfBenefit.ExplanationOfBenefitStatus? ToString(Code<ExplanationOfBenefit.ExplanationOfBenefitStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public EffectEvidenceSynthesis.ExposureStateCode? ToString(CqlContext context, Code<EffectEvidenceSynthesis.ExposureStateCode> value) => 
+	public EffectEvidenceSynthesis.ExposureStateCode? ToString(Code<EffectEvidenceSynthesis.ExposureStateCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureDefinition.ExtensionContextType? ToString(CqlContext context, Code<StructureDefinition.ExtensionContextType> value) => 
+	public StructureDefinition.ExtensionContextType? ToString(Code<StructureDefinition.ExtensionContextType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FHIRAllTypes? ToString(CqlContext context, Code<FHIRAllTypes> value) => 
+	public FHIRAllTypes? ToString(Code<FHIRAllTypes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FHIRDefinedType? ToString(CqlContext context, Code<FHIRDefinedType> value) => 
+	public FHIRDefinedType? ToString(Code<FHIRDefinedType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Device.FHIRDeviceStatus? ToString(CqlContext context, Code<Device.FHIRDeviceStatus> value) => 
+	public Device.FHIRDeviceStatus? ToString(Code<Device.FHIRDeviceStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ResourceType? ToString(CqlContext context, Code<ResourceType> value) => 
+	public ResourceType? ToString(Code<ResourceType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Substance.FHIRSubstanceStatus? ToString(CqlContext context, Code<Substance.FHIRSubstanceStatus> value) => 
+	public Substance.FHIRSubstanceStatus? ToString(Code<Substance.FHIRSubstanceStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FHIRVersion? ToString(CqlContext context, Code<FHIRVersion> value) => 
+	public FHIRVersion? ToString(Code<FHIRVersion> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FamilyMemberHistory.FamilyHistoryStatus? ToString(CqlContext context, Code<FamilyMemberHistory.FamilyHistoryStatus> value) => 
+	public FamilyMemberHistory.FamilyHistoryStatus? ToString(Code<FamilyMemberHistory.FamilyHistoryStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public FilterOperator? ToString(CqlContext context, Code<FilterOperator> value) => 
+	public FilterOperator? ToString(Code<FilterOperator> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Flag.FlagStatus? ToString(CqlContext context, Code<Flag.FlagStatus> value) => 
+	public Flag.FlagStatus? ToString(Code<Flag.FlagStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Goal.GoalLifecycleStatus? ToString(CqlContext context, Code<Goal.GoalLifecycleStatus> value) => 
+	public Goal.GoalLifecycleStatus? ToString(Code<Goal.GoalLifecycleStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public GraphDefinition.GraphCompartmentRule? ToString(CqlContext context, Code<GraphDefinition.GraphCompartmentRule> value) => 
+	public GraphDefinition.GraphCompartmentRule? ToString(Code<GraphDefinition.GraphCompartmentRule> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public GraphDefinition.GraphCompartmentUse? ToString(CqlContext context, Code<GraphDefinition.GraphCompartmentUse> value) => 
+	public GraphDefinition.GraphCompartmentUse? ToString(Code<GraphDefinition.GraphCompartmentUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public GroupMeasureCode? ToString(CqlContext context, Code<GroupMeasureCode> value) => 
+	public GroupMeasureCode? ToString(Code<GroupMeasureCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Group.GroupType? ToString(CqlContext context, Code<Group.GroupType> value) => 
+	public Group.GroupType? ToString(Code<Group.GroupType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public GuidanceResponse.GuidanceResponseStatus? ToString(CqlContext context, Code<GuidanceResponse.GuidanceResponseStatus> value) => 
+	public GuidanceResponse.GuidanceResponseStatus? ToString(Code<GuidanceResponse.GuidanceResponseStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ImplementationGuide.GuidePageGeneration? ToString(CqlContext context, Code<ImplementationGuide.GuidePageGeneration> value) => 
+	public ImplementationGuide.GuidePageGeneration? ToString(Code<ImplementationGuide.GuidePageGeneration> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ImplementationGuide.GuideParameterCode? ToString(CqlContext context, Code<ImplementationGuide.GuideParameterCode> value) => 
+	public ImplementationGuide.GuideParameterCode? ToString(Code<ImplementationGuide.GuideParameterCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Bundle.HTTPVerb? ToString(CqlContext context, Code<Bundle.HTTPVerb> value) => 
+	public Bundle.HTTPVerb? ToString(Code<Bundle.HTTPVerb> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Identifier.IdentifierUse? ToString(CqlContext context, Code<Identifier.IdentifierUse> value) => 
+	public Identifier.IdentifierUse? ToString(Code<Identifier.IdentifierUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Person.IdentityAssuranceLevel? ToString(CqlContext context, Code<Person.IdentityAssuranceLevel> value) => 
+	public Person.IdentityAssuranceLevel? ToString(Code<Person.IdentityAssuranceLevel> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ImagingStudy.ImagingStudyStatus? ToString(CqlContext context, Code<ImagingStudy.ImagingStudyStatus> value) => 
+	public ImagingStudy.ImagingStudyStatus? ToString(Code<ImagingStudy.ImagingStudyStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ImmunizationEvaluation.ImmunizationEvaluationStatusCodes? ToString(CqlContext context, Code<ImmunizationEvaluation.ImmunizationEvaluationStatusCodes> value) => 
+	public ImmunizationEvaluation.ImmunizationEvaluationStatusCodes? ToString(Code<ImmunizationEvaluation.ImmunizationEvaluationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Immunization.ImmunizationStatusCodes? ToString(CqlContext context, Code<Immunization.ImmunizationStatusCodes> value) => 
+	public Immunization.ImmunizationStatusCodes? ToString(Code<Immunization.ImmunizationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Invoice.InvoiceStatus? ToString(CqlContext context, Code<Invoice.InvoiceStatus> value) => 
+	public Invoice.InvoiceStatus? ToString(Code<Invoice.InvoiceStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public OperationOutcome.IssueSeverity? ToString(CqlContext context, Code<OperationOutcome.IssueSeverity> value) => 
+	public OperationOutcome.IssueSeverity? ToString(Code<OperationOutcome.IssueSeverity> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public OperationOutcome.IssueType? ToString(CqlContext context, Code<OperationOutcome.IssueType> value) => 
+	public OperationOutcome.IssueType? ToString(Code<OperationOutcome.IssueType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Patient.LinkType? ToString(CqlContext context, Code<Patient.LinkType> value) => 
+	public Patient.LinkType? ToString(Code<Patient.LinkType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Linkage.LinkageType? ToString(CqlContext context, Code<Linkage.LinkageType> value) => 
+	public Linkage.LinkageType? ToString(Code<Linkage.LinkageType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ListMode? ToString(CqlContext context, Code<ListMode> value) => 
+	public ListMode? ToString(Code<ListMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public List.ListStatus? ToString(CqlContext context, Code<List.ListStatus> value) => 
+	public List.ListStatus? ToString(Code<List.ListStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Location.LocationMode? ToString(CqlContext context, Code<Location.LocationMode> value) => 
+	public Location.LocationMode? ToString(Code<Location.LocationMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Location.LocationStatus? ToString(CqlContext context, Code<Location.LocationStatus> value) => 
+	public Location.LocationStatus? ToString(Code<Location.LocationStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MeasureReport.MeasureReportStatus? ToString(CqlContext context, Code<MeasureReport.MeasureReportStatus> value) => 
+	public MeasureReport.MeasureReportStatus? ToString(Code<MeasureReport.MeasureReportStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MeasureReport.MeasureReportType? ToString(CqlContext context, Code<MeasureReport.MeasureReportType> value) => 
+	public MeasureReport.MeasureReportType? ToString(Code<MeasureReport.MeasureReportType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationAdministration.MedicationAdministrationStatusCodes? ToString(CqlContext context, Code<MedicationAdministration.MedicationAdministrationStatusCodes> value) => 
+	public MedicationAdministration.MedicationAdministrationStatusCodes? ToString(Code<MedicationAdministration.MedicationAdministrationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationDispense.MedicationDispenseStatusCodes? ToString(CqlContext context, Code<MedicationDispense.MedicationDispenseStatusCodes> value) => 
+	public MedicationDispense.MedicationDispenseStatusCodes? ToString(Code<MedicationDispense.MedicationDispenseStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationKnowledge.MedicationKnowledgeStatusCodes? ToString(CqlContext context, Code<MedicationKnowledge.MedicationKnowledgeStatusCodes> value) => 
+	public MedicationKnowledge.MedicationKnowledgeStatusCodes? ToString(Code<MedicationKnowledge.MedicationKnowledgeStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationRequest.MedicationRequestIntent? ToString(CqlContext context, Code<MedicationRequest.MedicationRequestIntent> value) => 
+	public MedicationRequest.MedicationRequestIntent? ToString(Code<MedicationRequest.MedicationRequestIntent> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationRequest.MedicationrequestStatus? ToString(CqlContext context, Code<MedicationRequest.MedicationrequestStatus> value) => 
+	public MedicationRequest.MedicationrequestStatus? ToString(Code<MedicationRequest.MedicationrequestStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MedicationStatement.MedicationStatusCodes? ToString(CqlContext context, Code<MedicationStatement.MedicationStatusCodes> value) => 
+	public MedicationStatement.MedicationStatusCodes? ToString(Code<MedicationStatement.MedicationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Medication.MedicationStatusCodes? ToString(CqlContext context, Code<Medication.MedicationStatusCodes> value) => 
+	public Medication.MedicationStatusCodes? ToString(Code<Medication.MedicationStatusCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MessageDefinition.MessageSignificanceCategory? ToString(CqlContext context, Code<MessageDefinition.MessageSignificanceCategory> value) => 
+	public MessageDefinition.MessageSignificanceCategory? ToString(Code<MessageDefinition.MessageSignificanceCategory> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MessageheaderResponseRequest? ToString(CqlContext context, Code<MessageheaderResponseRequest> value) => 
+	public MessageheaderResponseRequest? ToString(Code<MessageheaderResponseRequest> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, Code value) => 
+	public string ToString(Code value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public HumanName.NameUse? ToString(CqlContext context, Code<HumanName.NameUse> value) => 
+	public HumanName.NameUse? ToString(Code<HumanName.NameUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public NamingSystem.NamingSystemIdentifierType? ToString(CqlContext context, Code<NamingSystem.NamingSystemIdentifierType> value) => 
+	public NamingSystem.NamingSystemIdentifierType? ToString(Code<NamingSystem.NamingSystemIdentifierType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public NamingSystem.NamingSystemType? ToString(CqlContext context, Code<NamingSystem.NamingSystemType> value) => 
+	public NamingSystem.NamingSystemType? ToString(Code<NamingSystem.NamingSystemType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Narrative.NarrativeStatus? ToString(CqlContext context, Code<Narrative.NarrativeStatus> value) => 
+	public Narrative.NarrativeStatus? ToString(Code<Narrative.NarrativeStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public NoteType? ToString(CqlContext context, Code<NoteType> value) => 
+	public NoteType? ToString(Code<NoteType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public RequestIntent? ToString(CqlContext context, Code<RequestIntent> value) => 
+	public RequestIntent? ToString(Code<RequestIntent> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ObservationDefinition.ObservationDataType? ToString(CqlContext context, Code<ObservationDefinition.ObservationDataType> value) => 
+	public ObservationDefinition.ObservationDataType? ToString(Code<ObservationDefinition.ObservationDataType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ObservationDefinition.ObservationRangeCategory? ToString(CqlContext context, Code<ObservationDefinition.ObservationRangeCategory> value) => 
+	public ObservationDefinition.ObservationRangeCategory? ToString(Code<ObservationDefinition.ObservationRangeCategory> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public OperationDefinition.OperationKind? ToString(CqlContext context, Code<OperationDefinition.OperationKind> value) => 
+	public OperationDefinition.OperationKind? ToString(Code<OperationDefinition.OperationKind> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public OperationParameterUse? ToString(CqlContext context, Code<OperationParameterUse> value) => 
+	public OperationParameterUse? ToString(Code<OperationParameterUse> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MolecularSequence.OrientationType? ToString(CqlContext context, Code<MolecularSequence.OrientationType> value) => 
+	public MolecularSequence.OrientationType? ToString(Code<MolecularSequence.OrientationType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Appointment.ParticipantRequired? ToString(CqlContext context, Code<Appointment.ParticipantRequired> value) => 
+	public Appointment.ParticipantRequired? ToString(Code<Appointment.ParticipantRequired> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ParticipationStatus? ToString(CqlContext context, Code<ParticipationStatus> value) => 
+	public ParticipationStatus? ToString(Code<ParticipationStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ElementDefinition.PropertyRepresentation? ToString(CqlContext context, Code<ElementDefinition.PropertyRepresentation> value) => 
+	public ElementDefinition.PropertyRepresentation? ToString(Code<ElementDefinition.PropertyRepresentation> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CodeSystem.PropertyType? ToString(CqlContext context, Code<CodeSystem.PropertyType> value) => 
+	public CodeSystem.PropertyType? ToString(Code<CodeSystem.PropertyType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Provenance.ProvenanceEntityRole? ToString(CqlContext context, Code<Provenance.ProvenanceEntityRole> value) => 
+	public Provenance.ProvenanceEntityRole? ToString(Code<Provenance.ProvenanceEntityRole> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public PublicationStatus? ToString(CqlContext context, Code<PublicationStatus> value) => 
+	public PublicationStatus? ToString(Code<PublicationStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MolecularSequence.QualityType? ToString(CqlContext context, Code<MolecularSequence.QualityType> value) => 
+	public MolecularSequence.QualityType? ToString(Code<MolecularSequence.QualityType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Quantity.QuantityComparator? ToString(CqlContext context, Code<Quantity.QuantityComparator> value) => 
+	public Quantity.QuantityComparator? ToString(Code<Quantity.QuantityComparator> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Questionnaire.QuestionnaireItemOperator? ToString(CqlContext context, Code<Questionnaire.QuestionnaireItemOperator> value) => 
+	public Questionnaire.QuestionnaireItemOperator? ToString(Code<Questionnaire.QuestionnaireItemOperator> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Questionnaire.QuestionnaireItemType? ToString(CqlContext context, Code<Questionnaire.QuestionnaireItemType> value) => 
+	public Questionnaire.QuestionnaireItemType? ToString(Code<Questionnaire.QuestionnaireItemType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public QuestionnaireResponse.QuestionnaireResponseStatus? ToString(CqlContext context, Code<QuestionnaireResponse.QuestionnaireResponseStatus> value) => 
+	public QuestionnaireResponse.QuestionnaireResponseStatus? ToString(Code<QuestionnaireResponse.QuestionnaireResponseStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.ReferenceHandlingPolicy? ToString(CqlContext context, Code<CapabilityStatement.ReferenceHandlingPolicy> value) => 
+	public CapabilityStatement.ReferenceHandlingPolicy? ToString(Code<CapabilityStatement.ReferenceHandlingPolicy> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ElementDefinition.ReferenceVersionRules? ToString(CqlContext context, Code<ElementDefinition.ReferenceVersionRules> value) => 
+	public ElementDefinition.ReferenceVersionRules? ToString(Code<ElementDefinition.ReferenceVersionRules> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public RelatedArtifact.RelatedArtifactType? ToString(CqlContext context, Code<RelatedArtifact.RelatedArtifactType> value) => 
+	public RelatedArtifact.RelatedArtifactType? ToString(Code<RelatedArtifact.RelatedArtifactType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ClaimProcessingCodes? ToString(CqlContext context, Code<ClaimProcessingCodes> value) => 
+	public ClaimProcessingCodes? ToString(Code<ClaimProcessingCodes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MolecularSequence.RepositoryType? ToString(CqlContext context, Code<MolecularSequence.RepositoryType> value) => 
+	public MolecularSequence.RepositoryType? ToString(Code<MolecularSequence.RepositoryType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ResearchElementDefinition.ResearchElementType? ToString(CqlContext context, Code<ResearchElementDefinition.ResearchElementType> value) => 
+	public ResearchElementDefinition.ResearchElementType? ToString(Code<ResearchElementDefinition.ResearchElementType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ResearchStudy.ResearchStudyStatus? ToString(CqlContext context, Code<ResearchStudy.ResearchStudyStatus> value) => 
+	public ResearchStudy.ResearchStudyStatus? ToString(Code<ResearchStudy.ResearchStudyStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ResearchSubject.ResearchSubjectStatus? ToString(CqlContext context, Code<ResearchSubject.ResearchSubjectStatus> value) => 
+	public ResearchSubject.ResearchSubjectStatus? ToString(Code<ResearchSubject.ResearchSubjectStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.ResourceVersionPolicy? ToString(CqlContext context, Code<CapabilityStatement.ResourceVersionPolicy> value) => 
+	public CapabilityStatement.ResourceVersionPolicy? ToString(Code<CapabilityStatement.ResourceVersionPolicy> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MessageHeader.ResponseType? ToString(CqlContext context, Code<MessageHeader.ResponseType> value) => 
+	public MessageHeader.ResponseType? ToString(Code<MessageHeader.ResponseType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.RestfulCapabilityMode? ToString(CqlContext context, Code<CapabilityStatement.RestfulCapabilityMode> value) => 
+	public CapabilityStatement.RestfulCapabilityMode? ToString(Code<CapabilityStatement.RestfulCapabilityMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ImplementationGuide.SPDXLicense? ToString(CqlContext context, Code<ImplementationGuide.SPDXLicense> value) => 
+	public ImplementationGuide.SPDXLicense? ToString(Code<ImplementationGuide.SPDXLicense> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SearchParameter.SearchComparator? ToString(CqlContext context, Code<SearchParameter.SearchComparator> value) => 
+	public SearchParameter.SearchComparator? ToString(Code<SearchParameter.SearchComparator> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Bundle.SearchEntryMode? ToString(CqlContext context, Code<Bundle.SearchEntryMode> value) => 
+	public Bundle.SearchEntryMode? ToString(Code<Bundle.SearchEntryMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SearchParameter.SearchModifierCode? ToString(CqlContext context, Code<SearchParameter.SearchModifierCode> value) => 
+	public SearchParameter.SearchModifierCode? ToString(Code<SearchParameter.SearchModifierCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SearchParamType? ToString(CqlContext context, Code<SearchParamType> value) => 
+	public SearchParamType? ToString(Code<SearchParamType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MolecularSequence.SequenceType? ToString(CqlContext context, Code<MolecularSequence.SequenceType> value) => 
+	public MolecularSequence.SequenceType? ToString(Code<MolecularSequence.SequenceType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ElementDefinition.SlicingRules? ToString(CqlContext context, Code<ElementDefinition.SlicingRules> value) => 
+	public ElementDefinition.SlicingRules? ToString(Code<ElementDefinition.SlicingRules> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Slot.SlotStatus? ToString(CqlContext context, Code<Slot.SlotStatus> value) => 
+	public Slot.SlotStatus? ToString(Code<Slot.SlotStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public DataRequirement.SortDirection? ToString(CqlContext context, Code<DataRequirement.SortDirection> value) => 
+	public DataRequirement.SortDirection? ToString(Code<DataRequirement.SortDirection> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SpecimenDefinition.SpecimenContainedPreference? ToString(CqlContext context, Code<SpecimenDefinition.SpecimenContainedPreference> value) => 
+	public SpecimenDefinition.SpecimenContainedPreference? ToString(Code<SpecimenDefinition.SpecimenContainedPreference> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Specimen.SpecimenStatus? ToString(CqlContext context, Code<Specimen.SpecimenStatus> value) => 
+	public Specimen.SpecimenStatus? ToString(Code<Specimen.SpecimenStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public VerificationResult.StatusCode? ToString(CqlContext context, Code<VerificationResult.StatusCode> value) => 
+	public VerificationResult.StatusCode? ToString(Code<VerificationResult.StatusCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public MolecularSequence.StrandType? ToString(CqlContext context, Code<MolecularSequence.StrandType> value) => 
+	public MolecularSequence.StrandType? ToString(Code<MolecularSequence.StrandType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureDefinition.StructureDefinitionKind? ToString(CqlContext context, Code<StructureDefinition.StructureDefinitionKind> value) => 
+	public StructureDefinition.StructureDefinitionKind? ToString(Code<StructureDefinition.StructureDefinitionKind> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapContextType? ToString(CqlContext context, Code<StructureMap.StructureMapContextType> value) => 
+	public StructureMap.StructureMapContextType? ToString(Code<StructureMap.StructureMapContextType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapGroupTypeMode? ToString(CqlContext context, Code<StructureMap.StructureMapGroupTypeMode> value) => 
+	public StructureMap.StructureMapGroupTypeMode? ToString(Code<StructureMap.StructureMapGroupTypeMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapInputMode? ToString(CqlContext context, Code<StructureMap.StructureMapInputMode> value) => 
+	public StructureMap.StructureMapInputMode? ToString(Code<StructureMap.StructureMapInputMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapModelMode? ToString(CqlContext context, Code<StructureMap.StructureMapModelMode> value) => 
+	public StructureMap.StructureMapModelMode? ToString(Code<StructureMap.StructureMapModelMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapSourceListMode? ToString(CqlContext context, Code<StructureMap.StructureMapSourceListMode> value) => 
+	public StructureMap.StructureMapSourceListMode? ToString(Code<StructureMap.StructureMapSourceListMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapTargetListMode? ToString(CqlContext context, Code<StructureMap.StructureMapTargetListMode> value) => 
+	public StructureMap.StructureMapTargetListMode? ToString(Code<StructureMap.StructureMapTargetListMode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureMap.StructureMapTransform? ToString(CqlContext context, Code<StructureMap.StructureMapTransform> value) => 
+	public StructureMap.StructureMapTransform? ToString(Code<StructureMap.StructureMapTransform> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Subscription.SubscriptionChannelType? ToString(CqlContext context, Code<Subscription.SubscriptionChannelType> value) => 
+	public Subscription.SubscriptionChannelType? ToString(Code<Subscription.SubscriptionChannelType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Subscription.SubscriptionStatus? ToString(CqlContext context, Code<Subscription.SubscriptionStatus> value) => 
+	public Subscription.SubscriptionStatus? ToString(Code<Subscription.SubscriptionStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SupplyDelivery.SupplyDeliveryStatus? ToString(CqlContext context, Code<SupplyDelivery.SupplyDeliveryStatus> value) => 
+	public SupplyDelivery.SupplyDeliveryStatus? ToString(Code<SupplyDelivery.SupplyDeliveryStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SupplyRequest.SupplyRequestStatus? ToString(CqlContext context, Code<SupplyRequest.SupplyRequestStatus> value) => 
+	public SupplyRequest.SupplyRequestStatus? ToString(Code<SupplyRequest.SupplyRequestStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.SystemRestfulInteraction? ToString(CqlContext context, Code<CapabilityStatement.SystemRestfulInteraction> value) => 
+	public CapabilityStatement.SystemRestfulInteraction? ToString(Code<CapabilityStatement.SystemRestfulInteraction> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Task.TaskIntent? ToString(CqlContext context, Code<Task.TaskIntent> value) => 
+	public Task.TaskIntent? ToString(Code<Task.TaskIntent> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Task.TaskStatus? ToString(CqlContext context, Code<Task.TaskStatus> value) => 
+	public Task.TaskStatus? ToString(Code<Task.TaskStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestReport.TestReportActionResult? ToString(CqlContext context, Code<TestReport.TestReportActionResult> value) => 
+	public TestReport.TestReportActionResult? ToString(Code<TestReport.TestReportActionResult> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestReport.TestReportParticipantType? ToString(CqlContext context, Code<TestReport.TestReportParticipantType> value) => 
+	public TestReport.TestReportParticipantType? ToString(Code<TestReport.TestReportParticipantType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestReport.TestReportResult? ToString(CqlContext context, Code<TestReport.TestReportResult> value) => 
+	public TestReport.TestReportResult? ToString(Code<TestReport.TestReportResult> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestReport.TestReportStatus? ToString(CqlContext context, Code<TestReport.TestReportStatus> value) => 
+	public TestReport.TestReportStatus? ToString(Code<TestReport.TestReportStatus> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TestScript.TestScriptRequestMethodCode? ToString(CqlContext context, Code<TestScript.TestScriptRequestMethodCode> value) => 
+	public TestScript.TestScriptRequestMethodCode? ToString(Code<TestScript.TestScriptRequestMethodCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public TriggerDefinition.TriggerType? ToString(CqlContext context, Code<TriggerDefinition.TriggerType> value) => 
+	public TriggerDefinition.TriggerType? ToString(Code<TriggerDefinition.TriggerType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public StructureDefinition.TypeDerivationRule? ToString(CqlContext context, Code<StructureDefinition.TypeDerivationRule> value) => 
+	public StructureDefinition.TypeDerivationRule? ToString(Code<StructureDefinition.TypeDerivationRule> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public CapabilityStatement.TypeRestfulInteraction? ToString(CqlContext context, Code<CapabilityStatement.TypeRestfulInteraction> value) => 
+	public CapabilityStatement.TypeRestfulInteraction? ToString(Code<CapabilityStatement.TypeRestfulInteraction> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Device.UDIEntryType? ToString(CqlContext context, Code<Device.UDIEntryType> value) => 
+	public Device.UDIEntryType? ToString(Code<Device.UDIEntryType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public Timing.UnitsOfTime? ToString(CqlContext context, Code<Timing.UnitsOfTime> value) => 
+	public Timing.UnitsOfTime? ToString(Code<Timing.UnitsOfTime> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public ClaimUseCode? ToString(CqlContext context, Code<ClaimUseCode> value) => 
+	public ClaimUseCode? ToString(Code<ClaimUseCode> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public VisionPrescription.VisionBase? ToString(CqlContext context, Code<VisionPrescription.VisionBase> value) => 
+	public VisionPrescription.VisionBase? ToString(Code<VisionPrescription.VisionBase> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public VisionPrescription.VisionEyes? ToString(CqlContext context, Code<VisionPrescription.VisionEyes> value) => 
+	public VisionPrescription.VisionEyes? ToString(Code<VisionPrescription.VisionEyes> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public SearchParameter.XPathUsageType? ToString(CqlContext context, Code<SearchParameter.XPathUsageType> value) => 
+	public SearchParameter.XPathUsageType? ToString(Code<SearchParameter.XPathUsageType> value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, Base64Binary value)
+	public string ToString(Base64Binary value)
 	{
 		var a_ = context.Operators.Convert<string>(value?.Value);
 
@@ -993,27 +1013,27 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, Id value) => 
+	public string ToString(Id value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, FhirString value) => 
+	public string ToString(FhirString value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, FhirUri value) => 
+	public string ToString(FhirUri value) => 
 		value?.Value;
 
     [CqlDeclaration("ToString")]
-	public string ToString(CqlContext context, XHtml value) => 
+	public string ToString(XHtml value) => 
 		value?.Value;
 
     [CqlDeclaration("ToBoolean")]
-	public bool? ToBoolean(CqlContext context, FhirBoolean value) => 
+	public bool? ToBoolean(FhirBoolean value) => 
 		value?.Value;
 
     [CqlDeclaration("ToDate")]
-	public CqlDate ToDate(CqlContext context, Date value)
+	public CqlDate ToDate(Date value)
 	{
 		var a_ = context.Operators.ConvertStringToDate(value?.Value);
 
@@ -1021,7 +1041,7 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToDateTime")]
-	public CqlDateTime ToDateTime(CqlContext context, FhirDateTime value)
+	public CqlDateTime ToDateTime(FhirDateTime value)
 	{
 		var a_ = context.Operators.Convert<CqlDateTime>(value);
 
@@ -1029,7 +1049,7 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToDateTime")]
-	public CqlDateTime ToDateTime(CqlContext context, Instant value)
+	public CqlDateTime ToDateTime(Instant value)
 	{
 		var a_ = context.Operators.Convert<CqlDateTime>(value?.Value);
 
@@ -1037,15 +1057,15 @@ public class FHIRHelpers_4_0_001
 	}
 
     [CqlDeclaration("ToDecimal")]
-	public decimal? ToDecimal(CqlContext context, FhirDecimal value) => 
+	public decimal? ToDecimal(FhirDecimal value) => 
 		value?.Value;
 
     [CqlDeclaration("ToInteger")]
-	public int? ToInteger(CqlContext context, Integer value) => 
+	public int? ToInteger(Integer value) => 
 		value?.Value;
 
     [CqlDeclaration("ToTime")]
-	public CqlTime ToTime(CqlContext context, Time value)
+	public CqlTime ToTime(Time value)
 	{
 		var a_ = context.Operators.ConvertStringToTime(value?.Value);
 

--- a/Demo/Measures/HospiceFHIR4-2.3.000.cs
+++ b/Demo/Measures/HospiceFHIR4-2.3.000.cs
@@ -14,28 +14,74 @@ using Task = Hl7.Fhir.Model.Task;
 public class HospiceFHIR4_2_3_000
 {
 
-    public static HospiceFHIR4_2_3_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Hospice_care_ambulatory;
+    internal Lazy<CqlCode> __Discharge_to_healthcare_facility_for_hospice_care__procedure_;
+    internal Lazy<CqlCode> __Discharge_to_home_for_hospice_care__procedure_;
+    internal Lazy<CqlCode[]> __SNOMEDCT_2017_09;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Hospice;
+
+    #endregion
+    public HospiceFHIR4_2_3_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Hospice_care_ambulatory = new Lazy<CqlValueSet>(this.Hospice_care_ambulatory_Value(context));
+        __Discharge_to_healthcare_facility_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_healthcare_facility_for_hospice_care__procedure__Value(context));
+        __Discharge_to_home_for_hospice_care__procedure_ = new Lazy<CqlCode>(this.Discharge_to_home_for_hospice_care__procedure__Value(context));
+        __SNOMEDCT_2017_09 = new Lazy<CqlCode[]>(this.SNOMEDCT_2017_09_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Has_Hospice = new Lazy<bool?>(this.Has_Hospice_Value(context));
+    }
+    #region Dependencies
+
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Hospice_care_ambulatory_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
 
     [CqlDeclaration("Hospice care ambulatory")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15")]
-	public CqlValueSet Hospice_care_ambulatory(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+	public CqlValueSet Hospice_care_ambulatory() => 
+		__Hospice_care_ambulatory?.Value;
 
-    [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
-	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_(CqlContext context) => 
+	private CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure__Value(CqlContext context) => 
 		new CqlCode("428371000124100", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("Discharge to home for hospice care (procedure)")]
-	public CqlCode Discharge_to_home_for_hospice_care__procedure_(CqlContext context) => 
+    [CqlDeclaration("Discharge to healthcare facility for hospice care (procedure)")]
+	public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_() => 
+		__Discharge_to_healthcare_facility_for_hospice_care__procedure_?.Value;
+
+	private CqlCode Discharge_to_home_for_hospice_care__procedure__Value(CqlContext context) => 
 		new CqlCode("428361000124107", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("SNOMEDCT:2017-09")]
-	public CqlCode[] SNOMEDCT_2017_09(CqlContext context)
+    [CqlDeclaration("Discharge to home for hospice care (procedure)")]
+	public CqlCode Discharge_to_home_for_hospice_care__procedure_() => 
+		__Discharge_to_home_for_hospice_care__procedure_?.Value;
+
+	private CqlCode[] SNOMEDCT_2017_09_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -46,16 +92,22 @@ public class HospiceFHIR4_2_3_000
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("SNOMEDCT:2017-09")]
+	public CqlCode[] SNOMEDCT_2017_09() => 
+		__SNOMEDCT_2017_09?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("HospiceFHIR4-2.3.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -63,27 +115,30 @@ public class HospiceFHIR4_2_3_000
 		return b_;
 	}
 
-    [CqlDeclaration("Has Hospice")]
-	public bool? Has_Hospice(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private bool? Has_Hospice_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter DischargeHospice)
 		{
 			var r_ = context.Operators.Convert<string>(DischargeHospice?.StatusElement);
 			var s_ = context.Operators.Equal(r_, "finished");
-			var t_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, DischargeHospice?.Hospitalization?.DischargeDisposition);
-			var u_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+			var t_ = FHIRHelpers_4_0_001.ToConcept(DischargeHospice?.Hospitalization?.DischargeDisposition);
+			var u_ = this.Discharge_to_home_for_hospice_care__procedure_();
 			var v_ = context.Operators.ConvertCodeToConcept(u_);
 			var w_ = context.Operators.Equivalent(t_, v_);
-			var y_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+			var y_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_();
 			var z_ = context.Operators.ConvertCodeToConcept(y_);
 			var aa_ = context.Operators.Equivalent(t_, z_);
 			var ab_ = context.Operators.Or(w_, aa_);
 			var ac_ = context.Operators.And(s_, ab_);
-			var ad_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (DischargeHospice?.Period as object));
+			var ad_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((DischargeHospice?.Period as object));
 			var ae_ = context.Operators.End(ad_);
-			var af_ = this.Measurement_Period(context);
+			var af_ = this.Measurement_Period();
 			var ag_ = context.Operators.ElementInInterval<CqlDateTime>(ae_, af_, null);
 			var ah_ = context.Operators.And(ac_, ag_);
 
@@ -91,7 +146,7 @@ public class HospiceFHIR4_2_3_000
 		};
 		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
 		var e_ = context.Operators.ExistsInList<Encounter>(d_);
-		var f_ = this.Hospice_care_ambulatory(context);
+		var f_ = this.Hospice_care_ambulatory();
 		var g_ = context.Operators.RetrieveByValueSet<ServiceRequest>(f_, null);
 		bool? h_(ServiceRequest HospiceOrder)
 		{
@@ -105,8 +160,8 @@ public class HospiceFHIR4_2_3_000
 			var al_ = context.Operators.Convert<string>(HospiceOrder?.IntentElement);
 			var am_ = context.Operators.Equal(al_, "order");
 			var an_ = context.Operators.And(ak_, am_);
-			var ao_ = this.Measurement_Period(context);
-			var ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (HospiceOrder?.AuthoredOnElement as object));
+			var ao_ = this.Measurement_Period();
+			var ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((HospiceOrder?.AuthoredOnElement as object));
 			var aq_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, ap_, null);
 			var ar_ = context.Operators.And(an_, aq_);
 
@@ -120,8 +175,8 @@ public class HospiceFHIR4_2_3_000
 		{
 			var as_ = context.Operators.Convert<string>(HospicePerformed?.StatusElement);
 			var at_ = context.Operators.Equal(as_, "completed");
-			var au_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, HospicePerformed?.Performed);
-			var av_ = this.Measurement_Period(context);
+			var au_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(HospicePerformed?.Performed);
+			var av_ = this.Measurement_Period();
 			var aw_ = context.Operators.Overlaps(au_, av_, null);
 			var ax_ = context.Operators.And(at_, aw_);
 
@@ -133,5 +188,9 @@ public class HospiceFHIR4_2_3_000
 
 		return q_;
 	}
+
+    [CqlDeclaration("Has Hospice")]
+	public bool? Has_Hospice() => 
+		__Has_Hospice?.Value;
 
 }

--- a/Demo/Measures/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.cs
+++ b/Demo/Measures/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.cs
@@ -14,39 +14,127 @@ using Task = Hl7.Fhir.Model.Task;
 public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 {
 
-    public static HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __birth_date;
+    internal Lazy<CqlValueSet> __Diabetes;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Glucose_lab_test;
+    internal Lazy<CqlValueSet> __Hypoglycemics_Treatment_Medications;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW>> __Qualifying_Encounters_With_Hospitalization_Period;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters_With_Existing_Diabetes_Diagnosis;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters_With_Hypoglycemic_Medication;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR>> __Pertinent_Encounters_With_Days;
+    internal Lazy<IEnumerable<Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK>> __Pertinent_Encounters_With_Glucose_Result_Days;
+    internal Lazy<IEnumerable<Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA>> __Pertinent_Encounters_With_Hyperglycemic_Event_Days;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+
+    #endregion
+    public HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __birth_date = new Lazy<CqlValueSet>(this.birth_date_Value(context));
+        __Diabetes = new Lazy<CqlValueSet>(this.Diabetes_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Glucose_lab_test = new Lazy<CqlValueSet>(this.Glucose_lab_test_Value(context));
+        __Hypoglycemics_Treatment_Medications = new Lazy<CqlValueSet>(this.Hypoglycemics_Treatment_Medications_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Inpatient_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounter_During_Measurement_Period_Value(context));
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value(context));
+        __Qualifying_Encounters_With_Hospitalization_Period = new Lazy<IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW>>(this.Qualifying_Encounters_With_Hospitalization_Period_Value(context));
+        __Qualifying_Encounters_With_Existing_Diabetes_Diagnosis = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_With_Existing_Diabetes_Diagnosis_Value(context));
+        __Qualifying_Encounters_With_Hypoglycemic_Medication = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_With_Hypoglycemic_Medication_Value(context));
+        __Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value(context));
+        __Pertinent_Encounters_With_Days = new Lazy<IEnumerable<Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR>>(this.Pertinent_Encounters_With_Days_Value(context));
+        __Pertinent_Encounters_With_Glucose_Result_Days = new Lazy<IEnumerable<Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK>>(this.Pertinent_Encounters_With_Glucose_Result_Days_Value(context));
+        __Pertinent_Encounters_With_Hyperglycemic_Event_Days = new Lazy<IEnumerable<Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA>>(this.Pertinent_Encounters_With_Hyperglycemic_Event_Days_Value(context));
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet birth_date_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
-	public CqlValueSet birth_date(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+	public CqlValueSet birth_date() => 
+		__birth_date?.Value;
+
+	private CqlValueSet Diabetes_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
 
     [CqlDeclaration("Diabetes")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001")]
-	public CqlValueSet Diabetes(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.103.12.1001", null);
+	public CqlValueSet Diabetes() => 
+		__Diabetes?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Glucose_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
-	public CqlValueSet Glucose_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+	public CqlValueSet Glucose_lab_test() => 
+		__Glucose_lab_test?.Value;
+
+	private CqlValueSet Hypoglycemics_Treatment_Medications_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", null);
 
     [CqlDeclaration("Hypoglycemics Treatment Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394")]
-	public CqlValueSet Hypoglycemics_Treatment_Medications(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.394", null);
+	public CqlValueSet Hypoglycemics_Treatment_Medications() => 
+		__Hypoglycemics_Treatment_Medications?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -56,16 +144,22 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -73,56 +167,74 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Inpatient Encounter During Measurement Period")]
-	public IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period(CqlContext context)
+	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 
 		return b_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters")]
-	public IEnumerable<Encounter> Qualifying_Encounters(CqlContext context)
+    [CqlDeclaration("Inpatient Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period() => 
+		__Inpatient_Encounter_During_Measurement_Period?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounter_During_Measurement_Period(context);
+		var a_ = this.Inpatient_Encounter_During_Measurement_Period();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var d_ = this.Patient(context);
+			var d_ = this.Patient();
 			var e_ = context.Operators.ConvertStringToDateTime(d_?.BirthDateElement?.Value);
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, InpatientEncounter);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(InpatientEncounter);
 			var g_ = context.Operators.Start(f_);
 			var h_ = context.Operators.CalculateAgeAt(e_, g_, "year");
 			var i_ = context.Operators.GreaterOrEqual(h_, (int?)18);
@@ -134,13 +246,16 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters With Hospitalization Period")]
-	public IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW> Qualifying_Encounters_With_Hospitalization_Period(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters?.Value;
+
+	private IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW> Qualifying_Encounters_With_Hospitalization_Period_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounters(context);
+		var a_ = this.Qualifying_Encounters();
 		Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW b_(Encounter QualifyingEncounter)
 		{
-			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 			var e_ = new Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW
 			{
 				encounter = QualifyingEncounter,
@@ -154,21 +269,24 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters With Existing Diabetes Diagnosis")]
-	public IEnumerable<Encounter> Qualifying_Encounters_With_Existing_Diabetes_Diagnosis(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters With Hospitalization Period")]
+	public IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW> Qualifying_Encounters_With_Hospitalization_Period() => 
+		__Qualifying_Encounters_With_Hospitalization_Period?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_With_Existing_Diabetes_Diagnosis_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period(context);
+		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period();
 		IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW> b_(Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW EncounterWithHospitalization)
 		{
-			var f_ = this.Diabetes(context);
+			var f_ = this.Diabetes();
 			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 			bool? h_(Condition DiabetesDiagnosis)
 			{
-				var l_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, DiabetesDiagnosis?.VerificationStatus);
-				var m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.confirmed(context);
+				var l_ = FHIRHelpers_4_0_001.ToConcept(DiabetesDiagnosis?.VerificationStatus);
+				var m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.confirmed();
 				var n_ = context.Operators.ConvertCodeToConcept(m_);
 				var o_ = context.Operators.Equivalent(l_, n_);
-				var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, DiabetesDiagnosis);
+				var p_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(DiabetesDiagnosis);
 				var q_ = context.Operators.Start(p_);
 				var r_ = context.Operators.End(EncounterWithHospitalization?.hospitalizationPeriod);
 				var s_ = context.Operators.Before(q_, r_, null);
@@ -191,13 +309,16 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return e_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters With Hypoglycemic Medication")]
-	public IEnumerable<Encounter> Qualifying_Encounters_With_Hypoglycemic_Medication(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters With Existing Diabetes Diagnosis")]
+	public IEnumerable<Encounter> Qualifying_Encounters_With_Existing_Diabetes_Diagnosis() => 
+		__Qualifying_Encounters_With_Existing_Diabetes_Diagnosis?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_With_Hypoglycemic_Medication_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period(context);
+		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period();
 		IEnumerable<MedicationAdministration> b_(Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW _EncounterWithHospitalization)
 		{
-			var i_ = this.Hypoglycemics_Treatment_Medications(context);
+			var i_ = this.Hypoglycemics_Treatment_Medications();
 			var j_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(i_, null);
 			var l_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(i_, null);
 			var m_ = context.Operators.ListUnion<MedicationAdministration>(j_, l_);
@@ -219,7 +340,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		{
 			var o_ = context.Operators.Convert<string>(tuple_ebceideejujlqkcdbhkcqvihw.HypoglycemicMedication?.StatusElement);
 			var p_ = context.Operators.Equal(o_, "completed");
-			var q_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, tuple_ebceideejujlqkcdbhkcqvihw.HypoglycemicMedication?.Effective);
+			var q_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(tuple_ebceideejujlqkcdbhkcqvihw.HypoglycemicMedication?.Effective);
 			var r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(tuple_ebceideejujlqkcdbhkcqvihw.EncounterWithHospitalization?.hospitalizationPeriod, q_, null);
 			var s_ = context.Operators.And(p_, r_);
 
@@ -233,22 +354,25 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return h_;
 	}
 
-    [CqlDeclaration("Qualifying Encounters With Elevated Blood Glucose Lab")]
-	public IEnumerable<Encounter> Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters With Hypoglycemic Medication")]
+	public IEnumerable<Encounter> Qualifying_Encounters_With_Hypoglycemic_Medication() => 
+		__Qualifying_Encounters_With_Hypoglycemic_Medication?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period(context);
+		var a_ = this.Qualifying_Encounters_With_Hospitalization_Period();
 		IEnumerable<Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW> b_(Tuples.Tuple_CXAFdKaHNVUHbTOBaaLVHDiaW EncounterWithHospitalization)
 		{
-			var f_ = this.Glucose_lab_test(context);
+			var f_ = this.Glucose_lab_test();
 			var g_ = context.Operators.RetrieveByValueSet<Observation>(f_, null);
 			bool? h_(Observation BloodGlucoseLab)
 			{
-				var l_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (BloodGlucoseLab?.Effective as FhirDateTime));
+				var l_ = FHIRHelpers_4_0_001.ToDateTime((BloodGlucoseLab?.Effective as FhirDateTime));
 				var m_ = context.Operators.ElementInInterval<CqlDateTime>(l_, EncounterWithHospitalization?.hospitalizationPeriod, null);
 				var n_ = context.Operators.Convert<string>(BloodGlucoseLab?.StatusElement);
 				var o_ = context.Operators.Equal(n_, "final");
 				var p_ = context.Operators.And(m_, o_);
-				var q_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (BloodGlucoseLab?.Value as Quantity));
+				var q_ = FHIRHelpers_4_0_001.ToQuantity((BloodGlucoseLab?.Value as Quantity));
 				var r_ = context.Operators.Quantity(200m, "mg/dL");
 				var s_ = context.Operators.GreaterOrEqual(q_, r_);
 				var t_ = context.Operators.And(p_, s_);
@@ -270,28 +394,38 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return e_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters With Elevated Blood Glucose Lab")]
+	public IEnumerable<Encounter> Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab() => 
+		__Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab?.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounters_With_Existing_Diabetes_Diagnosis(context);
-		var b_ = this.Qualifying_Encounters_With_Hypoglycemic_Medication(context);
+		var a_ = this.Qualifying_Encounters_With_Existing_Diabetes_Diagnosis();
+		var b_ = this.Qualifying_Encounters_With_Hypoglycemic_Medication();
 		var c_ = context.Operators.ListUnion<Encounter>(a_, b_);
-		var d_ = this.Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab(context);
+		var d_ = this.Qualifying_Encounters_With_Elevated_Blood_Glucose_Lab();
 		var e_ = context.Operators.ListUnion<Encounter>(c_, d_);
 
 		return e_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public IEnumerable<Encounter> Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private IEnumerable<Encounter> Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator?.Value;
+
     [CqlDeclaration("Crop Interval to 10 Days")]
-	public CqlInterval<CqlDateTime> Crop_Interval_to_10_Days(CqlContext context, CqlInterval<CqlDateTime> Period)
+	public CqlInterval<CqlDateTime> Crop_Interval_to_10_Days(CqlInterval<CqlDateTime> Period)
 	{
 		var a_ = context.Operators.Start(Period);
 		var b_ = context.Operators.End(Period);
@@ -309,7 +443,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	}
 
     [CqlDeclaration("Interval To Day Numbers")]
-	public IEnumerable<int?> Interval_To_Day_Numbers(CqlContext context, CqlInterval<CqlDateTime> Period)
+	public IEnumerable<int?> Interval_To_Day_Numbers(CqlInterval<CqlDateTime> Period)
 	{
 		var a_ = context.Operators.Start(Period);
 		var b_ = context.Operators.End(Period);
@@ -332,9 +466,9 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	}
 
     [CqlDeclaration("Days In Period")]
-	public IEnumerable<Tuples.Tuple_BZfjDHYASdKbVKTOeigaYPBVf> Days_In_Period(CqlContext context, CqlInterval<CqlDateTime> Period)
+	public IEnumerable<Tuples.Tuple_BZfjDHYASdKbVKTOeigaYPBVf> Days_In_Period(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Interval_To_Day_Numbers(context, Period);
+		var a_ = this.Interval_To_Day_Numbers(Period);
 		Tuples.Tuple_BZfjDHYASdKbVKTOeigaYPBVf b_(int? DayIndex)
 		{
 			var d_ = context.Operators.Start(Period);
@@ -381,16 +515,15 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Pertinent Encounters With Days")]
-	public IEnumerable<Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR> Pertinent_Encounters_With_Days(CqlContext context)
+	private IEnumerable<Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR> Pertinent_Encounters_With_Days_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
 		Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR b_(Encounter PertinentEncounter)
 		{
-			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, PertinentEncounter);
-			var f_ = this.Crop_Interval_to_10_Days(context, d_);
-			var h_ = this.Crop_Interval_to_10_Days(context, d_);
-			var i_ = this.Days_In_Period(context, h_);
+			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(PertinentEncounter);
+			var f_ = this.Crop_Interval_to_10_Days(d_);
+			var h_ = this.Crop_Interval_to_10_Days(d_);
+			var i_ = this.Days_In_Period(h_);
 			var j_ = new Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR
 			{
 				encounter = PertinentEncounter,
@@ -406,25 +539,28 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Pertinent Encounters With Glucose Result Days")]
-	public IEnumerable<Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK> Pertinent_Encounters_With_Glucose_Result_Days(CqlContext context)
+    [CqlDeclaration("Pertinent Encounters With Days")]
+	public IEnumerable<Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR> Pertinent_Encounters_With_Days() => 
+		__Pertinent_Encounters_With_Days?.Value;
+
+	private IEnumerable<Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK> Pertinent_Encounters_With_Glucose_Result_Days_Value(CqlContext context)
 	{
-		var a_ = this.Pertinent_Encounters_With_Days(context);
+		var a_ = this.Pertinent_Encounters_With_Days();
 		Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK b_(Tuples.Tuple_FdccSJcWTSebijGjABdUMLEdR PertinentEncounterDays)
 		{
 			Tuples.Tuple_EPQMNeOgChVRHOcBPRccPNZeF d_(Tuples.Tuple_BZfjDHYASdKbVKTOeigaYPBVf EncounterDay)
 			{
-				var g_ = this.Glucose_lab_test(context);
+				var g_ = this.Glucose_lab_test();
 				var h_ = context.Operators.RetrieveByValueSet<Observation>(g_, null);
 				bool? i_(Observation BloodGlucoseLab1)
 				{
 					var x_ = context.Operators.Convert<string>(BloodGlucoseLab1?.StatusElement);
 					var y_ = context.Operators.Equal(x_, "final");
-					var z_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (BloodGlucoseLab1?.Value as Quantity));
+					var z_ = FHIRHelpers_4_0_001.ToQuantity((BloodGlucoseLab1?.Value as Quantity));
 					var aa_ = context.Operators.Quantity(300m, "mg/dL");
 					var ab_ = context.Operators.Greater(z_, aa_);
 					var ac_ = context.Operators.And(y_, ab_);
-					var ad_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (BloodGlucoseLab1?.Effective as FhirDateTime));
+					var ad_ = FHIRHelpers_4_0_001.ToDateTime((BloodGlucoseLab1?.Effective as FhirDateTime));
 					var ae_ = context.Operators.ElementInInterval<CqlDateTime>(ad_, EncounterDay?.dayPeriod, null);
 					var af_ = context.Operators.And(ac_, ae_);
 
@@ -437,11 +573,11 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				{
 					var ag_ = context.Operators.Convert<string>(BloodGlucoseLab2?.StatusElement);
 					var ah_ = context.Operators.Equal(ag_, "final");
-					var ai_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (BloodGlucoseLab2?.Value as Quantity));
+					var ai_ = FHIRHelpers_4_0_001.ToQuantity((BloodGlucoseLab2?.Value as Quantity));
 					var aj_ = context.Operators.Quantity(200m, "mg/dL");
 					var ak_ = context.Operators.GreaterOrEqual(ai_, aj_);
 					var al_ = context.Operators.And(ah_, ak_);
-					var am_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (BloodGlucoseLab2?.Effective as FhirDateTime));
+					var am_ = FHIRHelpers_4_0_001.ToDateTime((BloodGlucoseLab2?.Effective as FhirDateTime));
 					var an_ = context.Operators.ElementInInterval<CqlDateTime>(am_, EncounterDay?.dayPeriod, null);
 					var ao_ = context.Operators.And(al_, an_);
 
@@ -454,7 +590,7 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 				{
 					var ap_ = context.Operators.Convert<string>(BloodGlucoseLab3?.StatusElement);
 					var aq_ = context.Operators.Equal(ap_, "final");
-					var ar_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (BloodGlucoseLab3?.Effective as FhirDateTime));
+					var ar_ = FHIRHelpers_4_0_001.ToDateTime((BloodGlucoseLab3?.Effective as FhirDateTime));
 					var as_ = context.Operators.ElementInInterval<CqlDateTime>(ar_, EncounterDay?.dayPeriod, null);
 					var at_ = context.Operators.And(aq_, as_);
 
@@ -489,10 +625,13 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Pertinent Encounters With Hyperglycemic Event Days")]
-	public IEnumerable<Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA> Pertinent_Encounters_With_Hyperglycemic_Event_Days(CqlContext context)
+    [CqlDeclaration("Pertinent Encounters With Glucose Result Days")]
+	public IEnumerable<Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK> Pertinent_Encounters_With_Glucose_Result_Days() => 
+		__Pertinent_Encounters_With_Glucose_Result_Days?.Value;
+
+	private IEnumerable<Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA> Pertinent_Encounters_With_Hyperglycemic_Event_Days_Value(CqlContext context)
 	{
-		var a_ = this.Pertinent_Encounters_With_Glucose_Result_Days(context);
+		var a_ = this.Pertinent_Encounters_With_Glucose_Result_Days();
 		Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA b_(Tuples.Tuple_GiWKJXbiXAiGGBDVZJdMTaVhK EncounterWithResultDays)
 		{
 			bool? d_(Tuples.Tuple_EPQMNeOgChVRHOcBPRccPNZeF EncounterDay)
@@ -535,10 +674,13 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return c_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public IEnumerable<Encounter> Numerator(CqlContext context)
+    [CqlDeclaration("Pertinent Encounters With Hyperglycemic Event Days")]
+	public IEnumerable<Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA> Pertinent_Encounters_With_Hyperglycemic_Event_Days() => 
+		__Pertinent_Encounters_With_Hyperglycemic_Event_Days?.Value;
+
+	private IEnumerable<Encounter> Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days(context);
+		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days();
 		bool? b_(Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA EncounterWithEventDays)
 		{
 			bool? f_(Tuples.Tuple_HBBaLFUhhUfQBEJKjEZegSRLi EligibleEventDay) => 
@@ -556,10 +698,14 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 		return e_;
 	}
 
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator?.Value;
+
     [CqlDeclaration("Denominator Observations")]
-	public int? Denominator_Observations(CqlContext context, Encounter QualifyingEncounter)
+	public int? Denominator_Observations(Encounter QualifyingEncounter)
 	{
-		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days(context);
+		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days();
 		bool? b_(Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA EncounterWithEventDays)
 		{
 			var g_ = context.Operators.Equal(EncounterWithEventDays?.encounter, QualifyingEncounter);
@@ -580,9 +726,9 @@ public class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
 	}
 
     [CqlDeclaration("Numerator Observations")]
-	public int? Numerator_Observations(CqlContext context, Encounter QualifyingEncounter)
+	public int? Numerator_Observations(Encounter QualifyingEncounter)
 	{
-		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days(context);
+		var a_ = this.Pertinent_Encounters_With_Hyperglycemic_Event_Days();
 		bool? b_(Tuples.Tuple_CAbQjTVRCSKOYWiIhECGMcDPA EncounterWithEventDays)
 		{
 			var g_ = context.Operators.Equal(EncounterWithEventDays?.encounter, QualifyingEncounter);

--- a/Demo/Measures/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.cs
+++ b/Demo/Measures/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.cs
@@ -14,49 +14,139 @@ using Task = Hl7.Fhir.Model.Task;
 public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 {
 
-    public static HospitalHarmSevereHypoglycemiaFHIR_0_0_012 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __birth_date;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Glucose_lab_test;
+    internal Lazy<CqlValueSet> __Hypoglycemics;
+    internal Lazy<CqlValueSet> __Hypoglycemics_Severe_Hypoglycemia;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounter_During_Measurement_Period;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter;
+    internal Lazy<IEnumerable<MedicationAdministration>> __Hypoglycemic_Medication_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounter_with_Hypoglycemic_Medication_Administration;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Encounter>> __Severe_Hypoglycemic_Harm_Event;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+
+    #endregion
+    public HospitalHarmSevereHypoglycemiaFHIR_0_0_012(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __birth_date = new Lazy<CqlValueSet>(this.birth_date_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Glucose_lab_test = new Lazy<CqlValueSet>(this.Glucose_lab_test_Value(context));
+        __Hypoglycemics = new Lazy<CqlValueSet>(this.Hypoglycemics_Value(context));
+        __Hypoglycemics_Severe_Hypoglycemia = new Lazy<CqlValueSet>(this.Hypoglycemics_Severe_Hypoglycemia_Value(context));
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Inpatient_Encounter_During_Measurement_Period = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounter_During_Measurement_Period_Value(context));
+        __Qualifying_Encounter = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_Value(context));
+        __Hypoglycemic_Medication_Administration = new Lazy<IEnumerable<MedicationAdministration>>(this.Hypoglycemic_Medication_Administration_Value(context));
+        __Qualifying_Encounter_with_Hypoglycemic_Medication_Administration = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounter_with_Hypoglycemic_Medication_Administration_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value(context));
+        __Severe_Hypoglycemic_Harm_Event = new Lazy<IEnumerable<Encounter>>(this.Severe_Hypoglycemic_Harm_Event_Value(context));
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet birth_date_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
 
     [CqlDeclaration("birth date")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4")]
-	public CqlValueSet birth_date(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.560.100.4", null);
+	public CqlValueSet birth_date() => 
+		__birth_date?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Glucose_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
-	public CqlValueSet Glucose_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+	public CqlValueSet Glucose_lab_test() => 
+		__Glucose_lab_test?.Value;
+
+	private CqlValueSet Hypoglycemics_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", null);
 
     [CqlDeclaration("Hypoglycemics")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3")]
-	public CqlValueSet Hypoglycemics(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1179.3", null);
+	public CqlValueSet Hypoglycemics() => 
+		__Hypoglycemics?.Value;
+
+	private CqlValueSet Hypoglycemics_Severe_Hypoglycemia_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
 
     [CqlDeclaration("Hypoglycemics Severe Hypoglycemia")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393")]
-	public CqlValueSet Hypoglycemics_Severe_Hypoglycemia(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1196.393", null);
+	public CqlValueSet Hypoglycemics_Severe_Hypoglycemia() => 
+		__Hypoglycemics_Severe_Hypoglycemia?.Value;
+
+	private CqlValueSet Observation_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
-	public CqlValueSet Observation_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -66,8 +156,11 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -78,8 +171,11 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -87,42 +183,54 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Inpatient Encounter During Measurement Period")]
-	public IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period(CqlContext context)
+	private IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			var e_ = context.Operators.Convert<string>(EncounterInpatient?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "finished");
-			var g_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterInpatient?.Period);
+			var g_ = FHIRHelpers_4_0_001.ToInterval(EncounterInpatient?.Period);
 			var h_ = context.Operators.End(g_);
-			var i_ = this.Measurement_Period(context);
+			var i_ = this.Measurement_Period();
 			var j_ = context.Operators.ElementInInterval<CqlDateTime>(h_, i_, null);
 			var k_ = context.Operators.And(f_, j_);
 
@@ -133,15 +241,18 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return d_;
 	}
 
-    [CqlDeclaration("Qualifying Encounter")]
-	public IEnumerable<Encounter> Qualifying_Encounter(CqlContext context)
+    [CqlDeclaration("Inpatient Encounter During Measurement Period")]
+	public IEnumerable<Encounter> Inpatient_Encounter_During_Measurement_Period() => 
+		__Inpatient_Encounter_During_Measurement_Period?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounter_During_Measurement_Period(context);
+		var a_ = this.Inpatient_Encounter_During_Measurement_Period();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var d_ = this.Patient(context);
+			var d_ = this.Patient();
 			var e_ = context.Operators.ConvertStringToDateTime(d_?.BirthDateElement?.Value);
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, InpatientEncounter);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(InpatientEncounter);
 			var g_ = context.Operators.Start(f_);
 			var h_ = context.Operators.CalculateAgeAt(e_, g_, "year");
 			var i_ = context.Operators.GreaterOrEqual(h_, (int?)18);
@@ -153,10 +264,13 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return c_;
 	}
 
-    [CqlDeclaration("Hypoglycemic Medication Administration")]
-	public IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration(CqlContext context)
+    [CqlDeclaration("Qualifying Encounter")]
+	public IEnumerable<Encounter> Qualifying_Encounter() => 
+		__Qualifying_Encounter?.Value;
+
+	private IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration_Value(CqlContext context)
 	{
-		var a_ = this.Hypoglycemics_Severe_Hypoglycemia(context);
+		var a_ = this.Hypoglycemics_Severe_Hypoglycemia();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<MedicationAdministration>(a_, null);
 		var e_ = context.Operators.ListUnion<MedicationAdministration>(b_, d_);
@@ -175,18 +289,21 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return g_;
 	}
 
-    [CqlDeclaration("Qualifying Encounter with Hypoglycemic Medication Administration")]
-	public IEnumerable<Encounter> Qualifying_Encounter_with_Hypoglycemic_Medication_Administration(CqlContext context)
+    [CqlDeclaration("Hypoglycemic Medication Administration")]
+	public IEnumerable<MedicationAdministration> Hypoglycemic_Medication_Administration() => 
+		__Hypoglycemic_Medication_Administration?.Value;
+
+	private IEnumerable<Encounter> Qualifying_Encounter_with_Hypoglycemic_Medication_Administration_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounter(context);
+		var a_ = this.Qualifying_Encounter();
 		IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
 		{
-			var d_ = this.Hypoglycemic_Medication_Administration(context);
+			var d_ = this.Hypoglycemic_Medication_Administration();
 			bool? e_(MedicationAdministration HypoglycemicMedication)
 			{
-				var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, HypoglycemicMedication?.Effective);
+				var i_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(HypoglycemicMedication?.Effective);
 				var j_ = context.Operators.Start(i_);
-				var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+				var k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 				var l_ = context.Operators.ElementInInterval<CqlDateTime>(j_, k_, null);
 
 				return l_;
@@ -203,38 +320,47 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return c_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    [CqlDeclaration("Qualifying Encounter with Hypoglycemic Medication Administration")]
+	public IEnumerable<Encounter> Qualifying_Encounter_with_Hypoglycemic_Medication_Administration() => 
+		__Qualifying_Encounter_with_Hypoglycemic_Medication_Administration?.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Qualifying_Encounter_with_Hypoglycemic_Medication_Administration(context);
+		var a_ = this.Qualifying_Encounter_with_Hypoglycemic_Medication_Administration();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private IEnumerable<Encounter> Denominator_Value(CqlContext context)
+	{
+		var a_ = this.Initial_Population();
 
 		return a_;
 	}
 
     [CqlDeclaration("Denominator")]
-	public IEnumerable<Encounter> Denominator(CqlContext context)
-	{
-		var a_ = this.Initial_Population(context);
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Severe Hypoglycemic Harm Event")]
-	public IEnumerable<Encounter> Severe_Hypoglycemic_Harm_Event(CqlContext context)
+	private IEnumerable<Encounter> Severe_Hypoglycemic_Harm_Event_Value(CqlContext context)
 	{
-		var a_ = this.Denominator(context);
+		var a_ = this.Denominator();
 		bool? b_(Encounter QualifyingEncounter)
 		{
-			var d_ = this.Glucose_lab_test(context);
+			var d_ = this.Glucose_lab_test();
 			var e_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
 			IEnumerable<Observation> f_(Observation BloodGlucoseLab)
 			{
-				var r_ = this.Hypoglycemic_Medication_Administration(context);
+				var r_ = this.Hypoglycemic_Medication_Administration();
 				bool? s_(MedicationAdministration HypoglycemicMeds)
 				{
-					var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, HypoglycemicMeds?.Effective);
+					var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(HypoglycemicMeds?.Effective);
 					var x_ = context.Operators.Start(w_);
-					var y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BloodGlucoseLab?.Effective);
+					var y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BloodGlucoseLab?.Effective);
 					var z_ = context.Operators.Start(y_);
 					var aa_ = context.Operators.Quantity(24m, "hours");
 					var ab_ = context.Operators.Subtract(z_, aa_);
@@ -251,7 +377,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					var ap_ = context.Operators.Not(ao_);
 					var aq_ = context.Operators.And(am_, ap_);
 					var as_ = context.Operators.Start(w_);
-					var at_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+					var at_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 					var au_ = context.Operators.ElementInInterval<CqlDateTime>(as_, at_, null);
 					var av_ = context.Operators.And(aq_, au_);
 
@@ -268,12 +394,12 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			var i_ = context.Operators.RetrieveByValueSet<Observation>(d_, null);
 			IEnumerable<Observation> j_(Observation BloodGlucoseLab)
 			{
-				var aw_ = this.Hypoglycemic_Medication_Administration(context);
+				var aw_ = this.Hypoglycemic_Medication_Administration();
 				bool? ax_(MedicationAdministration HypoglycemicMeds)
 				{
-					var bb_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, HypoglycemicMeds?.Effective);
+					var bb_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(HypoglycemicMeds?.Effective);
 					var bc_ = context.Operators.Start(bb_);
-					var bd_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BloodGlucoseLab?.Effective);
+					var bd_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BloodGlucoseLab?.Effective);
 					var be_ = context.Operators.Start(bd_);
 					var bf_ = context.Operators.Quantity(24m, "hours");
 					var bg_ = context.Operators.Subtract(be_, bf_);
@@ -290,7 +416,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					var bu_ = context.Operators.Not(bt_);
 					var bv_ = context.Operators.And(br_, bu_);
 					var bx_ = context.Operators.Start(bb_);
-					var by_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+					var by_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 					var bz_ = context.Operators.ElementInInterval<CqlDateTime>(bx_, by_, null);
 					var ca_ = context.Operators.And(bv_, bz_);
 
@@ -306,16 +432,16 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			var k_ = context.Operators.SelectManyOrNull<Observation, Observation>(i_, j_);
 			IEnumerable<Observation> l_(Observation BloodGlucoseLab)
 			{
-				var cb_ = this.Glucose_lab_test(context);
+				var cb_ = this.Glucose_lab_test();
 				var cc_ = context.Operators.RetrieveByValueSet<Observation>(cb_, null);
 				bool? cd_(Observation FollowupBloodGlucoseLab)
 				{
-					var ch_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FollowupBloodGlucoseLab?.Effective);
+					var ch_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FollowupBloodGlucoseLab?.Effective);
 					var ci_ = context.Operators.Start(ch_);
-					var cj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+					var cj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 					var ck_ = context.Operators.ElementInInterval<CqlDateTime>(ci_, cj_, null);
 					var cm_ = context.Operators.Start(ch_);
-					var cn_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BloodGlucoseLab?.Effective);
+					var cn_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BloodGlucoseLab?.Effective);
 					var co_ = context.Operators.Start(cn_);
 					var cq_ = context.Operators.Start(cn_);
 					var cr_ = context.Operators.Quantity(5m, "minutes");
@@ -332,7 +458,7 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 					var de_ = context.Operators.Equal(da_, "cancelled");
 					var df_ = context.Operators.Not(de_);
 					var dg_ = context.Operators.And(dc_, df_);
-					var dh_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (FollowupBloodGlucoseLab?.Value as Quantity));
+					var dh_ = FHIRHelpers_4_0_001.ToQuantity((FollowupBloodGlucoseLab?.Value as Quantity));
 					var di_ = context.Operators.Quantity(80m, "mg/dL");
 					var dj_ = context.Operators.Greater(dh_, di_);
 					var dk_ = context.Operators.And(dg_, dj_);
@@ -350,11 +476,11 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 			var n_ = context.Operators.ListExcept<Observation>(g_, m_);
 			bool? o_(Observation BloodGlucoseLab)
 			{
-				var dl_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, BloodGlucoseLab?.Effective);
+				var dl_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(BloodGlucoseLab?.Effective);
 				var dm_ = context.Operators.Start(dl_);
-				var dn_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
+				var dn_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(QualifyingEncounter);
 				var do_ = context.Operators.ElementInInterval<CqlDateTime>(dm_, dn_, null);
-				var dp_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (BloodGlucoseLab?.Value as Quantity));
+				var dp_ = FHIRHelpers_4_0_001.ToQuantity((BloodGlucoseLab?.Value as Quantity));
 				var dq_ = context.Operators.Quantity(40m, "mg/dL");
 				var dr_ = context.Operators.Less(dp_, dq_);
 				var ds_ = context.Operators.And(do_, dr_);
@@ -371,20 +497,30 @@ public class HospitalHarmSevereHypoglycemiaFHIR_0_0_012
 		return c_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public IEnumerable<Encounter> Numerator(CqlContext context)
+    [CqlDeclaration("Severe Hypoglycemic Harm Event")]
+	public IEnumerable<Encounter> Severe_Hypoglycemic_Harm_Event() => 
+		__Severe_Hypoglycemic_Harm_Event?.Value;
+
+	private IEnumerable<Encounter> Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Severe_Hypoglycemic_Harm_Event(context);
+		var a_ = this.Severe_Hypoglycemic_Harm_Event();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
-
-		return a_;
-	}
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
 
 }

--- a/Demo/Measures/HybridHWMFHIR-0.102.005.cs
+++ b/Demo/Measures/HybridHWMFHIR-0.102.005.cs
@@ -14,101 +14,236 @@ using Task = Hl7.Fhir.Model.Task;
 public class HybridHWMFHIR_0_102_005
 {
 
-    public static HybridHWMFHIR_0_102_005 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Bicarbonate_lab_test;
+    internal Lazy<CqlValueSet> __Body_temperature;
+    internal Lazy<CqlValueSet> __Creatinine_lab_test;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Ethnicity;
+    internal Lazy<CqlValueSet> __Hematocrit_lab_test;
+    internal Lazy<CqlValueSet> __Medicare_payer;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __ONC_Administrative_Sex;
+    internal Lazy<CqlValueSet> __Payer;
+    internal Lazy<CqlValueSet> __Platelet_count_lab_test;
+    internal Lazy<CqlValueSet> __Race;
+    internal Lazy<CqlValueSet> __Sodium_lab_test;
+    internal Lazy<CqlValueSet> __White_blood_cells_count_lab_test;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode> __Heart_rate;
+    internal Lazy<CqlCode> __Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry;
+    internal Lazy<CqlCode> __Systolic_blood_pressure;
+    internal Lazy<CqlCode[]> __LOINC_2_69;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounters;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<string>> __Results;
+
+    #endregion
+    public HybridHWMFHIR_0_102_005(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __Bicarbonate_lab_test = new Lazy<CqlValueSet>(this.Bicarbonate_lab_test_Value(context));
+        __Body_temperature = new Lazy<CqlValueSet>(this.Body_temperature_Value(context));
+        __Creatinine_lab_test = new Lazy<CqlValueSet>(this.Creatinine_lab_test_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Ethnicity = new Lazy<CqlValueSet>(this.Ethnicity_Value(context));
+        __Hematocrit_lab_test = new Lazy<CqlValueSet>(this.Hematocrit_lab_test_Value(context));
+        __Medicare_payer = new Lazy<CqlValueSet>(this.Medicare_payer_Value(context));
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value(context));
+        __ONC_Administrative_Sex = new Lazy<CqlValueSet>(this.ONC_Administrative_Sex_Value(context));
+        __Payer = new Lazy<CqlValueSet>(this.Payer_Value(context));
+        __Platelet_count_lab_test = new Lazy<CqlValueSet>(this.Platelet_count_lab_test_Value(context));
+        __Race = new Lazy<CqlValueSet>(this.Race_Value(context));
+        __Sodium_lab_test = new Lazy<CqlValueSet>(this.Sodium_lab_test_Value(context));
+        __White_blood_cells_count_lab_test = new Lazy<CqlValueSet>(this.White_blood_cells_count_lab_test_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __Heart_rate = new Lazy<CqlCode>(this.Heart_rate_Value(context));
+        __Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry = new Lazy<CqlCode>(this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value(context));
+        __Systolic_blood_pressure = new Lazy<CqlCode>(this.Systolic_blood_pressure_Value(context));
+        __LOINC_2_69 = new Lazy<CqlCode[]>(this.LOINC_2_69_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Inpatient_Encounters = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounters_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Results = new Lazy<IEnumerable<string>>(this.Results_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Bicarbonate_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
-	public CqlValueSet Bicarbonate_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+	public CqlValueSet Bicarbonate_lab_test() => 
+		__Bicarbonate_lab_test?.Value;
+
+	private CqlValueSet Body_temperature_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
-	public CqlValueSet Body_temperature(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
+	public CqlValueSet Body_temperature() => 
+		__Body_temperature?.Value;
+
+	private CqlValueSet Creatinine_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
-	public CqlValueSet Creatinine_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+	public CqlValueSet Creatinine_lab_test() => 
+		__Creatinine_lab_test?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Ethnicity_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
-	public CqlValueSet Ethnicity(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+	public CqlValueSet Ethnicity() => 
+		__Ethnicity?.Value;
+
+	private CqlValueSet Hematocrit_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
-	public CqlValueSet Hematocrit_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+	public CqlValueSet Hematocrit_lab_test() => 
+		__Hematocrit_lab_test?.Value;
+
+	private CqlValueSet Medicare_payer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
-	public CqlValueSet Medicare_payer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+	public CqlValueSet Medicare_payer() => 
+		__Medicare_payer?.Value;
+
+	private CqlValueSet Observation_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
-	public CqlValueSet Observation_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services?.Value;
+
+	private CqlValueSet ONC_Administrative_Sex_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
-	public CqlValueSet ONC_Administrative_Sex(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+	public CqlValueSet ONC_Administrative_Sex() => 
+		__ONC_Administrative_Sex?.Value;
+
+	private CqlValueSet Payer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
-	public CqlValueSet Payer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+	public CqlValueSet Payer() => 
+		__Payer?.Value;
+
+	private CqlValueSet Platelet_count_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", null);
 
     [CqlDeclaration("Platelet count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127")]
-	public CqlValueSet Platelet_count_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.127", null);
+	public CqlValueSet Platelet_count_lab_test() => 
+		__Platelet_count_lab_test?.Value;
+
+	private CqlValueSet Race_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
-	public CqlValueSet Race(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+	public CqlValueSet Race() => 
+		__Race?.Value;
+
+	private CqlValueSet Sodium_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
-	public CqlValueSet Sodium_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+	public CqlValueSet Sodium_lab_test() => 
+		__Sodium_lab_test?.Value;
+
+	private CqlValueSet White_blood_cells_count_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
-	public CqlValueSet White_blood_cells_count_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+	public CqlValueSet White_blood_cells_count_lab_test() => 
+		__White_blood_cells_count_lab_test?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Heart rate")]
-	public CqlCode Heart_rate(CqlContext context) => 
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode Heart_rate_Value(CqlContext context) => 
 		new CqlCode("8867-4", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
-	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry(CqlContext context) => 
+    [CqlDeclaration("Heart rate")]
+	public CqlCode Heart_rate() => 
+		__Heart_rate?.Value;
+
+	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value(CqlContext context) => 
 		new CqlCode("59408-5", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Systolic blood pressure")]
-	public CqlCode Systolic_blood_pressure(CqlContext context) => 
+    [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
+	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
+		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry?.Value;
+
+	private CqlCode Systolic_blood_pressure_Value(CqlContext context) => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC:2.69")]
-	public CqlCode[] LOINC_2_69(CqlContext context)
+    [CqlDeclaration("Systolic blood pressure")]
+	public CqlCode Systolic_blood_pressure() => 
+		__Systolic_blood_pressure?.Value;
+
+	private CqlCode[] LOINC_2_69_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -121,8 +256,11 @@ public class HybridHWMFHIR_0_102_005
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC:2.69")]
+	public CqlCode[] LOINC_2_69() => 
+		__LOINC_2_69?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -133,8 +271,11 @@ public class HybridHWMFHIR_0_102_005
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -142,40 +283,56 @@ public class HybridHWMFHIR_0_102_005
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
-
-		return a_;
-	}
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
     [CqlDeclaration("LengthInDays")]
-	public int? LengthInDays(CqlContext context, CqlInterval<CqlDateTime> Value)
+	public int? LengthInDays(CqlInterval<CqlDateTime> Value)
 	{
 		var a_ = context.Operators.Start(Value);
 		var b_ = context.Operators.End(Value);
@@ -184,14 +341,13 @@ public class HybridHWMFHIR_0_102_005
 		return c_;
 	}
 
-    [CqlDeclaration("Inpatient Encounters")]
-	public IEnumerable<Encounter> Inpatient_Encounters(CqlContext context)
+	private IEnumerable<Encounter> Inpatient_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		IEnumerable<Coverage> c_(Encounter _InpatientEncounter)
 		{
-			var j_ = this.Medicare_payer(context);
+			var j_ = this.Medicare_payer();
 			var k_ = context.Operators.RetrieveByValueSet<Coverage>(j_, null);
 
 			return k_;
@@ -211,16 +367,16 @@ public class HybridHWMFHIR_0_102_005
 		{
 			var m_ = context.Operators.Convert<string>(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.StatusElement);
 			var n_ = context.Operators.Equal(m_, "finished");
-			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter);
-			var p_ = this.LengthInDays(context, o_);
+			var o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter);
+			var p_ = this.LengthInDays(o_);
 			var q_ = context.Operators.Less(p_, (int?)365);
 			var r_ = context.Operators.And(n_, q_);
-			var s_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.Period);
+			var s_ = FHIRHelpers_4_0_001.ToInterval(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.Period);
 			var t_ = context.Operators.End(s_);
-			var u_ = this.Measurement_Period(context);
+			var u_ = this.Measurement_Period();
 			var v_ = context.Operators.ElementInInterval<CqlDateTime>(t_, u_, "day");
 			var w_ = context.Operators.And(r_, v_);
-			var x_ = this.Patient(context);
+			var x_ = this.Patient();
 			var y_ = context.Operators.Convert<CqlDate>(x_?.BirthDateElement?.Value);
 			var aa_ = context.Operators.Start(s_);
 			var ab_ = context.Operators.DateFrom(aa_);
@@ -239,18 +395,25 @@ public class HybridHWMFHIR_0_102_005
 		return i_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    [CqlDeclaration("Inpatient Encounters")]
+	public IEnumerable<Encounter> Inpatient_Encounters() => 
+		__Inpatient_Encounters?.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 
 		return a_;
 	}
 
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
     [CqlDeclaration("FirstPhysicalExamWithEncounterId")]
-	public IEnumerable<string> FirstPhysicalExamWithEncounterId(CqlContext context, IEnumerable<Observation> ExamList, string CCDE)
+	public IEnumerable<string> FirstPhysicalExamWithEncounterId(IEnumerable<Observation> ExamList, string CCDE)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 		string b_(Encounter Encounter)
 		{
 			var d_ = context.Operators.Concatenate("\r\n", (CCDE ?? ""));
@@ -260,11 +423,11 @@ public class HybridHWMFHIR_0_102_005
 			var h_ = context.Operators.Concatenate((g_ ?? ""), " , ");
 			bool? i_(Observation Exam)
 			{
-				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var ab_ = context.Operators.Start(aa_);
 				var ac_ = context.Operators.Not((bool?)(ab_ is null));
 				var ae_ = context.Operators.Start(aa_);
-				var af_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var af_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var ag_ = context.Operators.Start(af_);
 				var ah_ = context.Operators.Quantity(1440m, "minutes");
 				var ai_ = context.Operators.Subtract(ag_, ah_);
@@ -291,24 +454,24 @@ public class HybridHWMFHIR_0_102_005
 			var j_ = context.Operators.WhereOrNull<Observation>(ExamList, i_);
 			object k_(Observation @this)
 			{
-				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var ax_ = context.Operators.Start(aw_);
 
 				return ax_;
 			};
 			var l_ = context.Operators.ListSortBy<Observation>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var m_ = context.Operators.FirstOfList<Observation>(l_);
-			var n_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (m_?.Value as Quantity));
+			var n_ = FHIRHelpers_4_0_001.ToQuantity((m_?.Value as Quantity));
 			var o_ = context.Operators.ConvertQuantityToString(n_);
 			var p_ = context.Operators.Concatenate((h_ ?? ""), (o_ ?? ""));
 			var q_ = context.Operators.Concatenate((p_ ?? ""), ",");
 			bool? r_(Observation Exam)
 			{
-				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var az_ = context.Operators.Start(ay_);
 				var ba_ = context.Operators.Not((bool?)(az_ is null));
 				var bc_ = context.Operators.Start(ay_);
-				var bd_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var bd_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var be_ = context.Operators.Start(bd_);
 				var bf_ = context.Operators.Quantity(1440m, "minutes");
 				var bg_ = context.Operators.Subtract(be_, bf_);
@@ -335,14 +498,14 @@ public class HybridHWMFHIR_0_102_005
 			var s_ = context.Operators.WhereOrNull<Observation>(ExamList, r_);
 			object t_(Observation @this)
 			{
-				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var bv_ = context.Operators.Start(bu_);
 
 				return bv_;
 			};
 			var u_ = context.Operators.ListSortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
 			var v_ = context.Operators.FirstOfList<Observation>(u_);
-			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, v_?.Effective);
+			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(v_?.Effective);
 			var x_ = context.Operators.Start(w_);
 			var y_ = context.Operators.ConvertDateTimeToString(x_);
 			var z_ = context.Operators.Concatenate((q_ ?? ""), (y_ ?? ""));
@@ -355,9 +518,9 @@ public class HybridHWMFHIR_0_102_005
 	}
 
     [CqlDeclaration("FirstLabTestWithEncounterId")]
-	public IEnumerable<string> FirstLabTestWithEncounterId(CqlContext context, IEnumerable<Observation> LabList, string CCDE)
+	public IEnumerable<string> FirstLabTestWithEncounterId(IEnumerable<Observation> LabList, string CCDE)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 		string b_(Encounter Encounter)
 		{
 			var d_ = context.Operators.Concatenate("\r\n", (CCDE ?? ""));
@@ -368,8 +531,8 @@ public class HybridHWMFHIR_0_102_005
 			bool? i_(Observation Lab)
 			{
 				var z_ = context.Operators.Not((bool?)(Lab?.IssuedElement is null));
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, Lab?.IssuedElement);
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var aa_ = FHIRHelpers_4_0_001.ToDateTime(Lab?.IssuedElement);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var ac_ = context.Operators.Start(ab_);
 				var ad_ = context.Operators.Quantity(1440m, "minutes");
 				var ae_ = context.Operators.Subtract(ac_, ad_);
@@ -397,15 +560,15 @@ public class HybridHWMFHIR_0_102_005
 				@this?.IssuedElement;
 			var l_ = context.Operators.ListSortBy<Observation>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var m_ = context.Operators.FirstOfList<Observation>(l_);
-			var n_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (m_?.Value as Quantity));
+			var n_ = FHIRHelpers_4_0_001.ToQuantity((m_?.Value as Quantity));
 			var o_ = context.Operators.ConvertQuantityToString(n_);
 			var p_ = context.Operators.Concatenate((h_ ?? ""), (o_ ?? ""));
 			var q_ = context.Operators.Concatenate((p_ ?? ""), ",");
 			bool? r_(Observation Lab)
 			{
 				var as_ = context.Operators.Not((bool?)(Lab?.IssuedElement is null));
-				var at_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, Lab?.IssuedElement);
-				var au_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var at_ = FHIRHelpers_4_0_001.ToDateTime(Lab?.IssuedElement);
+				var au_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var av_ = context.Operators.Start(au_);
 				var aw_ = context.Operators.Quantity(1440m, "minutes");
 				var ax_ = context.Operators.Subtract(av_, aw_);
@@ -431,7 +594,7 @@ public class HybridHWMFHIR_0_102_005
 			var s_ = context.Operators.WhereOrNull<Observation>(LabList, r_);
 			var u_ = context.Operators.ListSortBy<Observation>(s_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var v_ = context.Operators.FirstOfList<Observation>(u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, v_?.IssuedElement);
+			var w_ = FHIRHelpers_4_0_001.ToDateTime(v_?.IssuedElement);
 			var x_ = context.Operators.ConvertDateTimeToString(w_);
 			var y_ = context.Operators.Concatenate((q_ ?? ""), (x_ ?? ""));
 
@@ -442,42 +605,41 @@ public class HybridHWMFHIR_0_102_005
 		return c_;
 	}
 
-    [CqlDeclaration("Results")]
-	public IEnumerable<string> Results(CqlContext context)
+	private IEnumerable<string> Results_Value(CqlContext context)
 	{
-		var a_ = this.Heart_rate(context);
+		var a_ = this.Heart_rate();
 		var b_ = context.Operators.ToList<CqlCode>(a_);
 		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = this.FirstPhysicalExamWithEncounterId(context, c_, "FirstHeartRate");
-		var e_ = this.Systolic_blood_pressure(context);
+		var d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
+		var e_ = this.Systolic_blood_pressure();
 		var f_ = context.Operators.ToList<CqlCode>(e_);
 		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = this.FirstPhysicalExamWithEncounterId(context, g_, "FirstSystolicBP");
-		var i_ = this.Body_temperature(context);
+		var h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
+		var i_ = this.Body_temperature();
 		var j_ = context.Operators.RetrieveByValueSet<Observation>(i_, null);
-		var k_ = this.FirstPhysicalExamWithEncounterId(context, j_, "FirstTemperature");
-		var l_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry(context);
+		var k_ = this.FirstPhysicalExamWithEncounterId(j_, "FirstTemperature");
+		var l_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		var m_ = context.Operators.ToList<CqlCode>(l_);
 		var n_ = context.Operators.RetrieveByCodes<Observation>(m_, null);
-		var o_ = this.FirstPhysicalExamWithEncounterId(context, n_, "FirstO2Saturation");
-		var p_ = this.Hematocrit_lab_test(context);
+		var o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstO2Saturation");
+		var p_ = this.Hematocrit_lab_test();
 		var q_ = context.Operators.RetrieveByValueSet<Observation>(p_, null);
-		var r_ = this.FirstLabTestWithEncounterId(context, q_, "FirstHematocrit");
-		var s_ = this.Platelet_count_lab_test(context);
+		var r_ = this.FirstLabTestWithEncounterId(q_, "FirstHematocrit");
+		var s_ = this.Platelet_count_lab_test();
 		var t_ = context.Operators.RetrieveByValueSet<Observation>(s_, null);
-		var u_ = this.FirstLabTestWithEncounterId(context, t_, "FirstPlateletCount");
-		var v_ = this.White_blood_cells_count_lab_test(context);
+		var u_ = this.FirstLabTestWithEncounterId(t_, "FirstPlateletCount");
+		var v_ = this.White_blood_cells_count_lab_test();
 		var w_ = context.Operators.RetrieveByValueSet<Observation>(v_, null);
-		var x_ = this.FirstLabTestWithEncounterId(context, w_, "FirstWhiteBloodCell");
-		var y_ = this.Sodium_lab_test(context);
+		var x_ = this.FirstLabTestWithEncounterId(w_, "FirstWhiteBloodCell");
+		var y_ = this.Sodium_lab_test();
 		var z_ = context.Operators.RetrieveByValueSet<Observation>(y_, null);
-		var aa_ = this.FirstLabTestWithEncounterId(context, z_, "FirstSodium");
-		var ab_ = this.Bicarbonate_lab_test(context);
+		var aa_ = this.FirstLabTestWithEncounterId(z_, "FirstSodium");
+		var ab_ = this.Bicarbonate_lab_test();
 		var ac_ = context.Operators.RetrieveByValueSet<Observation>(ab_, null);
-		var ad_ = this.FirstLabTestWithEncounterId(context, ac_, "FirstBicarbonate");
-		var ae_ = this.Creatinine_lab_test(context);
+		var ad_ = this.FirstLabTestWithEncounterId(ac_, "FirstBicarbonate");
+		var ae_ = this.Creatinine_lab_test();
 		var af_ = context.Operators.RetrieveByValueSet<Observation>(ae_, null);
-		var ag_ = this.FirstLabTestWithEncounterId(context, af_, "FirstCreatinine");
+		var ag_ = this.FirstLabTestWithEncounterId(af_, "FirstCreatinine");
 		var ah_ = new IEnumerable<string>[]
 		{
 			d_,
@@ -496,8 +658,12 @@ public class HybridHWMFHIR_0_102_005
 		return ai_;
 	}
 
+    [CqlDeclaration("Results")]
+	public IEnumerable<string> Results() => 
+		__Results?.Value;
+
     [CqlDeclaration("CalendarAgeInYearsAt")]
-	public int? CalendarAgeInYearsAt(CqlContext context, CqlDateTime BirthDateTime, CqlDateTime AsOf)
+	public int? CalendarAgeInYearsAt(CqlDateTime BirthDateTime, CqlDateTime AsOf)
 	{
 		var a_ = context.Operators.ConvertDateTimeToDate(BirthDateTime);
 		var b_ = context.Operators.ConvertDateTimeToDate(AsOf);
@@ -507,7 +673,7 @@ public class HybridHWMFHIR_0_102_005
 	}
 
     [CqlDeclaration("ToDate")]
-	public CqlDateTime ToDate(CqlContext context, CqlDateTime Value)
+	public CqlDateTime ToDate(CqlDateTime Value)
 	{
 		var a_ = context.Operators.ComponentFrom(Value, "year");
 		var b_ = context.Operators.ComponentFrom(Value, "month");
@@ -519,7 +685,7 @@ public class HybridHWMFHIR_0_102_005
 	}
 
     [CqlDeclaration("LengthOfStay")]
-	public int? LengthOfStay(CqlContext context, CqlInterval<CqlDateTime> Stay)
+	public int? LengthOfStay(CqlInterval<CqlDateTime> Stay)
 	{
 		var a_ = context.Operators.Start(Stay);
 		var b_ = context.Operators.End(Stay);
@@ -529,7 +695,7 @@ public class HybridHWMFHIR_0_102_005
 	}
 
     [CqlDeclaration("HospitalizationWithObservation")]
-	public CqlInterval<CqlDateTime> HospitalizationWithObservation(CqlContext context, Encounter TheEncounter)
+	public CqlInterval<CqlDateTime> HospitalizationWithObservation(Encounter TheEncounter)
 	{
 		var a_ = new Encounter[]
 		{
@@ -537,19 +703,19 @@ public class HybridHWMFHIR_0_102_005
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit(context);
+			var e_ = this.Emergency_Department_Visit();
 			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastED?.Period);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(LastED?.Period);
 				var ac_ = context.Operators.End(ab_);
-				var ad_ = this.Observation_Services(context);
+				var ad_ = this.Observation_Services();
 				var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? af_(Encounter LastObs)
 				{
-					var bq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var bq_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var br_ = context.Operators.End(bq_);
-					var bs_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var bs_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var bt_ = context.Operators.Start(bs_);
 					var bu_ = context.Operators.Quantity(1m, "hour");
 					var bv_ = context.Operators.Subtract(bt_, bu_);
@@ -565,25 +731,25 @@ public class HybridHWMFHIR_0_102_005
 				var ag_ = context.Operators.WhereOrNull<Encounter>(ae_, af_);
 				object ah_(Encounter @this)
 				{
-					var ce_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var ce_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cf_ = context.Operators.End(ce_);
 
 					return cf_;
 				};
 				var ai_ = context.Operators.ListSortBy<Encounter>(ag_, ah_, System.ComponentModel.ListSortDirection.Ascending);
 				var aj_ = context.Operators.LastOfList<Encounter>(ai_);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aj_?.Period);
+				var ak_ = FHIRHelpers_4_0_001.ToInterval(aj_?.Period);
 				var al_ = context.Operators.Start(ak_);
-				var am_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var am_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var an_ = context.Operators.Start(am_);
 				var ao_ = context.Operators.Quantity(1m, "hour");
 				var ap_ = context.Operators.Subtract((al_ ?? an_), ao_);
 				var ar_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? as_(Encounter LastObs)
 				{
-					var cg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cg_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var ch_ = context.Operators.End(cg_);
-					var ci_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var ci_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cj_ = context.Operators.Start(ci_);
 					var ck_ = context.Operators.Quantity(1m, "hour");
 					var cl_ = context.Operators.Subtract(cj_, ck_);
@@ -599,14 +765,14 @@ public class HybridHWMFHIR_0_102_005
 				var at_ = context.Operators.WhereOrNull<Encounter>(ar_, as_);
 				object au_(Encounter @this)
 				{
-					var cu_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var cu_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cv_ = context.Operators.End(cu_);
 
 					return cv_;
 				};
 				var av_ = context.Operators.ListSortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
 				var aw_ = context.Operators.LastOfList<Encounter>(av_);
-				var ax_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aw_?.Period);
+				var ax_ = FHIRHelpers_4_0_001.ToInterval(aw_?.Period);
 				var ay_ = context.Operators.Start(ax_);
 				var ba_ = context.Operators.Start(am_);
 				var bb_ = context.Operators.Interval(ap_, (ay_ ?? ba_), true, true);
@@ -614,9 +780,9 @@ public class HybridHWMFHIR_0_102_005
 				var be_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? bf_(Encounter LastObs)
 				{
-					var cw_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cw_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var cx_ = context.Operators.End(cw_);
-					var cy_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var cy_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cz_ = context.Operators.Start(cy_);
 					var da_ = context.Operators.Quantity(1m, "hour");
 					var db_ = context.Operators.Subtract(cz_, da_);
@@ -632,14 +798,14 @@ public class HybridHWMFHIR_0_102_005
 				var bg_ = context.Operators.WhereOrNull<Encounter>(be_, bf_);
 				object bh_(Encounter @this)
 				{
-					var dk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var dk_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var dl_ = context.Operators.End(dk_);
 
 					return dl_;
 				};
 				var bi_ = context.Operators.ListSortBy<Encounter>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
 				var bj_ = context.Operators.LastOfList<Encounter>(bi_);
-				var bk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, bj_?.Period);
+				var bk_ = FHIRHelpers_4_0_001.ToInterval(bj_?.Period);
 				var bl_ = context.Operators.Start(bk_);
 				var bn_ = context.Operators.Start(am_);
 				var bo_ = context.Operators.Not((bool?)((bl_ ?? bn_) is null));
@@ -650,22 +816,22 @@ public class HybridHWMFHIR_0_102_005
 			var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var dm_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var dm_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var dn_ = context.Operators.End(dm_);
 
 				return dn_;
 			};
 			var j_ = context.Operators.ListSortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
 			var k_ = context.Operators.LastOfList<Encounter>(j_);
-			var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_?.Period);
+			var l_ = FHIRHelpers_4_0_001.ToInterval(k_?.Period);
 			var m_ = context.Operators.Start(l_);
-			var n_ = this.Observation_Services(context);
+			var n_ = this.Observation_Services();
 			var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 			bool? p_(Encounter LastObs)
 			{
-				var do_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+				var do_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 				var dp_ = context.Operators.End(do_);
-				var dq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var dq_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var dr_ = context.Operators.Start(dq_);
 				var ds_ = context.Operators.Quantity(1m, "hour");
 				var dt_ = context.Operators.Subtract(dr_, ds_);
@@ -681,16 +847,16 @@ public class HybridHWMFHIR_0_102_005
 			var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
 			object r_(Encounter @this)
 			{
-				var ec_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var ec_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var ed_ = context.Operators.End(ec_);
 
 				return ed_;
 			};
 			var s_ = context.Operators.ListSortBy<Encounter>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
 			var t_ = context.Operators.LastOfList<Encounter>(s_);
-			var u_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, t_?.Period);
+			var u_ = FHIRHelpers_4_0_001.ToInterval(t_?.Period);
 			var v_ = context.Operators.Start(u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+			var w_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 			var x_ = context.Operators.Start(w_);
 			var z_ = context.Operators.End(w_);
 			var aa_ = context.Operators.Interval((m_ ?? (v_ ?? x_)), z_, true, true);
@@ -704,10 +870,10 @@ public class HybridHWMFHIR_0_102_005
 	}
 
     [CqlDeclaration("HospitalizationWithObservationLengthofStay")]
-	public int? HospitalizationWithObservationLengthofStay(CqlContext context, Encounter Encounter)
+	public int? HospitalizationWithObservationLengthofStay(Encounter Encounter)
 	{
-		var a_ = this.HospitalizationWithObservation(context, Encounter);
-		var b_ = this.LengthInDays(context, a_);
+		var a_ = this.HospitalizationWithObservation(Encounter);
+		var b_ = this.LengthInDays(a_);
 
 		return b_;
 	}

--- a/Demo/Measures/HybridHWRFHIR-1.3.005.cs
+++ b/Demo/Measures/HybridHWRFHIR-1.3.005.cs
@@ -14,115 +14,265 @@ using Task = Hl7.Fhir.Model.Task;
 public class HybridHWRFHIR_1_3_005
 {
 
-    public static HybridHWRFHIR_1_3_005 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Bicarbonate_lab_test;
+    internal Lazy<CqlValueSet> __Body_temperature;
+    internal Lazy<CqlValueSet> __Body_weight;
+    internal Lazy<CqlValueSet> __Creatinine_lab_test;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Ethnicity;
+    internal Lazy<CqlValueSet> __Glucose_lab_test;
+    internal Lazy<CqlValueSet> __Hematocrit_lab_test;
+    internal Lazy<CqlValueSet> __Medicare_payer;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __ONC_Administrative_Sex;
+    internal Lazy<CqlValueSet> __Payer;
+    internal Lazy<CqlValueSet> __Potassium_lab_test;
+    internal Lazy<CqlValueSet> __Race;
+    internal Lazy<CqlValueSet> __Sodium_lab_test;
+    internal Lazy<CqlValueSet> __White_blood_cells_count_lab_test;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode> __Heart_rate;
+    internal Lazy<CqlCode> __Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry;
+    internal Lazy<CqlCode> __Respiratory_rate;
+    internal Lazy<CqlCode> __Systolic_blood_pressure;
+    internal Lazy<CqlCode[]> __LOINC_2_69;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounters;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<string>> __Results;
+
+    #endregion
+    public HybridHWRFHIR_1_3_005(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __Bicarbonate_lab_test = new Lazy<CqlValueSet>(this.Bicarbonate_lab_test_Value(context));
+        __Body_temperature = new Lazy<CqlValueSet>(this.Body_temperature_Value(context));
+        __Body_weight = new Lazy<CqlValueSet>(this.Body_weight_Value(context));
+        __Creatinine_lab_test = new Lazy<CqlValueSet>(this.Creatinine_lab_test_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Ethnicity = new Lazy<CqlValueSet>(this.Ethnicity_Value(context));
+        __Glucose_lab_test = new Lazy<CqlValueSet>(this.Glucose_lab_test_Value(context));
+        __Hematocrit_lab_test = new Lazy<CqlValueSet>(this.Hematocrit_lab_test_Value(context));
+        __Medicare_payer = new Lazy<CqlValueSet>(this.Medicare_payer_Value(context));
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value(context));
+        __ONC_Administrative_Sex = new Lazy<CqlValueSet>(this.ONC_Administrative_Sex_Value(context));
+        __Payer = new Lazy<CqlValueSet>(this.Payer_Value(context));
+        __Potassium_lab_test = new Lazy<CqlValueSet>(this.Potassium_lab_test_Value(context));
+        __Race = new Lazy<CqlValueSet>(this.Race_Value(context));
+        __Sodium_lab_test = new Lazy<CqlValueSet>(this.Sodium_lab_test_Value(context));
+        __White_blood_cells_count_lab_test = new Lazy<CqlValueSet>(this.White_blood_cells_count_lab_test_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __Heart_rate = new Lazy<CqlCode>(this.Heart_rate_Value(context));
+        __Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry = new Lazy<CqlCode>(this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value(context));
+        __Respiratory_rate = new Lazy<CqlCode>(this.Respiratory_rate_Value(context));
+        __Systolic_blood_pressure = new Lazy<CqlCode>(this.Systolic_blood_pressure_Value(context));
+        __LOINC_2_69 = new Lazy<CqlCode[]>(this.LOINC_2_69_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Inpatient_Encounters = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounters_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Results = new Lazy<IEnumerable<string>>(this.Results_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Bicarbonate_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
 
     [CqlDeclaration("Bicarbonate lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139")]
-	public CqlValueSet Bicarbonate_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.139", null);
+	public CqlValueSet Bicarbonate_lab_test() => 
+		__Bicarbonate_lab_test?.Value;
+
+	private CqlValueSet Body_temperature_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
 
     [CqlDeclaration("Body temperature")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152")]
-	public CqlValueSet Body_temperature(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
+	public CqlValueSet Body_temperature() => 
+		__Body_temperature?.Value;
+
+	private CqlValueSet Body_weight_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", null);
 
     [CqlDeclaration("Body weight")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159")]
-	public CqlValueSet Body_weight(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.159", null);
+	public CqlValueSet Body_weight() => 
+		__Body_weight?.Value;
+
+	private CqlValueSet Creatinine_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
 
     [CqlDeclaration("Creatinine lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363")]
-	public CqlValueSet Creatinine_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.2363", null);
+	public CqlValueSet Creatinine_lab_test() => 
+		__Creatinine_lab_test?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Ethnicity_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
-	public CqlValueSet Ethnicity(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+	public CqlValueSet Ethnicity() => 
+		__Ethnicity?.Value;
+
+	private CqlValueSet Glucose_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
 
     [CqlDeclaration("Glucose lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134")]
-	public CqlValueSet Glucose_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.134", null);
+	public CqlValueSet Glucose_lab_test() => 
+		__Glucose_lab_test?.Value;
+
+	private CqlValueSet Hematocrit_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
 
     [CqlDeclaration("Hematocrit lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114")]
-	public CqlValueSet Hematocrit_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.114", null);
+	public CqlValueSet Hematocrit_lab_test() => 
+		__Hematocrit_lab_test?.Value;
+
+	private CqlValueSet Medicare_payer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
 
     [CqlDeclaration("Medicare payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10")]
-	public CqlValueSet Medicare_payer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1104.10", null);
+	public CqlValueSet Medicare_payer() => 
+		__Medicare_payer?.Value;
+
+	private CqlValueSet Observation_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
-	public CqlValueSet Observation_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services?.Value;
+
+	private CqlValueSet ONC_Administrative_Sex_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
-	public CqlValueSet ONC_Administrative_Sex(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+	public CqlValueSet ONC_Administrative_Sex() => 
+		__ONC_Administrative_Sex?.Value;
+
+	private CqlValueSet Payer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
-	public CqlValueSet Payer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+	public CqlValueSet Payer() => 
+		__Payer?.Value;
+
+	private CqlValueSet Potassium_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", null);
 
     [CqlDeclaration("Potassium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117")]
-	public CqlValueSet Potassium_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.117", null);
+	public CqlValueSet Potassium_lab_test() => 
+		__Potassium_lab_test?.Value;
+
+	private CqlValueSet Race_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
-	public CqlValueSet Race(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+	public CqlValueSet Race() => 
+		__Race?.Value;
+
+	private CqlValueSet Sodium_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
 
     [CqlDeclaration("Sodium lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119")]
-	public CqlValueSet Sodium_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.119", null);
+	public CqlValueSet Sodium_lab_test() => 
+		__Sodium_lab_test?.Value;
+
+	private CqlValueSet White_blood_cells_count_lab_test_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
 
     [CqlDeclaration("White blood cells count lab test")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129")]
-	public CqlValueSet White_blood_cells_count_lab_test(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.129", null);
+	public CqlValueSet White_blood_cells_count_lab_test() => 
+		__White_blood_cells_count_lab_test?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Heart rate")]
-	public CqlCode Heart_rate(CqlContext context) => 
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode Heart_rate_Value(CqlContext context) => 
 		new CqlCode("8867-4", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
-	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry(CqlContext context) => 
+    [CqlDeclaration("Heart rate")]
+	public CqlCode Heart_rate() => 
+		__Heart_rate?.Value;
+
+	private CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry_Value(CqlContext context) => 
 		new CqlCode("59408-5", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Respiratory rate")]
-	public CqlCode Respiratory_rate(CqlContext context) => 
+    [CqlDeclaration("Oxygen saturation in Arterial blood by Pulse oximetry")]
+	public CqlCode Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry() => 
+		__Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry?.Value;
+
+	private CqlCode Respiratory_rate_Value(CqlContext context) => 
 		new CqlCode("9279-1", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Systolic blood pressure")]
-	public CqlCode Systolic_blood_pressure(CqlContext context) => 
+    [CqlDeclaration("Respiratory rate")]
+	public CqlCode Respiratory_rate() => 
+		__Respiratory_rate?.Value;
+
+	private CqlCode Systolic_blood_pressure_Value(CqlContext context) => 
 		new CqlCode("8480-6", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC:2.69")]
-	public CqlCode[] LOINC_2_69(CqlContext context)
+    [CqlDeclaration("Systolic blood pressure")]
+	public CqlCode Systolic_blood_pressure() => 
+		__Systolic_blood_pressure?.Value;
+
+	private CqlCode[] LOINC_2_69_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -136,8 +286,11 @@ public class HybridHWRFHIR_1_3_005
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC:2.69")]
+	public CqlCode[] LOINC_2_69() => 
+		__LOINC_2_69?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -148,8 +301,11 @@ public class HybridHWRFHIR_1_3_005
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -157,40 +313,56 @@ public class HybridHWRFHIR_1_3_005
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
-
-		return a_;
-	}
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
     [CqlDeclaration("HospitalizationWithObservation")]
-	public CqlInterval<CqlDateTime> HospitalizationWithObservation(CqlContext context, Encounter TheEncounter)
+	public CqlInterval<CqlDateTime> HospitalizationWithObservation(Encounter TheEncounter)
 	{
 		var a_ = new Encounter[]
 		{
@@ -198,19 +370,19 @@ public class HybridHWRFHIR_1_3_005
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit(context);
+			var e_ = this.Emergency_Department_Visit();
 			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastED?.Period);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(LastED?.Period);
 				var ac_ = context.Operators.End(ab_);
-				var ad_ = this.Observation_Services(context);
+				var ad_ = this.Observation_Services();
 				var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? af_(Encounter LastObs)
 				{
-					var bq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var bq_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var br_ = context.Operators.End(bq_);
-					var bs_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var bs_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var bt_ = context.Operators.Start(bs_);
 					var bu_ = context.Operators.Quantity(1m, "hour");
 					var bv_ = context.Operators.Subtract(bt_, bu_);
@@ -226,25 +398,25 @@ public class HybridHWRFHIR_1_3_005
 				var ag_ = context.Operators.WhereOrNull<Encounter>(ae_, af_);
 				object ah_(Encounter @this)
 				{
-					var ce_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var ce_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cf_ = context.Operators.End(ce_);
 
 					return cf_;
 				};
 				var ai_ = context.Operators.ListSortBy<Encounter>(ag_, ah_, System.ComponentModel.ListSortDirection.Ascending);
 				var aj_ = context.Operators.LastOfList<Encounter>(ai_);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aj_?.Period);
+				var ak_ = FHIRHelpers_4_0_001.ToInterval(aj_?.Period);
 				var al_ = context.Operators.Start(ak_);
-				var am_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var am_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var an_ = context.Operators.Start(am_);
 				var ao_ = context.Operators.Quantity(1m, "hour");
 				var ap_ = context.Operators.Subtract((al_ ?? an_), ao_);
 				var ar_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? as_(Encounter LastObs)
 				{
-					var cg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cg_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var ch_ = context.Operators.End(cg_);
-					var ci_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var ci_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cj_ = context.Operators.Start(ci_);
 					var ck_ = context.Operators.Quantity(1m, "hour");
 					var cl_ = context.Operators.Subtract(cj_, ck_);
@@ -260,14 +432,14 @@ public class HybridHWRFHIR_1_3_005
 				var at_ = context.Operators.WhereOrNull<Encounter>(ar_, as_);
 				object au_(Encounter @this)
 				{
-					var cu_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var cu_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cv_ = context.Operators.End(cu_);
 
 					return cv_;
 				};
 				var av_ = context.Operators.ListSortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
 				var aw_ = context.Operators.LastOfList<Encounter>(av_);
-				var ax_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aw_?.Period);
+				var ax_ = FHIRHelpers_4_0_001.ToInterval(aw_?.Period);
 				var ay_ = context.Operators.Start(ax_);
 				var ba_ = context.Operators.Start(am_);
 				var bb_ = context.Operators.Interval(ap_, (ay_ ?? ba_), true, true);
@@ -275,9 +447,9 @@ public class HybridHWRFHIR_1_3_005
 				var be_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? bf_(Encounter LastObs)
 				{
-					var cw_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cw_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var cx_ = context.Operators.End(cw_);
-					var cy_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var cy_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cz_ = context.Operators.Start(cy_);
 					var da_ = context.Operators.Quantity(1m, "hour");
 					var db_ = context.Operators.Subtract(cz_, da_);
@@ -293,14 +465,14 @@ public class HybridHWRFHIR_1_3_005
 				var bg_ = context.Operators.WhereOrNull<Encounter>(be_, bf_);
 				object bh_(Encounter @this)
 				{
-					var dk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var dk_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var dl_ = context.Operators.End(dk_);
 
 					return dl_;
 				};
 				var bi_ = context.Operators.ListSortBy<Encounter>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
 				var bj_ = context.Operators.LastOfList<Encounter>(bi_);
-				var bk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, bj_?.Period);
+				var bk_ = FHIRHelpers_4_0_001.ToInterval(bj_?.Period);
 				var bl_ = context.Operators.Start(bk_);
 				var bn_ = context.Operators.Start(am_);
 				var bo_ = context.Operators.Not((bool?)((bl_ ?? bn_) is null));
@@ -311,22 +483,22 @@ public class HybridHWRFHIR_1_3_005
 			var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var dm_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var dm_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var dn_ = context.Operators.End(dm_);
 
 				return dn_;
 			};
 			var j_ = context.Operators.ListSortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
 			var k_ = context.Operators.LastOfList<Encounter>(j_);
-			var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_?.Period);
+			var l_ = FHIRHelpers_4_0_001.ToInterval(k_?.Period);
 			var m_ = context.Operators.Start(l_);
-			var n_ = this.Observation_Services(context);
+			var n_ = this.Observation_Services();
 			var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 			bool? p_(Encounter LastObs)
 			{
-				var do_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+				var do_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 				var dp_ = context.Operators.End(do_);
-				var dq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var dq_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var dr_ = context.Operators.Start(dq_);
 				var ds_ = context.Operators.Quantity(1m, "hour");
 				var dt_ = context.Operators.Subtract(dr_, ds_);
@@ -342,16 +514,16 @@ public class HybridHWRFHIR_1_3_005
 			var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
 			object r_(Encounter @this)
 			{
-				var ec_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var ec_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var ed_ = context.Operators.End(ec_);
 
 				return ed_;
 			};
 			var s_ = context.Operators.ListSortBy<Encounter>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
 			var t_ = context.Operators.LastOfList<Encounter>(s_);
-			var u_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, t_?.Period);
+			var u_ = FHIRHelpers_4_0_001.ToInterval(t_?.Period);
 			var v_ = context.Operators.Start(u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+			var w_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 			var x_ = context.Operators.Start(w_);
 			var z_ = context.Operators.End(w_);
 			var aa_ = context.Operators.Interval((m_ ?? (v_ ?? x_)), z_, true, true);
@@ -365,7 +537,7 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("LengthInDays")]
-	public int? LengthInDays(CqlContext context, CqlInterval<CqlDateTime> Value)
+	public int? LengthInDays(CqlInterval<CqlDateTime> Value)
 	{
 		var a_ = context.Operators.Start(Value);
 		var b_ = context.Operators.End(Value);
@@ -374,14 +546,13 @@ public class HybridHWRFHIR_1_3_005
 		return c_;
 	}
 
-    [CqlDeclaration("Inpatient Encounters")]
-	public IEnumerable<Encounter> Inpatient_Encounters(CqlContext context)
+	private IEnumerable<Encounter> Inpatient_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		IEnumerable<Coverage> c_(Encounter _InpatientEncounter)
 		{
-			var j_ = this.Medicare_payer(context);
+			var j_ = this.Medicare_payer();
 			var k_ = context.Operators.RetrieveByValueSet<Coverage>(j_, null);
 
 			return k_;
@@ -401,16 +572,16 @@ public class HybridHWRFHIR_1_3_005
 		{
 			var m_ = context.Operators.Convert<string>(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.StatusElement);
 			var n_ = context.Operators.Equal(m_, "finished");
-			var o_ = this.HospitalizationWithObservation(context, tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter);
-			var p_ = this.LengthInDays(context, o_);
+			var o_ = this.HospitalizationWithObservation(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter);
+			var p_ = this.LengthInDays(o_);
 			var q_ = context.Operators.Less(p_, (int?)365);
 			var r_ = context.Operators.And(n_, q_);
-			var s_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.Period);
+			var s_ = FHIRHelpers_4_0_001.ToInterval(tuple_czdryxljaejapsirauhdxvhpv.InpatientEncounter?.Period);
 			var t_ = context.Operators.End(s_);
-			var u_ = this.Measurement_Period(context);
+			var u_ = this.Measurement_Period();
 			var v_ = context.Operators.ElementInInterval<CqlDateTime>(t_, u_, "day");
 			var w_ = context.Operators.And(r_, v_);
-			var x_ = this.Patient(context);
+			var x_ = this.Patient();
 			var y_ = context.Operators.Convert<CqlDate>(x_?.BirthDateElement?.Value);
 			var aa_ = context.Operators.Start(s_);
 			var ab_ = context.Operators.DateFrom(aa_);
@@ -428,18 +599,25 @@ public class HybridHWRFHIR_1_3_005
 		return i_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    [CqlDeclaration("Inpatient Encounters")]
+	public IEnumerable<Encounter> Inpatient_Encounters() => 
+		__Inpatient_Encounters?.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 
 		return a_;
 	}
 
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
     [CqlDeclaration("FirstPhysicalExamWithEncounterId")]
-	public IEnumerable<string> FirstPhysicalExamWithEncounterId(CqlContext context, IEnumerable<Observation> ExamList, string CCDE)
+	public IEnumerable<string> FirstPhysicalExamWithEncounterId(IEnumerable<Observation> ExamList, string CCDE)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 		string b_(Encounter Encounter)
 		{
 			var d_ = context.Operators.Concatenate("\r\n", (CCDE ?? ""));
@@ -449,11 +627,11 @@ public class HybridHWRFHIR_1_3_005
 			var h_ = context.Operators.Concatenate((g_ ?? ""), ",");
 			bool? i_(Observation Exam)
 			{
-				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var ab_ = context.Operators.Start(aa_);
 				var ac_ = context.Operators.Not((bool?)(ab_ is null));
 				var ae_ = context.Operators.Start(aa_);
-				var af_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var af_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var ag_ = context.Operators.Start(af_);
 				var ah_ = context.Operators.Quantity(1440m, "minutes");
 				var ai_ = context.Operators.Subtract(ag_, ah_);
@@ -480,24 +658,24 @@ public class HybridHWRFHIR_1_3_005
 			var j_ = context.Operators.WhereOrNull<Observation>(ExamList, i_);
 			object k_(Observation @this)
 			{
-				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var ax_ = context.Operators.Start(aw_);
 
 				return ax_;
 			};
 			var l_ = context.Operators.ListSortBy<Observation>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var m_ = context.Operators.FirstOfList<Observation>(l_);
-			var n_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (m_?.Value as Quantity));
+			var n_ = FHIRHelpers_4_0_001.ToQuantity((m_?.Value as Quantity));
 			var o_ = context.Operators.ConvertQuantityToString(n_);
 			var p_ = context.Operators.Concatenate((h_ ?? ""), (o_ ?? ""));
 			var q_ = context.Operators.Concatenate((p_ ?? ""), ",");
 			bool? r_(Observation Exam)
 			{
-				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var az_ = context.Operators.Start(ay_);
 				var ba_ = context.Operators.Not((bool?)(az_ is null));
 				var bc_ = context.Operators.Start(ay_);
-				var bd_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var bd_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var be_ = context.Operators.Start(bd_);
 				var bf_ = context.Operators.Quantity(1440m, "minutes");
 				var bg_ = context.Operators.Subtract(be_, bf_);
@@ -524,14 +702,14 @@ public class HybridHWRFHIR_1_3_005
 			var s_ = context.Operators.WhereOrNull<Observation>(ExamList, r_);
 			object t_(Observation @this)
 			{
-				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var bv_ = context.Operators.Start(bu_);
 
 				return bv_;
 			};
 			var u_ = context.Operators.ListSortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
 			var v_ = context.Operators.FirstOfList<Observation>(u_);
-			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, v_?.Effective);
+			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(v_?.Effective);
 			var x_ = context.Operators.Start(w_);
 			var y_ = context.Operators.ConvertDateTimeToString(x_);
 			var z_ = context.Operators.Concatenate((q_ ?? ""), (y_ ?? ""));
@@ -544,9 +722,9 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("FirstPhysicalExamWithEncounterIdUsingLabTiming")]
-	public IEnumerable<string> FirstPhysicalExamWithEncounterIdUsingLabTiming(CqlContext context, IEnumerable<Observation> ExamList, string CCDE)
+	public IEnumerable<string> FirstPhysicalExamWithEncounterIdUsingLabTiming(IEnumerable<Observation> ExamList, string CCDE)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 		string b_(Encounter Encounter)
 		{
 			var d_ = context.Operators.Concatenate("\r\n", (CCDE ?? ""));
@@ -556,11 +734,11 @@ public class HybridHWRFHIR_1_3_005
 			var h_ = context.Operators.Concatenate((g_ ?? ""), ",");
 			bool? i_(Observation Exam)
 			{
-				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var ab_ = context.Operators.Start(aa_);
 				var ac_ = context.Operators.Not((bool?)(ab_ is null));
 				var ae_ = context.Operators.Start(aa_);
-				var af_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var af_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var ag_ = context.Operators.Start(af_);
 				var ah_ = context.Operators.Quantity(1440m, "minutes");
 				var ai_ = context.Operators.Subtract(ag_, ah_);
@@ -586,24 +764,24 @@ public class HybridHWRFHIR_1_3_005
 			var j_ = context.Operators.WhereOrNull<Observation>(ExamList, i_);
 			object k_(Observation @this)
 			{
-				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var aw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var ax_ = context.Operators.Start(aw_);
 
 				return ax_;
 			};
 			var l_ = context.Operators.ListSortBy<Observation>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var m_ = context.Operators.FirstOfList<Observation>(l_);
-			var n_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (m_?.Value as Quantity));
+			var n_ = FHIRHelpers_4_0_001.ToQuantity((m_?.Value as Quantity));
 			var o_ = context.Operators.ConvertQuantityToString(n_);
 			var p_ = context.Operators.Concatenate((h_ ?? ""), (o_ ?? ""));
 			var q_ = context.Operators.Concatenate((p_ ?? ""), ",");
 			bool? r_(Observation Exam)
 			{
-				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, Exam?.Effective);
+				var ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(Exam?.Effective);
 				var az_ = context.Operators.Start(ay_);
 				var ba_ = context.Operators.Not((bool?)(az_ is null));
 				var bc_ = context.Operators.Start(ay_);
-				var bd_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var bd_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var be_ = context.Operators.Start(bd_);
 				var bf_ = context.Operators.Quantity(1440m, "minutes");
 				var bg_ = context.Operators.Subtract(be_, bf_);
@@ -629,14 +807,14 @@ public class HybridHWRFHIR_1_3_005
 			var s_ = context.Operators.WhereOrNull<Observation>(ExamList, r_);
 			object t_(Observation @this)
 			{
-				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, @this?.Effective);
+				var bu_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(@this?.Effective);
 				var bv_ = context.Operators.Start(bu_);
 
 				return bv_;
 			};
 			var u_ = context.Operators.ListSortBy<Observation>(s_, t_, System.ComponentModel.ListSortDirection.Ascending);
 			var v_ = context.Operators.FirstOfList<Observation>(u_);
-			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, v_?.Effective);
+			var w_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(v_?.Effective);
 			var x_ = context.Operators.Start(w_);
 			var y_ = context.Operators.ConvertDateTimeToString(x_);
 			var z_ = context.Operators.Concatenate((q_ ?? ""), (y_ ?? ""));
@@ -649,9 +827,9 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("FirstLabTestWithEncounterId")]
-	public IEnumerable<string> FirstLabTestWithEncounterId(CqlContext context, IEnumerable<Observation> LabList, string CCDE)
+	public IEnumerable<string> FirstLabTestWithEncounterId(IEnumerable<Observation> LabList, string CCDE)
 	{
-		var a_ = this.Inpatient_Encounters(context);
+		var a_ = this.Inpatient_Encounters();
 		string b_(Encounter Encounter)
 		{
 			var d_ = context.Operators.Concatenate("\r\n", (CCDE ?? ""));
@@ -662,8 +840,8 @@ public class HybridHWRFHIR_1_3_005
 			bool? i_(Observation Lab)
 			{
 				var z_ = context.Operators.Not((bool?)(Lab?.IssuedElement is null));
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, Lab?.IssuedElement);
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var aa_ = FHIRHelpers_4_0_001.ToDateTime(Lab?.IssuedElement);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var ac_ = context.Operators.Start(ab_);
 				var ad_ = context.Operators.Quantity(1440m, "minutes");
 				var ae_ = context.Operators.Subtract(ac_, ad_);
@@ -691,15 +869,15 @@ public class HybridHWRFHIR_1_3_005
 				@this?.IssuedElement;
 			var l_ = context.Operators.ListSortBy<Observation>(j_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var m_ = context.Operators.FirstOfList<Observation>(l_);
-			var n_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (m_?.Value as Quantity));
+			var n_ = FHIRHelpers_4_0_001.ToQuantity((m_?.Value as Quantity));
 			var o_ = context.Operators.ConvertQuantityToString(n_);
 			var p_ = context.Operators.Concatenate((h_ ?? ""), (o_ ?? ""));
 			var q_ = context.Operators.Concatenate((p_ ?? ""), ",");
 			bool? r_(Observation Lab)
 			{
 				var as_ = context.Operators.Not((bool?)(Lab?.IssuedElement is null));
-				var at_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, Lab?.IssuedElement);
-				var au_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+				var at_ = FHIRHelpers_4_0_001.ToDateTime(Lab?.IssuedElement);
+				var au_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 				var av_ = context.Operators.Start(au_);
 				var aw_ = context.Operators.Quantity(1440m, "minutes");
 				var ax_ = context.Operators.Subtract(av_, aw_);
@@ -725,7 +903,7 @@ public class HybridHWRFHIR_1_3_005
 			var s_ = context.Operators.WhereOrNull<Observation>(LabList, r_);
 			var u_ = context.Operators.ListSortBy<Observation>(s_, k_, System.ComponentModel.ListSortDirection.Ascending);
 			var v_ = context.Operators.FirstOfList<Observation>(u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, v_?.IssuedElement);
+			var w_ = FHIRHelpers_4_0_001.ToDateTime(v_?.IssuedElement);
 			var x_ = context.Operators.ConvertDateTimeToString(w_);
 			var y_ = context.Operators.Concatenate((q_ ?? ""), (x_ ?? ""));
 
@@ -736,52 +914,51 @@ public class HybridHWRFHIR_1_3_005
 		return c_;
 	}
 
-    [CqlDeclaration("Results")]
-	public IEnumerable<string> Results(CqlContext context)
+	private IEnumerable<string> Results_Value(CqlContext context)
 	{
-		var a_ = this.Heart_rate(context);
+		var a_ = this.Heart_rate();
 		var b_ = context.Operators.ToList<CqlCode>(a_);
 		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
-		var d_ = this.FirstPhysicalExamWithEncounterId(context, c_, "FirstHeartRate");
-		var e_ = this.Systolic_blood_pressure(context);
+		var d_ = this.FirstPhysicalExamWithEncounterId(c_, "FirstHeartRate");
+		var e_ = this.Systolic_blood_pressure();
 		var f_ = context.Operators.ToList<CqlCode>(e_);
 		var g_ = context.Operators.RetrieveByCodes<Observation>(f_, null);
-		var h_ = this.FirstPhysicalExamWithEncounterId(context, g_, "FirstSystolicBP");
-		var i_ = this.Respiratory_rate(context);
+		var h_ = this.FirstPhysicalExamWithEncounterId(g_, "FirstSystolicBP");
+		var i_ = this.Respiratory_rate();
 		var j_ = context.Operators.ToList<CqlCode>(i_);
 		var k_ = context.Operators.RetrieveByCodes<Observation>(j_, null);
-		var l_ = this.FirstPhysicalExamWithEncounterId(context, k_, "FirstRespRate");
-		var m_ = this.Body_temperature(context);
+		var l_ = this.FirstPhysicalExamWithEncounterId(k_, "FirstRespRate");
+		var m_ = this.Body_temperature();
 		var n_ = context.Operators.RetrieveByValueSet<Observation>(m_, null);
-		var o_ = this.FirstPhysicalExamWithEncounterId(context, n_, "FirstTemperature");
-		var p_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry(context);
+		var o_ = this.FirstPhysicalExamWithEncounterId(n_, "FirstTemperature");
+		var p_ = this.Oxygen_saturation_in_Arterial_blood_by_Pulse_oximetry();
 		var q_ = context.Operators.ToList<CqlCode>(p_);
 		var r_ = context.Operators.RetrieveByCodes<Observation>(q_, null);
-		var s_ = this.FirstPhysicalExamWithEncounterId(context, r_, "FirstO2Saturation");
-		var t_ = this.Body_weight(context);
+		var s_ = this.FirstPhysicalExamWithEncounterId(r_, "FirstO2Saturation");
+		var t_ = this.Body_weight();
 		var u_ = context.Operators.RetrieveByValueSet<Observation>(t_, null);
-		var v_ = this.FirstPhysicalExamWithEncounterIdUsingLabTiming(context, u_, "FirstWeight");
-		var w_ = this.Hematocrit_lab_test(context);
+		var v_ = this.FirstPhysicalExamWithEncounterIdUsingLabTiming(u_, "FirstWeight");
+		var w_ = this.Hematocrit_lab_test();
 		var x_ = context.Operators.RetrieveByValueSet<Observation>(w_, null);
-		var y_ = this.FirstLabTestWithEncounterId(context, x_, "FirstHematocrit");
-		var z_ = this.White_blood_cells_count_lab_test(context);
+		var y_ = this.FirstLabTestWithEncounterId(x_, "FirstHematocrit");
+		var z_ = this.White_blood_cells_count_lab_test();
 		var aa_ = context.Operators.RetrieveByValueSet<Observation>(z_, null);
-		var ab_ = this.FirstLabTestWithEncounterId(context, aa_, "FirstWhiteBloodCell");
-		var ac_ = this.Potassium_lab_test(context);
+		var ab_ = this.FirstLabTestWithEncounterId(aa_, "FirstWhiteBloodCell");
+		var ac_ = this.Potassium_lab_test();
 		var ad_ = context.Operators.RetrieveByValueSet<Observation>(ac_, null);
-		var ae_ = this.FirstLabTestWithEncounterId(context, ad_, "FirstPotassium");
-		var af_ = this.Sodium_lab_test(context);
+		var ae_ = this.FirstLabTestWithEncounterId(ad_, "FirstPotassium");
+		var af_ = this.Sodium_lab_test();
 		var ag_ = context.Operators.RetrieveByValueSet<Observation>(af_, null);
-		var ah_ = this.FirstLabTestWithEncounterId(context, ag_, "FirstSodium");
-		var ai_ = this.Bicarbonate_lab_test(context);
+		var ah_ = this.FirstLabTestWithEncounterId(ag_, "FirstSodium");
+		var ai_ = this.Bicarbonate_lab_test();
 		var aj_ = context.Operators.RetrieveByValueSet<Observation>(ai_, null);
-		var ak_ = this.FirstLabTestWithEncounterId(context, aj_, "FirstBicarbonate");
-		var al_ = this.Creatinine_lab_test(context);
+		var ak_ = this.FirstLabTestWithEncounterId(aj_, "FirstBicarbonate");
+		var al_ = this.Creatinine_lab_test();
 		var am_ = context.Operators.RetrieveByValueSet<Observation>(al_, null);
-		var an_ = this.FirstLabTestWithEncounterId(context, am_, "FirstCreatinine");
-		var ao_ = this.Glucose_lab_test(context);
+		var an_ = this.FirstLabTestWithEncounterId(am_, "FirstCreatinine");
+		var ao_ = this.Glucose_lab_test();
 		var ap_ = context.Operators.RetrieveByValueSet<Observation>(ao_, null);
-		var aq_ = this.FirstLabTestWithEncounterId(context, ap_, "FirstGlucose");
+		var aq_ = this.FirstLabTestWithEncounterId(ap_, "FirstGlucose");
 		var ar_ = new IEnumerable<string>[]
 		{
 			d_,
@@ -803,8 +980,12 @@ public class HybridHWRFHIR_1_3_005
 		return as_;
 	}
 
+    [CqlDeclaration("Results")]
+	public IEnumerable<string> Results() => 
+		__Results?.Value;
+
     [CqlDeclaration("CalendarAgeInYearsAt")]
-	public int? CalendarAgeInYearsAt(CqlContext context, CqlDateTime BirthDateTime, CqlDateTime AsOf)
+	public int? CalendarAgeInYearsAt(CqlDateTime BirthDateTime, CqlDateTime AsOf)
 	{
 		var a_ = context.Operators.ConvertDateTimeToDate(BirthDateTime);
 		var b_ = context.Operators.ConvertDateTimeToDate(AsOf);
@@ -814,7 +995,7 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("ToDate")]
-	public CqlDateTime ToDate(CqlContext context, CqlDateTime Value)
+	public CqlDateTime ToDate(CqlDateTime Value)
 	{
 		var a_ = context.Operators.ComponentFrom(Value, "year");
 		var b_ = context.Operators.ComponentFrom(Value, "month");
@@ -826,7 +1007,7 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("LengthOfStay")]
-	public int? LengthOfStay(CqlContext context, CqlInterval<CqlDateTime> Stay)
+	public int? LengthOfStay(CqlInterval<CqlDateTime> Stay)
 	{
 		var a_ = context.Operators.Start(Stay);
 		var b_ = context.Operators.End(Stay);
@@ -836,10 +1017,10 @@ public class HybridHWRFHIR_1_3_005
 	}
 
     [CqlDeclaration("HospitalizationWithObservationLengthofStay")]
-	public int? HospitalizationWithObservationLengthofStay(CqlContext context, Encounter Encounter)
+	public int? HospitalizationWithObservationLengthofStay(Encounter Encounter)
 	{
-		var a_ = this.HospitalizationWithObservation(context, Encounter);
-		var b_ = this.LengthInDays(context, a_);
+		var a_ = this.HospitalizationWithObservation(Encounter);
+		var b_ = this.LengthInDays(a_);
 
 		return b_;
 	}

--- a/Demo/Measures/MATGlobalCommonFunctionsFHIR4-6.1.000.cs
+++ b/Demo/Measures/MATGlobalCommonFunctionsFHIR4-6.1.000.cs
@@ -14,130 +14,315 @@ using Task = Hl7.Fhir.Model.Task;
 public class MATGlobalCommonFunctionsFHIR4_6_1_000
 {
 
-    public static MATGlobalCommonFunctionsFHIR4_6_1_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __Present_on_Admission_or_Clinically_Undetermined;
+    internal Lazy<CqlCode> __active;
+    internal Lazy<CqlCode> __allergy_active;
+    internal Lazy<CqlCode> __allergy_confirmed;
+    internal Lazy<CqlCode> __allergy_inactive;
+    internal Lazy<CqlCode> __allergy_refuted;
+    internal Lazy<CqlCode> __allergy_resolved;
+    internal Lazy<CqlCode> __allergy_unconfirmed;
+    internal Lazy<CqlCode> __Billing;
+    internal Lazy<CqlCode> __Birthdate;
+    internal Lazy<CqlCode> __Community;
+    internal Lazy<CqlCode> __confirmed;
+    internal Lazy<CqlCode> __Dead;
+    internal Lazy<CqlCode> __differential;
+    internal Lazy<CqlCode> __Discharge;
+    internal Lazy<CqlCode> __entered_in_error;
+    internal Lazy<CqlCode> __ER;
+    internal Lazy<CqlCode> __ICU;
+    internal Lazy<CqlCode> __inactive;
+    internal Lazy<CqlCode> __provisional;
+    internal Lazy<CqlCode> __recurrence;
+    internal Lazy<CqlCode> __refuted;
+    internal Lazy<CqlCode> __relapse;
+    internal Lazy<CqlCode> __remission;
+    internal Lazy<CqlCode> __resolved;
+    internal Lazy<CqlCode> __unconfirmed;
+    internal Lazy<CqlCode[]> __ConditionClinicalStatusCodes;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceClinicalStatusCodes;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceVerificationStatusCodes;
+    internal Lazy<CqlCode[]> __Diagnosis_Role;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __MedicationRequestCategory;
+    internal Lazy<CqlCode[]> __ConditionVerificationStatusCodes;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __RoleCode;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounter;
+
+    #endregion
+    public MATGlobalCommonFunctionsFHIR4_6_1_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value(context));
+        __Present_on_Admission_or_Clinically_Undetermined = new Lazy<CqlValueSet>(this.Present_on_Admission_or_Clinically_Undetermined_Value(context));
+        __active = new Lazy<CqlCode>(this.active_Value(context));
+        __allergy_active = new Lazy<CqlCode>(this.allergy_active_Value(context));
+        __allergy_confirmed = new Lazy<CqlCode>(this.allergy_confirmed_Value(context));
+        __allergy_inactive = new Lazy<CqlCode>(this.allergy_inactive_Value(context));
+        __allergy_refuted = new Lazy<CqlCode>(this.allergy_refuted_Value(context));
+        __allergy_resolved = new Lazy<CqlCode>(this.allergy_resolved_Value(context));
+        __allergy_unconfirmed = new Lazy<CqlCode>(this.allergy_unconfirmed_Value(context));
+        __Billing = new Lazy<CqlCode>(this.Billing_Value(context));
+        __Birthdate = new Lazy<CqlCode>(this.Birthdate_Value(context));
+        __Community = new Lazy<CqlCode>(this.Community_Value(context));
+        __confirmed = new Lazy<CqlCode>(this.confirmed_Value(context));
+        __Dead = new Lazy<CqlCode>(this.Dead_Value(context));
+        __differential = new Lazy<CqlCode>(this.differential_Value(context));
+        __Discharge = new Lazy<CqlCode>(this.Discharge_Value(context));
+        __entered_in_error = new Lazy<CqlCode>(this.entered_in_error_Value(context));
+        __ER = new Lazy<CqlCode>(this.ER_Value(context));
+        __ICU = new Lazy<CqlCode>(this.ICU_Value(context));
+        __inactive = new Lazy<CqlCode>(this.inactive_Value(context));
+        __provisional = new Lazy<CqlCode>(this.provisional_Value(context));
+        __recurrence = new Lazy<CqlCode>(this.recurrence_Value(context));
+        __refuted = new Lazy<CqlCode>(this.refuted_Value(context));
+        __relapse = new Lazy<CqlCode>(this.relapse_Value(context));
+        __remission = new Lazy<CqlCode>(this.remission_Value(context));
+        __resolved = new Lazy<CqlCode>(this.resolved_Value(context));
+        __unconfirmed = new Lazy<CqlCode>(this.unconfirmed_Value(context));
+        __ConditionClinicalStatusCodes = new Lazy<CqlCode[]>(this.ConditionClinicalStatusCodes_Value(context));
+        __AllergyIntoleranceClinicalStatusCodes = new Lazy<CqlCode[]>(this.AllergyIntoleranceClinicalStatusCodes_Value(context));
+        __AllergyIntoleranceVerificationStatusCodes = new Lazy<CqlCode[]>(this.AllergyIntoleranceVerificationStatusCodes_Value(context));
+        __Diagnosis_Role = new Lazy<CqlCode[]>(this.Diagnosis_Role_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __MedicationRequestCategory = new Lazy<CqlCode[]>(this.MedicationRequestCategory_Value(context));
+        __ConditionVerificationStatusCodes = new Lazy<CqlCode[]>(this.ConditionVerificationStatusCodes_Value(context));
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value(context));
+        __RoleCode = new Lazy<CqlCode[]>(this.RoleCode_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Inpatient_Encounter = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounter_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Observation_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
-	public CqlValueSet Observation_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services?.Value;
+
+	private CqlValueSet Present_on_Admission_or_Clinically_Undetermined_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
 
     [CqlDeclaration("Present on Admission or Clinically Undetermined")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197")]
-	public CqlValueSet Present_on_Admission_or_Clinically_Undetermined(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+	public CqlValueSet Present_on_Admission_or_Clinically_Undetermined() => 
+		__Present_on_Admission_or_Clinically_Undetermined?.Value;
 
-    [CqlDeclaration("active")]
-	public CqlCode active(CqlContext context) => 
+	private CqlCode active_Value(CqlContext context) => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("allergy-active")]
-	public CqlCode allergy_active(CqlContext context) => 
+    [CqlDeclaration("active")]
+	public CqlCode active() => 
+		__active?.Value;
+
+	private CqlCode allergy_active_Value(CqlContext context) => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-confirmed")]
-	public CqlCode allergy_confirmed(CqlContext context) => 
+    [CqlDeclaration("allergy-active")]
+	public CqlCode allergy_active() => 
+		__allergy_active?.Value;
+
+	private CqlCode allergy_confirmed_Value(CqlContext context) => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("allergy-inactive")]
-	public CqlCode allergy_inactive(CqlContext context) => 
+    [CqlDeclaration("allergy-confirmed")]
+	public CqlCode allergy_confirmed() => 
+		__allergy_confirmed?.Value;
+
+	private CqlCode allergy_inactive_Value(CqlContext context) => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-refuted")]
-	public CqlCode allergy_refuted(CqlContext context) => 
+    [CqlDeclaration("allergy-inactive")]
+	public CqlCode allergy_inactive() => 
+		__allergy_inactive?.Value;
+
+	private CqlCode allergy_refuted_Value(CqlContext context) => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("allergy-resolved")]
-	public CqlCode allergy_resolved(CqlContext context) => 
+    [CqlDeclaration("allergy-refuted")]
+	public CqlCode allergy_refuted() => 
+		__allergy_refuted?.Value;
+
+	private CqlCode allergy_resolved_Value(CqlContext context) => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-unconfirmed")]
-	public CqlCode allergy_unconfirmed(CqlContext context) => 
+    [CqlDeclaration("allergy-resolved")]
+	public CqlCode allergy_resolved() => 
+		__allergy_resolved?.Value;
+
+	private CqlCode allergy_unconfirmed_Value(CqlContext context) => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("Billing")]
-	public CqlCode Billing(CqlContext context) => 
+    [CqlDeclaration("allergy-unconfirmed")]
+	public CqlCode allergy_unconfirmed() => 
+		__allergy_unconfirmed?.Value;
+
+	private CqlCode Billing_Value(CqlContext context) => 
 		new CqlCode("billing", "http://terminology.hl7.org/CodeSystem/diagnosis-role", null, null);
 
-    [CqlDeclaration("Birthdate")]
-	public CqlCode Birthdate(CqlContext context) => 
+    [CqlDeclaration("Billing")]
+	public CqlCode Billing() => 
+		__Billing?.Value;
+
+	private CqlCode Birthdate_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("Community")]
-	public CqlCode Community(CqlContext context) => 
+    [CqlDeclaration("Birthdate")]
+	public CqlCode Birthdate() => 
+		__Birthdate?.Value;
+
+	private CqlCode Community_Value(CqlContext context) => 
 		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("confirmed")]
-	public CqlCode confirmed(CqlContext context) => 
+    [CqlDeclaration("Community")]
+	public CqlCode Community() => 
+		__Community?.Value;
+
+	private CqlCode confirmed_Value(CqlContext context) => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("Dead")]
-	public CqlCode Dead(CqlContext context) => 
+    [CqlDeclaration("confirmed")]
+	public CqlCode confirmed() => 
+		__confirmed?.Value;
+
+	private CqlCode Dead_Value(CqlContext context) => 
 		new CqlCode("419099009", "http://snomed.info/sct", null, null);
 
-    [CqlDeclaration("differential")]
-	public CqlCode differential(CqlContext context) => 
+    [CqlDeclaration("Dead")]
+	public CqlCode Dead() => 
+		__Dead?.Value;
+
+	private CqlCode differential_Value(CqlContext context) => 
 		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("Discharge")]
-	public CqlCode Discharge(CqlContext context) => 
+    [CqlDeclaration("differential")]
+	public CqlCode differential() => 
+		__differential?.Value;
+
+	private CqlCode Discharge_Value(CqlContext context) => 
 		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("entered-in-error")]
-	public CqlCode entered_in_error(CqlContext context) => 
+    [CqlDeclaration("Discharge")]
+	public CqlCode Discharge() => 
+		__Discharge?.Value;
+
+	private CqlCode entered_in_error_Value(CqlContext context) => 
 		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("ER")]
-	public CqlCode ER(CqlContext context) => 
+    [CqlDeclaration("entered-in-error")]
+	public CqlCode entered_in_error() => 
+		__entered_in_error?.Value;
+
+	private CqlCode ER_Value(CqlContext context) => 
 		new CqlCode("ER", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
 
-    [CqlDeclaration("ICU")]
-	public CqlCode ICU(CqlContext context) => 
+    [CqlDeclaration("ER")]
+	public CqlCode ER() => 
+		__ER?.Value;
+
+	private CqlCode ICU_Value(CqlContext context) => 
 		new CqlCode("ICU", "http://terminology.hl7.org/CodeSystem/v3-RoleCode", null, null);
 
-    [CqlDeclaration("inactive")]
-	public CqlCode inactive(CqlContext context) => 
+    [CqlDeclaration("ICU")]
+	public CqlCode ICU() => 
+		__ICU?.Value;
+
+	private CqlCode inactive_Value(CqlContext context) => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("provisional")]
-	public CqlCode provisional(CqlContext context) => 
+    [CqlDeclaration("inactive")]
+	public CqlCode inactive() => 
+		__inactive?.Value;
+
+	private CqlCode provisional_Value(CqlContext context) => 
 		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("recurrence")]
-	public CqlCode recurrence(CqlContext context) => 
+    [CqlDeclaration("provisional")]
+	public CqlCode provisional() => 
+		__provisional?.Value;
+
+	private CqlCode recurrence_Value(CqlContext context) => 
 		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("refuted")]
-	public CqlCode refuted(CqlContext context) => 
+    [CqlDeclaration("recurrence")]
+	public CqlCode recurrence() => 
+		__recurrence?.Value;
+
+	private CqlCode refuted_Value(CqlContext context) => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("relapse")]
-	public CqlCode relapse(CqlContext context) => 
+    [CqlDeclaration("refuted")]
+	public CqlCode refuted() => 
+		__refuted?.Value;
+
+	private CqlCode relapse_Value(CqlContext context) => 
 		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("remission")]
-	public CqlCode remission(CqlContext context) => 
+    [CqlDeclaration("relapse")]
+	public CqlCode relapse() => 
+		__relapse?.Value;
+
+	private CqlCode remission_Value(CqlContext context) => 
 		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("resolved")]
-	public CqlCode resolved(CqlContext context) => 
+    [CqlDeclaration("remission")]
+	public CqlCode remission() => 
+		__remission?.Value;
+
+	private CqlCode resolved_Value(CqlContext context) => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("unconfirmed")]
-	public CqlCode unconfirmed(CqlContext context) => 
+    [CqlDeclaration("resolved")]
+	public CqlCode resolved() => 
+		__resolved?.Value;
+
+	private CqlCode unconfirmed_Value(CqlContext context) => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-ver-status", null, null);
 
-    [CqlDeclaration("ConditionClinicalStatusCodes")]
-	public CqlCode[] ConditionClinicalStatusCodes(CqlContext context)
+    [CqlDeclaration("unconfirmed")]
+	public CqlCode unconfirmed() => 
+		__unconfirmed?.Value;
+
+	private CqlCode[] ConditionClinicalStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -152,8 +337,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceClinicalStatusCodes")]
-	public CqlCode[] AllergyIntoleranceClinicalStatusCodes(CqlContext context)
+    [CqlDeclaration("ConditionClinicalStatusCodes")]
+	public CqlCode[] ConditionClinicalStatusCodes() => 
+		__ConditionClinicalStatusCodes?.Value;
+
+	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -165,8 +353,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
-	public CqlCode[] AllergyIntoleranceVerificationStatusCodes(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceClinicalStatusCodes")]
+	public CqlCode[] AllergyIntoleranceClinicalStatusCodes() => 
+		__AllergyIntoleranceClinicalStatusCodes?.Value;
+
+	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -178,8 +369,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("Diagnosis Role")]
-	public CqlCode[] Diagnosis_Role(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
+	public CqlCode[] AllergyIntoleranceVerificationStatusCodes() => 
+		__AllergyIntoleranceVerificationStatusCodes?.Value;
+
+	private CqlCode[] Diagnosis_Role_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -189,8 +383,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Diagnosis Role")]
+	public CqlCode[] Diagnosis_Role() => 
+		__Diagnosis_Role?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -200,8 +397,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("MedicationRequestCategory")]
-	public CqlCode[] MedicationRequestCategory(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlCode[] MedicationRequestCategory_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -212,8 +412,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("ConditionVerificationStatusCodes")]
-	public CqlCode[] ConditionVerificationStatusCodes(CqlContext context)
+    [CqlDeclaration("MedicationRequestCategory")]
+	public CqlCode[] MedicationRequestCategory() => 
+		__MedicationRequestCategory?.Value;
+
+	private CqlCode[] ConditionVerificationStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -228,8 +431,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("SNOMEDCT")]
-	public CqlCode[] SNOMEDCT(CqlContext context)
+    [CqlDeclaration("ConditionVerificationStatusCodes")]
+	public CqlCode[] ConditionVerificationStatusCodes() => 
+		__ConditionVerificationStatusCodes?.Value;
+
+	private CqlCode[] SNOMEDCT_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -239,8 +445,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("RoleCode")]
-	public CqlCode[] RoleCode(CqlContext context)
+    [CqlDeclaration("SNOMEDCT")]
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT?.Value;
+
+	private CqlCode[] RoleCode_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -251,8 +460,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("RoleCode")]
+	public CqlCode[] RoleCode() => 
+		__RoleCode?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -263,8 +475,11 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -272,8 +487,12 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("LengthInDays")]
-	public int? LengthInDays(CqlContext context, CqlInterval<CqlDateTime> Value)
+	public int? LengthInDays(CqlInterval<CqlDateTime> Value)
 	{
 		var a_ = context.Operators.Start(Value);
 		var b_ = context.Operators.End(Value);
@@ -282,21 +501,20 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return c_;
 	}
 
-    [CqlDeclaration("Inpatient Encounter")]
-	public IEnumerable<Encounter> Inpatient_Encounter(CqlContext context)
+	private IEnumerable<Encounter> Inpatient_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_Inpatient(context);
+		var a_ = this.Encounter_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EncounterInpatient)
 		{
 			var e_ = context.Operators.Convert<string>(EncounterInpatient?.StatusElement);
 			var f_ = context.Operators.Equal(e_, "finished");
-			var g_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterInpatient?.Period);
-			var h_ = this.LengthInDays(context, g_);
+			var g_ = FHIRHelpers_4_0_001.ToInterval(EncounterInpatient?.Period);
+			var h_ = this.LengthInDays(g_);
 			var i_ = context.Operators.LessOrEqual(h_, (int?)120);
 			var j_ = context.Operators.And(f_, i_);
 			var l_ = context.Operators.End(g_);
-			var m_ = this.Measurement_Period(context);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.ElementInInterval<CqlDateTime>(l_, m_, null);
 			var o_ = context.Operators.And(j_, n_);
 
@@ -307,18 +525,22 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		return d_;
 	}
 
+    [CqlDeclaration("Inpatient Encounter")]
+	public IEnumerable<Encounter> Inpatient_Encounter() => 
+		__Inpatient_Encounter?.Value;
+
     [CqlDeclaration("ED Visit")]
-	public Encounter ED_Visit(CqlContext context, Encounter TheEncounter)
+	public Encounter ED_Visit(Encounter TheEncounter)
 	{
-		var a_ = this.Emergency_Department_Visit(context);
+		var a_ = this.Emergency_Department_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter EDVisit)
 		{
 			var h_ = context.Operators.Convert<string>(EDVisit?.StatusElement);
 			var i_ = context.Operators.Equal(h_, "finished");
-			var j_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EDVisit?.Period);
+			var j_ = FHIRHelpers_4_0_001.ToInterval(EDVisit?.Period);
 			var k_ = context.Operators.End(j_);
-			var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, TheEncounter?.Period);
+			var l_ = FHIRHelpers_4_0_001.ToInterval(TheEncounter?.Period);
 			var m_ = context.Operators.Start(l_);
 			var n_ = context.Operators.Quantity(1m, "hour");
 			var o_ = context.Operators.Subtract(m_, n_);
@@ -335,7 +557,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		var d_ = context.Operators.WhereOrNull<Encounter>(b_, c_);
 		object e_(Encounter @this)
 		{
-			var y_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+			var y_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 			var z_ = context.Operators.End(y_);
 
 			return z_;
@@ -347,9 +569,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Hospitalization")]
-	public CqlInterval<CqlDateTime> Hospitalization(CqlContext context, Encounter TheEncounter)
+	public CqlInterval<CqlDateTime> Hospitalization(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(context, TheEncounter);
+		var a_ = this.ED_Visit(TheEncounter);
 		var b_ = new Encounter[]
 		{
 			a_,
@@ -360,15 +582,15 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			{
 				if ((X is null))
 				{
-					var g_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, TheEncounter?.Period);
+					var g_ = FHIRHelpers_4_0_001.ToInterval(TheEncounter?.Period);
 
 					return g_;
 				}
 				else
 				{
-					var h_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, X?.Period);
+					var h_ = FHIRHelpers_4_0_001.ToInterval(X?.Period);
 					var i_ = context.Operators.Start(h_);
-					var j_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, TheEncounter?.Period);
+					var j_ = FHIRHelpers_4_0_001.ToInterval(TheEncounter?.Period);
 					var k_ = context.Operators.End(j_);
 					var l_ = context.Operators.Interval(i_, k_, true, true);
 
@@ -385,9 +607,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Hospitalization Locations")]
-	public IEnumerable<Encounter.LocationComponent> Hospitalization_Locations(CqlContext context, Encounter TheEncounter)
+	public IEnumerable<Encounter.LocationComponent> Hospitalization_Locations(Encounter TheEncounter)
 	{
-		var a_ = this.ED_Visit(context, TheEncounter);
+		var a_ = this.ED_Visit(TheEncounter);
 		var b_ = new Encounter[]
 		{
 			a_,
@@ -422,53 +644,53 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Hospitalization Length of Stay")]
-	public int? Hospitalization_Length_of_Stay(CqlContext context, Encounter TheEncounter)
+	public int? Hospitalization_Length_of_Stay(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(context, TheEncounter);
-		var b_ = this.LengthInDays(context, a_);
+		var a_ = this.Hospitalization(TheEncounter);
+		var b_ = this.LengthInDays(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("Hospital Admission Time")]
-	public CqlDateTime Hospital_Admission_Time(CqlContext context, Encounter TheEncounter)
+	public CqlDateTime Hospital_Admission_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization(context, TheEncounter);
+		var a_ = this.Hospitalization(TheEncounter);
 		var b_ = context.Operators.Start(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("Hospital Discharge Time")]
-	public CqlDateTime Hospital_Discharge_Time(CqlContext context, Encounter TheEncounter)
+	public CqlDateTime Hospital_Discharge_Time(Encounter TheEncounter)
 	{
-		var a_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, TheEncounter?.Period);
+		var a_ = FHIRHelpers_4_0_001.ToInterval(TheEncounter?.Period);
 		var b_ = context.Operators.End(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("Hospital Arrival Time")]
-	public CqlDateTime Hospital_Arrival_Time(CqlContext context, Encounter TheEncounter)
+	public CqlDateTime Hospital_Arrival_Time(Encounter TheEncounter)
 	{
-		var a_ = this.Hospitalization_Locations(context, TheEncounter);
+		var a_ = this.Hospitalization_Locations(TheEncounter);
 		object b_(Encounter.LocationComponent @this)
 		{
-			var g_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+			var g_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 			var h_ = context.Operators.Start(g_);
 
 			return h_;
 		};
 		var c_ = context.Operators.ListSortBy<Encounter.LocationComponent>(a_, b_, System.ComponentModel.ListSortDirection.Ascending);
 		var d_ = context.Operators.FirstOfList<Encounter.LocationComponent>(c_);
-		var e_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, d_?.Period);
+		var e_ = FHIRHelpers_4_0_001.ToInterval(d_?.Period);
 		var f_ = context.Operators.Start(e_);
 
 		return f_;
 	}
 
     [CqlDeclaration("HospitalizationWithObservation")]
-	public CqlInterval<CqlDateTime> HospitalizationWithObservation(CqlContext context, Encounter TheEncounter)
+	public CqlInterval<CqlDateTime> HospitalizationWithObservation(Encounter TheEncounter)
 	{
 		var a_ = new Encounter[]
 		{
@@ -476,19 +698,19 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		};
 		CqlInterval<CqlDateTime> b_(Encounter Visit)
 		{
-			var e_ = this.Emergency_Department_Visit(context);
+			var e_ = this.Emergency_Department_Visit();
 			var f_ = context.Operators.RetrieveByValueSet<Encounter>(e_, null);
 			bool? g_(Encounter LastED)
 			{
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastED?.Period);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(LastED?.Period);
 				var ac_ = context.Operators.End(ab_);
-				var ad_ = this.Observation_Services(context);
+				var ad_ = this.Observation_Services();
 				var ae_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? af_(Encounter LastObs)
 				{
-					var bq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var bq_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var br_ = context.Operators.End(bq_);
-					var bs_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var bs_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var bt_ = context.Operators.Start(bs_);
 					var bu_ = context.Operators.Quantity(1m, "hour");
 					var bv_ = context.Operators.Subtract(bt_, bu_);
@@ -504,25 +726,25 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				var ag_ = context.Operators.WhereOrNull<Encounter>(ae_, af_);
 				object ah_(Encounter @this)
 				{
-					var ce_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var ce_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cf_ = context.Operators.End(ce_);
 
 					return cf_;
 				};
 				var ai_ = context.Operators.ListSortBy<Encounter>(ag_, ah_, System.ComponentModel.ListSortDirection.Ascending);
 				var aj_ = context.Operators.LastOfList<Encounter>(ai_);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aj_?.Period);
+				var ak_ = FHIRHelpers_4_0_001.ToInterval(aj_?.Period);
 				var al_ = context.Operators.Start(ak_);
-				var am_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var am_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var an_ = context.Operators.Start(am_);
 				var ao_ = context.Operators.Quantity(1m, "hour");
 				var ap_ = context.Operators.Subtract((al_ ?? an_), ao_);
 				var ar_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? as_(Encounter LastObs)
 				{
-					var cg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cg_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var ch_ = context.Operators.End(cg_);
-					var ci_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var ci_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cj_ = context.Operators.Start(ci_);
 					var ck_ = context.Operators.Quantity(1m, "hour");
 					var cl_ = context.Operators.Subtract(cj_, ck_);
@@ -538,14 +760,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				var at_ = context.Operators.WhereOrNull<Encounter>(ar_, as_);
 				object au_(Encounter @this)
 				{
-					var cu_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var cu_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var cv_ = context.Operators.End(cu_);
 
 					return cv_;
 				};
 				var av_ = context.Operators.ListSortBy<Encounter>(at_, au_, System.ComponentModel.ListSortDirection.Ascending);
 				var aw_ = context.Operators.LastOfList<Encounter>(av_);
-				var ax_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aw_?.Period);
+				var ax_ = FHIRHelpers_4_0_001.ToInterval(aw_?.Period);
 				var ay_ = context.Operators.Start(ax_);
 				var ba_ = context.Operators.Start(am_);
 				var bb_ = context.Operators.Interval(ap_, (ay_ ?? ba_), true, true);
@@ -553,9 +775,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				var be_ = context.Operators.RetrieveByValueSet<Encounter>(ad_, null);
 				bool? bf_(Encounter LastObs)
 				{
-					var cw_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+					var cw_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 					var cx_ = context.Operators.End(cw_);
-					var cy_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+					var cy_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 					var cz_ = context.Operators.Start(cy_);
 					var da_ = context.Operators.Quantity(1m, "hour");
 					var db_ = context.Operators.Subtract(cz_, da_);
@@ -571,14 +793,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				var bg_ = context.Operators.WhereOrNull<Encounter>(be_, bf_);
 				object bh_(Encounter @this)
 				{
-					var dk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+					var dk_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 					var dl_ = context.Operators.End(dk_);
 
 					return dl_;
 				};
 				var bi_ = context.Operators.ListSortBy<Encounter>(bg_, bh_, System.ComponentModel.ListSortDirection.Ascending);
 				var bj_ = context.Operators.LastOfList<Encounter>(bi_);
-				var bk_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, bj_?.Period);
+				var bk_ = FHIRHelpers_4_0_001.ToInterval(bj_?.Period);
 				var bl_ = context.Operators.Start(bk_);
 				var bn_ = context.Operators.Start(am_);
 				var bo_ = context.Operators.Not((bool?)((bl_ ?? bn_) is null));
@@ -589,22 +811,22 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			var h_ = context.Operators.WhereOrNull<Encounter>(f_, g_);
 			object i_(Encounter @this)
 			{
-				var dm_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var dm_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var dn_ = context.Operators.End(dm_);
 
 				return dn_;
 			};
 			var j_ = context.Operators.ListSortBy<Encounter>(h_, i_, System.ComponentModel.ListSortDirection.Ascending);
 			var k_ = context.Operators.LastOfList<Encounter>(j_);
-			var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_?.Period);
+			var l_ = FHIRHelpers_4_0_001.ToInterval(k_?.Period);
 			var m_ = context.Operators.Start(l_);
-			var n_ = this.Observation_Services(context);
+			var n_ = this.Observation_Services();
 			var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 			bool? p_(Encounter LastObs)
 			{
-				var do_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, LastObs?.Period);
+				var do_ = FHIRHelpers_4_0_001.ToInterval(LastObs?.Period);
 				var dp_ = context.Operators.End(do_);
-				var dq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+				var dq_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 				var dr_ = context.Operators.Start(dq_);
 				var ds_ = context.Operators.Quantity(1m, "hour");
 				var dt_ = context.Operators.Subtract(dr_, ds_);
@@ -620,16 +842,16 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
 			object r_(Encounter @this)
 			{
-				var ec_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+				var ec_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 				var ed_ = context.Operators.End(ec_);
 
 				return ed_;
 			};
 			var s_ = context.Operators.ListSortBy<Encounter>(q_, r_, System.ComponentModel.ListSortDirection.Ascending);
 			var t_ = context.Operators.LastOfList<Encounter>(s_);
-			var u_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, t_?.Period);
+			var u_ = FHIRHelpers_4_0_001.ToInterval(t_?.Period);
 			var v_ = context.Operators.Start(u_);
-			var w_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Visit?.Period);
+			var w_ = FHIRHelpers_4_0_001.ToInterval(Visit?.Period);
 			var x_ = context.Operators.Start(w_);
 			var z_ = context.Operators.End(w_);
 			var aa_ = context.Operators.Interval((m_ ?? (v_ ?? x_)), z_, true, true);
@@ -643,58 +865,58 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Normalize Interval")]
-	public CqlInterval<CqlDateTime> Normalize_Interval(CqlContext context, object choice)
+	public CqlInterval<CqlDateTime> Normalize_Interval(object choice)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (choice is FhirDateTime)
 			{
-				var b_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (choice as FhirDateTime));
+				var b_ = FHIRHelpers_4_0_001.ToDateTime((choice as FhirDateTime));
 				var d_ = context.Operators.Interval(b_, b_, true, true);
 
 				return d_;
 			}
 			else if (choice is Period)
 			{
-				var e_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (choice as Period));
+				var e_ = FHIRHelpers_4_0_001.ToInterval((choice as Period));
 
 				return e_;
 			}
 			else if (choice is Instant)
 			{
-				var f_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (choice as Instant));
+				var f_ = FHIRHelpers_4_0_001.ToDateTime((choice as Instant));
 				var h_ = context.Operators.Interval(f_, f_, true, true);
 
 				return h_;
 			}
 			else if (choice is Age)
 			{
-				var i_ = this.Patient(context);
-				var j_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
-				var k_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Age));
+				var i_ = this.Patient();
+				var j_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
+				var k_ = FHIRHelpers_4_0_001.ToQuantity((choice as Age));
 				var l_ = context.Operators.Add(j_, k_);
-				var n_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var n_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var p_ = context.Operators.Add(n_, k_);
 				var q_ = context.Operators.Quantity(1m, "year");
 				var r_ = context.Operators.Add(p_, q_);
 				var s_ = context.Operators.Interval(l_, r_, true, false);
 				var t_ = context.Operators.ConvertDateToDateTime(s_?.low);
-				var v_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var v_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var x_ = context.Operators.Add(v_, k_);
-				var z_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var z_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var ab_ = context.Operators.Add(z_, k_);
 				var ad_ = context.Operators.Add(ab_, q_);
 				var ae_ = context.Operators.Interval(x_, ad_, true, false);
 				var af_ = context.Operators.ConvertDateToDateTime(ae_?.high);
-				var ah_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var ah_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var aj_ = context.Operators.Add(ah_, k_);
-				var al_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var al_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var an_ = context.Operators.Add(al_, k_);
 				var ap_ = context.Operators.Add(an_, q_);
 				var aq_ = context.Operators.Interval(aj_, ap_, true, false);
-				var as_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var as_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var au_ = context.Operators.Add(as_, k_);
-				var aw_ = FHIRHelpers_4_0_001.Instance.ToDate(context, i_?.BirthDateElement);
+				var aw_ = FHIRHelpers_4_0_001.ToDate(i_?.BirthDateElement);
 				var ay_ = context.Operators.Add(aw_, k_);
 				var ba_ = context.Operators.Add(ay_, q_);
 				var bb_ = context.Operators.Interval(au_, ba_, true, false);
@@ -704,33 +926,33 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else if (choice is Range)
 			{
-				var bd_ = this.Patient(context);
-				var be_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
-				var bf_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Range)?.Low);
+				var bd_ = this.Patient();
+				var be_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
+				var bf_ = FHIRHelpers_4_0_001.ToQuantity((choice as Range)?.Low);
 				var bg_ = context.Operators.Add(be_, bf_);
-				var bi_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
-				var bj_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Range)?.High);
+				var bi_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
+				var bj_ = FHIRHelpers_4_0_001.ToQuantity((choice as Range)?.High);
 				var bk_ = context.Operators.Add(bi_, bj_);
 				var bl_ = context.Operators.Quantity(1m, "year");
 				var bm_ = context.Operators.Add(bk_, bl_);
 				var bn_ = context.Operators.Interval(bg_, bm_, true, false);
 				var bo_ = context.Operators.ConvertDateToDateTime(bn_?.low);
-				var bq_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var bq_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var bs_ = context.Operators.Add(bq_, bf_);
-				var bu_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var bu_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var bw_ = context.Operators.Add(bu_, bj_);
 				var by_ = context.Operators.Add(bw_, bl_);
 				var bz_ = context.Operators.Interval(bs_, by_, true, false);
 				var ca_ = context.Operators.ConvertDateToDateTime(bz_?.high);
-				var cc_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var cc_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var ce_ = context.Operators.Add(cc_, bf_);
-				var cg_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var cg_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var ci_ = context.Operators.Add(cg_, bj_);
 				var ck_ = context.Operators.Add(ci_, bl_);
 				var cl_ = context.Operators.Interval(ce_, ck_, true, false);
-				var cn_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var cn_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var cp_ = context.Operators.Add(cn_, bf_);
-				var cr_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bd_?.BirthDateElement);
+				var cr_ = FHIRHelpers_4_0_001.ToDate(bd_?.BirthDateElement);
 				var ct_ = context.Operators.Add(cr_, bj_);
 				var cv_ = context.Operators.Add(ct_, bl_);
 				var cw_ = context.Operators.Interval(cp_, cv_, true, false);
@@ -764,20 +986,20 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Normalize Abatement")]
-	public CqlInterval<CqlDateTime> Normalize_Abatement(CqlContext context, Condition condition)
+	public CqlInterval<CqlDateTime> Normalize_Abatement(Condition condition)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (condition?.Abatement is FhirDateTime)
 			{
-				var b_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (condition?.Abatement as FhirDateTime));
+				var b_ = FHIRHelpers_4_0_001.ToDateTime((condition?.Abatement as FhirDateTime));
 				var d_ = context.Operators.Interval(b_, b_, true, true);
 
 				return d_;
 			}
 			else if (condition?.Abatement is Period)
 			{
-				var e_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, (condition?.Abatement as Period));
+				var e_ = FHIRHelpers_4_0_001.ToInterval((condition?.Abatement as Period));
 
 				return e_;
 			}
@@ -790,32 +1012,32 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else if (condition?.Abatement is Age)
 			{
-				var h_ = this.Patient(context);
-				var i_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
-				var j_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (condition?.Abatement as Age));
+				var h_ = this.Patient();
+				var i_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
+				var j_ = FHIRHelpers_4_0_001.ToQuantity((condition?.Abatement as Age));
 				var k_ = context.Operators.Add(i_, j_);
-				var m_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var m_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var o_ = context.Operators.Add(m_, j_);
 				var p_ = context.Operators.Quantity(1m, "year");
 				var q_ = context.Operators.Add(o_, p_);
 				var r_ = context.Operators.Interval(k_, q_, true, false);
 				var s_ = context.Operators.ConvertDateToDateTime(r_?.low);
-				var u_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var u_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var w_ = context.Operators.Add(u_, j_);
-				var y_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var y_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var aa_ = context.Operators.Add(y_, j_);
 				var ac_ = context.Operators.Add(aa_, p_);
 				var ad_ = context.Operators.Interval(w_, ac_, true, false);
 				var ae_ = context.Operators.ConvertDateToDateTime(ad_?.high);
-				var ag_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var ag_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var ai_ = context.Operators.Add(ag_, j_);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var ak_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var am_ = context.Operators.Add(ak_, j_);
 				var ao_ = context.Operators.Add(am_, p_);
 				var ap_ = context.Operators.Interval(ai_, ao_, true, false);
-				var ar_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var ar_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var at_ = context.Operators.Add(ar_, j_);
-				var av_ = FHIRHelpers_4_0_001.Instance.ToDate(context, h_?.BirthDateElement);
+				var av_ = FHIRHelpers_4_0_001.ToDate(h_?.BirthDateElement);
 				var ax_ = context.Operators.Add(av_, j_);
 				var az_ = context.Operators.Add(ax_, p_);
 				var ba_ = context.Operators.Interval(at_, az_, true, false);
@@ -825,33 +1047,33 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else if (condition?.Abatement is Range)
 			{
-				var bc_ = this.Patient(context);
-				var bd_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
-				var be_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (condition?.Abatement as Range)?.Low);
+				var bc_ = this.Patient();
+				var bd_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
+				var be_ = FHIRHelpers_4_0_001.ToQuantity((condition?.Abatement as Range)?.Low);
 				var bf_ = context.Operators.Add(bd_, be_);
-				var bh_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
-				var bi_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (condition?.Abatement as Range)?.High);
+				var bh_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
+				var bi_ = FHIRHelpers_4_0_001.ToQuantity((condition?.Abatement as Range)?.High);
 				var bj_ = context.Operators.Add(bh_, bi_);
 				var bk_ = context.Operators.Quantity(1m, "year");
 				var bl_ = context.Operators.Add(bj_, bk_);
 				var bm_ = context.Operators.Interval(bf_, bl_, true, false);
 				var bn_ = context.Operators.ConvertDateToDateTime(bm_?.low);
-				var bp_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var bp_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var br_ = context.Operators.Add(bp_, be_);
-				var bt_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var bt_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var bv_ = context.Operators.Add(bt_, bi_);
 				var bx_ = context.Operators.Add(bv_, bk_);
 				var by_ = context.Operators.Interval(br_, bx_, true, false);
 				var bz_ = context.Operators.ConvertDateToDateTime(by_?.high);
-				var cb_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var cb_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var cd_ = context.Operators.Add(cb_, be_);
-				var cf_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var cf_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var ch_ = context.Operators.Add(cf_, bi_);
 				var cj_ = context.Operators.Add(ch_, bk_);
 				var ck_ = context.Operators.Interval(cd_, cj_, true, false);
-				var cm_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var cm_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var co_ = context.Operators.Add(cm_, be_);
-				var cq_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bc_?.BirthDateElement);
+				var cq_ = FHIRHelpers_4_0_001.ToDate(bc_?.BirthDateElement);
 				var cs_ = context.Operators.Add(cq_, bi_);
 				var cu_ = context.Operators.Add(cs_, bk_);
 				var cv_ = context.Operators.Interval(co_, cu_, true, false);
@@ -861,9 +1083,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else if (condition?.Abatement is FhirBoolean)
 			{
-				var cx_ = this.Normalize_Interval(context, condition?.Onset);
+				var cx_ = this.Normalize_Interval(condition?.Onset);
 				var cy_ = context.Operators.End(cx_);
-				var cz_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, condition?.RecordedDateElement);
+				var cz_ = FHIRHelpers_4_0_001.ToDateTime(condition?.RecordedDateElement);
 				var da_ = context.Operators.Interval(cy_, cz_, true, false);
 
 				return da_;
@@ -880,15 +1102,15 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Prevalence Period")]
-	public CqlInterval<CqlDateTime> Prevalence_Period(CqlContext context, Condition condition)
+	public CqlInterval<CqlDateTime> Prevalence_Period(Condition condition)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
-			if ((context.Operators.Or(context.Operators.Or(context.Operators.Equivalent(FHIRHelpers_4_0_001.Instance.ToConcept(context, condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.active(context))), context.Operators.Equivalent(FHIRHelpers_4_0_001.Instance.ToConcept(context, condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.recurrence(context)))), context.Operators.Equivalent(FHIRHelpers_4_0_001.Instance.ToConcept(context, condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.relapse(context)))) ?? false))
+			if ((context.Operators.Or(context.Operators.Or(context.Operators.Equivalent(FHIRHelpers_4_0_001.ToConcept(condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.active())), context.Operators.Equivalent(FHIRHelpers_4_0_001.ToConcept(condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.recurrence()))), context.Operators.Equivalent(FHIRHelpers_4_0_001.ToConcept(condition?.ClinicalStatus), context.Operators.ConvertCodeToConcept(this.relapse()))) ?? false))
 			{
-				var b_ = this.Normalize_Interval(context, condition?.Onset);
+				var b_ = this.Normalize_Interval(condition?.Onset);
 				var c_ = context.Operators.Start(b_);
-				var d_ = this.Normalize_Abatement(context, condition);
+				var d_ = this.Normalize_Abatement(condition);
 				var e_ = context.Operators.End(d_);
 				var f_ = context.Operators.Interval(c_, e_, true, true);
 
@@ -896,9 +1118,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			}
 			else
 			{
-				var g_ = this.Normalize_Interval(context, condition?.Onset);
+				var g_ = this.Normalize_Interval(condition?.Onset);
 				var h_ = context.Operators.Start(g_);
-				var i_ = this.Normalize_Abatement(context, condition);
+				var i_ = this.Normalize_Abatement(condition);
 				var j_ = context.Operators.End(i_);
 				var k_ = context.Operators.Interval(h_, j_, true, false);
 
@@ -910,7 +1132,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetId")]
-	public string GetId(CqlContext context, string uri)
+	public string GetId(string uri)
 	{
 		var a_ = context.Operators.Split(uri, "/");
 		var b_ = context.Operators.LastOfList<string>(a_);
@@ -919,7 +1141,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("EncounterDiagnosis")]
-	public IEnumerable<Condition> EncounterDiagnosis(CqlContext context, Encounter Encounter)
+	public IEnumerable<Condition> EncounterDiagnosis(Encounter Encounter)
 	{
 		Condition a_(Encounter.DiagnosisComponent D)
 		{
@@ -928,7 +1150,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			{
 				var g_ = context.Operators.Convert<string>(C?.IdElement);
 				var h_ = context.Operators.Convert<string>(D?.Condition?.ReferenceElement);
-				var i_ = this.GetId(context, h_);
+				var i_ = this.GetId(h_);
 				var j_ = context.Operators.Equal(g_, i_);
 
 				return j_;
@@ -944,14 +1166,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetCondition")]
-	public Condition GetCondition(CqlContext context, ResourceReference reference)
+	public Condition GetCondition(ResourceReference reference)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Condition>(null, null);
 		bool? b_(Condition C)
 		{
 			var e_ = context.Operators.Convert<string>(C?.IdElement);
 			var f_ = context.Operators.Convert<string>(reference?.ReferenceElement);
-			var g_ = this.GetId(context, f_);
+			var g_ = this.GetId(f_);
 			var h_ = context.Operators.Equal(e_, g_);
 
 			return h_;
@@ -963,7 +1185,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetExtensions")]
-	public IEnumerable<Extension> GetExtensions(CqlContext context, DomainResource domainResource, string url)
+	public IEnumerable<Extension> GetExtensions(DomainResource domainResource, string url)
 	{
 		bool? a_(Extension E)
 		{
@@ -983,7 +1205,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetExtensions")]
-	public IEnumerable<Extension> GetExtensions(CqlContext context, Element element, string url)
+	public IEnumerable<Extension> GetExtensions(Element element, string url)
 	{
 		bool? a_(Extension E)
 		{
@@ -1002,38 +1224,38 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetExtension")]
-	public Extension GetExtension(CqlContext context, DomainResource domainResource, string url)
+	public Extension GetExtension(DomainResource domainResource, string url)
 	{
-		var a_ = this.GetExtensions(context, domainResource, url);
+		var a_ = this.GetExtensions(domainResource, url);
 		var b_ = context.Operators.SingleOrNull<Extension>(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("GetExtension")]
-	public Extension GetExtension(CqlContext context, Element element, string url)
+	public Extension GetExtension(Element element, string url)
 	{
-		var a_ = this.GetExtensions(context, element, url);
+		var a_ = this.GetExtensions(element, url);
 		var b_ = context.Operators.SingleOrNull<Extension>(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("PresentOnAdmissionIndicator")]
-	public CodeableConcept PresentOnAdmissionIndicator(CqlContext context, Element element)
+	public CodeableConcept PresentOnAdmissionIndicator(Element element)
 	{
-		var a_ = this.GetExtension(context, element, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
+		var a_ = this.GetExtension(element, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter-diagnosisPresentOnAdmission");
 
 		return (a_?.Value as CodeableConcept);
 	}
 
     [CqlDeclaration("PrincipalDiagnosis")]
-	public Condition PrincipalDiagnosis(CqlContext context, Encounter Encounter)
+	public Condition PrincipalDiagnosis(Encounter Encounter)
 	{
 		bool? a_(Encounter.DiagnosisComponent D)
 		{
 			var h_ = context.Operators.Convert<Integer>(D?.RankElement);
-			var i_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, h_);
+			var i_ = FHIRHelpers_4_0_001.ToInteger(h_);
 			var j_ = context.Operators.Equal(i_, (int?)1);
 
 			return j_;
@@ -1051,7 +1273,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 			{
 				var o_ = context.Operators.Convert<string>(C?.IdElement);
 				var p_ = context.Operators.Convert<string>(PD?.Condition?.ReferenceElement);
-				var q_ = this.GetId(context, p_);
+				var q_ = this.GetId(p_);
 				var r_ = context.Operators.Equal(o_, q_);
 
 				return r_;
@@ -1068,14 +1290,14 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetLocation")]
-	public Location GetLocation(CqlContext context, ResourceReference reference)
+	public Location GetLocation(ResourceReference reference)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Location>(null, null);
 		bool? b_(Location L)
 		{
 			var e_ = context.Operators.Convert<string>(L?.IdElement);
 			var f_ = context.Operators.Convert<string>(reference?.ReferenceElement);
-			var g_ = this.GetId(context, f_);
+			var g_ = this.GetId(f_);
 			var h_ = context.Operators.Equal(e_, g_);
 
 			return h_;
@@ -1087,7 +1309,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetBaseExtensions")]
-	public IEnumerable<Extension> GetBaseExtensions(CqlContext context, DomainResource domainResource, string url)
+	public IEnumerable<Extension> GetBaseExtensions(DomainResource domainResource, string url)
 	{
 		bool? a_(Extension E)
 		{
@@ -1107,9 +1329,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("GetBaseExtension")]
-	public Extension GetBaseExtension(CqlContext context, DomainResource domainResource, string url)
+	public Extension GetBaseExtension(DomainResource domainResource, string url)
 	{
-		var a_ = this.GetBaseExtensions(context, domainResource, url);
+		var a_ = this.GetBaseExtensions(domainResource, url);
 		var b_ = context.Operators.SingleOrNull<Extension>(a_);
 
 		return b_;
@@ -1118,7 +1340,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("BaseExtensions")]
     [CqlTag("description", "Returns any base-FHIR extensions defined on the given element with the specified id.")]
     [CqlTag("comment", "NOTE: Extensions are not the preferred approach, but are used as a way to access content that is defined by extensions but not yet surfaced in the CQL model info.")]
-	public IEnumerable<Extension> BaseExtensions(CqlContext context, Element element, string id)
+	public IEnumerable<Extension> BaseExtensions(Element element, string id)
 	{
 		bool? a_(Extension E)
 		{
@@ -1140,16 +1362,16 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
     [CqlDeclaration("BaseExtension")]
     [CqlTag("description", "Returns the single base-FHIR extension (if present) on the given element with the specified id.")]
     [CqlTag("comment", "This function uses singleton from to ensure that a run-time exception is thrown if there is more than one extension on the given resource with the specified url.")]
-	public Extension BaseExtension(CqlContext context, Element element, string id)
+	public Extension BaseExtension(Element element, string id)
 	{
-		var a_ = this.BaseExtensions(context, element, id);
+		var a_ = this.BaseExtensions(element, id);
 		var b_ = context.Operators.SingleOrNull<Extension>(a_);
 
 		return b_;
 	}
 
     [CqlDeclaration("GetMedicationCode")]
-	public CodeableConcept GetMedicationCode(CqlContext context, MedicationRequest request)
+	public CodeableConcept GetMedicationCode(MedicationRequest request)
 	{
 		CodeableConcept a_()
 		{
@@ -1164,7 +1386,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 				{
 					var f_ = context.Operators.Convert<string>(M?.IdElement);
 					var g_ = context.Operators.Convert<string>((request?.Medication as ResourceReference)?.ReferenceElement);
-					var h_ = this.GetId(context, g_);
+					var h_ = this.GetId(g_);
 					var i_ = context.Operators.Equal(f_, h_);
 
 					return i_;
@@ -1180,7 +1402,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("HasStart")]
-	public bool? HasStart(CqlContext context, CqlInterval<CqlDateTime> period)
+	public bool? HasStart(CqlInterval<CqlDateTime> period)
 	{
 		var a_ = context.Operators.Start(period);
 		var c_ = context.Operators.Minimum<CqlDateTime>();
@@ -1192,7 +1414,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("HasEnd")]
-	public bool? HasEnd(CqlContext context, CqlInterval<CqlDateTime> period)
+	public bool? HasEnd(CqlInterval<CqlDateTime> period)
 	{
 		var a_ = context.Operators.End(period);
 		var c_ = context.Operators.Maximum<CqlDateTime>();
@@ -1204,9 +1426,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Latest")]
-	public CqlDateTime Latest(CqlContext context, object choice)
+	public CqlDateTime Latest(object choice)
 	{
-		var a_ = this.Normalize_Interval(context, choice);
+		var a_ = this.Normalize_Interval(choice);
 		var b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
@@ -1215,7 +1437,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		{
 			CqlDateTime f_()
 			{
-				if ((this.HasEnd(context, period) ?? false))
+				if ((this.HasEnd(period) ?? false))
 				{
 					var g_ = context.Operators.End(period);
 
@@ -1238,9 +1460,9 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 	}
 
     [CqlDeclaration("Earliest")]
-	public CqlDateTime Earliest(CqlContext context, object choice)
+	public CqlDateTime Earliest(object choice)
 	{
-		var a_ = this.Normalize_Interval(context, choice);
+		var a_ = this.Normalize_Interval(choice);
 		var b_ = new CqlInterval<CqlDateTime>[]
 		{
 			a_,
@@ -1249,7 +1471,7 @@ public class MATGlobalCommonFunctionsFHIR4_6_1_000
 		{
 			CqlDateTime f_()
 			{
-				if ((this.HasStart(context, period) ?? false))
+				if ((this.HasStart(period) ?? false))
 				{
 					var g_ = context.Operators.Start(period);
 

--- a/Demo/Measures/NCQAAdvancedIllnessandFrailty-1.0.0.cs
+++ b/Demo/Measures/NCQAAdvancedIllnessandFrailty-1.0.0.cs
@@ -14,83 +14,199 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAAdvancedIllnessandFrailty_1_0_0
 {
 
-    public static NCQAAdvancedIllnessandFrailty_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Acute_Inpatient;
+    internal Lazy<CqlValueSet> __Advanced_Illness;
+    internal Lazy<CqlValueSet> __Dementia_Medications;
+    internal Lazy<CqlValueSet> __ED;
+    internal Lazy<CqlValueSet> __Frailty_Device;
+    internal Lazy<CqlValueSet> __Frailty_Diagnosis;
+    internal Lazy<CqlValueSet> __Frailty_Encounter;
+    internal Lazy<CqlValueSet> __Frailty_Symptom;
+    internal Lazy<CqlValueSet> __Nonacute_Inpatient;
+    internal Lazy<CqlValueSet> __Observation;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Outpatient;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Has_Criteria_Indicating_Frailty;
+    internal Lazy<IEnumerable<CqlDate>> __Outpatient_Encounters_with_Advanced_Illness;
+    internal Lazy<IEnumerable<CqlDate>> __Nonacute_Inpatient_Discharge_with_Advanced_Illness;
+    internal Lazy<IEnumerable<CqlDate>> __Outpatient_Encounters_or_Discharges_with_Advanced_Illness;
+    internal Lazy<bool?> __Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service;
+    internal Lazy<bool?> __Acute_Inpatient_Encounter_with_Advanced_Illness;
+    internal Lazy<bool?> __Acute_Inpatient_Discharge_with_Advanced_Illness;
+    internal Lazy<bool?> __Dementia_Medications_In_Year_Before_or_During_Measurement_Period;
+    internal Lazy<bool?> __Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80;
+    internal Lazy<bool?> __Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80;
+
+    #endregion
+    public NCQAAdvancedIllnessandFrailty_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQAStatus_1_0_0 = new NCQAStatus_1_0_0(context);
+        NCQAEncounter_1_0_0 = new NCQAEncounter_1_0_0(context);
+        NCQAClaims_1_0_0 = new NCQAClaims_1_0_0(context);
+
+        __Acute_Inpatient = new Lazy<CqlValueSet>(this.Acute_Inpatient_Value(context));
+        __Advanced_Illness = new Lazy<CqlValueSet>(this.Advanced_Illness_Value(context));
+        __Dementia_Medications = new Lazy<CqlValueSet>(this.Dementia_Medications_Value(context));
+        __ED = new Lazy<CqlValueSet>(this.ED_Value(context));
+        __Frailty_Device = new Lazy<CqlValueSet>(this.Frailty_Device_Value(context));
+        __Frailty_Diagnosis = new Lazy<CqlValueSet>(this.Frailty_Diagnosis_Value(context));
+        __Frailty_Encounter = new Lazy<CqlValueSet>(this.Frailty_Encounter_Value(context));
+        __Frailty_Symptom = new Lazy<CqlValueSet>(this.Frailty_Symptom_Value(context));
+        __Nonacute_Inpatient = new Lazy<CqlValueSet>(this.Nonacute_Inpatient_Value(context));
+        __Observation = new Lazy<CqlValueSet>(this.Observation_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Outpatient = new Lazy<CqlValueSet>(this.Outpatient_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Has_Criteria_Indicating_Frailty = new Lazy<bool?>(this.Has_Criteria_Indicating_Frailty_Value(context));
+        __Outpatient_Encounters_with_Advanced_Illness = new Lazy<IEnumerable<CqlDate>>(this.Outpatient_Encounters_with_Advanced_Illness_Value(context));
+        __Nonacute_Inpatient_Discharge_with_Advanced_Illness = new Lazy<IEnumerable<CqlDate>>(this.Nonacute_Inpatient_Discharge_with_Advanced_Illness_Value(context));
+        __Outpatient_Encounters_or_Discharges_with_Advanced_Illness = new Lazy<IEnumerable<CqlDate>>(this.Outpatient_Encounters_or_Discharges_with_Advanced_Illness_Value(context));
+        __Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service = new Lazy<bool?>(this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service_Value(context));
+        __Acute_Inpatient_Encounter_with_Advanced_Illness = new Lazy<bool?>(this.Acute_Inpatient_Encounter_with_Advanced_Illness_Value(context));
+        __Acute_Inpatient_Discharge_with_Advanced_Illness = new Lazy<bool?>(this.Acute_Inpatient_Discharge_with_Advanced_Illness_Value(context));
+        __Dementia_Medications_In_Year_Before_or_During_Measurement_Period = new Lazy<bool?>(this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value(context));
+        __Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80 = new Lazy<bool?>(this.Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80_Value(context));
+        __Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80 = new Lazy<bool?>(this.Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQAStatus_1_0_0 NCQAStatus_1_0_0 { get; }
+    public NCQAEncounter_1_0_0 NCQAEncounter_1_0_0 { get; }
+    public NCQAClaims_1_0_0 NCQAClaims_1_0_0 { get; }
+
+    #endregion
+
+	private CqlValueSet Acute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", null);
 
     [CqlDeclaration("Acute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810")]
-	public CqlValueSet Acute_Inpatient(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1810", null);
+	public CqlValueSet Acute_Inpatient() => 
+		__Acute_Inpatient?.Value;
+
+	private CqlValueSet Advanced_Illness_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", null);
 
     [CqlDeclaration("Advanced Illness")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465")]
-	public CqlValueSet Advanced_Illness(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1465", null);
+	public CqlValueSet Advanced_Illness() => 
+		__Advanced_Illness?.Value;
+
+	private CqlValueSet Dementia_Medications_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", null);
 
     [CqlDeclaration("Dementia Medications")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729")]
-	public CqlValueSet Dementia_Medications(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1729", null);
+	public CqlValueSet Dementia_Medications() => 
+		__Dementia_Medications?.Value;
+
+	private CqlValueSet ED_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", null);
 
     [CqlDeclaration("ED")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086")]
-	public CqlValueSet ED(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1086", null);
+	public CqlValueSet ED() => 
+		__ED?.Value;
+
+	private CqlValueSet Frailty_Device_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", null);
 
     [CqlDeclaration("Frailty Device")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530")]
-	public CqlValueSet Frailty_Device(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1530", null);
+	public CqlValueSet Frailty_Device() => 
+		__Frailty_Device?.Value;
+
+	private CqlValueSet Frailty_Diagnosis_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", null);
 
     [CqlDeclaration("Frailty Diagnosis")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531")]
-	public CqlValueSet Frailty_Diagnosis(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1531", null);
+	public CqlValueSet Frailty_Diagnosis() => 
+		__Frailty_Diagnosis?.Value;
+
+	private CqlValueSet Frailty_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", null);
 
     [CqlDeclaration("Frailty Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532")]
-	public CqlValueSet Frailty_Encounter(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1532", null);
+	public CqlValueSet Frailty_Encounter() => 
+		__Frailty_Encounter?.Value;
+
+	private CqlValueSet Frailty_Symptom_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", null);
 
     [CqlDeclaration("Frailty Symptom")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533")]
-	public CqlValueSet Frailty_Symptom(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1533", null);
+	public CqlValueSet Frailty_Symptom() => 
+		__Frailty_Symptom?.Value;
+
+	private CqlValueSet Nonacute_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", null);
 
     [CqlDeclaration("Nonacute Inpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189")]
-	public CqlValueSet Nonacute_Inpatient(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1189", null);
+	public CqlValueSet Nonacute_Inpatient() => 
+		__Nonacute_Inpatient?.Value;
+
+	private CqlValueSet Observation_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", null);
 
     [CqlDeclaration("Observation")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191")]
-	public CqlValueSet Observation(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1191", null);
+	public CqlValueSet Observation() => 
+		__Observation?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1446", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Outpatient_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", null);
 
     [CqlDeclaration("Outpatient")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202")]
-	public CqlValueSet Outpatient(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1202", null);
+	public CqlValueSet Outpatient() => 
+		__Outpatient?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1246", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("NCQAAdvancedIllnessandFrailty-1.0.0", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -98,28 +214,31 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return b_;
 	}
 
-    [CqlDeclaration("Has Criteria Indicating Frailty")]
-	public bool? Has_Criteria_Indicating_Frailty(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private bool? Has_Criteria_Indicating_Frailty_Value(CqlContext context)
 	{
-		var a_ = this.Frailty_Device(context);
+		var a_ = this.Frailty_Device();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation FrailtyDeviceApplied)
 		{
-			var z_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, FrailtyDeviceApplied?.Effective);
-			var aa_ = this.Measurement_Period(context);
+			var z_ = NCQAFHIRBase_1_0_0.Normalize_Interval(FrailtyDeviceApplied?.Effective);
+			var aa_ = this.Measurement_Period();
 			var ab_ = context.Operators.Overlaps(z_, aa_, null);
 
 			return ab_;
 		};
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		var e_ = context.Operators.ExistsInList<Observation>(d_);
-		var f_ = this.Frailty_Diagnosis(context);
+		var f_ = this.Frailty_Diagnosis();
 		var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
-		var h_ = NCQAStatus_1_0_0.Instance.Active_Condition(context, g_);
+		var h_ = NCQAStatus_1_0_0.Active_Condition(g_);
 		bool? i_(Condition FrailtyDiagnosis)
 		{
-			var ac_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, FrailtyDiagnosis);
-			var ad_ = this.Measurement_Period(context);
+			var ac_ = NCQAFHIRBase_1_0_0.Prevalence_Period(FrailtyDiagnosis);
+			var ad_ = this.Measurement_Period();
 			var ae_ = context.Operators.Overlaps(ac_, ad_, null);
 
 			return ae_;
@@ -127,13 +246,13 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		var j_ = context.Operators.WhereOrNull<Condition>(h_, i_);
 		var k_ = context.Operators.ExistsInList<Condition>(j_);
 		var l_ = context.Operators.Or(e_, k_);
-		var m_ = this.Frailty_Encounter(context);
+		var m_ = this.Frailty_Encounter();
 		var n_ = context.Operators.RetrieveByValueSet<Encounter>(m_, null);
-		var o_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, n_);
+		var o_ = NCQAStatus_1_0_0.Finished_Encounter(n_);
 		bool? p_(Encounter FrailtyEncounter)
 		{
-			var af_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (FrailtyEncounter?.Period as object));
-			var ag_ = this.Measurement_Period(context);
+			var af_ = NCQAFHIRBase_1_0_0.Normalize_Interval((FrailtyEncounter?.Period as object));
+			var ag_ = this.Measurement_Period();
 			var ah_ = context.Operators.Overlaps(af_, ag_, null);
 
 			return ah_;
@@ -141,12 +260,12 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		var q_ = context.Operators.WhereOrNull<Encounter>(o_, p_);
 		var r_ = context.Operators.ExistsInList<Encounter>(q_);
 		var s_ = context.Operators.Or(l_, r_);
-		var t_ = this.Frailty_Symptom(context);
+		var t_ = this.Frailty_Symptom();
 		var u_ = context.Operators.RetrieveByValueSet<Observation>(t_, null);
 		bool? v_(Observation FrailtySymptom)
 		{
-			var ai_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, FrailtySymptom?.Effective);
-			var aj_ = this.Measurement_Period(context);
+			var ai_ = NCQAFHIRBase_1_0_0.Normalize_Interval(FrailtySymptom?.Effective);
+			var aj_ = this.Measurement_Period();
 			var ak_ = context.Operators.Overlaps(ai_, aj_, null);
 
 			return ak_;
@@ -158,36 +277,39 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return y_;
 	}
 
-    [CqlDeclaration("Outpatient Encounters with Advanced Illness")]
-	public IEnumerable<CqlDate> Outpatient_Encounters_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Has Criteria Indicating Frailty")]
+	public bool? Has_Criteria_Indicating_Frailty() => 
+		__Has_Criteria_Indicating_Frailty?.Value;
+
+	private IEnumerable<CqlDate> Outpatient_Encounters_with_Advanced_Illness_Value(CqlContext context)
 	{
-		var a_ = this.Outpatient(context);
+		var a_ = this.Outpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Observation(context);
+		var c_ = this.Observation();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.ED(context);
+		var f_ = this.ED();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Telephone_Visits(context);
+		var h_ = this.Telephone_Visits();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Online_Assessments(context);
+		var l_ = this.Online_Assessments();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Nonacute_Inpatient(context);
+		var n_ = this.Nonacute_Inpatient();
 		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
 		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
-		var r_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, q_);
+		var r_ = NCQAStatus_1_0_0.Finished_Encounter(q_);
 		bool? s_(Encounter OutpatientEncounter)
 		{
-			var w_ = this.Advanced_Illness(context);
+			var w_ = this.Advanced_Illness();
 			var x_ = context.Operators.RetrieveByValueSet<Condition>(w_, null);
-			var y_ = NCQAEncounter_1_0_0.Instance.Encounter_Has_Diagnosis(context, OutpatientEncounter, x_);
-			var z_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (OutpatientEncounter?.Period as object));
+			var y_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(OutpatientEncounter, x_);
+			var z_ = NCQAFHIRBase_1_0_0.Normalize_Interval((OutpatientEncounter?.Period as object));
 			var aa_ = context.Operators.Start(z_);
 			var ab_ = context.Operators.DateFrom(aa_);
-			var ac_ = this.Measurement_Period(context);
+			var ac_ = this.Measurement_Period();
 			var ad_ = context.Operators.Start(ac_);
 			var ae_ = context.Operators.DateFrom(ad_);
 			var af_ = context.Operators.Quantity(1m, "year");
@@ -203,7 +325,7 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		var t_ = context.Operators.WhereOrNull<Encounter>(r_, s_);
 		CqlDate u_(Encounter EncounterWithDiagnosis)
 		{
-			var an_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (EncounterWithDiagnosis?.Period as object));
+			var an_ = NCQAFHIRBase_1_0_0.Normalize_Interval((EncounterWithDiagnosis?.Period as object));
 			var ao_ = context.Operators.End(an_);
 			var ap_ = context.Operators.DateFrom(ao_);
 
@@ -214,19 +336,22 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return v_;
 	}
 
-    [CqlDeclaration("Nonacute Inpatient Discharge with Advanced Illness")]
-	public IEnumerable<CqlDate> Nonacute_Inpatient_Discharge_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Outpatient Encounters with Advanced Illness")]
+	public IEnumerable<CqlDate> Outpatient_Encounters_with_Advanced_Illness() => 
+		__Outpatient_Encounters_with_Advanced_Illness?.Value;
+
+	private IEnumerable<CqlDate> Nonacute_Inpatient_Discharge_with_Advanced_Illness_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Claim>(null, null);
-		var b_ = NCQAClaims_1_0_0.Instance.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(context, a_);
-		var c_ = this.Advanced_Illness(context);
+		var b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
+		var c_ = this.Advanced_Illness();
 		var d_ = context.Operators.CreateValueSetFacade(c_);
-		var e_ = NCQAClaims_1_0_0.Instance.Medical_Claims_With_Diagnosis(context, b_?.NonacuteInpatientDischarge, d_);
+		var e_ = NCQAClaims_1_0_0.Medical_Claims_With_Diagnosis(b_?.NonacuteInpatientDischarge, d_);
 		bool? f_(CqlInterval<CqlDateTime> DischargeWithDiagnosis)
 		{
 			var j_ = context.Operators.End(DischargeWithDiagnosis);
 			var k_ = context.Operators.DateFrom(j_);
-			var l_ = this.Measurement_Period(context);
+			var l_ = this.Measurement_Period();
 			var m_ = context.Operators.Start(l_);
 			var n_ = context.Operators.DateFrom(m_);
 			var o_ = context.Operators.Quantity(1m, "year");
@@ -251,28 +376,31 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return i_;
 	}
 
-    [CqlDeclaration("Outpatient Encounters or Discharges with Advanced Illness")]
-	public IEnumerable<CqlDate> Outpatient_Encounters_or_Discharges_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Nonacute Inpatient Discharge with Advanced Illness")]
+	public IEnumerable<CqlDate> Nonacute_Inpatient_Discharge_with_Advanced_Illness() => 
+		__Nonacute_Inpatient_Discharge_with_Advanced_Illness?.Value;
+
+	private IEnumerable<CqlDate> Outpatient_Encounters_or_Discharges_with_Advanced_Illness_Value(CqlContext context)
 	{
 		IEnumerable<CqlDate> a_()
 		{
-			if ((context.Operators.Not((bool?)(context.Operators.ListUnion<CqlDate>(this.Outpatient_Encounters_with_Advanced_Illness(context), this.Nonacute_Inpatient_Discharge_with_Advanced_Illness(context)) is null)) ?? false))
+			if ((context.Operators.Not((bool?)(context.Operators.ListUnion<CqlDate>(this.Outpatient_Encounters_with_Advanced_Illness(), this.Nonacute_Inpatient_Discharge_with_Advanced_Illness()) is null)) ?? false))
 			{
-				var b_ = this.Outpatient_Encounters_with_Advanced_Illness(context);
-				var c_ = this.Nonacute_Inpatient_Discharge_with_Advanced_Illness(context);
+				var b_ = this.Outpatient_Encounters_with_Advanced_Illness();
+				var c_ = this.Nonacute_Inpatient_Discharge_with_Advanced_Illness();
 				var d_ = context.Operators.ListUnion<CqlDate>(b_, c_);
 
 				return d_;
 			}
-			else if ((this.Outpatient_Encounters_with_Advanced_Illness(context) is null))
+			else if ((this.Outpatient_Encounters_with_Advanced_Illness() is null))
 			{
-				var e_ = this.Nonacute_Inpatient_Discharge_with_Advanced_Illness(context);
+				var e_ = this.Nonacute_Inpatient_Discharge_with_Advanced_Illness();
 
 				return e_;
 			}
-			else if ((this.Nonacute_Inpatient_Discharge_with_Advanced_Illness(context) is null))
+			else if ((this.Nonacute_Inpatient_Discharge_with_Advanced_Illness() is null))
 			{
-				var f_ = this.Outpatient_Encounters_with_Advanced_Illness(context);
+				var f_ = this.Outpatient_Encounters_with_Advanced_Illness();
 
 				return f_;
 			}
@@ -287,13 +415,16 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return a_();
 	}
 
-    [CqlDeclaration("Two Outpatient Visits with Advanced Illness on Different Dates of Service")]
-	public bool? Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service(CqlContext context)
+    [CqlDeclaration("Outpatient Encounters or Discharges with Advanced Illness")]
+	public IEnumerable<CqlDate> Outpatient_Encounters_or_Discharges_with_Advanced_Illness() => 
+		__Outpatient_Encounters_or_Discharges_with_Advanced_Illness?.Value;
+
+	private bool? Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service_Value(CqlContext context)
 	{
-		var a_ = this.Outpatient_Encounters_or_Discharges_with_Advanced_Illness(context);
+		var a_ = this.Outpatient_Encounters_or_Discharges_with_Advanced_Illness();
 		IEnumerable<CqlDate> b_(CqlDate _OutpatientVisit1)
 		{
-			var j_ = this.Outpatient_Encounters_or_Discharges_with_Advanced_Illness(context);
+			var j_ = this.Outpatient_Encounters_or_Discharges_with_Advanced_Illness();
 
 			return j_;
 		};
@@ -325,21 +456,24 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return i_;
 	}
 
-    [CqlDeclaration("Acute Inpatient Encounter with Advanced Illness")]
-	public bool? Acute_Inpatient_Encounter_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Two Outpatient Visits with Advanced Illness on Different Dates of Service")]
+	public bool? Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service() => 
+		__Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service?.Value;
+
+	private bool? Acute_Inpatient_Encounter_with_Advanced_Illness_Value(CqlContext context)
 	{
-		var a_ = this.Acute_Inpatient(context);
+		var a_ = this.Acute_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, b_);
+		var c_ = NCQAStatus_1_0_0.Finished_Encounter(b_);
 		bool? d_(Encounter InpatientEncounter)
 		{
-			var g_ = this.Advanced_Illness(context);
+			var g_ = this.Advanced_Illness();
 			var h_ = context.Operators.RetrieveByValueSet<Condition>(g_, null);
-			var i_ = NCQAEncounter_1_0_0.Instance.Encounter_Has_Diagnosis(context, InpatientEncounter, h_);
-			var j_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (InpatientEncounter?.Period as object));
+			var i_ = NCQAEncounter_1_0_0.Encounter_Has_Diagnosis(InpatientEncounter, h_);
+			var j_ = NCQAFHIRBase_1_0_0.Normalize_Interval((InpatientEncounter?.Period as object));
 			var k_ = context.Operators.Start(j_);
 			var l_ = context.Operators.DateFrom(k_);
-			var m_ = this.Measurement_Period(context);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.Start(m_);
 			var o_ = context.Operators.DateFrom(n_);
 			var p_ = context.Operators.Quantity(1m, "year");
@@ -358,19 +492,22 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return f_;
 	}
 
-    [CqlDeclaration("Acute Inpatient Discharge with Advanced Illness")]
-	public bool? Acute_Inpatient_Discharge_with_Advanced_Illness(CqlContext context)
+    [CqlDeclaration("Acute Inpatient Encounter with Advanced Illness")]
+	public bool? Acute_Inpatient_Encounter_with_Advanced_Illness() => 
+		__Acute_Inpatient_Encounter_with_Advanced_Illness?.Value;
+
+	private bool? Acute_Inpatient_Discharge_with_Advanced_Illness_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Claim>(null, null);
-		var b_ = NCQAClaims_1_0_0.Instance.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(context, a_);
-		var c_ = this.Advanced_Illness(context);
+		var b_ = NCQAClaims_1_0_0.Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(a_);
+		var c_ = this.Advanced_Illness();
 		var d_ = context.Operators.CreateValueSetFacade(c_);
-		var e_ = NCQAClaims_1_0_0.Instance.Medical_Claims_With_Diagnosis(context, b_?.AcuteInpatientDischarge, d_);
+		var e_ = NCQAClaims_1_0_0.Medical_Claims_With_Diagnosis(b_?.AcuteInpatientDischarge, d_);
 		bool? f_(CqlInterval<CqlDateTime> InpatientDischarge)
 		{
 			var i_ = context.Operators.End(InpatientDischarge);
 			var j_ = context.Operators.DateFrom(i_);
-			var k_ = this.Measurement_Period(context);
+			var k_ = this.Measurement_Period();
 			var l_ = context.Operators.Start(k_);
 			var m_ = context.Operators.DateFrom(l_);
 			var n_ = context.Operators.Quantity(1m, "year");
@@ -388,20 +525,23 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return h_;
 	}
 
-    [CqlDeclaration("Dementia Medications In Year Before or During Measurement Period")]
-	public bool? Dementia_Medications_In_Year_Before_or_During_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Acute Inpatient Discharge with Advanced Illness")]
+	public bool? Acute_Inpatient_Discharge_with_Advanced_Illness() => 
+		__Acute_Inpatient_Discharge_with_Advanced_Illness?.Value;
+
+	private bool? Dementia_Medications_In_Year_Before_or_During_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Dementia_Medications(context);
+		var a_ = this.Dementia_Medications();
 		var b_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
 		var d_ = context.Operators.RetrieveByValueSet<MedicationDispense>(a_, null);
 		var e_ = context.Operators.ListUnion<MedicationDispense>(b_, d_);
-		var f_ = NCQAStatus_1_0_0.Instance.Dispensed_Medication(context, e_);
+		var f_ = NCQAStatus_1_0_0.Dispensed_Medication(e_);
 		bool? g_(MedicationDispense DementiaMedDispensed)
 		{
-			var j_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (DementiaMedDispensed?.WhenHandedOverElement as object));
+			var j_ = NCQAFHIRBase_1_0_0.Normalize_Interval((DementiaMedDispensed?.WhenHandedOverElement as object));
 			var k_ = context.Operators.Start(j_);
 			var l_ = context.Operators.DateFrom(k_);
-			var m_ = this.Measurement_Period(context);
+			var m_ = this.Measurement_Period();
 			var n_ = context.Operators.Start(m_);
 			var o_ = context.Operators.DateFrom(n_);
 			var p_ = context.Operators.Quantity(1m, "year");
@@ -419,25 +559,28 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return i_;
 	}
 
-    [CqlDeclaration("Advanced Illness and Frailty Exclusion Including Over Age 80")]
-	public bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80(CqlContext context)
+    [CqlDeclaration("Dementia Medications In Year Before or During Measurement Period")]
+	public bool? Dementia_Medications_In_Year_Before_or_During_Measurement_Period() => 
+		__Dementia_Medications_In_Year_Before_or_During_Measurement_Period?.Value;
+
+	private bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.End(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.Interval((int?)66, (int?)80, true, true);
 		var h_ = context.Operators.ElementInInterval<int?>(f_, g_, null);
-		var i_ = this.Has_Criteria_Indicating_Frailty(context);
+		var i_ = this.Has_Criteria_Indicating_Frailty();
 		var j_ = context.Operators.And(h_, i_);
-		var k_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service(context);
-		var l_ = this.Acute_Inpatient_Encounter_with_Advanced_Illness(context);
+		var k_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service();
+		var l_ = this.Acute_Inpatient_Encounter_with_Advanced_Illness();
 		var m_ = context.Operators.Or(k_, l_);
-		var n_ = this.Acute_Inpatient_Discharge_with_Advanced_Illness(context);
+		var n_ = this.Acute_Inpatient_Discharge_with_Advanced_Illness();
 		var o_ = context.Operators.Or(m_, n_);
-		var p_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period(context);
+		var p_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period();
 		var q_ = context.Operators.Or(o_, p_);
 		var r_ = context.Operators.And(j_, q_);
 		var t_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
@@ -451,28 +594,35 @@ public class NCQAAdvancedIllnessandFrailty_1_0_0
 		return ab_;
 	}
 
-    [CqlDeclaration("Advanced Illness and Frailty Exclusion Not Including Over Age 80")]
-	public bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80(CqlContext context)
+    [CqlDeclaration("Advanced Illness and Frailty Exclusion Including Over Age 80")]
+	public bool? Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80() => 
+		__Advanced_Illness_and_Frailty_Exclusion_Including_Over_Age_80?.Value;
+
+	private bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.End(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
 		var g_ = context.Operators.GreaterOrEqual(f_, (int?)66);
-		var h_ = this.Has_Criteria_Indicating_Frailty(context);
+		var h_ = this.Has_Criteria_Indicating_Frailty();
 		var i_ = context.Operators.And(g_, h_);
-		var j_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service(context);
-		var k_ = this.Acute_Inpatient_Encounter_with_Advanced_Illness(context);
+		var j_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service();
+		var k_ = this.Acute_Inpatient_Encounter_with_Advanced_Illness();
 		var l_ = context.Operators.Or(j_, k_);
-		var m_ = this.Acute_Inpatient_Discharge_with_Advanced_Illness(context);
+		var m_ = this.Acute_Inpatient_Discharge_with_Advanced_Illness();
 		var n_ = context.Operators.Or(l_, m_);
-		var o_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period(context);
+		var o_ = this.Dementia_Medications_In_Year_Before_or_During_Measurement_Period();
 		var p_ = context.Operators.Or(n_, o_);
 		var q_ = context.Operators.And(i_, p_);
 
 		return q_;
 	}
+
+    [CqlDeclaration("Advanced Illness and Frailty Exclusion Not Including Over Age 80")]
+	public bool? Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80() => 
+		__Advanced_Illness_and_Frailty_Exclusion_Not_Including_Over_Age_80?.Value;
 
 }

--- a/Demo/Measures/NCQACQLBase-1.0.0.cs
+++ b/Demo/Measures/NCQACQLBase-1.0.0.cs
@@ -16,6 +16,11 @@ public class NCQACQLBase_1_0_0
 
     public static NCQACQLBase_1_0_0 Instance { get; }  = new();
 
+    #region Dependencies
+
+
+    #endregion
+
     [CqlDeclaration("Sort Date Intervals")]
 	public IEnumerable<CqlInterval<CqlDate>> Sort_Date_Intervals(CqlContext context, IEnumerable<CqlInterval<CqlDate>> intervals)
 	{

--- a/Demo/Measures/NCQAClaims-1.0.0.cs
+++ b/Demo/Measures/NCQAClaims-1.0.0.cs
@@ -14,27 +14,58 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAClaims_1_0_0
 {
 
-    public static NCQAClaims_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Inpatient_Stay;
+    internal Lazy<CqlValueSet> __Nonacute_Inpatient_Stay;
+
+    #endregion
+    public NCQAClaims_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQATerminology_1_0_0 = new NCQATerminology_1_0_0(context);
+
+        __Inpatient_Stay = new Lazy<CqlValueSet>(this.Inpatient_Stay_Value(context));
+        __Nonacute_Inpatient_Stay = new Lazy<CqlValueSet>(this.Nonacute_Inpatient_Stay_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQATerminology_1_0_0 NCQATerminology_1_0_0 { get; }
+
+    #endregion
+
+	private CqlValueSet Inpatient_Stay_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", null);
 
     [CqlDeclaration("Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395")]
-	public CqlValueSet Inpatient_Stay(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1395", null);
+	public CqlValueSet Inpatient_Stay() => 
+		__Inpatient_Stay?.Value;
+
+	private CqlValueSet Nonacute_Inpatient_Stay_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", null);
 
     [CqlDeclaration("Nonacute Inpatient Stay")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398")]
-	public CqlValueSet Nonacute_Inpatient_Stay(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1398", null);
+	public CqlValueSet Nonacute_Inpatient_Stay() => 
+		__Nonacute_Inpatient_Stay?.Value;
 
     [CqlDeclaration("Professional or Institutional Claims")]
-	public IEnumerable<Claim> Professional_or_Institutional_Claims(CqlContext context, IEnumerable<Claim> claim)
+	public IEnumerable<Claim> Professional_or_Institutional_Claims(IEnumerable<Claim> claim)
 	{
 		bool? a_(Claim MedicalClaim)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, MedicalClaim?.Type);
-			var d_ = NCQATerminology_1_0_0.Instance.Professional(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(MedicalClaim?.Type);
+			var d_ = NCQATerminology_1_0_0.Professional();
 			var e_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), d_);
-			var g_ = NCQATerminology_1_0_0.Instance.Institutional(context);
+			var g_ = NCQATerminology_1_0_0.Institutional();
 			var h_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), g_);
 			var i_ = context.Operators.Or(e_, h_);
 
@@ -46,12 +77,12 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Pharmacy Claims")]
-	public IEnumerable<Claim> Pharmacy_Claims(CqlContext context, IEnumerable<Claim> claim)
+	public IEnumerable<Claim> Pharmacy_Claims(IEnumerable<Claim> claim)
 	{
 		bool? a_(Claim PharmacyClaim)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, PharmacyClaim?.Type);
-			var d_ = NCQATerminology_1_0_0.Instance.Pharmacy(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(PharmacyClaim?.Type);
+			var d_ = NCQATerminology_1_0_0.Pharmacy();
 			var e_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), d_);
 
 			return e_;
@@ -62,14 +93,14 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Professional or Institutional Claims Response")]
-	public IEnumerable<ClaimResponse> Professional_or_Institutional_Claims_Response(CqlContext context, IEnumerable<ClaimResponse> claimResponse)
+	public IEnumerable<ClaimResponse> Professional_or_Institutional_Claims_Response(IEnumerable<ClaimResponse> claimResponse)
 	{
 		bool? a_(ClaimResponse MedicalResponse)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, MedicalResponse?.Type);
-			var d_ = NCQATerminology_1_0_0.Instance.Professional(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(MedicalResponse?.Type);
+			var d_ = NCQATerminology_1_0_0.Professional();
 			var e_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), d_);
-			var g_ = NCQATerminology_1_0_0.Instance.Institutional(context);
+			var g_ = NCQATerminology_1_0_0.Institutional();
 			var h_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), g_);
 			var i_ = context.Operators.Or(e_, h_);
 
@@ -81,12 +112,12 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Pharmacy Claims Response")]
-	public IEnumerable<ClaimResponse> Pharmacy_Claims_Response(CqlContext context, IEnumerable<ClaimResponse> claimResponse)
+	public IEnumerable<ClaimResponse> Pharmacy_Claims_Response(IEnumerable<ClaimResponse> claimResponse)
 	{
 		bool? a_(ClaimResponse PharmacyResponse)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, PharmacyResponse?.Type);
-			var d_ = NCQATerminology_1_0_0.Instance.Pharmacy(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(PharmacyResponse?.Type);
+			var d_ = NCQATerminology_1_0_0.Pharmacy();
 			var e_ = context.Operators.ListContains<CqlCode>((c_?.codes as IEnumerable<CqlCode>), d_);
 
 			return e_;
@@ -97,9 +128,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Procedure and POS")]
-	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Procedure_and_POS(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> posCodes, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Procedure_and_POS(IEnumerable<Claim> claim, IEnumerable<CqlCode> posCodes, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode p) => 
 			p?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(ProductOrServiceValueSet, b_);
@@ -132,7 +163,7 @@ public class NCQAClaims_1_0_0
 					{
 						bool? v_(Claim.ItemComponent ItemOnLine)
 						{
-							var x_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, ItemOnLine?.ProductOrService);
+							var x_ = FHIRHelpers_4_0_001.ToConcept(ItemOnLine?.ProductOrService);
 							bool? y_(CqlCode LineCode)
 							{
 								var ag_ = context.Operators.InList<string>(LineCode?.code, ClaimWithPosCode?.ProceduresAsStrings);
@@ -141,7 +172,7 @@ public class NCQAClaims_1_0_0
 							};
 							var z_ = context.Operators.WhereOrNull<CqlCode>((x_?.codes as IEnumerable<CqlCode>), y_);
 							var aa_ = context.Operators.ExistsInList<CqlCode>(z_);
-							var ab_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, (ItemOnLine?.Location as CodeableConcept));
+							var ab_ = FHIRHelpers_4_0_001.ToConcept((ItemOnLine?.Location as CodeableConcept));
 							bool? ac_(CqlCode PosCode)
 							{
 								var ah_ = context.Operators.InList<string>(PosCode?.code, ClaimWithPosCode?.POSAsString);
@@ -186,7 +217,7 @@ public class NCQAClaims_1_0_0
 							var am_ = context.Operators.SelectOrNull<Claim.ItemComponent, DataType>(ak_, al_);
 							CqlInterval<CqlDateTime> an_(DataType NormalDate)
 							{
-								var ar_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate);
+								var ar_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate);
 
 								return ar_;
 							};
@@ -232,9 +263,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Procedure in Header or on Line Item")]
-	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Procedure_in_Header_or_on_Line_Item(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Procedure_in_Header_or_on_Line_Item(IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode p) => 
 			p?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(ProductOrServiceValueSet, b_);
@@ -263,7 +294,7 @@ public class NCQAClaims_1_0_0
 					{
 						bool? t_(Claim.ItemComponent ItemOnLine)
 						{
-							var v_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, ItemOnLine?.ProductOrService);
+							var v_ = FHIRHelpers_4_0_001.ToConcept(ItemOnLine?.ProductOrService);
 							bool? w_(CqlCode LineCode)
 							{
 								var ao_ = context.Operators.InList<string>(LineCode?.code, ClaimWithProcedure?.ProceduresAsStrings);
@@ -345,7 +376,7 @@ public class NCQAClaims_1_0_0
 							var ay_ = context.Operators.SelectOrNull<Claim.ItemComponent, DataType>(aw_, ax_);
 							CqlInterval<CqlDateTime> az_(DataType NormalDate)
 							{
-								var bd_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate);
+								var bd_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate);
 
 								return bd_;
 							};
@@ -391,9 +422,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Diagnosis")]
-	public Tuples.Tuple_HLLRUdKceDPKeIXGFiiNKjMKI Medical_Claims_With_Diagnosis(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet)
+	public Tuples.Tuple_HLLRUdKceDPKeIXGFiiNKjMKI Medical_Claims_With_Diagnosis(IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode d) => 
 			d?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(DiagnosisValueSet, b_);
@@ -492,7 +523,7 @@ public class NCQAClaims_1_0_0
 						var at_ = context.Operators.FlattenList<Claim.ItemComponent>(as_);
 						CqlInterval<CqlDateTime> au_(Claim.ItemComponent NormalDate)
 						{
-							var ay_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate?.Serviced);
+							var ay_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate?.Serviced);
 
 							return ay_;
 						};
@@ -539,9 +570,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Pharmacy Claim With Medication")]
-	public IEnumerable<Tuples.Tuple_FOLKddIQBPRMYYfjeMUjEIBhC> Pharmacy_Claim_With_Medication(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> MedicationCodes)
+	public IEnumerable<Tuples.Tuple_FOLKddIQBPRMYYfjeMUjEIBhC> Pharmacy_Claim_With_Medication(IEnumerable<Claim> claim, IEnumerable<CqlCode> MedicationCodes)
 	{
-		var a_ = this.Pharmacy_Claims(context, claim);
+		var a_ = this.Pharmacy_Claims(claim);
 		string b_(CqlCode p) => 
 			p?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(MedicationCodes, b_);
@@ -560,7 +591,7 @@ public class NCQAClaims_1_0_0
 			{
 				bool? m_(Claim.ItemComponent ItemOnLine)
 				{
-					var t_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, ItemOnLine?.ProductOrService);
+					var t_ = FHIRHelpers_4_0_001.ToConcept(ItemOnLine?.ProductOrService);
 					bool? u_(CqlCode LineCode)
 					{
 						var x_ = context.Operators.InList<string>(LineCode?.code, ClaimWithMedication?.MedicationsAsStrings);
@@ -592,7 +623,7 @@ public class NCQAClaims_1_0_0
 					{
 						bool? ac_(Claim.ItemComponent i)
 						{
-							var al_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, i?.ProductOrService);
+							var al_ = FHIRHelpers_4_0_001.ToConcept(i?.ProductOrService);
 							bool? am_(CqlCode LineCode)
 							{
 								var ap_ = context.Operators.InList<string>(LineCode?.code, ClaimWithMedication?.MedicationsAsStrings);
@@ -615,10 +646,10 @@ public class NCQAClaims_1_0_0
 									{
 										if (i?.Serviced is Period)
 										{
-											var at_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, i?.Serviced);
+											var at_ = NCQAFHIRBase_1_0_0.Normalize_Interval(i?.Serviced);
 											var au_ = context.Operators.Start(at_);
 											var aw_ = context.Operators.Start(at_);
-											var ax_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, i?.Quantity?.ValueElement);
+											var ax_ = FHIRHelpers_4_0_001.ToDecimal(i?.Quantity?.ValueElement);
 											var ay_ = context.Operators.Add(aw_, new CqlQuantity(ax_, "day"));
 											var az_ = context.Operators.Quantity(1m, "day");
 											var ba_ = context.Operators.Subtract(ay_, az_);
@@ -628,8 +659,8 @@ public class NCQAClaims_1_0_0
 										}
 										else
 										{
-											var bc_ = FHIRHelpers_4_0_001.Instance.ToDate(context, (i?.Serviced as Date));
-											var be_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, i?.Quantity?.ValueElement);
+											var bc_ = FHIRHelpers_4_0_001.ToDate((i?.Serviced as Date));
+											var be_ = FHIRHelpers_4_0_001.ToDecimal(i?.Quantity?.ValueElement);
 											var bf_ = context.Operators.Add(bc_, new CqlQuantity(be_, "day"));
 											var bg_ = context.Operators.Quantity(1m, "day");
 											var bh_ = context.Operators.Subtract(bf_, bg_);
@@ -694,7 +725,7 @@ public class NCQAClaims_1_0_0
 									var cm_ = context.Operators.SelectOrNull<Claim.ItemComponent, DataType>(ck_, cl_);
 									CqlInterval<CqlDateTime> cn_(DataType NormalDate)
 									{
-										var ct_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate);
+										var ct_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate);
 
 										return ct_;
 									};
@@ -755,9 +786,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Diagnosis and Procedure")]
-	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Diagnosis_and_Procedure(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Diagnosis_and_Procedure(IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode d) => 
 			d?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(DiagnosisValueSet, b_);
@@ -951,7 +982,7 @@ public class NCQAClaims_1_0_0
 							{
 								CqlInterval<CqlDateTime> ck_(Claim.ItemComponent NormalDate)
 								{
-									var cn_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate?.Serviced);
+									var cn_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate?.Serviced);
 
 									return cn_;
 								};
@@ -1002,9 +1033,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Principal Diagnosis and Procedure")]
-	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Principal_Diagnosis_and_Procedure(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public IEnumerable<Tuples.Tuple_DTeHhjMPXBSEFRBcdiBHhKQDA> Medical_Claims_With_Principal_Diagnosis_and_Procedure(IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode d) => 
 			d?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(DiagnosisValueSet, b_);
@@ -1149,7 +1180,7 @@ public class NCQAClaims_1_0_0
 									bool? bv_(Claim.DiagnosisComponent RightDiagnosis)
 									{
 										var by_ = context.Operators.Convert<Integer>(RightDiagnosis?.SequenceElement);
-										var bz_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, by_);
+										var bz_ = FHIRHelpers_4_0_001.ToInteger(by_);
 										var ca_ = context.Operators.Equal(bz_, (int?)1);
 										var cb_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(RightDiagnosis?.Diagnosis, "coding");
 										bool? cc_(Coding DiagnosisCode)
@@ -1192,7 +1223,7 @@ public class NCQAClaims_1_0_0
 								{
 									CqlInterval<CqlDateTime> ci_(Claim.ItemComponent NormalDate)
 									{
-										var cl_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate?.Serviced);
+										var cl_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate?.Serviced);
 
 										return cl_;
 									};
@@ -1248,9 +1279,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Principal Diagnosis")]
-	public IEnumerable<Tuples.Tuple_HLLRUdKceDPKeIXGFiiNKjMKI> Medical_Claims_With_Principal_Diagnosis(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet)
+	public IEnumerable<Tuples.Tuple_HLLRUdKceDPKeIXGFiiNKjMKI> Medical_Claims_With_Principal_Diagnosis(IEnumerable<Claim> claim, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		string b_(CqlCode d) => 
 			d?.code;
 		var c_ = context.Operators.SelectOrNull<CqlCode, string>(DiagnosisValueSet, b_);
@@ -1280,7 +1311,7 @@ public class NCQAClaims_1_0_0
 						bool? r_(Claim.DiagnosisComponent RightDiagnosis)
 						{
 							var u_ = context.Operators.Convert<Integer>(RightDiagnosis?.SequenceElement);
-							var v_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, u_);
+							var v_ = FHIRHelpers_4_0_001.ToInteger(u_);
 							var w_ = context.Operators.Equal(v_, (int?)1);
 							var x_ = context.Operators.LateBoundProperty<IEnumerable<Coding>>(RightDiagnosis?.Diagnosis, "coding");
 							bool? y_(Coding DiagnosisCode)
@@ -1334,7 +1365,7 @@ public class NCQAClaims_1_0_0
 							var am_ = context.Operators.FlattenList<Claim.ItemComponent>(al_);
 							CqlInterval<CqlDateTime> an_(Claim.ItemComponent NormalDate)
 							{
-								var ar_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, NormalDate?.Serviced);
+								var ar_ = NCQAFHIRBase_1_0_0.Normalize_Interval(NormalDate?.Serviced);
 
 								return ar_;
 							};
@@ -1380,10 +1411,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Professional and Institutional Claims and Claim Responses")]
-	public Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
+	public Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
 	{
-		var a_ = this.Professional_or_Institutional_Claims_Response(context, claimResponse);
-		var b_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims_Response(claimResponse);
+		var b_ = this.Professional_or_Institutional_Claims(claim);
 		var c_ = new Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM
 		{
 			MedicalClaimResponse = a_,
@@ -1394,7 +1425,7 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Paid Claim Reponses")]
-	public IEnumerable<Tuples.Tuple_EbJRLQXEhRCeIIZLcXEYbTEDL> Get_All_Paid_Claim_Reponses(CqlContext context, IEnumerable<ClaimResponse> claimResponse)
+	public IEnumerable<Tuples.Tuple_EbJRLQXEhRCeIIZLcXEYbTEDL> Get_All_Paid_Claim_Reponses(IEnumerable<ClaimResponse> claimResponse)
 	{
 		bool? a_(ClaimResponse ResponseItem)
 		{
@@ -1422,7 +1453,7 @@ public class NCQAClaims_1_0_0
 			Tuples.Tuple_EbJRLQXEhRCeIIZLcXEYbTEDL k_(ClaimResponse ClmResp)
 			{
 				var m_ = context.Operators.Convert<string>(ClmResp?.Request?.ReferenceElement);
-				var n_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, m_);
+				var n_ = NCQAFHIRBase_1_0_0.GetId(m_);
 				bool? o_(ClaimResponse.ItemComponent ResponseItem)
 				{
 					bool? r_(ClaimResponse.AdjudicationComponent @this)
@@ -1466,7 +1497,7 @@ public class NCQAClaims_1_0_0
 					var ag_ = context.Operators.SelectOrNull<ClaimResponse.AdjudicationComponent, Money>(ae_, af_);
 					bool? ah_(Money DollarAmount)
 					{
-						var ap_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, DollarAmount?.ValueElement);
+						var ap_ = FHIRHelpers_4_0_001.ToDecimal(DollarAmount?.ValueElement);
 						var aq_ = context.Operators.ConvertIntegerToDecimal((int?)0);
 						var ar_ = context.Operators.Greater(ap_, aq_);
 
@@ -1499,7 +1530,7 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Claims With Procedure and Diagnosis")]
-	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_and_Diagnosis(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_and_Diagnosis(IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
 		bool? a_(Claim AllClaims)
 		{
@@ -1526,7 +1557,7 @@ public class NCQAClaims_1_0_0
 			var m_ = context.Operators.FlattenList<Coding>(l_);
 			bool? n_(Coding ProductOrServiceCode)
 			{
-				var ah_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+				var ah_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 				var ai_ = context.Operators.CodeInList(ah_, ProductOrServiceValueSet);
 
 				return ai_;
@@ -1564,7 +1595,7 @@ public class NCQAClaims_1_0_0
 			var aa_ = context.Operators.SelectOrNull<object, Coding>(y_, z_);
 			bool? ab_(Coding DiagnosisCode)
 			{
-				var an_ = FHIRHelpers_4_0_001.Instance.ToCode(context, DiagnosisCode);
+				var an_ = FHIRHelpers_4_0_001.ToCode(DiagnosisCode);
 				var ao_ = context.Operators.CodeInList(an_, DiagnosisValueSet);
 
 				return ao_;
@@ -1582,7 +1613,7 @@ public class NCQAClaims_1_0_0
 			{
 				bool? as_(Coding ProductOrServiceCode)
 				{
-					var av_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+					var av_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 					var aw_ = context.Operators.CodeInList(av_, ProductOrServiceValueSet);
 
 					return aw_;
@@ -1608,10 +1639,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Corresponding Claim for Services and Conditions")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_and_Conditions(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_and_Conditions(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Get_All_Paid_Claim_Reponses(context, claimResponse);
-		var b_ = this.Get_All_Claims_With_Procedure_and_Diagnosis(context, claim, ProductOrServiceValueSet, DiagnosisValueSet);
+		var a_ = this.Get_All_Paid_Claim_Reponses(claimResponse);
+		var b_ = this.Get_All_Claims_With_Procedure_and_Diagnosis(claim, ProductOrServiceValueSet, DiagnosisValueSet);
 		var c_ = new Tuples.Tuple_ELXXNjRZXJcQDXjEEQXFeNQKZ
 		{
 			PaidMedicalClaimResponse = a_,
@@ -1635,7 +1666,7 @@ public class NCQAClaims_1_0_0
 									? ((medClaim?.ClaimofInterest as Resource).IdElement)
 									: null));
 							var z_ = context.Operators.Convert<string>(pClaim?.Response?.Request?.ReferenceElement);
-							var aa_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, z_);
+							var aa_ = NCQAFHIRBase_1_0_0.GetId(z_);
 							var ab_ = context.Operators.Equal(y_, aa_);
 							var ac_ = context.Operators.Convert<Integer>(medClaimLineItem?.SequenceElement);
 							var ad_ = context.Operators.Convert<Integer>(pClaimLineItem?.ItemSequenceElement);
@@ -1705,7 +1736,7 @@ public class NCQAClaims_1_0_0
 						var at_ = context.Operators.FlattenList<Claim.ItemComponent>(as_);
 						CqlInterval<CqlDateTime> au_(Claim.ItemComponent PaidItem)
 						{
-							var az_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PaidItem?.Serviced);
+							var az_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PaidItem?.Serviced);
 
 							return az_;
 						};
@@ -1752,9 +1783,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Paid Claims for Provided Service and Condition")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Service_and_Condition(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Service_and_Condition(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(context, claimResponse, claim);
+		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(claimResponse, claim);
 		var b_ = new Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM[]
 		{
 			a_,
@@ -1771,7 +1802,7 @@ public class NCQAClaims_1_0_0
 				}
 				else
 				{
-					var l_ = this.Get_Corresponding_Claim_for_Services_and_Conditions(context, MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet, DiagnosisValueSet);
+					var l_ = this.Get_Corresponding_Claim_for_Services_and_Conditions(MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet, DiagnosisValueSet);
 
 					return l_;
 				};
@@ -1798,7 +1829,7 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Claims With Procedure or Diagnosis")]
-	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_or_Diagnosis(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_or_Diagnosis(IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
 		bool? a_(Claim AllClaims)
 		{
@@ -1825,7 +1856,7 @@ public class NCQAClaims_1_0_0
 			var m_ = context.Operators.FlattenList<Coding>(l_);
 			bool? n_(Coding ProductOrServiceCode)
 			{
-				var ah_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+				var ah_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 				var ai_ = context.Operators.CodeInList(ah_, ProductOrServiceValueSet);
 
 				return ai_;
@@ -1863,7 +1894,7 @@ public class NCQAClaims_1_0_0
 			var aa_ = context.Operators.SelectOrNull<object, Coding>(y_, z_);
 			bool? ab_(Coding DiagnosisCode)
 			{
-				var an_ = FHIRHelpers_4_0_001.Instance.ToCode(context, DiagnosisCode);
+				var an_ = FHIRHelpers_4_0_001.ToCode(DiagnosisCode);
 				var ao_ = context.Operators.CodeInList(an_, DiagnosisValueSet);
 
 				return ao_;
@@ -1881,13 +1912,13 @@ public class NCQAClaims_1_0_0
 			{
 				if ((context.Operators.ExistsInList<Claim.ItemComponent>(context.Operators.WhereOrNull<Claim.ItemComponent>((ProcedureClaims?.Item as IEnumerable<Claim.ItemComponent>), (Claim.ItemComponent ResponseItem) => 
 								context.Operators.ExistsInList<Coding>(context.Operators.WhereOrNull<Coding>((ResponseItem?.ProductOrService?.Coding as IEnumerable<Coding>), (Coding ProductOrServiceCode) => 
-											context.Operators.CodeInList(FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode), ProductOrServiceValueSet))))) ?? false))
+											context.Operators.CodeInList(FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode), ProductOrServiceValueSet))))) ?? false))
 				{
 					bool? aq_(Claim.ItemComponent ResponseItem)
 					{
 						bool? at_(Coding ProductOrServiceCode)
 						{
-							var aw_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+							var aw_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 							var ax_ = context.Operators.CodeInList(aw_, ProductOrServiceValueSet);
 
 							return ax_;
@@ -1936,10 +1967,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Corresponding Claim for Services or Conditions")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_or_Conditions(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_or_Conditions(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Get_All_Paid_Claim_Reponses(context, claimResponse);
-		var b_ = this.Get_All_Claims_With_Procedure_or_Diagnosis(context, claim, ProductOrServiceValueSet, DiagnosisValueSet);
+		var a_ = this.Get_All_Paid_Claim_Reponses(claimResponse);
+		var b_ = this.Get_All_Claims_With_Procedure_or_Diagnosis(claim, ProductOrServiceValueSet, DiagnosisValueSet);
 		var c_ = new Tuples.Tuple_ELXXNjRZXJcQDXjEEQXFeNQKZ
 		{
 			PaidMedicalClaimResponse = a_,
@@ -1963,7 +1994,7 @@ public class NCQAClaims_1_0_0
 									? ((medClaim?.ClaimofInterest as Resource).IdElement)
 									: null));
 							var z_ = context.Operators.Convert<string>(pClaim?.Response?.Request?.ReferenceElement);
-							var aa_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, z_);
+							var aa_ = NCQAFHIRBase_1_0_0.GetId(z_);
 							var ab_ = context.Operators.Equal(y_, aa_);
 							var ac_ = context.Operators.Convert<Integer>(medClaimLineItem?.SequenceElement);
 							var ad_ = context.Operators.Convert<Integer>(pClaimLineItem?.ItemSequenceElement);
@@ -2033,7 +2064,7 @@ public class NCQAClaims_1_0_0
 						var at_ = context.Operators.FlattenList<Claim.ItemComponent>(as_);
 						CqlInterval<CqlDateTime> au_(Claim.ItemComponent PaidItem)
 						{
-							var az_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PaidItem?.Serviced);
+							var az_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PaidItem?.Serviced);
 
 							return az_;
 						};
@@ -2080,9 +2111,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Paid Claims for Provided Services or Conditions")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Services_or_Conditions(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Services_or_Conditions(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet, IEnumerable<CqlCode> DiagnosisValueSet)
 	{
-		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(context, claimResponse, claim);
+		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(claimResponse, claim);
 		var b_ = new Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM[]
 		{
 			a_,
@@ -2099,7 +2130,7 @@ public class NCQAClaims_1_0_0
 				}
 				else
 				{
-					var h_ = this.Get_Corresponding_Claim_for_Services_or_Conditions(context, MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet, DiagnosisValueSet);
+					var h_ = this.Get_Corresponding_Claim_for_Services_or_Conditions(MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet, DiagnosisValueSet);
 
 					return h_;
 				};
@@ -2114,7 +2145,7 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Claims With Procedure Only")]
-	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_Only(CqlContext context, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public IEnumerable<Tuples.Tuple_DXaYeZVOEAELKIhLMVHZBeASM> Get_All_Claims_With_Procedure_Only(IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
 		bool? a_(Claim AllClaims)
 		{
@@ -2141,7 +2172,7 @@ public class NCQAClaims_1_0_0
 			var m_ = context.Operators.FlattenList<Coding>(l_);
 			bool? n_(Coding ProductOrServiceCode)
 			{
-				var s_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+				var s_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 				var t_ = context.Operators.CodeInList(s_, ProductOrServiceValueSet);
 
 				return t_;
@@ -2158,7 +2189,7 @@ public class NCQAClaims_1_0_0
 			{
 				bool? x_(Coding ProductOrServiceCode)
 				{
-					var aa_ = FHIRHelpers_4_0_001.Instance.ToCode(context, ProductOrServiceCode);
+					var aa_ = FHIRHelpers_4_0_001.ToCode(ProductOrServiceCode);
 					var ab_ = context.Operators.CodeInList(aa_, ProductOrServiceValueSet);
 
 					return ab_;
@@ -2184,10 +2215,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Corresponding Claim for Services Only")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_Only(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Corresponding_Claim_for_Services_Only(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Get_All_Paid_Claim_Reponses(context, claimResponse);
-		var b_ = this.Get_All_Claims_With_Procedure_Only(context, claim, ProductOrServiceValueSet);
+		var a_ = this.Get_All_Paid_Claim_Reponses(claimResponse);
+		var b_ = this.Get_All_Claims_With_Procedure_Only(claim, ProductOrServiceValueSet);
 		var c_ = new Tuples.Tuple_ELXXNjRZXJcQDXjEEQXFeNQKZ
 		{
 			PaidMedicalClaimResponse = a_,
@@ -2211,7 +2242,7 @@ public class NCQAClaims_1_0_0
 									? ((medClaim?.ClaimofInterest as Resource).IdElement)
 									: null));
 							var z_ = context.Operators.Convert<string>(pClaim?.Response?.Request?.ReferenceElement);
-							var aa_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, z_);
+							var aa_ = NCQAFHIRBase_1_0_0.GetId(z_);
 							var ab_ = context.Operators.Equal(y_, aa_);
 							var ac_ = context.Operators.Convert<Integer>(medClaimLineItem?.SequenceElement);
 							var ad_ = context.Operators.Convert<Integer>(pClaimLineItem?.ItemSequenceElement);
@@ -2281,7 +2312,7 @@ public class NCQAClaims_1_0_0
 						var at_ = context.Operators.FlattenList<Claim.ItemComponent>(as_);
 						CqlInterval<CqlDateTime> au_(Claim.ItemComponent PaidItem)
 						{
-							var az_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PaidItem?.Serviced);
+							var az_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PaidItem?.Serviced);
 
 							return az_;
 						};
@@ -2328,9 +2359,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Paid Claims for Provided Services Only")]
-	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Services_Only(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public Tuples.Tuple_FbAEUOYETObSHBafYbFNIeSNO Get_Paid_Claims_for_Provided_Services_Only(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(context, claimResponse, claim);
+		var a_ = this.Get_All_Professional_and_Institutional_Claims_and_Claim_Responses(claimResponse, claim);
 		var b_ = new Tuples.Tuple_GjTATZbNccdVYWChGHHdRUXSM[]
 		{
 			a_,
@@ -2347,7 +2378,7 @@ public class NCQAClaims_1_0_0
 				}
 				else
 				{
-					var h_ = this.Get_Corresponding_Claim_for_Services_Only(context, MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet);
+					var h_ = this.Get_Corresponding_Claim_for_Services_Only(MedicalClaimAndResponse?.MedicalClaimResponse, MedicalClaimAndResponse?.MedicalClaim, ProductOrServiceValueSet);
 
 					return h_;
 				};
@@ -2362,10 +2393,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get All Pharmacy Claims and Claim Responses")]
-	public Tuples.Tuple_ENRfaLDabXeaNdJYVdOfebBTR Get_All_Pharmacy_Claims_and_Claim_Responses(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
+	public Tuples.Tuple_ENRfaLDabXeaNdJYVdOfebBTR Get_All_Pharmacy_Claims_and_Claim_Responses(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
 	{
-		var a_ = this.Pharmacy_Claims_Response(context, claimResponse);
-		var b_ = this.Pharmacy_Claims(context, claim);
+		var a_ = this.Pharmacy_Claims_Response(claimResponse);
+		var b_ = this.Pharmacy_Claims(claim);
 		var c_ = new Tuples.Tuple_ENRfaLDabXeaNdJYVdOfebBTR
 		{
 			PharmacyClaimResponse = a_,
@@ -2376,10 +2407,10 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Corresponding Claim for Pharmacy Services")]
-	public Tuples.Tuple_BOANHMYNiCIfFjRZRMEXCcXTO Get_Corresponding_Claim_for_Pharmacy_Services(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public Tuples.Tuple_BOANHMYNiCIfFjRZRMEXCcXTO Get_Corresponding_Claim_for_Pharmacy_Services(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Get_All_Paid_Claim_Reponses(context, claimResponse);
-		var b_ = this.Pharmacy_Claim_With_Medication(context, claim, ProductOrServiceValueSet);
+		var a_ = this.Get_All_Paid_Claim_Reponses(claimResponse);
+		var b_ = this.Pharmacy_Claim_With_Medication(claim, ProductOrServiceValueSet);
 		var c_ = new Tuples.Tuple_EDASHZgEHSQJbecPJIZegfOIB
 		{
 			PaidPharmacyClaimResponse = a_,
@@ -2403,7 +2434,7 @@ public class NCQAClaims_1_0_0
 									? ((medClaim?.Claim as Resource).IdElement)
 									: null));
 							var z_ = context.Operators.Convert<string>(pClaim?.Response?.Request?.ReferenceElement);
-							var aa_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, z_);
+							var aa_ = NCQAFHIRBase_1_0_0.GetId(z_);
 							var ab_ = context.Operators.Equal(y_, aa_);
 							var ac_ = context.Operators.Convert<Integer>(medClaimLineItem?.SequenceElement);
 							var ad_ = context.Operators.Convert<Integer>(pClaimLineItem?.ItemSequenceElement);
@@ -2473,7 +2504,7 @@ public class NCQAClaims_1_0_0
 						var at_ = context.Operators.FlattenList<Claim.ItemComponent>(as_);
 						CqlInterval<CqlDateTime> au_(Claim.ItemComponent PaidItem)
 						{
-							var bg_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PaidItem?.Serviced);
+							var bg_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PaidItem?.Serviced);
 
 							return bg_;
 						};
@@ -2493,11 +2524,11 @@ public class NCQAClaims_1_0_0
 							{
 								if ((context.Operators.Not((bool?)(i?.Quantity is null)) ?? false))
 								{
-									var bj_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, i?.Serviced);
+									var bj_ = NCQAFHIRBase_1_0_0.Normalize_Interval(i?.Serviced);
 									var bk_ = context.Operators.Start(bj_);
 									var bl_ = context.Operators.ConvertDateTimeToDate(bk_);
 									var bn_ = context.Operators.Start(bj_);
-									var bo_ = FHIRHelpers_4_0_001.Instance.ToDecimal(context, i?.Quantity?.ValueElement);
+									var bo_ = FHIRHelpers_4_0_001.ToDecimal(i?.Quantity?.ValueElement);
 									var bp_ = context.Operators.Add(bn_, new CqlQuantity(bo_, "day"));
 									var bq_ = context.Operators.Quantity(1m, "day");
 									var br_ = context.Operators.Subtract(bp_, bq_);
@@ -2560,9 +2591,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Paid Claims for Pharmacy Services")]
-	public Tuples.Tuple_BOANHMYNiCIfFjRZRMEXCcXTO Get_Paid_Claims_for_Pharmacy_Services(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
+	public Tuples.Tuple_BOANHMYNiCIfFjRZRMEXCcXTO Get_Paid_Claims_for_Pharmacy_Services(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim, IEnumerable<CqlCode> ProductOrServiceValueSet)
 	{
-		var a_ = this.Get_All_Pharmacy_Claims_and_Claim_Responses(context, claimResponse, claim);
+		var a_ = this.Get_All_Pharmacy_Claims_and_Claim_Responses(claimResponse, claim);
 		var b_ = new Tuples.Tuple_ENRfaLDabXeaNdJYVdOfebBTR[]
 		{
 			a_,
@@ -2579,7 +2610,7 @@ public class NCQAClaims_1_0_0
 				}
 				else
 				{
-					var h_ = this.Get_Corresponding_Claim_for_Pharmacy_Services(context, PharmacyClaimAndResponse?.PharmacyClaimResponse, PharmacyClaimAndResponse?.PharmacyClaim, ProductOrServiceValueSet);
+					var h_ = this.Get_Corresponding_Claim_for_Pharmacy_Services(PharmacyClaimAndResponse?.PharmacyClaimResponse, PharmacyClaimAndResponse?.PharmacyClaim, ProductOrServiceValueSet);
 
 					return h_;
 				};
@@ -2594,7 +2625,7 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Claim With Corresponding Claim Response")]
-	public IEnumerable<Tuples.Tuple_HQUdYchKGNXjEWMCbcWSEKdVI> Get_Claim_With_Corresponding_Claim_Response(CqlContext context, IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
+	public IEnumerable<Tuples.Tuple_HQUdYchKGNXjEWMCbcWSEKdVI> Get_Claim_With_Corresponding_Claim_Response(IEnumerable<ClaimResponse> claimResponse, IEnumerable<Claim> claim)
 	{
 		Tuples.Tuple_HQUdYchKGNXjEWMCbcWSEKdVI a_(Claim Claim)
 		{
@@ -2602,7 +2633,7 @@ public class NCQAClaims_1_0_0
 			{
 				var h_ = context.Operators.Convert<string>(Claim?.IdElement);
 				var i_ = context.Operators.Convert<string>(CR?.Request?.ReferenceElement);
-				var j_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, i_);
+				var j_ = NCQAFHIRBase_1_0_0.GetId(i_);
 				var k_ = context.Operators.Equal(h_, j_);
 
 				return k_;
@@ -2615,7 +2646,7 @@ public class NCQAClaims_1_0_0
 				{
 					var aa_ = context.Operators.Convert<string>(Claim?.IdElement);
 					var ab_ = context.Operators.Convert<string>(CR?.Request?.ReferenceElement);
-					var ac_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, ab_);
+					var ac_ = NCQAFHIRBase_1_0_0.GetId(ab_);
 					var ad_ = context.Operators.Equal(aa_, ac_);
 
 					return ad_;
@@ -2643,7 +2674,7 @@ public class NCQAClaims_1_0_0
 				var v_ = context.Operators.SelectOrNull<ResourceReference, FhirString>(t_, u_);
 				var w_ = context.Operators.SingleOrNull<FhirString>(v_);
 				var x_ = context.Operators.Convert<string>(w_);
-				var y_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, x_);
+				var y_ = NCQAFHIRBase_1_0_0.GetId(x_);
 				var z_ = context.Operators.Equal(l_, y_);
 
 				return z_;
@@ -2663,9 +2694,9 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Medical Claims With Nonacute or Acute Inpatient Discharge")]
-	public Tuples.Tuple_CYfZbbEjJgLODachBhLiZaXQE Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(CqlContext context, IEnumerable<Claim> claim)
+	public Tuples.Tuple_CYfZbbEjJgLODachBhLiZaXQE Medical_Claims_With_Nonacute_or_Acute_Inpatient_Discharge(IEnumerable<Claim> claim)
 	{
-		var a_ = this.Professional_or_Institutional_Claims(context, claim);
+		var a_ = this.Professional_or_Institutional_Claims(claim);
 		var b_ = new Tuples.Tuple_EWMRhBHgcOUGZLgIBDbjPHISO
 		{
 			MedicalClaim = a_,
@@ -2690,10 +2721,10 @@ public class NCQAClaims_1_0_0
 					{
 						bool? q_(Claim.ItemComponent i)
 						{
-							var t_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, i?.Revenue);
+							var t_ = FHIRHelpers_4_0_001.ToConcept(i?.Revenue);
 							bool? u_(CqlCode rev)
 							{
-								var x_ = this.Inpatient_Stay(context);
+								var x_ = this.Inpatient_Stay();
 								var y_ = context.Operators.StringInValueSet(rev?.code, x_);
 
 								return y_;
@@ -2727,10 +2758,10 @@ public class NCQAClaims_1_0_0
 					{
 						bool? ac_(Claim.ItemComponent i)
 						{
-							var aj_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, i?.Revenue);
+							var aj_ = FHIRHelpers_4_0_001.ToConcept(i?.Revenue);
 							bool? ak_(CqlCode rev)
 							{
-								var an_ = this.Nonacute_Inpatient_Stay(context);
+								var an_ = this.Nonacute_Inpatient_Stay();
 								var ao_ = context.Operators.StringInValueSet(rev?.code, an_);
 
 								return ao_;
@@ -2744,7 +2775,7 @@ public class NCQAClaims_1_0_0
 						var ae_ = context.Operators.ExistsInList<Claim.ItemComponent>(ad_);
 						bool? af_(Coding tob)
 						{
-							var ap_ = this.Nonacute_Inpatient_Stay(context);
+							var ap_ = this.Nonacute_Inpatient_Stay();
 							var aq_ = context.Operators.StringInValueSet(tob?.CodeElement?.Value, ap_);
 
 							return aq_;
@@ -2825,14 +2856,14 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Prescriber NPI from Claims")]
-	public Tuples.Tuple_CEXhgaFKbhdeeAYTYBhHTGXUY Get_Prescriber_NPI_from_Claims(CqlContext context, IEnumerable<Claim> claim)
+	public Tuples.Tuple_CEXhgaFKbhdeeAYTYBhHTGXUY Get_Prescriber_NPI_from_Claims(IEnumerable<Claim> claim)
 	{
 		Tuples.Tuple_GIfhUVACThMQNGPGjYhYHEfGS a_(Claim C)
 		{
 			bool? h_(Claim.CareTeamComponent ct)
 			{
 				var w_ = context.Operators.Convert<Integer>(ct?.SequenceElement);
-				var x_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, w_);
+				var x_ = FHIRHelpers_4_0_001.ToInteger(w_);
 				var y_ = context.Operators.Equal(x_, (int?)1);
 
 				return y_;
@@ -2851,7 +2882,7 @@ public class NCQAClaims_1_0_0
 			bool? n_(Claim.CareTeamComponent ct)
 			{
 				var aa_ = context.Operators.Convert<Integer>(ct?.SequenceElement);
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, aa_);
+				var ab_ = FHIRHelpers_4_0_001.ToInteger(aa_);
 				var ac_ = context.Operators.Equal(ab_, (int?)1);
 
 				return ac_;
@@ -2874,7 +2905,7 @@ public class NCQAClaims_1_0_0
 				string af_(FhirString r)
 				{
 					var ai_ = context.Operators.Convert<string>(r);
-					var aj_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, ai_);
+					var aj_ = NCQAFHIRBase_1_0_0.GetId(ai_);
 
 					return aj_;
 				};
@@ -2946,8 +2977,8 @@ public class NCQAClaims_1_0_0
 					bool? bk_(Identifier l)
 					{
 						var bt_ = context.Operators.Equal(l?.SystemElement?.Value, "http://hl7.org/fhir/sid/us-npi");
-						var bu_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, l?.Type);
-						var bv_ = NCQATerminology_1_0_0.Instance.Provider_number(context);
+						var bu_ = FHIRHelpers_4_0_001.ToConcept(l?.Type);
+						var bv_ = NCQATerminology_1_0_0.Provider_number();
 						var bw_ = context.Operators.ConvertCodeToConcept(bv_);
 						var bx_ = context.Operators.Equivalent(bu_, bw_);
 						var by_ = context.Operators.And(bt_, bx_);
@@ -2963,8 +2994,8 @@ public class NCQAClaims_1_0_0
 					bool? bo_(Identifier l)
 					{
 						var cb_ = context.Operators.Equal(l?.SystemElement?.Value, "http://hl7.org/fhir/sid/us-npi");
-						var cc_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, l?.Type);
-						var cd_ = NCQATerminology_1_0_0.Instance.Provider_number(context);
+						var cc_ = FHIRHelpers_4_0_001.ToConcept(l?.Type);
+						var cd_ = NCQATerminology_1_0_0.Provider_number();
 						var ce_ = context.Operators.ConvertCodeToConcept(cd_);
 						var cf_ = context.Operators.Equivalent(cc_, ce_);
 						var cg_ = context.Operators.And(cb_, cf_);
@@ -3062,14 +3093,14 @@ public class NCQAClaims_1_0_0
 	}
 
     [CqlDeclaration("Get Pharmacy NPI from Claims")]
-	public Tuples.Tuple_CEXhgaFKbhdeeAYTYBhHTGXUY Get_Pharmacy_NPI_from_Claims(CqlContext context, IEnumerable<Claim> claim)
+	public Tuples.Tuple_CEXhgaFKbhdeeAYTYBhHTGXUY Get_Pharmacy_NPI_from_Claims(IEnumerable<Claim> claim)
 	{
 		Tuples.Tuple_FPCXihcEeChSjIUJHVXRcEXMI a_(Claim C)
 		{
 			bool? h_(Claim.ItemComponent i)
 			{
 				var y_ = context.Operators.Convert<Integer>(i?.SequenceElement);
-				var z_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, y_);
+				var z_ = FHIRHelpers_4_0_001.ToInteger(y_);
 				var aa_ = context.Operators.Equal(z_, (int?)1);
 
 				return aa_;
@@ -3091,7 +3122,7 @@ public class NCQAClaims_1_0_0
 			bool? p_(Claim.ItemComponent i)
 			{
 				var ac_ = context.Operators.Convert<Integer>(i?.SequenceElement);
-				var ad_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, ac_);
+				var ad_ = FHIRHelpers_4_0_001.ToInteger(ac_);
 				var ae_ = context.Operators.Equal(ad_, (int?)1);
 
 				return ae_;
@@ -3114,7 +3145,7 @@ public class NCQAClaims_1_0_0
 				string ah_(FhirString r)
 				{
 					var ak_ = context.Operators.Convert<string>(r);
-					var al_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, ak_);
+					var al_ = NCQAFHIRBase_1_0_0.GetId(ak_);
 
 					return al_;
 				};
@@ -3186,8 +3217,8 @@ public class NCQAClaims_1_0_0
 					bool? bm_(Identifier l)
 					{
 						var bv_ = context.Operators.Equal(l?.SystemElement?.Value, "http://hl7.org/fhir/sid/us-npi");
-						var bw_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, l?.Type);
-						var bx_ = NCQATerminology_1_0_0.Instance.Provider_number(context);
+						var bw_ = FHIRHelpers_4_0_001.ToConcept(l?.Type);
+						var bx_ = NCQATerminology_1_0_0.Provider_number();
 						var by_ = context.Operators.ConvertCodeToConcept(bx_);
 						var bz_ = context.Operators.Equivalent(bw_, by_);
 						var ca_ = context.Operators.And(bv_, bz_);
@@ -3203,8 +3234,8 @@ public class NCQAClaims_1_0_0
 					bool? bq_(Identifier l)
 					{
 						var cd_ = context.Operators.Equal(l?.SystemElement?.Value, "http://hl7.org/fhir/sid/us-npi");
-						var ce_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, l?.Type);
-						var cf_ = NCQATerminology_1_0_0.Instance.Provider_number(context);
+						var ce_ = FHIRHelpers_4_0_001.ToConcept(l?.Type);
+						var cf_ = NCQATerminology_1_0_0.Provider_number();
 						var cg_ = context.Operators.ConvertCodeToConcept(cf_);
 						var ch_ = context.Operators.Equivalent(ce_, cg_);
 						var ci_ = context.Operators.And(cd_, ch_);

--- a/Demo/Measures/NCQAEncounter-1.0.0.cs
+++ b/Demo/Measures/NCQAEncounter-1.0.0.cs
@@ -14,10 +14,33 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAEncounter_1_0_0
 {
 
-    public static NCQAEncounter_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+
+    #endregion
+    public NCQAEncounter_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQAStatus_1_0_0 = new NCQAStatus_1_0_0(context);
+        NCQATerminology_1_0_0 = new NCQATerminology_1_0_0(context);
+
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQAStatus_1_0_0 NCQAStatus_1_0_0 { get; }
+    public NCQATerminology_1_0_0 NCQATerminology_1_0_0 { get; }
+
+    #endregion
 
     [CqlDeclaration("Encounter Has Diagnosis")]
-	public bool? Encounter_Has_Diagnosis(CqlContext context, Encounter Encounter, IEnumerable<Condition> Conditions)
+	public bool? Encounter_Has_Diagnosis(Encounter Encounter, IEnumerable<Condition> Conditions)
 	{
 		FhirString a_(Encounter.DiagnosisComponent D) => 
 			D?.Condition?.ReferenceElement;
@@ -28,7 +51,7 @@ public class NCQAEncounter_1_0_0
 			{
 				var i_ = context.Operators.Convert<string>(C?.IdElement);
 				var j_ = context.Operators.Convert<string>(CRef);
-				var k_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, j_);
+				var k_ = NCQAFHIRBase_1_0_0.GetId(j_);
 				var l_ = context.Operators.Equal(i_, k_);
 
 				return l_;
@@ -45,12 +68,12 @@ public class NCQAEncounter_1_0_0
 	}
 
     [CqlDeclaration("Encounter Has Principal Diagnosis")]
-	public bool? Encounter_Has_Principal_Diagnosis(CqlContext context, Encounter Encounter, IEnumerable<Condition> Conditions)
+	public bool? Encounter_Has_Principal_Diagnosis(Encounter Encounter, IEnumerable<Condition> Conditions)
 	{
 		bool? a_(Encounter.DiagnosisComponent D)
 		{
 			var h_ = context.Operators.Convert<Integer>(D?.RankElement);
-			var i_ = FHIRHelpers_4_0_001.Instance.ToInteger(context, h_);
+			var i_ = FHIRHelpers_4_0_001.ToInteger(h_);
 			var j_ = context.Operators.Equal(i_, (int?)1);
 
 			return j_;
@@ -67,7 +90,7 @@ public class NCQAEncounter_1_0_0
 			{
 				var n_ = context.Operators.Convert<string>(C?.IdElement);
 				var o_ = context.Operators.Convert<string>(PrincipalDiagnosis?.Condition?.ReferenceElement);
-				var p_ = NCQAFHIRBase_1_0_0.Instance.GetId(context, o_);
+				var p_ = NCQAFHIRBase_1_0_0.GetId(o_);
 				var q_ = context.Operators.Equal(n_, p_);
 
 				return q_;
@@ -84,12 +107,12 @@ public class NCQAEncounter_1_0_0
 	}
 
     [CqlDeclaration("Encounter Completed during Period")]
-	public bool? Encounter_Completed_during_Period(CqlContext context, IEnumerable<Encounter> Enc, CqlInterval<CqlDateTime> timeperiod)
+	public bool? Encounter_Completed_during_Period(IEnumerable<Encounter> Enc, CqlInterval<CqlDateTime> timeperiod)
 	{
-		var a_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, Enc);
+		var a_ = NCQAStatus_1_0_0.Finished_Encounter(Enc);
 		bool? b_(Encounter EncounterPeriod)
 		{
-			var e_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (EncounterPeriod?.Period as object));
+			var e_ = NCQAFHIRBase_1_0_0.Normalize_Interval((EncounterPeriod?.Period as object));
 			var f_ = context.Operators.End(e_);
 			var g_ = context.Operators.ElementInInterval<CqlDateTime>(f_, timeperiod, null);
 
@@ -102,14 +125,14 @@ public class NCQAEncounter_1_0_0
 	}
 
     [CqlDeclaration("Finished Encounter with Telehealth POS")]
-	public IEnumerable<Encounter> Finished_Encounter_with_Telehealth_POS(CqlContext context, IEnumerable<Encounter> Encounter)
+	public IEnumerable<Encounter> Finished_Encounter_with_Telehealth_POS(IEnumerable<Encounter> Encounter)
 	{
-		var a_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, Encounter);
+		var a_ = NCQAStatus_1_0_0.Finished_Encounter(Encounter);
 		bool? b_(Encounter E)
 		{
 			var d_ = context.Operators.Not((bool?)(E?.Class is null));
-			var e_ = FHIRHelpers_4_0_001.Instance.ToCode(context, E?.Class);
-			var f_ = NCQATerminology_1_0_0.Instance.@virtual(context);
+			var e_ = FHIRHelpers_4_0_001.ToCode(E?.Class);
+			var f_ = NCQATerminology_1_0_0.@virtual();
 			var g_ = context.Operators.Equivalent(e_, f_);
 			var h_ = context.Operators.And(d_, g_);
 
@@ -121,16 +144,16 @@ public class NCQAEncounter_1_0_0
 	}
 
     [CqlDeclaration("Finished Encounter with Outpatient POS")]
-	public IEnumerable<Encounter> Finished_Encounter_with_Outpatient_POS(CqlContext context, IEnumerable<Encounter> Encounter)
+	public IEnumerable<Encounter> Finished_Encounter_with_Outpatient_POS(IEnumerable<Encounter> Encounter)
 	{
-		var a_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, Encounter);
+		var a_ = NCQAStatus_1_0_0.Finished_Encounter(Encounter);
 		bool? b_(Encounter E)
 		{
 			var d_ = context.Operators.Not((bool?)(E?.Class is null));
-			var e_ = FHIRHelpers_4_0_001.Instance.ToCode(context, E?.Class);
-			var f_ = NCQATerminology_1_0_0.Instance.ambulatory(context);
+			var e_ = FHIRHelpers_4_0_001.ToCode(E?.Class);
+			var f_ = NCQATerminology_1_0_0.ambulatory();
 			var g_ = context.Operators.Equivalent(e_, f_);
-			var i_ = NCQATerminology_1_0_0.Instance.home_health(context);
+			var i_ = NCQATerminology_1_0_0.home_health();
 			var j_ = context.Operators.Equivalent(e_, i_);
 			var k_ = context.Operators.Or(g_, j_);
 			var l_ = context.Operators.And(d_, k_);
@@ -143,14 +166,14 @@ public class NCQAEncounter_1_0_0
 	}
 
     [CqlDeclaration("Finished Encounter with Ambulatory POS")]
-	public IEnumerable<Encounter> Finished_Encounter_with_Ambulatory_POS(CqlContext context, IEnumerable<Encounter> Encounter)
+	public IEnumerable<Encounter> Finished_Encounter_with_Ambulatory_POS(IEnumerable<Encounter> Encounter)
 	{
-		var a_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, Encounter);
+		var a_ = NCQAStatus_1_0_0.Finished_Encounter(Encounter);
 		bool? b_(Encounter E)
 		{
 			var d_ = context.Operators.Not((bool?)(E?.Class is null));
-			var e_ = FHIRHelpers_4_0_001.Instance.ToCode(context, E?.Class);
-			var f_ = NCQATerminology_1_0_0.Instance.ambulatory(context);
+			var e_ = FHIRHelpers_4_0_001.ToCode(E?.Class);
+			var f_ = NCQATerminology_1_0_0.ambulatory();
 			var g_ = context.Operators.Equivalent(e_, f_);
 			var h_ = context.Operators.And(d_, g_);
 

--- a/Demo/Measures/NCQAFHIRBase-1.0.0.cs
+++ b/Demo/Measures/NCQAFHIRBase-1.0.0.cs
@@ -14,10 +14,28 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAFHIRBase_1_0_0
 {
 
-    public static NCQAFHIRBase_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    #region Cached values
+
+    internal Lazy<Patient> __Patient;
+
+    #endregion
+    public NCQAFHIRBase_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -25,14 +43,18 @@ public class NCQAFHIRBase_1_0_0
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("Normalize Onset")]
-	public CqlInterval<CqlDateTime> Normalize_Onset(CqlContext context, object onset)
+	public CqlInterval<CqlDateTime> Normalize_Onset(object onset)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (onset is FhirDateTime)
 			{
-				var b_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (onset as FhirDateTime));
+				var b_ = FHIRHelpers_4_0_001.ToDateTime((onset as FhirDateTime));
 				var d_ = context.Operators.Interval(b_, b_, true, true);
 
 				return d_;
@@ -60,11 +82,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (onset is Age)
 					{
-						var s_ = this.Patient(context);
-						var t_ = FHIRHelpers_4_0_001.Instance.ToDate(context, s_?.BirthDateElement);
-						var u_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Age));
+						var s_ = this.Patient();
+						var t_ = FHIRHelpers_4_0_001.ToDate(s_?.BirthDateElement);
+						var u_ = FHIRHelpers_4_0_001.ToQuantity((onset as Age));
 						var v_ = context.Operators.Add(t_, u_);
-						var x_ = FHIRHelpers_4_0_001.Instance.ToDate(context, s_?.BirthDateElement);
+						var x_ = FHIRHelpers_4_0_001.ToDate(s_?.BirthDateElement);
 						var z_ = context.Operators.Add(x_, u_);
 						var aa_ = context.Operators.Quantity(1m, "year");
 						var ab_ = context.Operators.Add(z_, aa_);
@@ -74,12 +96,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (onset is Range)
 					{
-						var ad_ = this.Patient(context);
-						var ae_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ad_?.BirthDateElement);
-						var af_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.Low);
+						var ad_ = this.Patient();
+						var ae_ = FHIRHelpers_4_0_001.ToDate(ad_?.BirthDateElement);
+						var af_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.Low);
 						var ag_ = context.Operators.Add(ae_, af_);
-						var ai_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ad_?.BirthDateElement);
-						var aj_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.High);
+						var ai_ = FHIRHelpers_4_0_001.ToDate(ad_?.BirthDateElement);
+						var aj_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.High);
 						var ak_ = context.Operators.Add(ai_, aj_);
 						var al_ = context.Operators.Quantity(1m, "year");
 						var am_ = context.Operators.Add(ak_, al_);
@@ -99,11 +121,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (onset is Age)
 					{
-						var ap_ = this.Patient(context);
-						var aq_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ap_?.BirthDateElement);
-						var ar_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Age));
+						var ap_ = this.Patient();
+						var aq_ = FHIRHelpers_4_0_001.ToDate(ap_?.BirthDateElement);
+						var ar_ = FHIRHelpers_4_0_001.ToQuantity((onset as Age));
 						var as_ = context.Operators.Add(aq_, ar_);
-						var au_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ap_?.BirthDateElement);
+						var au_ = FHIRHelpers_4_0_001.ToDate(ap_?.BirthDateElement);
 						var aw_ = context.Operators.Add(au_, ar_);
 						var ax_ = context.Operators.Quantity(1m, "year");
 						var ay_ = context.Operators.Add(aw_, ax_);
@@ -113,12 +135,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (onset is Range)
 					{
-						var ba_ = this.Patient(context);
-						var bb_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ba_?.BirthDateElement);
-						var bc_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.Low);
+						var ba_ = this.Patient();
+						var bb_ = FHIRHelpers_4_0_001.ToDate(ba_?.BirthDateElement);
+						var bc_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.Low);
 						var bd_ = context.Operators.Add(bb_, bc_);
-						var bf_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ba_?.BirthDateElement);
-						var bg_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.High);
+						var bf_ = FHIRHelpers_4_0_001.ToDate(ba_?.BirthDateElement);
+						var bg_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.High);
 						var bh_ = context.Operators.Add(bf_, bg_);
 						var bi_ = context.Operators.Quantity(1m, "year");
 						var bj_ = context.Operators.Add(bh_, bi_);
@@ -138,11 +160,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (onset is Age)
 					{
-						var bm_ = this.Patient(context);
-						var bn_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
-						var bo_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Age));
+						var bm_ = this.Patient();
+						var bn_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
+						var bo_ = FHIRHelpers_4_0_001.ToQuantity((onset as Age));
 						var bp_ = context.Operators.Add(bn_, bo_);
-						var br_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+						var br_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 						var bt_ = context.Operators.Add(br_, bo_);
 						var bu_ = context.Operators.Quantity(1m, "year");
 						var bv_ = context.Operators.Add(bt_, bu_);
@@ -152,12 +174,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (onset is Range)
 					{
-						var bx_ = this.Patient(context);
-						var by_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bx_?.BirthDateElement);
-						var bz_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.Low);
+						var bx_ = this.Patient();
+						var by_ = FHIRHelpers_4_0_001.ToDate(bx_?.BirthDateElement);
+						var bz_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.Low);
 						var ca_ = context.Operators.Add(by_, bz_);
-						var cc_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bx_?.BirthDateElement);
-						var cd_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.High);
+						var cc_ = FHIRHelpers_4_0_001.ToDate(bx_?.BirthDateElement);
+						var cd_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.High);
 						var ce_ = context.Operators.Add(cc_, cd_);
 						var cf_ = context.Operators.Quantity(1m, "year");
 						var cg_ = context.Operators.Add(ce_, cf_);
@@ -176,11 +198,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (onset is Age)
 					{
-						var cj_ = this.Patient(context);
-						var ck_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cj_?.BirthDateElement);
-						var cl_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Age));
+						var cj_ = this.Patient();
+						var ck_ = FHIRHelpers_4_0_001.ToDate(cj_?.BirthDateElement);
+						var cl_ = FHIRHelpers_4_0_001.ToQuantity((onset as Age));
 						var cm_ = context.Operators.Add(ck_, cl_);
-						var co_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cj_?.BirthDateElement);
+						var co_ = FHIRHelpers_4_0_001.ToDate(cj_?.BirthDateElement);
 						var cq_ = context.Operators.Add(co_, cl_);
 						var cr_ = context.Operators.Quantity(1m, "year");
 						var cs_ = context.Operators.Add(cq_, cr_);
@@ -190,12 +212,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (onset is Range)
 					{
-						var cu_ = this.Patient(context);
-						var cv_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cu_?.BirthDateElement);
-						var cw_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.Low);
+						var cu_ = this.Patient();
+						var cv_ = FHIRHelpers_4_0_001.ToDate(cu_?.BirthDateElement);
+						var cw_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.Low);
 						var cx_ = context.Operators.Add(cv_, cw_);
-						var cz_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cu_?.BirthDateElement);
-						var da_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (onset as Range)?.High);
+						var cz_ = FHIRHelpers_4_0_001.ToDate(cu_?.BirthDateElement);
+						var da_ = FHIRHelpers_4_0_001.ToQuantity((onset as Range)?.High);
 						var db_ = context.Operators.Add(cz_, da_);
 						var dc_ = context.Operators.Quantity(1m, "year");
 						var dd_ = context.Operators.Add(db_, dc_);
@@ -220,13 +242,13 @@ public class NCQAFHIRBase_1_0_0
 	}
 
     [CqlDeclaration("Normalize Abatement")]
-	public CqlInterval<CqlDateTime> Normalize_Abatement(CqlContext context, object abatement)
+	public CqlInterval<CqlDateTime> Normalize_Abatement(object abatement)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (abatement is FhirDateTime)
 			{
-				var b_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (abatement as FhirDateTime));
+				var b_ = FHIRHelpers_4_0_001.ToDateTime((abatement as FhirDateTime));
 				var d_ = context.Operators.Interval(b_, b_, true, true);
 
 				return d_;
@@ -254,11 +276,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (abatement is Age)
 					{
-						var s_ = this.Patient(context);
-						var t_ = FHIRHelpers_4_0_001.Instance.ToDate(context, s_?.BirthDateElement);
-						var u_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Age));
+						var s_ = this.Patient();
+						var t_ = FHIRHelpers_4_0_001.ToDate(s_?.BirthDateElement);
+						var u_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Age));
 						var v_ = context.Operators.Add(t_, u_);
-						var x_ = FHIRHelpers_4_0_001.Instance.ToDate(context, s_?.BirthDateElement);
+						var x_ = FHIRHelpers_4_0_001.ToDate(s_?.BirthDateElement);
 						var z_ = context.Operators.Add(x_, u_);
 						var aa_ = context.Operators.Quantity(1m, "year");
 						var ab_ = context.Operators.Add(z_, aa_);
@@ -268,12 +290,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (abatement is Range)
 					{
-						var ad_ = this.Patient(context);
-						var ae_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ad_?.BirthDateElement);
-						var af_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.Low);
+						var ad_ = this.Patient();
+						var ae_ = FHIRHelpers_4_0_001.ToDate(ad_?.BirthDateElement);
+						var af_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.Low);
 						var ag_ = context.Operators.Add(ae_, af_);
-						var ai_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ad_?.BirthDateElement);
-						var aj_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.High);
+						var ai_ = FHIRHelpers_4_0_001.ToDate(ad_?.BirthDateElement);
+						var aj_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.High);
 						var ak_ = context.Operators.Add(ai_, aj_);
 						var al_ = context.Operators.Quantity(1m, "year");
 						var am_ = context.Operators.Add(ak_, al_);
@@ -293,11 +315,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (abatement is Age)
 					{
-						var ap_ = this.Patient(context);
-						var aq_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ap_?.BirthDateElement);
-						var ar_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Age));
+						var ap_ = this.Patient();
+						var aq_ = FHIRHelpers_4_0_001.ToDate(ap_?.BirthDateElement);
+						var ar_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Age));
 						var as_ = context.Operators.Add(aq_, ar_);
-						var au_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ap_?.BirthDateElement);
+						var au_ = FHIRHelpers_4_0_001.ToDate(ap_?.BirthDateElement);
 						var aw_ = context.Operators.Add(au_, ar_);
 						var ax_ = context.Operators.Quantity(1m, "year");
 						var ay_ = context.Operators.Add(aw_, ax_);
@@ -307,12 +329,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (abatement is Range)
 					{
-						var ba_ = this.Patient(context);
-						var bb_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ba_?.BirthDateElement);
-						var bc_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.Low);
+						var ba_ = this.Patient();
+						var bb_ = FHIRHelpers_4_0_001.ToDate(ba_?.BirthDateElement);
+						var bc_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.Low);
 						var bd_ = context.Operators.Add(bb_, bc_);
-						var bf_ = FHIRHelpers_4_0_001.Instance.ToDate(context, ba_?.BirthDateElement);
-						var bg_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.High);
+						var bf_ = FHIRHelpers_4_0_001.ToDate(ba_?.BirthDateElement);
+						var bg_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.High);
 						var bh_ = context.Operators.Add(bf_, bg_);
 						var bi_ = context.Operators.Quantity(1m, "year");
 						var bj_ = context.Operators.Add(bh_, bi_);
@@ -332,11 +354,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (abatement is Age)
 					{
-						var bm_ = this.Patient(context);
-						var bn_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
-						var bo_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Age));
+						var bm_ = this.Patient();
+						var bn_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
+						var bo_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Age));
 						var bp_ = context.Operators.Add(bn_, bo_);
-						var br_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+						var br_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 						var bt_ = context.Operators.Add(br_, bo_);
 						var bu_ = context.Operators.Quantity(1m, "year");
 						var bv_ = context.Operators.Add(bt_, bu_);
@@ -346,12 +368,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (abatement is Range)
 					{
-						var bx_ = this.Patient(context);
-						var by_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bx_?.BirthDateElement);
-						var bz_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.Low);
+						var bx_ = this.Patient();
+						var by_ = FHIRHelpers_4_0_001.ToDate(bx_?.BirthDateElement);
+						var bz_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.Low);
 						var ca_ = context.Operators.Add(by_, bz_);
-						var cc_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bx_?.BirthDateElement);
-						var cd_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.High);
+						var cc_ = FHIRHelpers_4_0_001.ToDate(bx_?.BirthDateElement);
+						var cd_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.High);
 						var ce_ = context.Operators.Add(cc_, cd_);
 						var cf_ = context.Operators.Quantity(1m, "year");
 						var cg_ = context.Operators.Add(ce_, cf_);
@@ -370,11 +392,11 @@ public class NCQAFHIRBase_1_0_0
 				{
 					if (abatement is Age)
 					{
-						var cj_ = this.Patient(context);
-						var ck_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cj_?.BirthDateElement);
-						var cl_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Age));
+						var cj_ = this.Patient();
+						var ck_ = FHIRHelpers_4_0_001.ToDate(cj_?.BirthDateElement);
+						var cl_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Age));
 						var cm_ = context.Operators.Add(ck_, cl_);
-						var co_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cj_?.BirthDateElement);
+						var co_ = FHIRHelpers_4_0_001.ToDate(cj_?.BirthDateElement);
 						var cq_ = context.Operators.Add(co_, cl_);
 						var cr_ = context.Operators.Quantity(1m, "year");
 						var cs_ = context.Operators.Add(cq_, cr_);
@@ -384,12 +406,12 @@ public class NCQAFHIRBase_1_0_0
 					}
 					else if (abatement is Range)
 					{
-						var cu_ = this.Patient(context);
-						var cv_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cu_?.BirthDateElement);
-						var cw_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.Low);
+						var cu_ = this.Patient();
+						var cv_ = FHIRHelpers_4_0_001.ToDate(cu_?.BirthDateElement);
+						var cw_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.Low);
 						var cx_ = context.Operators.Add(cv_, cw_);
-						var cz_ = FHIRHelpers_4_0_001.Instance.ToDate(context, cu_?.BirthDateElement);
-						var da_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (abatement as Range)?.High);
+						var cz_ = FHIRHelpers_4_0_001.ToDate(cu_?.BirthDateElement);
+						var da_ = FHIRHelpers_4_0_001.ToQuantity((abatement as Range)?.High);
 						var db_ = context.Operators.Add(cz_, da_);
 						var dc_ = context.Operators.Quantity(1m, "year");
 						var dd_ = context.Operators.Add(db_, dc_);
@@ -414,11 +436,11 @@ public class NCQAFHIRBase_1_0_0
 	}
 
     [CqlDeclaration("Prevalence Period")]
-	public CqlInterval<CqlDateTime> Prevalence_Period(CqlContext context, Condition condition)
+	public CqlInterval<CqlDateTime> Prevalence_Period(Condition condition)
 	{
-		var a_ = this.Normalize_Onset(context, condition?.Onset);
+		var a_ = this.Normalize_Onset(condition?.Onset);
 		var b_ = context.Operators.Start(a_);
-		var c_ = this.Normalize_Abatement(context, condition?.Abatement);
+		var c_ = this.Normalize_Abatement(condition?.Abatement);
 		var d_ = context.Operators.End(c_);
 		var e_ = context.Operators.Interval(b_, d_, true, true);
 
@@ -426,20 +448,20 @@ public class NCQAFHIRBase_1_0_0
 	}
 
     [CqlDeclaration("Normalize Interval")]
-	public CqlInterval<CqlDateTime> Normalize_Interval(CqlContext context, object choice)
+	public CqlInterval<CqlDateTime> Normalize_Interval(object choice)
 	{
 		CqlInterval<CqlDateTime> a_()
 		{
 			if (choice is FhirDateTime)
 			{
-				var b_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (choice as FhirDateTime));
+				var b_ = FHIRHelpers_4_0_001.ToDateTime((choice as FhirDateTime));
 				var d_ = context.Operators.Interval(b_, b_, true, true);
 
 				return d_;
 			}
 			else if (choice is Date)
 			{
-				var e_ = FHIRHelpers_4_0_001.Instance.ToDate(context, (choice as Date));
+				var e_ = FHIRHelpers_4_0_001.ToDate((choice as Date));
 				var f_ = context.Operators.ConvertDateToDateTime(e_);
 				var h_ = context.Operators.ConvertDateToDateTime(e_);
 				var i_ = context.Operators.Interval(f_, h_, true, true);
@@ -458,39 +480,39 @@ public class NCQAFHIRBase_1_0_0
 			}
 			else if (choice is Instant)
 			{
-				var o_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (choice as Instant));
+				var o_ = FHIRHelpers_4_0_001.ToDateTime((choice as Instant));
 				var q_ = context.Operators.Interval(o_, o_, true, true);
 
 				return q_;
 			}
 			else if (choice is Age)
 			{
-				var r_ = this.Patient(context);
-				var s_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
-				var t_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Age));
+				var r_ = this.Patient();
+				var s_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
+				var t_ = FHIRHelpers_4_0_001.ToQuantity((choice as Age));
 				var u_ = context.Operators.Add(s_, t_);
-				var w_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var w_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var y_ = context.Operators.Add(w_, t_);
 				var z_ = context.Operators.Quantity(1m, "year");
 				var aa_ = context.Operators.Add(y_, z_);
 				var ab_ = context.Operators.Interval(u_, aa_, true, false);
 				var ac_ = context.Operators.ConvertDateToDateTime(ab_?.low);
-				var ae_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var ae_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var ag_ = context.Operators.Add(ae_, t_);
-				var ai_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var ai_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var ak_ = context.Operators.Add(ai_, t_);
 				var am_ = context.Operators.Add(ak_, z_);
 				var an_ = context.Operators.Interval(ag_, am_, true, false);
 				var ao_ = context.Operators.ConvertDateToDateTime(an_?.high);
-				var aq_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var aq_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var as_ = context.Operators.Add(aq_, t_);
-				var au_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var au_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var aw_ = context.Operators.Add(au_, t_);
 				var ay_ = context.Operators.Add(aw_, z_);
 				var az_ = context.Operators.Interval(as_, ay_, true, false);
-				var bb_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var bb_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var bd_ = context.Operators.Add(bb_, t_);
-				var bf_ = FHIRHelpers_4_0_001.Instance.ToDate(context, r_?.BirthDateElement);
+				var bf_ = FHIRHelpers_4_0_001.ToDate(r_?.BirthDateElement);
 				var bh_ = context.Operators.Add(bf_, t_);
 				var bj_ = context.Operators.Add(bh_, z_);
 				var bk_ = context.Operators.Interval(bd_, bj_, true, false);
@@ -500,33 +522,33 @@ public class NCQAFHIRBase_1_0_0
 			}
 			else if (choice is Range)
 			{
-				var bm_ = this.Patient(context);
-				var bn_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
-				var bo_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Range)?.Low);
+				var bm_ = this.Patient();
+				var bn_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
+				var bo_ = FHIRHelpers_4_0_001.ToQuantity((choice as Range)?.Low);
 				var bp_ = context.Operators.Add(bn_, bo_);
-				var br_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
-				var bs_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, (choice as Range)?.High);
+				var br_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
+				var bs_ = FHIRHelpers_4_0_001.ToQuantity((choice as Range)?.High);
 				var bt_ = context.Operators.Add(br_, bs_);
 				var bu_ = context.Operators.Quantity(1m, "year");
 				var bv_ = context.Operators.Add(bt_, bu_);
 				var bw_ = context.Operators.Interval(bp_, bv_, true, false);
 				var bx_ = context.Operators.ConvertDateToDateTime(bw_?.low);
-				var bz_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var bz_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var cb_ = context.Operators.Add(bz_, bo_);
-				var cd_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var cd_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var cf_ = context.Operators.Add(cd_, bs_);
 				var ch_ = context.Operators.Add(cf_, bu_);
 				var ci_ = context.Operators.Interval(cb_, ch_, true, false);
 				var cj_ = context.Operators.ConvertDateToDateTime(ci_?.high);
-				var cl_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var cl_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var cn_ = context.Operators.Add(cl_, bo_);
-				var cp_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var cp_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var cr_ = context.Operators.Add(cp_, bs_);
 				var ct_ = context.Operators.Add(cr_, bu_);
 				var cu_ = context.Operators.Interval(cn_, ct_, true, false);
-				var cw_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var cw_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var cy_ = context.Operators.Add(cw_, bo_);
-				var da_ = FHIRHelpers_4_0_001.Instance.ToDate(context, bm_?.BirthDateElement);
+				var da_ = FHIRHelpers_4_0_001.ToDate(bm_?.BirthDateElement);
 				var dc_ = context.Operators.Add(da_, bs_);
 				var de_ = context.Operators.Add(dc_, bu_);
 				var df_ = context.Operators.Interval(cy_, de_, true, false);
@@ -560,7 +582,7 @@ public class NCQAFHIRBase_1_0_0
 	}
 
     [CqlDeclaration("GetId")]
-	public string GetId(CqlContext context, string uri)
+	public string GetId(string uri)
 	{
 		string a_()
 		{
@@ -581,11 +603,11 @@ public class NCQAFHIRBase_1_0_0
 	}
 
     [CqlDeclaration("VS Cast Function")]
-	public IEnumerable<CqlCode> VS_Cast_Function(CqlContext context, IEnumerable<CqlCode> VSet) => 
+	public IEnumerable<CqlCode> VS_Cast_Function(IEnumerable<CqlCode> VSet) => 
 		VSet;
 
     [CqlDeclaration("First Dates per 31 Day Periods")]
-	public Tuples.Tuple_DUDddjZaCdFGjLXVHKdDKIRfT First_Dates_per_31_Day_Periods(CqlContext context, IEnumerable<CqlDate> DateList)
+	public Tuples.Tuple_DUDddjZaCdFGjLXVHKdDKIRfT First_Dates_per_31_Day_Periods(IEnumerable<CqlDate> DateList)
 	{
 		CqlDate a_(CqlDate d) => 
 			d;

--- a/Demo/Measures/NCQAHealthPlanEnrollment-1.0.0.cs
+++ b/Demo/Measures/NCQAHealthPlanEnrollment-1.0.0.cs
@@ -14,14 +14,35 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAHealthPlanEnrollment_1_0_0
 {
 
-    public static NCQAHealthPlanEnrollment_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+
+    #endregion
+    public NCQAHealthPlanEnrollment_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQATerminology_1_0_0 = new NCQATerminology_1_0_0(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQATerminology_1_0_0 NCQATerminology_1_0_0 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+
+    #endregion
 
     [CqlDeclaration("CoverageIntervals")]
-	public IEnumerable<CqlInterval<CqlDate>> CoverageIntervals(CqlContext context, IEnumerable<Coverage> Coverage, CqlInterval<CqlDate> participationPeriod)
+	public IEnumerable<CqlInterval<CqlDate>> CoverageIntervals(IEnumerable<Coverage> Coverage, CqlInterval<CqlDate> participationPeriod)
 	{
 		CqlInterval<CqlDate> a_(Coverage C)
 		{
-			var c_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (C?.Period as object));
+			var c_ = NCQAFHIRBase_1_0_0.Normalize_Interval((C?.Period as object));
 			var d_ = context.Operators.Start(c_);
 			var e_ = context.Operators.DateFrom(d_);
 			var g_ = context.Operators.End(c_);
@@ -40,7 +61,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Collapsed Coverage Intervals")]
-	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Coverage_Intervals(CqlContext context, IEnumerable<CqlInterval<CqlDate>> Intervals)
+	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Coverage_Intervals(IEnumerable<CqlInterval<CqlDate>> Intervals)
 	{
 		var a_ = NCQACQLBase_1_0_0.Instance.Collapse_Date_Interval_Workaround(context, Intervals);
 
@@ -48,7 +69,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Collapsed Coverage Adjacent Intervals")]
-	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Coverage_Adjacent_Intervals(CqlContext context, IEnumerable<CqlInterval<CqlDate>> Intervals)
+	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Coverage_Adjacent_Intervals(IEnumerable<CqlInterval<CqlDate>> Intervals)
 	{
 		IEnumerable<CqlInterval<CqlDate>> a_(CqlInterval<CqlDate> _Coverage1) => 
 			Intervals;
@@ -92,10 +113,10 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Collapsed Final Coverage Intervals")]
-	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Final_Coverage_Intervals(CqlContext context, IEnumerable<CqlInterval<CqlDate>> collapsedI, IEnumerable<CqlInterval<CqlDate>> adjacentI)
+	public IEnumerable<CqlInterval<CqlDate>> Collapsed_Final_Coverage_Intervals(IEnumerable<CqlInterval<CqlDate>> collapsedI, IEnumerable<CqlInterval<CqlDate>> adjacentI)
 	{
-		var a_ = this.Collapsed_Coverage_Intervals(context, collapsedI);
-		var b_ = this.Collapsed_Coverage_Adjacent_Intervals(context, adjacentI);
+		var a_ = this.Collapsed_Coverage_Intervals(collapsedI);
+		var b_ = this.Collapsed_Coverage_Adjacent_Intervals(adjacentI);
 		var c_ = context.Operators.ListUnion<CqlInterval<CqlDate>>(a_, b_);
 		var d_ = NCQACQLBase_1_0_0.Instance.Collapse_Date_Interval_Workaround(context, c_);
 
@@ -103,18 +124,18 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("All Coverage Info")]
-	public IEnumerable<Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC> All_Coverage_Info(CqlContext context, IEnumerable<Coverage> Coverage, CqlInterval<CqlDate> participationPeriod)
+	public IEnumerable<Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC> All_Coverage_Info(IEnumerable<Coverage> Coverage, CqlInterval<CqlDate> participationPeriod)
 	{
 		Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC a_(Coverage C)
 		{
-			var c_ = this.CoverageIntervals(context, Coverage, participationPeriod);
-			var e_ = this.Collapsed_Coverage_Intervals(context, c_);
-			var g_ = this.Collapsed_Coverage_Intervals(context, c_);
-			var h_ = this.Collapsed_Coverage_Adjacent_Intervals(context, g_);
-			var j_ = this.Collapsed_Coverage_Intervals(context, c_);
-			var l_ = this.Collapsed_Coverage_Intervals(context, c_);
-			var m_ = this.Collapsed_Coverage_Adjacent_Intervals(context, l_);
-			var n_ = this.Collapsed_Final_Coverage_Intervals(context, j_, m_);
+			var c_ = this.CoverageIntervals(Coverage, participationPeriod);
+			var e_ = this.Collapsed_Coverage_Intervals(c_);
+			var g_ = this.Collapsed_Coverage_Intervals(c_);
+			var h_ = this.Collapsed_Coverage_Adjacent_Intervals(g_);
+			var j_ = this.Collapsed_Coverage_Intervals(c_);
+			var l_ = this.Collapsed_Coverage_Intervals(c_);
+			var m_ = this.Collapsed_Coverage_Adjacent_Intervals(l_);
+			var n_ = this.Collapsed_Final_Coverage_Intervals(j_, m_);
 			var o_ = new Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC
 			{
 				IntervalInfo = c_,
@@ -131,19 +152,19 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Health Plan Coverage Resources")]
-	public IEnumerable<Coverage> Health_Plan_Coverage_Resources(CqlContext context, IEnumerable<Coverage> Coverage)
+	public IEnumerable<Coverage> Health_Plan_Coverage_Resources(IEnumerable<Coverage> Coverage)
 	{
 		bool? a_(Coverage C)
 		{
 			bool? e_(Coding cTypeCoding)
 			{
-				var h_ = FHIRHelpers_4_0_001.Instance.ToCode(context, cTypeCoding);
-				var i_ = NCQATerminology_1_0_0.Instance.managed_care_policy(context);
+				var h_ = FHIRHelpers_4_0_001.ToCode(cTypeCoding);
+				var i_ = NCQATerminology_1_0_0.managed_care_policy();
 				var j_ = context.Operators.Equivalent(h_, i_);
-				var l_ = NCQATerminology_1_0_0.Instance.retiree_health_program(context);
+				var l_ = NCQATerminology_1_0_0.retiree_health_program();
 				var m_ = context.Operators.Equivalent(h_, l_);
 				var n_ = context.Operators.Or(j_, m_);
-				var p_ = NCQATerminology_1_0_0.Instance.subsidized_health_program(context);
+				var p_ = NCQATerminology_1_0_0.subsidized_health_program();
 				var q_ = context.Operators.Equivalent(h_, p_);
 				var r_ = context.Operators.Or(n_, q_);
 
@@ -167,13 +188,13 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Anchor Date Criteria")]
-	public bool? Anchor_Date_Criteria(CqlContext context, IEnumerable<Coverage> Coverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod)
+	public bool? Anchor_Date_Criteria(IEnumerable<Coverage> Coverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod)
 	{
 		bool? a_()
 		{
 			if ((context.Operators.ElementInInterval<CqlDate>(AnchorDate, participationPeriod, null) ?? false))
 			{
-				var b_ = this.All_Coverage_Info(context, Coverage, participationPeriod);
+				var b_ = this.All_Coverage_Info(Coverage, participationPeriod);
 				bool? c_(Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC @this)
 				{
 					var k_ = context.Operators.Not((bool?)(@this?.CollapsedFinal is null));
@@ -210,7 +231,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 				var p_ = context.Operators.SelectOrNull<Coverage, Period>(n_, o_);
 				bool? q_(Period Cperiod)
 				{
-					var u_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (Cperiod as object));
+					var u_ = NCQAFHIRBase_1_0_0.Normalize_Interval((Cperiod as object));
 					var v_ = context.Operators.Start(u_);
 					var w_ = context.Operators.DateFrom(v_);
 					var y_ = context.Operators.End(u_);
@@ -239,10 +260,10 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Health Plan Enrollment Criteria")]
-	public bool? Health_Plan_Enrollment_Criteria(CqlContext context, IEnumerable<Coverage> Coverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
+	public bool? Health_Plan_Enrollment_Criteria(IEnumerable<Coverage> Coverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
 	{
-		var a_ = this.Health_Plan_Coverage_Resources(context, Coverage);
-		var b_ = this.All_Coverage_Info(context, a_, participationPeriod);
+		var a_ = this.Health_Plan_Coverage_Resources(Coverage);
+		var b_ = this.All_Coverage_Info(a_, participationPeriod);
 		bool? c_(Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC @this)
 		{
 			var m_ = context.Operators.Not((bool?)(@this?.CollapsedFinal is null));
@@ -264,7 +285,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 			var n_ = context.Operators.LessOrEqual(GapsInEnrollment?.Interval_Count, (int?)1);
 			var o_ = context.Operators.LessOrEqual(GapsInEnrollment?.Total_Days_In_Longest_Interval, AllowedGapDays);
 			var p_ = context.Operators.And(n_, o_);
-			var q_ = this.Anchor_Date_Criteria(context, Coverage, AnchorDate, participationPeriod);
+			var q_ = this.Anchor_Date_Criteria(Coverage, AnchorDate, participationPeriod);
 			var r_ = context.Operators.And(p_, q_);
 
 			return r_;
@@ -276,14 +297,14 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Pharmacy Benefit Coverage Resources")]
-	public IEnumerable<Coverage> Pharmacy_Benefit_Coverage_Resources(CqlContext context, IEnumerable<Coverage> Coverage)
+	public IEnumerable<Coverage> Pharmacy_Benefit_Coverage_Resources(IEnumerable<Coverage> Coverage)
 	{
 		bool? a_(Coverage C)
 		{
 			bool? e_(Coding cTypeCoding)
 			{
-				var h_ = FHIRHelpers_4_0_001.Instance.ToCode(context, cTypeCoding);
-				var i_ = NCQATerminology_1_0_0.Instance.drug_policy(context);
+				var h_ = FHIRHelpers_4_0_001.ToCode(cTypeCoding);
+				var i_ = NCQATerminology_1_0_0.drug_policy();
 				var j_ = context.Operators.Equivalent(h_, i_);
 
 				return j_;
@@ -306,10 +327,10 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Pharmacy Benefit Enrollment Criteria")]
-	public bool? Pharmacy_Benefit_Enrollment_Criteria(CqlContext context, IEnumerable<Coverage> PharmCoverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
+	public bool? Pharmacy_Benefit_Enrollment_Criteria(IEnumerable<Coverage> PharmCoverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
 	{
-		var a_ = this.Pharmacy_Benefit_Coverage_Resources(context, PharmCoverage);
-		var b_ = this.All_Coverage_Info(context, a_, participationPeriod);
+		var a_ = this.Pharmacy_Benefit_Coverage_Resources(PharmCoverage);
+		var b_ = this.All_Coverage_Info(a_, participationPeriod);
 		bool? c_(Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC @this)
 		{
 			var m_ = context.Operators.Not((bool?)(@this?.CollapsedFinal is null));
@@ -331,7 +352,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 			var n_ = context.Operators.LessOrEqual(GapsInEnrollment?.Interval_Count, (int?)1);
 			var o_ = context.Operators.LessOrEqual(GapsInEnrollment?.Total_Days_In_Longest_Interval, AllowedGapDays);
 			var p_ = context.Operators.And(n_, o_);
-			var q_ = this.Anchor_Date_Criteria(context, PharmCoverage, AnchorDate, participationPeriod);
+			var q_ = this.Anchor_Date_Criteria(PharmCoverage, AnchorDate, participationPeriod);
 			var r_ = context.Operators.And(p_, q_);
 
 			return r_;
@@ -343,14 +364,14 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Mental Health Benefit Coverage Resources")]
-	public IEnumerable<Coverage> Mental_Health_Benefit_Coverage_Resources(CqlContext context, IEnumerable<Coverage> Coverage)
+	public IEnumerable<Coverage> Mental_Health_Benefit_Coverage_Resources(IEnumerable<Coverage> Coverage)
 	{
 		bool? a_(Coverage C)
 		{
 			bool? e_(Coding cTypeCoding)
 			{
-				var h_ = FHIRHelpers_4_0_001.Instance.ToCode(context, cTypeCoding);
-				var i_ = NCQATerminology_1_0_0.Instance.mental_health_policy(context);
+				var h_ = FHIRHelpers_4_0_001.ToCode(cTypeCoding);
+				var i_ = NCQATerminology_1_0_0.mental_health_policy();
 				var j_ = context.Operators.Equivalent(h_, i_);
 
 				return j_;
@@ -373,10 +394,10 @@ public class NCQAHealthPlanEnrollment_1_0_0
 	}
 
     [CqlDeclaration("Mental Health Benefit Enrollment Criteria")]
-	public bool? Mental_Health_Benefit_Enrollment_Criteria(CqlContext context, IEnumerable<Coverage> MHCoverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
+	public bool? Mental_Health_Benefit_Enrollment_Criteria(IEnumerable<Coverage> MHCoverage, CqlDate AnchorDate, CqlInterval<CqlDate> participationPeriod, int? AllowedGapDays)
 	{
-		var a_ = this.Mental_Health_Benefit_Coverage_Resources(context, MHCoverage);
-		var b_ = this.All_Coverage_Info(context, a_, participationPeriod);
+		var a_ = this.Mental_Health_Benefit_Coverage_Resources(MHCoverage);
+		var b_ = this.All_Coverage_Info(a_, participationPeriod);
 		bool? c_(Tuples.Tuple_EEdUbUaNBDSUUQFEZDJDbZRcC @this)
 		{
 			var m_ = context.Operators.Not((bool?)(@this?.CollapsedFinal is null));
@@ -398,7 +419,7 @@ public class NCQAHealthPlanEnrollment_1_0_0
 			var n_ = context.Operators.LessOrEqual(GapsInEnrollment?.Interval_Count, (int?)1);
 			var o_ = context.Operators.LessOrEqual(GapsInEnrollment?.Total_Days_In_Longest_Interval, AllowedGapDays);
 			var p_ = context.Operators.And(n_, o_);
-			var q_ = this.Anchor_Date_Criteria(context, MHCoverage, AnchorDate, participationPeriod);
+			var q_ = this.Anchor_Date_Criteria(MHCoverage, AnchorDate, participationPeriod);
 			var r_ = context.Operators.And(p_, q_);
 
 			return r_;

--- a/Demo/Measures/NCQAHospice-1.0.0.cs
+++ b/Demo/Measures/NCQAHospice-1.0.0.cs
@@ -14,28 +14,67 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAHospice_1_0_0
 {
 
-    public static NCQAHospice_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Hospice_Encounter;
+    internal Lazy<CqlValueSet> __Hospice_Intervention;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Hospice_Intervention_or_Encounter;
+
+    #endregion
+    public NCQAHospice_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQAStatus_1_0_0 = new NCQAStatus_1_0_0(context);
+
+        __Hospice_Encounter = new Lazy<CqlValueSet>(this.Hospice_Encounter_Value(context));
+        __Hospice_Intervention = new Lazy<CqlValueSet>(this.Hospice_Intervention_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Hospice_Intervention_or_Encounter = new Lazy<bool?>(this.Hospice_Intervention_or_Encounter_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQAStatus_1_0_0 NCQAStatus_1_0_0 { get; }
+
+    #endregion
+
+	private CqlValueSet Hospice_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", null);
 
     [CqlDeclaration("Hospice Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761")]
-	public CqlValueSet Hospice_Encounter(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1761", null);
+	public CqlValueSet Hospice_Encounter() => 
+		__Hospice_Encounter?.Value;
+
+	private CqlValueSet Hospice_Intervention_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", null);
 
     [CqlDeclaration("Hospice Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762")]
-	public CqlValueSet Hospice_Intervention(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1762", null);
+	public CqlValueSet Hospice_Intervention() => 
+		__Hospice_Intervention?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("NCQAHospice-1.0.0", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -43,29 +82,32 @@ public class NCQAHospice_1_0_0
 		return b_;
 	}
 
-    [CqlDeclaration("Hospice Intervention or Encounter")]
-	public bool? Hospice_Intervention_or_Encounter(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private bool? Hospice_Intervention_or_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Hospice_Intervention(context);
+		var a_ = this.Hospice_Intervention();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
-		var c_ = NCQAStatus_1_0_0.Instance.Completed_or_Ongoing_Procedure(context, b_);
+		var c_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(b_);
 		bool? d_(Procedure HospiceInt)
 		{
-			var n_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, HospiceInt?.Performed);
-			var o_ = this.Measurement_Period(context);
+			var n_ = NCQAFHIRBase_1_0_0.Normalize_Interval(HospiceInt?.Performed);
+			var o_ = this.Measurement_Period();
 			var p_ = context.Operators.Overlaps(n_, o_, null);
 
 			return p_;
 		};
 		var e_ = context.Operators.WhereOrNull<Procedure>(c_, d_);
 		var f_ = context.Operators.ExistsInList<Procedure>(e_);
-		var g_ = this.Hospice_Encounter(context);
+		var g_ = this.Hospice_Encounter();
 		var h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
-		var i_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, h_);
+		var i_ = NCQAStatus_1_0_0.Finished_Encounter(h_);
 		bool? j_(Encounter HospiceEnc)
 		{
-			var q_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (HospiceEnc?.Period as object));
-			var r_ = this.Measurement_Period(context);
+			var q_ = NCQAFHIRBase_1_0_0.Normalize_Interval((HospiceEnc?.Period as object));
+			var r_ = this.Measurement_Period();
 			var s_ = context.Operators.Overlaps(q_, r_, null);
 
 			return s_;
@@ -76,5 +118,9 @@ public class NCQAHospice_1_0_0
 
 		return m_;
 	}
+
+    [CqlDeclaration("Hospice Intervention or Encounter")]
+	public bool? Hospice_Intervention_or_Encounter() => 
+		__Hospice_Intervention_or_Encounter?.Value;
 
 }

--- a/Demo/Measures/NCQAPalliativeCare-1.0.0.cs
+++ b/Demo/Measures/NCQAPalliativeCare-1.0.0.cs
@@ -14,29 +14,71 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAPalliativeCare_1_0_0
 {
 
-    public static NCQAPalliativeCare_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Palliative_Care_Assessment;
+    internal Lazy<CqlValueSet> __Palliative_Care_Encounter;
+    internal Lazy<CqlValueSet> __Palliative_Care_Intervention;
+    internal Lazy<CqlCode> __Encounter_for_palliative_care;
+    internal Lazy<CqlCode[]> __ICD_10;
+
+    #endregion
+    public NCQAPalliativeCare_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQAFHIRBase_1_0_0 = new NCQAFHIRBase_1_0_0(context);
+        NCQAStatus_1_0_0 = new NCQAStatus_1_0_0(context);
+
+        __Palliative_Care_Assessment = new Lazy<CqlValueSet>(this.Palliative_Care_Assessment_Value(context));
+        __Palliative_Care_Encounter = new Lazy<CqlValueSet>(this.Palliative_Care_Encounter_Value(context));
+        __Palliative_Care_Intervention = new Lazy<CqlValueSet>(this.Palliative_Care_Intervention_Value(context));
+        __Encounter_for_palliative_care = new Lazy<CqlCode>(this.Encounter_for_palliative_care_Value(context));
+        __ICD_10 = new Lazy<CqlCode[]>(this.ICD_10_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQAFHIRBase_1_0_0 NCQAFHIRBase_1_0_0 { get; }
+    public NCQAStatus_1_0_0 NCQAStatus_1_0_0 { get; }
+
+    #endregion
+
+	private CqlValueSet Palliative_Care_Assessment_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", null);
 
     [CqlDeclaration("Palliative Care Assessment")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225")]
-	public CqlValueSet Palliative_Care_Assessment(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2225", null);
+	public CqlValueSet Palliative_Care_Assessment() => 
+		__Palliative_Care_Assessment?.Value;
+
+	private CqlValueSet Palliative_Care_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", null);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450")]
-	public CqlValueSet Palliative_Care_Encounter(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.1450", null);
+	public CqlValueSet Palliative_Care_Encounter() => 
+		__Palliative_Care_Encounter?.Value;
+
+	private CqlValueSet Palliative_Care_Intervention_Value(CqlContext context) => 
+		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", null);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224")]
-	public CqlValueSet Palliative_Care_Intervention(CqlContext context) => 
-		new CqlValueSet("https://www.ncqa.org/fhir/valueset/2.16.840.1.113883.3.464.1004.2224", null);
+	public CqlValueSet Palliative_Care_Intervention() => 
+		__Palliative_Care_Intervention?.Value;
 
-    [CqlDeclaration("Encounter for palliative care")]
-	public CqlCode Encounter_for_palliative_care(CqlContext context) => 
+	private CqlCode Encounter_for_palliative_care_Value(CqlContext context) => 
 		new CqlCode("Z51.5", "http://hl7.org/fhir/sid/icd-10-cm", null, null);
 
-    [CqlDeclaration("ICD-10")]
-	public CqlCode[] ICD_10(CqlContext context)
+    [CqlDeclaration("Encounter for palliative care")]
+	public CqlCode Encounter_for_palliative_care() => 
+		__Encounter_for_palliative_care?.Value;
+
+	private CqlCode[] ICD_10_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -46,14 +88,18 @@ public class NCQAPalliativeCare_1_0_0
 		return a_;
 	}
 
+    [CqlDeclaration("ICD-10")]
+	public CqlCode[] ICD_10() => 
+		__ICD_10?.Value;
+
     [CqlDeclaration("Palliative Care Overlapping Period")]
-	public bool? Palliative_Care_Overlapping_Period(CqlContext context, CqlInterval<CqlDateTime> Period)
+	public bool? Palliative_Care_Overlapping_Period(CqlInterval<CqlDateTime> Period)
 	{
-		var a_ = this.Palliative_Care_Assessment(context);
+		var a_ = this.Palliative_Care_Assessment();
 		var b_ = context.Operators.RetrieveByValueSet<Observation>(a_, null);
 		bool? c_(Observation PalliativeAssessment)
 		{
-			var ab_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PalliativeAssessment?.Effective);
+			var ab_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PalliativeAssessment?.Effective);
 			var ac_ = context.Operators.Start(ab_);
 			var ad_ = context.Operators.DateFrom(ac_);
 			var af_ = context.Operators.End(ab_);
@@ -70,12 +116,12 @@ public class NCQAPalliativeCare_1_0_0
 		};
 		var d_ = context.Operators.WhereOrNull<Observation>(b_, c_);
 		var e_ = context.Operators.ExistsInList<Observation>(d_);
-		var f_ = this.Palliative_Care_Encounter(context);
+		var f_ = this.Palliative_Care_Encounter();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = NCQAStatus_1_0_0.Instance.Finished_Encounter(context, g_);
+		var h_ = NCQAStatus_1_0_0.Finished_Encounter(g_);
 		bool? i_(Encounter PalliativeEncounter)
 		{
-			var ao_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, (PalliativeEncounter?.Period as object));
+			var ao_ = NCQAFHIRBase_1_0_0.Normalize_Interval((PalliativeEncounter?.Period as object));
 			var ap_ = context.Operators.Start(ao_);
 			var aq_ = context.Operators.DateFrom(ap_);
 			var as_ = context.Operators.End(ao_);
@@ -93,12 +139,12 @@ public class NCQAPalliativeCare_1_0_0
 		var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
 		var k_ = context.Operators.ExistsInList<Encounter>(j_);
 		var l_ = context.Operators.Or(e_, k_);
-		var m_ = this.Palliative_Care_Intervention(context);
+		var m_ = this.Palliative_Care_Intervention();
 		var n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, null);
-		var o_ = NCQAStatus_1_0_0.Instance.Completed_or_Ongoing_Procedure(context, n_);
+		var o_ = NCQAStatus_1_0_0.Completed_or_Ongoing_Procedure(n_);
 		bool? p_(Procedure PalliativeIntervention)
 		{
-			var bb_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, PalliativeIntervention?.Performed);
+			var bb_ = NCQAFHIRBase_1_0_0.Normalize_Interval(PalliativeIntervention?.Performed);
 			var bc_ = context.Operators.Start(bb_);
 			var bd_ = context.Operators.DateFrom(bc_);
 			var bf_ = context.Operators.End(bb_);
@@ -116,13 +162,13 @@ public class NCQAPalliativeCare_1_0_0
 		var q_ = context.Operators.WhereOrNull<Procedure>(o_, p_);
 		var r_ = context.Operators.ExistsInList<Procedure>(q_);
 		var s_ = context.Operators.Or(l_, r_);
-		var t_ = this.Encounter_for_palliative_care(context);
+		var t_ = this.Encounter_for_palliative_care();
 		var u_ = context.Operators.ToList<CqlCode>(t_);
 		var v_ = context.Operators.RetrieveByCodes<Condition>(u_, null);
-		var w_ = NCQAStatus_1_0_0.Instance.Active_Condition(context, v_);
+		var w_ = NCQAStatus_1_0_0.Active_Condition(v_);
 		bool? x_(Condition PalliativeDiagnosis)
 		{
-			var bo_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, PalliativeDiagnosis);
+			var bo_ = NCQAFHIRBase_1_0_0.Prevalence_Period(PalliativeDiagnosis);
 			var bp_ = context.Operators.Start(bo_);
 			var bq_ = context.Operators.DateFrom(bp_);
 			var bs_ = context.Operators.End(bo_);

--- a/Demo/Measures/NCQAStatus-1.0.0.cs
+++ b/Demo/Measures/NCQAStatus-1.0.0.cs
@@ -14,10 +14,30 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQAStatus_1_0_0
 {
 
-    public static NCQAStatus_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    #region Cached values
+
+    internal Lazy<Patient> __Patient;
+
+    #endregion
+    public NCQAStatus_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        NCQATerminology_1_0_0 = new NCQATerminology_1_0_0(context);
+
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public NCQATerminology_1_0_0 NCQATerminology_1_0_0 { get; }
+
+    #endregion
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -25,13 +45,17 @@ public class NCQAStatus_1_0_0
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("Active Allergy")]
-	public IEnumerable<AllergyIntolerance> Active_Allergy(CqlContext context, IEnumerable<AllergyIntolerance> Allergy)
+	public IEnumerable<AllergyIntolerance> Active_Allergy(IEnumerable<AllergyIntolerance> Allergy)
 	{
 		bool? a_(AllergyIntolerance A)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, A?.ClinicalStatus);
-			var d_ = NCQATerminology_1_0_0.Instance.allergy_active(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(A?.ClinicalStatus);
+			var d_ = NCQATerminology_1_0_0.allergy_active();
 			var e_ = context.Operators.ConvertCodeToConcept(d_);
 			var f_ = context.Operators.Equal(c_, e_);
 
@@ -43,12 +67,12 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Active Condition")]
-	public IEnumerable<Condition> Active_Condition(CqlContext context, IEnumerable<Condition> Condition)
+	public IEnumerable<Condition> Active_Condition(IEnumerable<Condition> Condition)
 	{
 		bool? a_(Condition C)
 		{
-			var c_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, C?.ClinicalStatus);
-			var d_ = NCQATerminology_1_0_0.Instance.active(context);
+			var c_ = FHIRHelpers_4_0_001.ToConcept(C?.ClinicalStatus);
+			var d_ = NCQATerminology_1_0_0.active();
 			var e_ = context.Operators.ConvertCodeToConcept(d_);
 			var f_ = context.Operators.Equal(c_, e_);
 
@@ -60,7 +84,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Finished Encounter")]
-	public IEnumerable<Encounter> Finished_Encounter(CqlContext context, IEnumerable<Encounter> Enc)
+	public IEnumerable<Encounter> Finished_Encounter(IEnumerable<Encounter> Enc)
 	{
 		bool? a_(Encounter E)
 		{
@@ -75,7 +99,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Completed Immunization")]
-	public IEnumerable<Immunization> Completed_Immunization(CqlContext context, IEnumerable<Immunization> Immunization)
+	public IEnumerable<Immunization> Completed_Immunization(IEnumerable<Immunization> Immunization)
 	{
 		bool? a_(Immunization I)
 		{
@@ -90,7 +114,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Dispensed Medication")]
-	public IEnumerable<MedicationDispense> Dispensed_Medication(CqlContext context, IEnumerable<MedicationDispense> Med)
+	public IEnumerable<MedicationDispense> Dispensed_Medication(IEnumerable<MedicationDispense> Med)
 	{
 		bool? a_(MedicationDispense M)
 		{
@@ -105,7 +129,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Active Medication")]
-	public IEnumerable<MedicationRequest> Active_Medication(CqlContext context, IEnumerable<MedicationRequest> Med)
+	public IEnumerable<MedicationRequest> Active_Medication(IEnumerable<MedicationRequest> Med)
 	{
 		bool? a_(MedicationRequest M)
 		{
@@ -124,7 +148,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Completed Procedure")]
-	public IEnumerable<Procedure> Completed_Procedure(CqlContext context, IEnumerable<Procedure> Proc)
+	public IEnumerable<Procedure> Completed_Procedure(IEnumerable<Procedure> Proc)
 	{
 		bool? a_(Procedure P)
 		{
@@ -139,7 +163,7 @@ public class NCQAStatus_1_0_0
 	}
 
     [CqlDeclaration("Completed or Ongoing Procedure")]
-	public IEnumerable<Procedure> Completed_or_Ongoing_Procedure(CqlContext context, IEnumerable<Procedure> Proc)
+	public IEnumerable<Procedure> Completed_or_Ongoing_Procedure(IEnumerable<Procedure> Proc)
 	{
 		bool? a_(Procedure P)
 		{

--- a/Demo/Measures/NCQATerminology-1.0.0.cs
+++ b/Demo/Measures/NCQATerminology-1.0.0.cs
@@ -14,202 +14,504 @@ using Task = Hl7.Fhir.Model.Task;
 public class NCQATerminology_1_0_0
 {
 
-    public static NCQATerminology_1_0_0 Instance { get; }  = new();
+    internal CqlContext context;
 
-    [CqlDeclaration("problem-list-item")]
-	public CqlCode problem_list_item(CqlContext context) => 
+    #region Cached values
+
+    internal Lazy<CqlCode> __problem_list_item;
+    internal Lazy<CqlCode> __encounter_diagnosis;
+    internal Lazy<CqlCode> __active;
+    internal Lazy<CqlCode> __recurrence;
+    internal Lazy<CqlCode> __relapse;
+    internal Lazy<CqlCode> __inactive;
+    internal Lazy<CqlCode> __remission;
+    internal Lazy<CqlCode> __resolved;
+    internal Lazy<CqlCode> __unconfirmed;
+    internal Lazy<CqlCode> __provisional;
+    internal Lazy<CqlCode> __differential;
+    internal Lazy<CqlCode> __confirmed;
+    internal Lazy<CqlCode> __refuted;
+    internal Lazy<CqlCode> __entered_in_error;
+    internal Lazy<CqlCode> __allergy_active;
+    internal Lazy<CqlCode> __allergy_inactive;
+    internal Lazy<CqlCode> __allergy_resolved;
+    internal Lazy<CqlCode> __allergy_unconfirmed;
+    internal Lazy<CqlCode> __allergy_confirmed;
+    internal Lazy<CqlCode> __allergy_refuted;
+    internal Lazy<CqlCode> __food;
+    internal Lazy<CqlCode> __medication;
+    internal Lazy<CqlCode> __environment;
+    internal Lazy<CqlCode> __biologic;
+    internal Lazy<CqlCode> __Allergy;
+    internal Lazy<CqlCode> __Intolerance;
+    internal Lazy<CqlCode> __Inpatient;
+    internal Lazy<CqlCode> __Outpatient;
+    internal Lazy<CqlCode> __Community;
+    internal Lazy<CqlCode> __Discharge;
+    internal Lazy<CqlCode> __Pharmacy;
+    internal Lazy<CqlCode> __Institutional;
+    internal Lazy<CqlCode> __Professional;
+    internal Lazy<CqlCode> __Oral;
+    internal Lazy<CqlCode> __Vision;
+    internal Lazy<CqlCode> __virtual;
+    internal Lazy<CqlCode> __ambulatory;
+    internal Lazy<CqlCode> __home_health;
+    internal Lazy<CqlCode> __inpatient_non_acute;
+    internal Lazy<CqlCode> __emergency;
+    internal Lazy<CqlCode> __inpatient_acute;
+    internal Lazy<CqlCode> __drug_policy;
+    internal Lazy<CqlCode> __mental_health_policy;
+    internal Lazy<CqlCode> __managed_care_policy;
+    internal Lazy<CqlCode> __subsidized_health_program;
+    internal Lazy<CqlCode> __retiree_health_program;
+    internal Lazy<CqlCode> __substance_use_policy;
+    internal Lazy<CqlCode> __Provider_number;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __SNOMEDCT;
+    internal Lazy<CqlCode[]> __RoleCode;
+    internal Lazy<CqlCode[]> __Diagnosis_Role;
+    internal Lazy<CqlCode[]> __RequestIntent;
+    internal Lazy<CqlCode[]> __MedicationRequestCategory;
+    internal Lazy<CqlCode[]> __ConditionClinicalStatusCodes;
+    internal Lazy<CqlCode[]> __ConditionVerificationStatusCodes;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceClinicalStatusCodes;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceVerificationStatusCodes;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceType;
+    internal Lazy<CqlCode[]> __AllergyIntoleranceCategory;
+    internal Lazy<CqlCode[]> __ConditionCategoryCodes;
+    internal Lazy<CqlCode[]> __claim_type;
+    internal Lazy<CqlCode[]> __ActEncounterCodes;
+    internal Lazy<CqlCode[]> __coverage_type;
+    internal Lazy<CqlCode[]> __IdentifierType;
+
+    #endregion
+    public NCQATerminology_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __problem_list_item = new Lazy<CqlCode>(this.problem_list_item_Value(context));
+        __encounter_diagnosis = new Lazy<CqlCode>(this.encounter_diagnosis_Value(context));
+        __active = new Lazy<CqlCode>(this.active_Value(context));
+        __recurrence = new Lazy<CqlCode>(this.recurrence_Value(context));
+        __relapse = new Lazy<CqlCode>(this.relapse_Value(context));
+        __inactive = new Lazy<CqlCode>(this.inactive_Value(context));
+        __remission = new Lazy<CqlCode>(this.remission_Value(context));
+        __resolved = new Lazy<CqlCode>(this.resolved_Value(context));
+        __unconfirmed = new Lazy<CqlCode>(this.unconfirmed_Value(context));
+        __provisional = new Lazy<CqlCode>(this.provisional_Value(context));
+        __differential = new Lazy<CqlCode>(this.differential_Value(context));
+        __confirmed = new Lazy<CqlCode>(this.confirmed_Value(context));
+        __refuted = new Lazy<CqlCode>(this.refuted_Value(context));
+        __entered_in_error = new Lazy<CqlCode>(this.entered_in_error_Value(context));
+        __allergy_active = new Lazy<CqlCode>(this.allergy_active_Value(context));
+        __allergy_inactive = new Lazy<CqlCode>(this.allergy_inactive_Value(context));
+        __allergy_resolved = new Lazy<CqlCode>(this.allergy_resolved_Value(context));
+        __allergy_unconfirmed = new Lazy<CqlCode>(this.allergy_unconfirmed_Value(context));
+        __allergy_confirmed = new Lazy<CqlCode>(this.allergy_confirmed_Value(context));
+        __allergy_refuted = new Lazy<CqlCode>(this.allergy_refuted_Value(context));
+        __food = new Lazy<CqlCode>(this.food_Value(context));
+        __medication = new Lazy<CqlCode>(this.medication_Value(context));
+        __environment = new Lazy<CqlCode>(this.environment_Value(context));
+        __biologic = new Lazy<CqlCode>(this.biologic_Value(context));
+        __Allergy = new Lazy<CqlCode>(this.Allergy_Value(context));
+        __Intolerance = new Lazy<CqlCode>(this.Intolerance_Value(context));
+        __Inpatient = new Lazy<CqlCode>(this.Inpatient_Value(context));
+        __Outpatient = new Lazy<CqlCode>(this.Outpatient_Value(context));
+        __Community = new Lazy<CqlCode>(this.Community_Value(context));
+        __Discharge = new Lazy<CqlCode>(this.Discharge_Value(context));
+        __Pharmacy = new Lazy<CqlCode>(this.Pharmacy_Value(context));
+        __Institutional = new Lazy<CqlCode>(this.Institutional_Value(context));
+        __Professional = new Lazy<CqlCode>(this.Professional_Value(context));
+        __Oral = new Lazy<CqlCode>(this.Oral_Value(context));
+        __Vision = new Lazy<CqlCode>(this.Vision_Value(context));
+        __virtual = new Lazy<CqlCode>(this.@virtual_Value(context));
+        __ambulatory = new Lazy<CqlCode>(this.ambulatory_Value(context));
+        __home_health = new Lazy<CqlCode>(this.home_health_Value(context));
+        __inpatient_non_acute = new Lazy<CqlCode>(this.inpatient_non_acute_Value(context));
+        __emergency = new Lazy<CqlCode>(this.emergency_Value(context));
+        __inpatient_acute = new Lazy<CqlCode>(this.inpatient_acute_Value(context));
+        __drug_policy = new Lazy<CqlCode>(this.drug_policy_Value(context));
+        __mental_health_policy = new Lazy<CqlCode>(this.mental_health_policy_Value(context));
+        __managed_care_policy = new Lazy<CqlCode>(this.managed_care_policy_Value(context));
+        __subsidized_health_program = new Lazy<CqlCode>(this.subsidized_health_program_Value(context));
+        __retiree_health_program = new Lazy<CqlCode>(this.retiree_health_program_Value(context));
+        __substance_use_policy = new Lazy<CqlCode>(this.substance_use_policy_Value(context));
+        __Provider_number = new Lazy<CqlCode>(this.Provider_number_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __SNOMEDCT = new Lazy<CqlCode[]>(this.SNOMEDCT_Value(context));
+        __RoleCode = new Lazy<CqlCode[]>(this.RoleCode_Value(context));
+        __Diagnosis_Role = new Lazy<CqlCode[]>(this.Diagnosis_Role_Value(context));
+        __RequestIntent = new Lazy<CqlCode[]>(this.RequestIntent_Value(context));
+        __MedicationRequestCategory = new Lazy<CqlCode[]>(this.MedicationRequestCategory_Value(context));
+        __ConditionClinicalStatusCodes = new Lazy<CqlCode[]>(this.ConditionClinicalStatusCodes_Value(context));
+        __ConditionVerificationStatusCodes = new Lazy<CqlCode[]>(this.ConditionVerificationStatusCodes_Value(context));
+        __AllergyIntoleranceClinicalStatusCodes = new Lazy<CqlCode[]>(this.AllergyIntoleranceClinicalStatusCodes_Value(context));
+        __AllergyIntoleranceVerificationStatusCodes = new Lazy<CqlCode[]>(this.AllergyIntoleranceVerificationStatusCodes_Value(context));
+        __AllergyIntoleranceType = new Lazy<CqlCode[]>(this.AllergyIntoleranceType_Value(context));
+        __AllergyIntoleranceCategory = new Lazy<CqlCode[]>(this.AllergyIntoleranceCategory_Value(context));
+        __ConditionCategoryCodes = new Lazy<CqlCode[]>(this.ConditionCategoryCodes_Value(context));
+        __claim_type = new Lazy<CqlCode[]>(this.claim_type_Value(context));
+        __ActEncounterCodes = new Lazy<CqlCode[]>(this.ActEncounterCodes_Value(context));
+        __coverage_type = new Lazy<CqlCode[]>(this.coverage_type_Value(context));
+        __IdentifierType = new Lazy<CqlCode[]>(this.IdentifierType_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlCode problem_list_item_Value(CqlContext context) => 
 		new CqlCode("problem-list-item", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
 
-    [CqlDeclaration("encounter-diagnosis")]
-	public CqlCode encounter_diagnosis(CqlContext context) => 
+    [CqlDeclaration("problem-list-item")]
+	public CqlCode problem_list_item() => 
+		__problem_list_item?.Value;
+
+	private CqlCode encounter_diagnosis_Value(CqlContext context) => 
 		new CqlCode("encounter-diagnosis", "http://terminology.hl7.org/CodeSystem/condition-category", null, null);
 
-    [CqlDeclaration("active")]
-	public CqlCode active(CqlContext context) => 
+    [CqlDeclaration("encounter-diagnosis")]
+	public CqlCode encounter_diagnosis() => 
+		__encounter_diagnosis?.Value;
+
+	private CqlCode active_Value(CqlContext context) => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("recurrence")]
-	public CqlCode recurrence(CqlContext context) => 
+    [CqlDeclaration("active")]
+	public CqlCode active() => 
+		__active?.Value;
+
+	private CqlCode recurrence_Value(CqlContext context) => 
 		new CqlCode("recurrence", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("relapse")]
-	public CqlCode relapse(CqlContext context) => 
+    [CqlDeclaration("recurrence")]
+	public CqlCode recurrence() => 
+		__recurrence?.Value;
+
+	private CqlCode relapse_Value(CqlContext context) => 
 		new CqlCode("relapse", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("inactive")]
-	public CqlCode inactive(CqlContext context) => 
+    [CqlDeclaration("relapse")]
+	public CqlCode relapse() => 
+		__relapse?.Value;
+
+	private CqlCode inactive_Value(CqlContext context) => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("remission")]
-	public CqlCode remission(CqlContext context) => 
+    [CqlDeclaration("inactive")]
+	public CqlCode inactive() => 
+		__inactive?.Value;
+
+	private CqlCode remission_Value(CqlContext context) => 
 		new CqlCode("remission", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("resolved")]
-	public CqlCode resolved(CqlContext context) => 
+    [CqlDeclaration("remission")]
+	public CqlCode remission() => 
+		__remission?.Value;
+
+	private CqlCode resolved_Value(CqlContext context) => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/condition-clinical", null, null);
 
-    [CqlDeclaration("unconfirmed")]
-	public CqlCode unconfirmed(CqlContext context) => 
+    [CqlDeclaration("resolved")]
+	public CqlCode resolved() => 
+		__resolved?.Value;
+
+	private CqlCode unconfirmed_Value(CqlContext context) => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("provisional")]
-	public CqlCode provisional(CqlContext context) => 
+    [CqlDeclaration("unconfirmed")]
+	public CqlCode unconfirmed() => 
+		__unconfirmed?.Value;
+
+	private CqlCode provisional_Value(CqlContext context) => 
 		new CqlCode("provisional", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("differential")]
-	public CqlCode differential(CqlContext context) => 
+    [CqlDeclaration("provisional")]
+	public CqlCode provisional() => 
+		__provisional?.Value;
+
+	private CqlCode differential_Value(CqlContext context) => 
 		new CqlCode("differential", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("confirmed")]
-	public CqlCode confirmed(CqlContext context) => 
+    [CqlDeclaration("differential")]
+	public CqlCode differential() => 
+		__differential?.Value;
+
+	private CqlCode confirmed_Value(CqlContext context) => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("refuted")]
-	public CqlCode refuted(CqlContext context) => 
+    [CqlDeclaration("confirmed")]
+	public CqlCode confirmed() => 
+		__confirmed?.Value;
+
+	private CqlCode refuted_Value(CqlContext context) => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("entered-in-error")]
-	public CqlCode entered_in_error(CqlContext context) => 
+    [CqlDeclaration("refuted")]
+	public CqlCode refuted() => 
+		__refuted?.Value;
+
+	private CqlCode entered_in_error_Value(CqlContext context) => 
 		new CqlCode("entered-in-error", "http://terminology.hl7.org/CodeSystem/condition-verification", null, null);
 
-    [CqlDeclaration("allergy-active")]
-	public CqlCode allergy_active(CqlContext context) => 
+    [CqlDeclaration("entered-in-error")]
+	public CqlCode entered_in_error() => 
+		__entered_in_error?.Value;
+
+	private CqlCode allergy_active_Value(CqlContext context) => 
 		new CqlCode("active", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-inactive")]
-	public CqlCode allergy_inactive(CqlContext context) => 
+    [CqlDeclaration("allergy-active")]
+	public CqlCode allergy_active() => 
+		__allergy_active?.Value;
+
+	private CqlCode allergy_inactive_Value(CqlContext context) => 
 		new CqlCode("inactive", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-resolved")]
-	public CqlCode allergy_resolved(CqlContext context) => 
+    [CqlDeclaration("allergy-inactive")]
+	public CqlCode allergy_inactive() => 
+		__allergy_inactive?.Value;
+
+	private CqlCode allergy_resolved_Value(CqlContext context) => 
 		new CqlCode("resolved", "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical", null, null);
 
-    [CqlDeclaration("allergy-unconfirmed")]
-	public CqlCode allergy_unconfirmed(CqlContext context) => 
+    [CqlDeclaration("allergy-resolved")]
+	public CqlCode allergy_resolved() => 
+		__allergy_resolved?.Value;
+
+	private CqlCode allergy_unconfirmed_Value(CqlContext context) => 
 		new CqlCode("unconfirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("allergy-confirmed")]
-	public CqlCode allergy_confirmed(CqlContext context) => 
+    [CqlDeclaration("allergy-unconfirmed")]
+	public CqlCode allergy_unconfirmed() => 
+		__allergy_unconfirmed?.Value;
+
+	private CqlCode allergy_confirmed_Value(CqlContext context) => 
 		new CqlCode("confirmed", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("allergy-refuted")]
-	public CqlCode allergy_refuted(CqlContext context) => 
+    [CqlDeclaration("allergy-confirmed")]
+	public CqlCode allergy_confirmed() => 
+		__allergy_confirmed?.Value;
+
+	private CqlCode allergy_refuted_Value(CqlContext context) => 
 		new CqlCode("refuted", "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification", null, null);
 
-    [CqlDeclaration("food")]
-	public CqlCode food(CqlContext context) => 
+    [CqlDeclaration("allergy-refuted")]
+	public CqlCode allergy_refuted() => 
+		__allergy_refuted?.Value;
+
+	private CqlCode food_Value(CqlContext context) => 
 		new CqlCode("food", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
 
-    [CqlDeclaration("medication")]
-	public CqlCode medication(CqlContext context) => 
+    [CqlDeclaration("food")]
+	public CqlCode food() => 
+		__food?.Value;
+
+	private CqlCode medication_Value(CqlContext context) => 
 		new CqlCode("medication", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
 
-    [CqlDeclaration("environment")]
-	public CqlCode environment(CqlContext context) => 
+    [CqlDeclaration("medication")]
+	public CqlCode medication() => 
+		__medication?.Value;
+
+	private CqlCode environment_Value(CqlContext context) => 
 		new CqlCode("environment", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
 
-    [CqlDeclaration("biologic")]
-	public CqlCode biologic(CqlContext context) => 
+    [CqlDeclaration("environment")]
+	public CqlCode environment() => 
+		__environment?.Value;
+
+	private CqlCode biologic_Value(CqlContext context) => 
 		new CqlCode("biologic", "http://hl7.org/fhir/allergy-intolerance-category", null, null);
 
-    [CqlDeclaration("Allergy")]
-	public CqlCode Allergy(CqlContext context) => 
+    [CqlDeclaration("biologic")]
+	public CqlCode biologic() => 
+		__biologic?.Value;
+
+	private CqlCode Allergy_Value(CqlContext context) => 
 		new CqlCode("allergy", "http://hl7.org/fhir/allergy-intolerance-type", null, null);
 
-    [CqlDeclaration("Intolerance")]
-	public CqlCode Intolerance(CqlContext context) => 
+    [CqlDeclaration("Allergy")]
+	public CqlCode Allergy() => 
+		__Allergy?.Value;
+
+	private CqlCode Intolerance_Value(CqlContext context) => 
 		new CqlCode("intolerance", "http://hl7.org/fhir/allergy-intolerance-type", null, null);
 
-    [CqlDeclaration("Inpatient")]
-	public CqlCode Inpatient(CqlContext context) => 
+    [CqlDeclaration("Intolerance")]
+	public CqlCode Intolerance() => 
+		__Intolerance?.Value;
+
+	private CqlCode Inpatient_Value(CqlContext context) => 
 		new CqlCode("inpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("Outpatient")]
-	public CqlCode Outpatient(CqlContext context) => 
+    [CqlDeclaration("Inpatient")]
+	public CqlCode Inpatient() => 
+		__Inpatient?.Value;
+
+	private CqlCode Outpatient_Value(CqlContext context) => 
 		new CqlCode("outpatient", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("Community")]
-	public CqlCode Community(CqlContext context) => 
+    [CqlDeclaration("Outpatient")]
+	public CqlCode Outpatient() => 
+		__Outpatient?.Value;
+
+	private CqlCode Community_Value(CqlContext context) => 
 		new CqlCode("community", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("Discharge")]
-	public CqlCode Discharge(CqlContext context) => 
+    [CqlDeclaration("Community")]
+	public CqlCode Community() => 
+		__Community?.Value;
+
+	private CqlCode Discharge_Value(CqlContext context) => 
 		new CqlCode("discharge", "http://terminology.hl7.org/CodeSystem/medicationrequest-category", null, null);
 
-    [CqlDeclaration("Pharmacy")]
-	public CqlCode Pharmacy(CqlContext context) => 
+    [CqlDeclaration("Discharge")]
+	public CqlCode Discharge() => 
+		__Discharge?.Value;
+
+	private CqlCode Pharmacy_Value(CqlContext context) => 
 		new CqlCode("pharmacy", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
 
-    [CqlDeclaration("Institutional")]
-	public CqlCode Institutional(CqlContext context) => 
+    [CqlDeclaration("Pharmacy")]
+	public CqlCode Pharmacy() => 
+		__Pharmacy?.Value;
+
+	private CqlCode Institutional_Value(CqlContext context) => 
 		new CqlCode("institutional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
 
-    [CqlDeclaration("Professional")]
-	public CqlCode Professional(CqlContext context) => 
+    [CqlDeclaration("Institutional")]
+	public CqlCode Institutional() => 
+		__Institutional?.Value;
+
+	private CqlCode Professional_Value(CqlContext context) => 
 		new CqlCode("professional", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
 
-    [CqlDeclaration("Oral")]
-	public CqlCode Oral(CqlContext context) => 
+    [CqlDeclaration("Professional")]
+	public CqlCode Professional() => 
+		__Professional?.Value;
+
+	private CqlCode Oral_Value(CqlContext context) => 
 		new CqlCode("oral", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
 
-    [CqlDeclaration("Vision")]
-	public CqlCode Vision(CqlContext context) => 
+    [CqlDeclaration("Oral")]
+	public CqlCode Oral() => 
+		__Oral?.Value;
+
+	private CqlCode Vision_Value(CqlContext context) => 
 		new CqlCode("vision", "http://terminology.hl7.org/CodeSystem/claim-type", null, null);
 
-    [CqlDeclaration("virtual")]
-	public CqlCode @virtual(CqlContext context) => 
+    [CqlDeclaration("Vision")]
+	public CqlCode Vision() => 
+		__Vision?.Value;
+
+	private CqlCode @virtual_Value(CqlContext context) => 
 		new CqlCode("VR", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("ambulatory")]
-	public CqlCode ambulatory(CqlContext context) => 
+    [CqlDeclaration("virtual")]
+	public CqlCode @virtual() => 
+		__virtual?.Value;
+
+	private CqlCode ambulatory_Value(CqlContext context) => 
 		new CqlCode("AMB", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("home health")]
-	public CqlCode home_health(CqlContext context) => 
+    [CqlDeclaration("ambulatory")]
+	public CqlCode ambulatory() => 
+		__ambulatory?.Value;
+
+	private CqlCode home_health_Value(CqlContext context) => 
 		new CqlCode("HH", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("inpatient non-acute")]
-	public CqlCode inpatient_non_acute(CqlContext context) => 
+    [CqlDeclaration("home health")]
+	public CqlCode home_health() => 
+		__home_health?.Value;
+
+	private CqlCode inpatient_non_acute_Value(CqlContext context) => 
 		new CqlCode("NONAC", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("emergency")]
-	public CqlCode emergency(CqlContext context) => 
+    [CqlDeclaration("inpatient non-acute")]
+	public CqlCode inpatient_non_acute() => 
+		__inpatient_non_acute?.Value;
+
+	private CqlCode emergency_Value(CqlContext context) => 
 		new CqlCode("EMER", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("inpatient acute")]
-	public CqlCode inpatient_acute(CqlContext context) => 
+    [CqlDeclaration("emergency")]
+	public CqlCode emergency() => 
+		__emergency?.Value;
+
+	private CqlCode inpatient_acute_Value(CqlContext context) => 
 		new CqlCode("ACUTE", "http://terminology.hl7.org/ValueSet/v3-ActEncounterCode", null, null);
 
-    [CqlDeclaration("drug policy")]
-	public CqlCode drug_policy(CqlContext context) => 
+    [CqlDeclaration("inpatient acute")]
+	public CqlCode inpatient_acute() => 
+		__inpatient_acute?.Value;
+
+	private CqlCode drug_policy_Value(CqlContext context) => 
 		new CqlCode("DRUGPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("mental health policy")]
-	public CqlCode mental_health_policy(CqlContext context) => 
+    [CqlDeclaration("drug policy")]
+	public CqlCode drug_policy() => 
+		__drug_policy?.Value;
+
+	private CqlCode mental_health_policy_Value(CqlContext context) => 
 		new CqlCode("MENTPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("managed care policy")]
-	public CqlCode managed_care_policy(CqlContext context) => 
+    [CqlDeclaration("mental health policy")]
+	public CqlCode mental_health_policy() => 
+		__mental_health_policy?.Value;
+
+	private CqlCode managed_care_policy_Value(CqlContext context) => 
 		new CqlCode("MCPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("subsidized health program")]
-	public CqlCode subsidized_health_program(CqlContext context) => 
+    [CqlDeclaration("managed care policy")]
+	public CqlCode managed_care_policy() => 
+		__managed_care_policy?.Value;
+
+	private CqlCode subsidized_health_program_Value(CqlContext context) => 
 		new CqlCode("SUBSIDIZ", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("retiree health program")]
-	public CqlCode retiree_health_program(CqlContext context) => 
+    [CqlDeclaration("subsidized health program")]
+	public CqlCode subsidized_health_program() => 
+		__subsidized_health_program?.Value;
+
+	private CqlCode retiree_health_program_Value(CqlContext context) => 
 		new CqlCode("RETIRE", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("substance use policy")]
-	public CqlCode substance_use_policy(CqlContext context) => 
+    [CqlDeclaration("retiree health program")]
+	public CqlCode retiree_health_program() => 
+		__retiree_health_program?.Value;
+
+	private CqlCode substance_use_policy_Value(CqlContext context) => 
 		new CqlCode("SUBPOL", "http://terminology.hl7.org/ValueSet/v3-ActCoverageTypeCode", null, null);
 
-    [CqlDeclaration("Provider number")]
-	public CqlCode Provider_number(CqlContext context) => 
+    [CqlDeclaration("substance use policy")]
+	public CqlCode substance_use_policy() => 
+		__substance_use_policy?.Value;
+
+	private CqlCode Provider_number_Value(CqlContext context) => 
 		new CqlCode("PRN", "http://terminology.hl7.org/CodeSystem/v2-0203", null, null);
 
+    [CqlDeclaration("Provider number")]
+	public CqlCode Provider_number() => 
+		__Provider_number?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
+	{
+		var a_ = new CqlCode[0]
+;
+
+		return a_;
+	}
+
     [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlCode[] SNOMEDCT_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[0]
 ;
@@ -218,7 +520,10 @@ public class NCQATerminology_1_0_0
 	}
 
     [CqlDeclaration("SNOMEDCT")]
-	public CqlCode[] SNOMEDCT(CqlContext context)
+	public CqlCode[] SNOMEDCT() => 
+		__SNOMEDCT?.Value;
+
+	private CqlCode[] RoleCode_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[0]
 ;
@@ -227,7 +532,10 @@ public class NCQATerminology_1_0_0
 	}
 
     [CqlDeclaration("RoleCode")]
-	public CqlCode[] RoleCode(CqlContext context)
+	public CqlCode[] RoleCode() => 
+		__RoleCode?.Value;
+
+	private CqlCode[] Diagnosis_Role_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[0]
 ;
@@ -236,7 +544,10 @@ public class NCQATerminology_1_0_0
 	}
 
     [CqlDeclaration("Diagnosis Role")]
-	public CqlCode[] Diagnosis_Role(CqlContext context)
+	public CqlCode[] Diagnosis_Role() => 
+		__Diagnosis_Role?.Value;
+
+	private CqlCode[] RequestIntent_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[0]
 ;
@@ -245,16 +556,10 @@ public class NCQATerminology_1_0_0
 	}
 
     [CqlDeclaration("RequestIntent")]
-	public CqlCode[] RequestIntent(CqlContext context)
-	{
-		var a_ = new CqlCode[0]
-;
+	public CqlCode[] RequestIntent() => 
+		__RequestIntent?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("MedicationRequestCategory")]
-	public CqlCode[] MedicationRequestCategory(CqlContext context)
+	private CqlCode[] MedicationRequestCategory_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -267,8 +572,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("ConditionClinicalStatusCodes")]
-	public CqlCode[] ConditionClinicalStatusCodes(CqlContext context)
+    [CqlDeclaration("MedicationRequestCategory")]
+	public CqlCode[] MedicationRequestCategory() => 
+		__MedicationRequestCategory?.Value;
+
+	private CqlCode[] ConditionClinicalStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -283,8 +591,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("ConditionVerificationStatusCodes")]
-	public CqlCode[] ConditionVerificationStatusCodes(CqlContext context)
+    [CqlDeclaration("ConditionClinicalStatusCodes")]
+	public CqlCode[] ConditionClinicalStatusCodes() => 
+		__ConditionClinicalStatusCodes?.Value;
+
+	private CqlCode[] ConditionVerificationStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -299,8 +610,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceClinicalStatusCodes")]
-	public CqlCode[] AllergyIntoleranceClinicalStatusCodes(CqlContext context)
+    [CqlDeclaration("ConditionVerificationStatusCodes")]
+	public CqlCode[] ConditionVerificationStatusCodes() => 
+		__ConditionVerificationStatusCodes?.Value;
+
+	private CqlCode[] AllergyIntoleranceClinicalStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -312,8 +626,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
-	public CqlCode[] AllergyIntoleranceVerificationStatusCodes(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceClinicalStatusCodes")]
+	public CqlCode[] AllergyIntoleranceClinicalStatusCodes() => 
+		__AllergyIntoleranceClinicalStatusCodes?.Value;
+
+	private CqlCode[] AllergyIntoleranceVerificationStatusCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -325,8 +642,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceType")]
-	public CqlCode[] AllergyIntoleranceType(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceVerificationStatusCodes")]
+	public CqlCode[] AllergyIntoleranceVerificationStatusCodes() => 
+		__AllergyIntoleranceVerificationStatusCodes?.Value;
+
+	private CqlCode[] AllergyIntoleranceType_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -337,8 +657,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("AllergyIntoleranceCategory")]
-	public CqlCode[] AllergyIntoleranceCategory(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceType")]
+	public CqlCode[] AllergyIntoleranceType() => 
+		__AllergyIntoleranceType?.Value;
+
+	private CqlCode[] AllergyIntoleranceCategory_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -351,8 +674,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("ConditionCategoryCodes")]
-	public CqlCode[] ConditionCategoryCodes(CqlContext context)
+    [CqlDeclaration("AllergyIntoleranceCategory")]
+	public CqlCode[] AllergyIntoleranceCategory() => 
+		__AllergyIntoleranceCategory?.Value;
+
+	private CqlCode[] ConditionCategoryCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -363,8 +689,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("claim-type")]
-	public CqlCode[] claim_type(CqlContext context)
+    [CqlDeclaration("ConditionCategoryCodes")]
+	public CqlCode[] ConditionCategoryCodes() => 
+		__ConditionCategoryCodes?.Value;
+
+	private CqlCode[] claim_type_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -378,8 +707,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("ActEncounterCodes")]
-	public CqlCode[] ActEncounterCodes(CqlContext context)
+    [CqlDeclaration("claim-type")]
+	public CqlCode[] claim_type() => 
+		__claim_type?.Value;
+
+	private CqlCode[] ActEncounterCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -394,8 +726,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("coverage-type")]
-	public CqlCode[] coverage_type(CqlContext context)
+    [CqlDeclaration("ActEncounterCodes")]
+	public CqlCode[] ActEncounterCodes() => 
+		__ActEncounterCodes?.Value;
+
+	private CqlCode[] coverage_type_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -410,8 +745,11 @@ public class NCQATerminology_1_0_0
 		return a_;
 	}
 
-    [CqlDeclaration("IdentifierType")]
-	public CqlCode[] IdentifierType(CqlContext context)
+    [CqlDeclaration("coverage-type")]
+	public CqlCode[] coverage_type() => 
+		__coverage_type?.Value;
+
+	private CqlCode[] IdentifierType_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -420,5 +758,9 @@ public class NCQATerminology_1_0_0
 
 		return a_;
 	}
+
+    [CqlDeclaration("IdentifierType")]
+	public CqlCode[] IdentifierType() => 
+		__IdentifierType?.Value;
 
 }

--- a/Demo/Measures/PalliativeCareFHIR-0.6.000.cs
+++ b/Demo/Measures/PalliativeCareFHIR-0.6.000.cs
@@ -14,28 +14,76 @@ using Task = Hl7.Fhir.Model.Task;
 public class PalliativeCareFHIR_0_6_000
 {
 
-    public static PalliativeCareFHIR_0_6_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Palliative_Care_Encounter;
+    internal Lazy<CqlValueSet> __Palliative_Care_Intervention;
+    internal Lazy<CqlCode> __Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_;
+    internal Lazy<CqlCode> __survey;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlCode[]> __ObservationCategoryCodes;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<bool?> __Palliative_Care_in_the_Measurement_Period;
+
+    #endregion
+    public PalliativeCareFHIR_0_6_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Palliative_Care_Encounter = new Lazy<CqlValueSet>(this.Palliative_Care_Encounter_Value(context));
+        __Palliative_Care_Intervention = new Lazy<CqlValueSet>(this.Palliative_Care_Intervention_Value(context));
+        __Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_ = new Lazy<CqlCode>(this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value(context));
+        __survey = new Lazy<CqlCode>(this.survey_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __ObservationCategoryCodes = new Lazy<CqlCode[]>(this.ObservationCategoryCodes_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Palliative_Care_in_the_Measurement_Period = new Lazy<bool?>(this.Palliative_Care_in_the_Measurement_Period_Value(context));
+    }
+    #region Dependencies
+
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Palliative_Care_Encounter_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
 
     [CqlDeclaration("Palliative Care Encounter")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090")]
-	public CqlValueSet Palliative_Care_Encounter(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
+	public CqlValueSet Palliative_Care_Encounter() => 
+		__Palliative_Care_Encounter?.Value;
+
+	private CqlValueSet Palliative_Care_Intervention_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
 
     [CqlDeclaration("Palliative Care Intervention")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135")]
-	public CqlValueSet Palliative_Care_Intervention(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
+	public CqlValueSet Palliative_Care_Intervention() => 
+		__Palliative_Care_Intervention?.Value;
 
-    [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
-	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_(CqlContext context) => 
+	private CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal__Value(CqlContext context) => 
 		new CqlCode("71007-9", "http://loinc.org", null, null);
 
-    [CqlDeclaration("survey")]
-	public CqlCode survey(CqlContext context) => 
+    [CqlDeclaration("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)")]
+	public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_() => 
+		__Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_?.Value;
+
+	private CqlCode survey_Value(CqlContext context) => 
 		new CqlCode("survey", "http://terminology.hl7.org/CodeSystem/observation-category", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("survey")]
+	public CqlCode survey() => 
+		__survey?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -45,8 +93,11 @@ public class PalliativeCareFHIR_0_6_000
 		return a_;
 	}
 
-    [CqlDeclaration("ObservationCategoryCodes")]
-	public CqlCode[] ObservationCategoryCodes(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlCode[] ObservationCategoryCodes_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -56,16 +107,22 @@ public class PalliativeCareFHIR_0_6_000
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("ObservationCategoryCodes")]
+	public CqlCode[] ObservationCategoryCodes() => 
+		__ObservationCategoryCodes?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("PalliativeCareFHIR-0.6.000", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -73,10 +130,13 @@ public class PalliativeCareFHIR_0_6_000
 		return b_;
 	}
 
-    [CqlDeclaration("Palliative Care in the Measurement Period")]
-	public bool? Palliative_Care_in_the_Measurement_Period(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private bool? Palliative_Care_in_the_Measurement_Period_Value(CqlContext context)
 	{
-		var a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_(context);
+		var a_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_();
 		var b_ = context.Operators.ToList<CqlCode>(a_);
 		var c_ = context.Operators.RetrieveByCodes<Observation>(b_, null);
 		bool? d_(Observation PalliativeAssessment)
@@ -91,8 +151,8 @@ public class PalliativeCareFHIR_0_6_000
 			var u_ = context.Operators.InList<string>(s_, (t_ as IEnumerable<string>));
 			bool? v_(CodeableConcept PalliativeAssessmentCategory)
 			{
-				var ad_ = this.survey(context);
-				var ae_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, PalliativeAssessmentCategory);
+				var ad_ = this.survey();
+				var ae_ = FHIRHelpers_4_0_001.ToConcept(PalliativeAssessmentCategory);
 				var af_ = context.Operators.CodeInList(ad_, (ae_?.codes as IEnumerable<CqlCode>));
 
 				return af_;
@@ -100,8 +160,8 @@ public class PalliativeCareFHIR_0_6_000
 			var w_ = context.Operators.WhereOrNull<CodeableConcept>((PalliativeAssessment?.Category as IEnumerable<CodeableConcept>), v_);
 			var x_ = context.Operators.ExistsInList<CodeableConcept>(w_);
 			var y_ = context.Operators.And(u_, x_);
-			var z_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, PalliativeAssessment?.Effective);
-			var aa_ = this.Measurement_Period(context);
+			var z_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(PalliativeAssessment?.Effective);
+			var aa_ = this.Measurement_Period();
 			var ab_ = context.Operators.Overlaps(z_, aa_, null);
 			var ac_ = context.Operators.And(y_, ab_);
 
@@ -109,14 +169,14 @@ public class PalliativeCareFHIR_0_6_000
 		};
 		var e_ = context.Operators.WhereOrNull<Observation>(c_, d_);
 		var f_ = context.Operators.ExistsInList<Observation>(e_);
-		var g_ = this.Palliative_Care_Encounter(context);
+		var g_ = this.Palliative_Care_Encounter();
 		var h_ = context.Operators.RetrieveByValueSet<Encounter>(g_, null);
 		bool? i_(Encounter PalliativeEncounter)
 		{
 			var ag_ = context.Operators.Convert<string>(PalliativeEncounter?.StatusElement);
 			var ah_ = context.Operators.Equal(ag_, "finished");
-			var ai_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (PalliativeEncounter?.Period as object));
-			var aj_ = this.Measurement_Period(context);
+			var ai_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((PalliativeEncounter?.Period as object));
+			var aj_ = this.Measurement_Period();
 			var ak_ = context.Operators.Overlaps(ai_, aj_, null);
 			var al_ = context.Operators.And(ah_, ak_);
 
@@ -125,7 +185,7 @@ public class PalliativeCareFHIR_0_6_000
 		var j_ = context.Operators.WhereOrNull<Encounter>(h_, i_);
 		var k_ = context.Operators.ExistsInList<Encounter>(j_);
 		var l_ = context.Operators.Or(f_, k_);
-		var m_ = this.Palliative_Care_Intervention(context);
+		var m_ = this.Palliative_Care_Intervention();
 		var n_ = context.Operators.RetrieveByValueSet<Procedure>(m_, null);
 		bool? o_(Procedure PalliativeIntervention)
 		{
@@ -136,8 +196,8 @@ public class PalliativeCareFHIR_0_6_000
 				"in-progress",
 			};
 			var ao_ = context.Operators.InList<string>(am_, (an_ as IEnumerable<string>));
-			var ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, PalliativeIntervention?.Performed);
-			var aq_ = this.Measurement_Period(context);
+			var ap_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(PalliativeIntervention?.Performed);
+			var aq_ = this.Measurement_Period();
 			var ar_ = context.Operators.Overlaps(ap_, aq_, null);
 			var as_ = context.Operators.And(ao_, ar_);
 
@@ -149,5 +209,9 @@ public class PalliativeCareFHIR_0_6_000
 
 		return r_;
 	}
+
+    [CqlDeclaration("Palliative Care in the Measurement Period")]
+	public bool? Palliative_Care_in_the_Measurement_Period() => 
+		__Palliative_Care_in_the_Measurement_Period?.Value;
 
 }

--- a/Demo/Measures/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.cs
+++ b/Demo/Measures/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.cs
@@ -14,59 +14,161 @@ using Task = Hl7.Fhir.Model.Task;
 public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 {
 
-    public static PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Clinical_Oral_Evaluation;
+    internal Lazy<CqlValueSet> __Fluoride_Varnish_Application_for_Children;
+    internal Lazy<CqlValueSet> __Office_Visit;
+    internal Lazy<CqlValueSet> __Online_Assessments;
+    internal Lazy<CqlValueSet> __Preventive_Care___Established_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services___Established_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care_Services_Initial_Office_Visit__18_and_Up;
+    internal Lazy<CqlValueSet> __Preventive_Care__Initial_Office_Visit__0_to_17;
+    internal Lazy<CqlValueSet> __Telephone_Visits;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Qualifying_Encounters;
+    internal Lazy<bool?> __Initial_Population;
+    internal Lazy<bool?> __Denominator;
+    internal Lazy<bool?> __Denominator_Exclusions;
+    internal Lazy<bool?> __Stratification_1;
+    internal Lazy<bool?> __Stratification_2;
+    internal Lazy<bool?> __Stratification_3;
+    internal Lazy<bool?> __Numerator;
+
+    #endregion
+    public PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        HospiceFHIR4_2_3_000 = new HospiceFHIR4_2_3_000(context);
+
+        __Clinical_Oral_Evaluation = new Lazy<CqlValueSet>(this.Clinical_Oral_Evaluation_Value(context));
+        __Fluoride_Varnish_Application_for_Children = new Lazy<CqlValueSet>(this.Fluoride_Varnish_Application_for_Children_Value(context));
+        __Office_Visit = new Lazy<CqlValueSet>(this.Office_Visit_Value(context));
+        __Online_Assessments = new Lazy<CqlValueSet>(this.Online_Assessments_Value(context));
+        __Preventive_Care___Established_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care___Established_Office_Visit__0_to_17_Value(context));
+        __Preventive_Care_Services___Established_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care_Services_Initial_Office_Visit__18_and_Up = new Lazy<CqlValueSet>(this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(context));
+        __Preventive_Care__Initial_Office_Visit__0_to_17 = new Lazy<CqlValueSet>(this.Preventive_Care__Initial_Office_Visit__0_to_17_Value(context));
+        __Telephone_Visits = new Lazy<CqlValueSet>(this.Telephone_Visits_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Qualifying_Encounters = new Lazy<IEnumerable<Encounter>>(this.Qualifying_Encounters_Value(context));
+        __Initial_Population = new Lazy<bool?>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<bool?>(this.Denominator_Value(context));
+        __Denominator_Exclusions = new Lazy<bool?>(this.Denominator_Exclusions_Value(context));
+        __Stratification_1 = new Lazy<bool?>(this.Stratification_1_Value(context));
+        __Stratification_2 = new Lazy<bool?>(this.Stratification_2_Value(context));
+        __Stratification_3 = new Lazy<bool?>(this.Stratification_3_Value(context));
+        __Numerator = new Lazy<bool?>(this.Numerator_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public HospiceFHIR4_2_3_000 HospiceFHIR4_2_3_000 { get; }
+
+    #endregion
+
+	private CqlValueSet Clinical_Oral_Evaluation_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
 
     [CqlDeclaration("Clinical Oral Evaluation")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003")]
-	public CqlValueSet Clinical_Oral_Evaluation(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1003", null);
+	public CqlValueSet Clinical_Oral_Evaluation() => 
+		__Clinical_Oral_Evaluation?.Value;
+
+	private CqlValueSet Fluoride_Varnish_Application_for_Children_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
 
     [CqlDeclaration("Fluoride Varnish Application for Children")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002")]
-	public CqlValueSet Fluoride_Varnish_Application_for_Children(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.125.12.1002", null);
+	public CqlValueSet Fluoride_Varnish_Application_for_Children() => 
+		__Fluoride_Varnish_Application_for_Children?.Value;
+
+	private CqlValueSet Office_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
 
     [CqlDeclaration("Office Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001")]
-	public CqlValueSet Office_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+	public CqlValueSet Office_Visit() => 
+		__Office_Visit?.Value;
+
+	private CqlValueSet Online_Assessments_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
 
     [CqlDeclaration("Online Assessments")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089")]
-	public CqlValueSet Online_Assessments(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1089", null);
+	public CqlValueSet Online_Assessments() => 
+		__Online_Assessments?.Value;
+
+	private CqlValueSet Preventive_Care___Established_Office_Visit__0_to_17_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
 
     [CqlDeclaration("Preventive Care - Established Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024")]
-	public CqlValueSet Preventive_Care___Established_Office_Visit__0_to_17(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1024", null);
+	public CqlValueSet Preventive_Care___Established_Office_Visit__0_to_17() => 
+		__Preventive_Care___Established_Office_Visit__0_to_17?.Value;
+
+	private CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
 
     [CqlDeclaration("Preventive Care Services - Established Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025")]
-	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025", null);
+	public CqlValueSet Preventive_Care_Services___Established_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services___Established_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
 
     [CqlDeclaration("Preventive Care Services-Initial Office Visit, 18 and Up")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023")]
-	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023", null);
+	public CqlValueSet Preventive_Care_Services_Initial_Office_Visit__18_and_Up() => 
+		__Preventive_Care_Services_Initial_Office_Visit__18_and_Up?.Value;
+
+	private CqlValueSet Preventive_Care__Initial_Office_Visit__0_to_17_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
 
     [CqlDeclaration("Preventive Care- Initial Office Visit, 0 to 17")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022")]
-	public CqlValueSet Preventive_Care__Initial_Office_Visit__0_to_17(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1022", null);
+	public CqlValueSet Preventive_Care__Initial_Office_Visit__0_to_17() => 
+		__Preventive_Care__Initial_Office_Visit__0_to_17?.Value;
+
+	private CqlValueSet Telephone_Visits_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
 
     [CqlDeclaration("Telephone Visits")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080")]
-	public CqlValueSet Telephone_Visits(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+	public CqlValueSet Telephone_Visits() => 
+		__Telephone_Visits?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -76,16 +178,22 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -93,68 +201,83 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
+
+		return a_;
+	}
+
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Qualifying Encounters")]
-	public IEnumerable<Encounter> Qualifying_Encounters(CqlContext context)
+	private IEnumerable<Encounter> Qualifying_Encounters_Value(CqlContext context)
 	{
-		var a_ = this.Office_Visit(context);
+		var a_ = this.Office_Visit();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
-		var c_ = this.Preventive_Care___Established_Office_Visit__0_to_17(context);
+		var c_ = this.Preventive_Care___Established_Office_Visit__0_to_17();
 		var d_ = context.Operators.RetrieveByValueSet<Encounter>(c_, null);
 		var e_ = context.Operators.ListUnion<Encounter>(b_, d_);
-		var f_ = this.Preventive_Care__Initial_Office_Visit__0_to_17(context);
+		var f_ = this.Preventive_Care__Initial_Office_Visit__0_to_17();
 		var g_ = context.Operators.RetrieveByValueSet<Encounter>(f_, null);
-		var h_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up(context);
+		var h_ = this.Preventive_Care_Services___Established_Office_Visit__18_and_Up();
 		var i_ = context.Operators.RetrieveByValueSet<Encounter>(h_, null);
 		var j_ = context.Operators.ListUnion<Encounter>(g_, i_);
 		var k_ = context.Operators.ListUnion<Encounter>(e_, j_);
-		var l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up(context);
+		var l_ = this.Preventive_Care_Services_Initial_Office_Visit__18_and_Up();
 		var m_ = context.Operators.RetrieveByValueSet<Encounter>(l_, null);
-		var n_ = this.Clinical_Oral_Evaluation(context);
+		var n_ = this.Clinical_Oral_Evaluation();
 		var o_ = context.Operators.RetrieveByValueSet<Encounter>(n_, null);
 		var p_ = context.Operators.ListUnion<Encounter>(m_, o_);
 		var q_ = context.Operators.ListUnion<Encounter>(k_, p_);
-		var r_ = this.Telephone_Visits(context);
+		var r_ = this.Telephone_Visits();
 		var s_ = context.Operators.RetrieveByValueSet<Encounter>(r_, null);
-		var t_ = this.Online_Assessments(context);
+		var t_ = this.Online_Assessments();
 		var u_ = context.Operators.RetrieveByValueSet<Encounter>(t_, null);
 		var v_ = context.Operators.ListUnion<Encounter>(s_, u_);
 		var w_ = context.Operators.ListUnion<Encounter>(q_, v_);
 		bool? x_(Encounter ValidEncounter)
 		{
-			var z_ = this.Measurement_Period(context);
-			var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, (ValidEncounter?.Period as object));
+			var z_ = this.Measurement_Period();
+			var aa_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval((ValidEncounter?.Period as object));
 			var ab_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, aa_, null);
 			var ac_ = context.Operators.Convert<string>(ValidEncounter?.StatusElement);
 			var ad_ = context.Operators.Equal(ac_, "finished");
@@ -167,12 +290,15 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return y_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public bool? Initial_Population(CqlContext context)
+    [CqlDeclaration("Qualifying Encounters")]
+	public IEnumerable<Encounter> Qualifying_Encounters() => 
+		__Qualifying_Encounters?.Value;
+
+	private bool? Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "month");
@@ -183,35 +309,44 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		var m_ = context.Operators.CalculateAgeAt(i_, l_, "year");
 		var n_ = context.Operators.Less(m_, (int?)20);
 		var o_ = context.Operators.And(g_, n_);
-		var p_ = this.Qualifying_Encounters(context);
+		var p_ = this.Qualifying_Encounters();
 		var q_ = context.Operators.ExistsInList<Encounter>(p_);
 		var r_ = context.Operators.And(o_, q_);
 
 		return r_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public bool? Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public bool? Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private bool? Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public bool? Denominator() => 
+		__Denominator?.Value;
+
+	private bool? Denominator_Exclusions_Value(CqlContext context)
+	{
+		var a_ = HospiceFHIR4_2_3_000.Has_Hospice();
 
 		return a_;
 	}
 
     [CqlDeclaration("Denominator Exclusions")]
-	public bool? Denominator_Exclusions(CqlContext context)
-	{
-		var a_ = HospiceFHIR4_2_3_000.Instance.Has_Hospice(context);
+	public bool? Denominator_Exclusions() => 
+		__Denominator_Exclusions?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Stratification 1")]
-	public bool? Stratification_1(CqlContext context)
+	private bool? Stratification_1_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "month");
@@ -226,12 +361,15 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return o_;
 	}
 
-    [CqlDeclaration("Stratification 2")]
-	public bool? Stratification_2(CqlContext context)
+    [CqlDeclaration("Stratification 1")]
+	public bool? Stratification_1() => 
+		__Stratification_1?.Value;
+
+	private bool? Stratification_2_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -241,12 +379,15 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return h_;
 	}
 
-    [CqlDeclaration("Stratification 3")]
-	public bool? Stratification_3(CqlContext context)
+    [CqlDeclaration("Stratification 2")]
+	public bool? Stratification_2() => 
+		__Stratification_2?.Value;
+
+	private bool? Stratification_3_Value(CqlContext context)
 	{
-		var a_ = this.Patient(context);
+		var a_ = this.Patient();
 		var b_ = context.Operators.Convert<CqlDate>(a_?.BirthDateElement?.Value);
-		var c_ = this.Measurement_Period(context);
+		var c_ = this.Measurement_Period();
 		var d_ = context.Operators.Start(c_);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.CalculateAgeAt(b_, e_, "year");
@@ -256,15 +397,18 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 		return h_;
 	}
 
-    [CqlDeclaration("Numerator")]
-	public bool? Numerator(CqlContext context)
+    [CqlDeclaration("Stratification 3")]
+	public bool? Stratification_3() => 
+		__Stratification_3?.Value;
+
+	private bool? Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Fluoride_Varnish_Application_for_Children(context);
+		var a_ = this.Fluoride_Varnish_Application_for_Children();
 		var b_ = context.Operators.RetrieveByValueSet<Procedure>(a_, null);
 		bool? c_(Procedure FluorideApplication)
 		{
-			var f_ = this.Measurement_Period(context);
-			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, FluorideApplication?.Performed);
+			var f_ = this.Measurement_Period();
+			var g_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(FluorideApplication?.Performed);
 			var h_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, g_, null);
 			var i_ = context.Operators.Convert<string>(FluorideApplication?.StatusElement);
 			var j_ = context.Operators.Equal(i_, "completed");
@@ -277,5 +421,9 @@ public class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008
 
 		return e_;
 	}
+
+    [CqlDeclaration("Numerator")]
+	public bool? Numerator() => 
+		__Numerator?.Value;
 
 }

--- a/Demo/Measures/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.cs
+++ b/Demo/Measures/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.cs
@@ -14,54 +14,143 @@ using Task = Hl7.Fhir.Model.Task;
 public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 {
 
-    public static SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __All_Primary_and_Secondary_Cancer;
+    internal Lazy<CqlValueSet> __Discharge_To_Acute_Care_Facility;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Hospice_Care_Referral_or_Admission;
+    internal Lazy<CqlValueSet> __Palliative_or_Hospice_Care;
+    internal Lazy<CqlValueSet> __Patient_Expired;
+    internal Lazy<CqlValueSet> __Schedule_II_and_III_Opioid_Medications;
+    internal Lazy<CqlValueSet> __Schedule_IV_Benzodiazepines;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18;
+    internal Lazy<IEnumerable<Encounter>> __Initial_Population;
+    internal Lazy<IEnumerable<Encounter>> __Denominator;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+    internal Lazy<IEnumerable<Encounter>> __Numerator;
+    internal Lazy<IEnumerable<Encounter>> __Denominator_Exclusion;
+
+    #endregion
+    public SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+        SupplementalDataElementsFHIR4_2_0_000 = new SupplementalDataElementsFHIR4_2_0_000(context);
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+
+        __All_Primary_and_Secondary_Cancer = new Lazy<CqlValueSet>(this.All_Primary_and_Secondary_Cancer_Value(context));
+        __Discharge_To_Acute_Care_Facility = new Lazy<CqlValueSet>(this.Discharge_To_Acute_Care_Facility_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Hospice_Care_Referral_or_Admission = new Lazy<CqlValueSet>(this.Hospice_Care_Referral_or_Admission_Value(context));
+        __Palliative_or_Hospice_Care = new Lazy<CqlValueSet>(this.Palliative_or_Hospice_Care_Value(context));
+        __Patient_Expired = new Lazy<CqlValueSet>(this.Patient_Expired_Value(context));
+        __Schedule_II_and_III_Opioid_Medications = new Lazy<CqlValueSet>(this.Schedule_II_and_III_Opioid_Medications_Value(context));
+        __Schedule_IV_Benzodiazepines = new Lazy<CqlValueSet>(this.Schedule_IV_Benzodiazepines_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18 = new Lazy<IEnumerable<Encounter>>(this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18_Value(context));
+        __Initial_Population = new Lazy<IEnumerable<Encounter>>(this.Initial_Population_Value(context));
+        __Denominator = new Lazy<IEnumerable<Encounter>>(this.Denominator_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+        __Numerator = new Lazy<IEnumerable<Encounter>>(this.Numerator_Value(context));
+        __Denominator_Exclusion = new Lazy<IEnumerable<Encounter>>(this.Denominator_Exclusion_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+    public SupplementalDataElementsFHIR4_2_0_000 SupplementalDataElementsFHIR4_2_0_000 { get; }
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+
+    #endregion
+
+	private CqlValueSet All_Primary_and_Secondary_Cancer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", null);
 
     [CqlDeclaration("All Primary and Secondary Cancer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161")]
-	public CqlValueSet All_Primary_and_Secondary_Cancer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.161", null);
+	public CqlValueSet All_Primary_and_Secondary_Cancer() => 
+		__All_Primary_and_Secondary_Cancer?.Value;
+
+	private CqlValueSet Discharge_To_Acute_Care_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
-	public CqlValueSet Discharge_To_Acute_Care_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
+		__Discharge_To_Acute_Care_Facility?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Hospice_Care_Referral_or_Admission_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", null);
 
     [CqlDeclaration("Hospice Care Referral or Admission")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365")]
-	public CqlValueSet Hospice_Care_Referral_or_Admission(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1116.365", null);
+	public CqlValueSet Hospice_Care_Referral_or_Admission() => 
+		__Hospice_Care_Referral_or_Admission?.Value;
+
+	private CqlValueSet Palliative_or_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
 
     [CqlDeclaration("Palliative or Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579")]
-	public CqlValueSet Palliative_or_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1.1579", null);
+	public CqlValueSet Palliative_or_Hospice_Care() => 
+		__Palliative_or_Hospice_Care?.Value;
+
+	private CqlValueSet Patient_Expired_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
-	public CqlValueSet Patient_Expired(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+	public CqlValueSet Patient_Expired() => 
+		__Patient_Expired?.Value;
+
+	private CqlValueSet Schedule_II_and_III_Opioid_Medications_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", null);
 
     [CqlDeclaration("Schedule II & III Opioid Medications")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165")]
-	public CqlValueSet Schedule_II_and_III_Opioid_Medications(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.165", null);
+	public CqlValueSet Schedule_II_and_III_Opioid_Medications() => 
+		__Schedule_II_and_III_Opioid_Medications?.Value;
+
+	private CqlValueSet Schedule_IV_Benzodiazepines_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", null);
 
     [CqlDeclaration("Schedule IV Benzodiazepines")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1")]
-	public CqlValueSet Schedule_IV_Benzodiazepines(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1125.1", null);
+	public CqlValueSet Schedule_IV_Benzodiazepines() => 
+		__Schedule_IV_Benzodiazepines?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -71,16 +160,22 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.ResolveParameter("SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012", "Measurement Period", null);
 
 		return (CqlInterval<CqlDateTime>)a_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -88,15 +183,18 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		return b_;
 	}
 
-    [CqlDeclaration("Inpatient Encounter with Age Greater than or Equal to 18")]
-	public IEnumerable<Encounter> Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Encounter> Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18_Value(CqlContext context)
 	{
-		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Inpatient_Encounter(context);
+		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Inpatient_Encounter();
 		bool? b_(Encounter EncounterInpatient)
 		{
-			var d_ = this.Patient(context);
+			var d_ = this.Patient();
 			var e_ = context.Operators.Convert<CqlDate>(d_?.BirthDateElement?.Value);
-			var f_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, EncounterInpatient?.Period);
+			var f_ = FHIRHelpers_4_0_001.ToInterval(EncounterInpatient?.Period);
 			var g_ = context.Operators.Start(f_);
 			var h_ = context.Operators.DateFrom(g_);
 			var i_ = context.Operators.CalculateAgeAt(e_, h_, "year");
@@ -112,17 +210,20 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		return c_;
 	}
 
-    [CqlDeclaration("Initial Population")]
-	public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    [CqlDeclaration("Inpatient Encounter with Age Greater than or Equal to 18")]
+	public IEnumerable<Encounter> Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18() => 
+		__Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18?.Value;
+
+	private IEnumerable<Encounter> Initial_Population_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18(context);
+		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18();
 		IEnumerable<Encounter> b_(Encounter InpatientEncounter)
 		{
-			var d_ = this.Schedule_II_and_III_Opioid_Medications(context);
+			var d_ = this.Schedule_II_and_III_Opioid_Medications();
 			var e_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
 			var g_ = context.Operators.RetrieveByValueSet<MedicationRequest>(d_, null);
 			var h_ = context.Operators.ListUnion<MedicationRequest>(e_, g_);
-			var i_ = this.Schedule_IV_Benzodiazepines(context);
+			var i_ = this.Schedule_IV_Benzodiazepines();
 			var j_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, null);
 			var l_ = context.Operators.RetrieveByValueSet<MedicationRequest>(i_, null);
 			var m_ = context.Operators.ListUnion<MedicationRequest>(j_, l_);
@@ -130,8 +231,8 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			{
 				bool? u_(CodeableConcept C)
 				{
-					var x_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, C);
-					var y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Discharge(context);
+					var x_ = FHIRHelpers_4_0_001.ToConcept(C);
+					var y_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Discharge();
 					var z_ = context.Operators.ConvertCodeToConcept(y_);
 					var aa_ = context.Operators.Equivalent(x_, z_);
 
@@ -146,8 +247,8 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			var p_ = context.Operators.ListUnion<MedicationRequest>(h_, o_);
 			bool? q_(MedicationRequest OpioidOrBenzodiazepineDischargeMedication)
 			{
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, OpioidOrBenzodiazepineDischargeMedication?.AuthoredOnElement);
-				var ac_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var ab_ = FHIRHelpers_4_0_001.ToDateTime(OpioidOrBenzodiazepineDischargeMedication?.AuthoredOnElement);
+				var ac_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var ad_ = context.Operators.ElementInInterval<CqlDateTime>(ab_, ac_, null);
 				var ae_ = context.Operators.Convert<string>(OpioidOrBenzodiazepineDischargeMedication?.StatusElement);
 				var af_ = context.Operators.Equal(ae_, "active");
@@ -170,58 +271,76 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		return c_;
 	}
 
-    [CqlDeclaration("Denominator")]
-	public IEnumerable<Encounter> Denominator(CqlContext context)
+    [CqlDeclaration("Initial Population")]
+	public IEnumerable<Encounter> Initial_Population() => 
+		__Initial_Population?.Value;
+
+	private IEnumerable<Encounter> Denominator_Value(CqlContext context)
 	{
-		var a_ = this.Initial_Population(context);
+		var a_ = this.Initial_Population();
+
+		return a_;
+	}
+
+    [CqlDeclaration("Denominator")]
+	public IEnumerable<Encounter> Denominator() => 
+		__Denominator?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
+	{
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Ethnicity();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Ethnicity(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Payer();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Payer(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Race();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Race(context);
+		var a_ = SupplementalDataElementsFHIR4_2_0_000.SDE_Sex();
 
 		return a_;
 	}
 
     [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
-	{
-		var a_ = SupplementalDataElementsFHIR4_2_0_000.Instance.SDE_Sex(context);
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
-		return a_;
-	}
-
-    [CqlDeclaration("Numerator")]
-	public IEnumerable<Encounter> Numerator(CqlContext context)
+	private IEnumerable<Encounter> Numerator_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18(context);
+		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var j_ = this.Schedule_II_and_III_Opioid_Medications(context);
+			var j_ = this.Schedule_II_and_III_Opioid_Medications();
 			var k_ = context.Operators.RetrieveByValueSet<MedicationRequest>(j_, null);
 			bool? l_(MedicationRequest Opioids)
 			{
-				var r_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, Opioids?.AuthoredOnElement);
-				var s_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var r_ = FHIRHelpers_4_0_001.ToDateTime(Opioids?.AuthoredOnElement);
+				var s_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var t_ = context.Operators.ElementInInterval<CqlDateTime>(r_, s_, null);
 
 				return t_;
@@ -238,12 +357,12 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		var c_ = context.Operators.WhereOrNull<Encounter>(a_, b_);
 		IEnumerable<Encounter> e_(Encounter InpatientEncounter)
 		{
-			var u_ = this.Schedule_II_and_III_Opioid_Medications(context);
+			var u_ = this.Schedule_II_and_III_Opioid_Medications();
 			var v_ = context.Operators.RetrieveByValueSet<MedicationRequest>(u_, null);
 			bool? w_(MedicationRequest OpioidsDischarge)
 			{
-				var aa_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, OpioidsDischarge?.AuthoredOnElement);
-				var ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var aa_ = FHIRHelpers_4_0_001.ToDateTime(OpioidsDischarge?.AuthoredOnElement);
+				var ab_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var ac_ = context.Operators.ElementInInterval<CqlDateTime>(aa_, ab_, null);
 
 				return ac_;
@@ -258,12 +377,12 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		var f_ = context.Operators.SelectManyOrNull<Encounter, Encounter>(a_, e_);
 		IEnumerable<Encounter> g_(Encounter InpatientEncounter)
 		{
-			var ad_ = this.Schedule_IV_Benzodiazepines(context);
+			var ad_ = this.Schedule_IV_Benzodiazepines();
 			var ae_ = context.Operators.RetrieveByValueSet<MedicationRequest>(ad_, null);
 			bool? af_(MedicationRequest BenzodiazepinesDischarge)
 			{
-				var aj_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, BenzodiazepinesDischarge?.AuthoredOnElement);
-				var ak_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var aj_ = FHIRHelpers_4_0_001.ToDateTime(BenzodiazepinesDischarge?.AuthoredOnElement);
+				var ak_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var al_ = context.Operators.ElementInInterval<CqlDateTime>(aj_, ak_, null);
 
 				return al_;
@@ -281,30 +400,33 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 		return i_;
 	}
 
-    [CqlDeclaration("Denominator Exclusion")]
-	public IEnumerable<Encounter> Denominator_Exclusion(CqlContext context)
+    [CqlDeclaration("Numerator")]
+	public IEnumerable<Encounter> Numerator() => 
+		__Numerator?.Value;
+
+	private IEnumerable<Encounter> Denominator_Exclusion_Value(CqlContext context)
 	{
-		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18(context);
+		var a_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18();
 		bool? b_(Encounter InpatientEncounter)
 		{
-			var f_ = this.All_Primary_and_Secondary_Cancer(context);
+			var f_ = this.All_Primary_and_Secondary_Cancer();
 			var g_ = context.Operators.RetrieveByValueSet<Condition>(f_, null);
 			bool? h_(Condition Cancer)
 			{
-				var ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Cancer);
-				var ac_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Prevalence_Period(Cancer);
+				var ac_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var ad_ = context.Operators.Overlaps(ab_, ac_, null);
 
 				return ad_;
 			};
 			var i_ = context.Operators.WhereOrNull<Condition>(g_, h_);
 			var j_ = context.Operators.ExistsInList<Condition>(i_);
-			var k_ = this.Palliative_or_Hospice_Care(context);
+			var k_ = this.Palliative_or_Hospice_Care();
 			var l_ = context.Operators.RetrieveByValueSet<ServiceRequest>(k_, null);
 			bool? m_(ServiceRequest PalliativeOrHospiceCareOrder)
 			{
-				var ae_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, PalliativeOrHospiceCareOrder?.AuthoredOnElement);
-				var af_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var ae_ = FHIRHelpers_4_0_001.ToDateTime(PalliativeOrHospiceCareOrder?.AuthoredOnElement);
+				var af_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var ag_ = context.Operators.ElementInInterval<CqlDateTime>(ae_, af_, null);
 				var ah_ = context.Operators.Convert<string>(PalliativeOrHospiceCareOrder?.IntentElement);
 				var ai_ = context.Operators.Equal(ah_, "order");
@@ -318,8 +440,8 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			var r_ = context.Operators.RetrieveByValueSet<Procedure>(k_, null);
 			bool? s_(Procedure PalliativeOrHospiceCarePerformed)
 			{
-				var ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, PalliativeOrHospiceCarePerformed?.Performed);
-				var al_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, InpatientEncounter?.Period);
+				var ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(PalliativeOrHospiceCarePerformed?.Performed);
+				var al_ = FHIRHelpers_4_0_001.ToInterval(InpatientEncounter?.Period);
 				var am_ = context.Operators.Overlaps(ak_, al_, null);
 
 				return am_;
@@ -327,16 +449,16 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 			var t_ = context.Operators.WhereOrNull<Procedure>(r_, s_);
 			var u_ = context.Operators.ExistsInList<Procedure>(t_);
 			var v_ = context.Operators.Or(p_, u_);
-			var w_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18(context);
+			var w_ = this.Inpatient_Encounter_with_Age_Greater_than_or_Equal_to_18();
 			bool? x_(Encounter InpatientEncounter)
 			{
-				var an_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, InpatientEncounter?.Hospitalization?.DischargeDisposition);
-				var ao_ = this.Discharge_To_Acute_Care_Facility(context);
+				var an_ = FHIRHelpers_4_0_001.ToConcept(InpatientEncounter?.Hospitalization?.DischargeDisposition);
+				var ao_ = this.Discharge_To_Acute_Care_Facility();
 				var ap_ = context.Operators.ConceptInValueSet(an_, ao_);
-				var ar_ = this.Hospice_Care_Referral_or_Admission(context);
+				var ar_ = this.Hospice_Care_Referral_or_Admission();
 				var as_ = context.Operators.ConceptInValueSet(an_, ar_);
 				var at_ = context.Operators.Or(ap_, as_);
-				var av_ = this.Patient_Expired(context);
+				var av_ = this.Patient_Expired();
 				var aw_ = context.Operators.ConceptInValueSet(an_, av_);
 				var ax_ = context.Operators.Or(at_, aw_);
 
@@ -355,5 +477,9 @@ public class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012
 
 		return e_;
 	}
+
+    [CqlDeclaration("Denominator Exclusion")]
+	public IEnumerable<Encounter> Denominator_Exclusion() => 
+		__Denominator_Exclusion?.Value;
 
 }

--- a/Demo/Measures/SupplementalDataElementsFHIR4-2.0.000.cs
+++ b/Demo/Measures/SupplementalDataElementsFHIR4-2.0.000.cs
@@ -14,30 +14,76 @@ using Task = Hl7.Fhir.Model.Task;
 public class SupplementalDataElementsFHIR4_2_0_000
 {
 
-    public static SupplementalDataElementsFHIR4_2_0_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Ethnicity;
+    internal Lazy<CqlValueSet> __ONC_Administrative_Sex;
+    internal Lazy<CqlValueSet> __Payer;
+    internal Lazy<CqlValueSet> __Race;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Coding>> __SDE_Ethnicity;
+    internal Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>> __SDE_Payer;
+    internal Lazy<IEnumerable<Coding>> __SDE_Race;
+    internal Lazy<CqlCode> __SDE_Sex;
+
+    #endregion
+    public SupplementalDataElementsFHIR4_2_0_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Ethnicity = new Lazy<CqlValueSet>(this.Ethnicity_Value(context));
+        __ONC_Administrative_Sex = new Lazy<CqlValueSet>(this.ONC_Administrative_Sex_Value(context));
+        __Payer = new Lazy<CqlValueSet>(this.Payer_Value(context));
+        __Race = new Lazy<CqlValueSet>(this.Race_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __SDE_Ethnicity = new Lazy<IEnumerable<Coding>>(this.SDE_Ethnicity_Value(context));
+        __SDE_Payer = new Lazy<IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG>>(this.SDE_Payer_Value(context));
+        __SDE_Race = new Lazy<IEnumerable<Coding>>(this.SDE_Race_Value(context));
+        __SDE_Sex = new Lazy<CqlCode>(this.SDE_Sex_Value(context));
+    }
+    #region Dependencies
+
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Ethnicity_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
 
     [CqlDeclaration("Ethnicity")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837")]
-	public CqlValueSet Ethnicity(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+	public CqlValueSet Ethnicity() => 
+		__Ethnicity?.Value;
+
+	private CqlValueSet ONC_Administrative_Sex_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
 
     [CqlDeclaration("ONC Administrative Sex")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1")]
-	public CqlValueSet ONC_Administrative_Sex(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1", null);
+	public CqlValueSet ONC_Administrative_Sex() => 
+		__ONC_Administrative_Sex?.Value;
+
+	private CqlValueSet Payer_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
 
     [CqlDeclaration("Payer")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591")]
-	public CqlValueSet Payer(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.3591", null);
+	public CqlValueSet Payer() => 
+		__Payer?.Value;
+
+	private CqlValueSet Race_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
 
     [CqlDeclaration("Race")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836")]
-	public CqlValueSet Race(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.836", null);
+	public CqlValueSet Race() => 
+		__Race?.Value;
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -45,14 +91,17 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		return b_;
 	}
 
-    [CqlDeclaration("SDE Ethnicity")]
-	public IEnumerable<Coding> SDE_Ethnicity(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Coding> SDE_Ethnicity_Value(CqlContext context)
 	{
 		IEnumerable<Extension> a_()
 		{
-			if (this.Patient(context) is DomainResource)
+			if (this.Patient() is DomainResource)
 			{
-				var k_ = this.Patient(context);
+				var k_ = this.Patient();
 
 				return ((k_ as DomainResource).Extension as IEnumerable<Extension>);
 			}
@@ -93,10 +142,13 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		return j_;
 	}
 
-    [CqlDeclaration("SDE Payer")]
-	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer(CqlContext context)
+    [CqlDeclaration("SDE Ethnicity")]
+	public IEnumerable<Coding> SDE_Ethnicity() => 
+		__SDE_Ethnicity?.Value;
+
+	private IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer_Value(CqlContext context)
 	{
-		var a_ = this.Payer(context);
+		var a_ = this.Payer();
 		var b_ = context.Operators.RetrieveByValueSet<Coverage>(a_, null);
 		Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG c_(Coverage Payer)
 		{
@@ -113,14 +165,17 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		return d_;
 	}
 
-    [CqlDeclaration("SDE Race")]
-	public IEnumerable<Coding> SDE_Race(CqlContext context)
+    [CqlDeclaration("SDE Payer")]
+	public IEnumerable<Tuples.Tuple_CFQHSgYJOXjAOCKdWLdZNNHDG> SDE_Payer() => 
+		__SDE_Payer?.Value;
+
+	private IEnumerable<Coding> SDE_Race_Value(CqlContext context)
 	{
 		IEnumerable<Extension> a_()
 		{
-			if (this.Patient(context) is DomainResource)
+			if (this.Patient() is DomainResource)
 			{
-				var k_ = this.Patient(context);
+				var k_ = this.Patient();
 
 				return ((k_ as DomainResource).Extension as IEnumerable<Extension>);
 			}
@@ -161,18 +216,21 @@ public class SupplementalDataElementsFHIR4_2_0_000
 		return j_;
 	}
 
-    [CqlDeclaration("SDE Sex")]
-	public CqlCode SDE_Sex(CqlContext context)
+    [CqlDeclaration("SDE Race")]
+	public IEnumerable<Coding> SDE_Race() => 
+		__SDE_Race?.Value;
+
+	private CqlCode SDE_Sex_Value(CqlContext context)
 	{
 		CqlCode a_()
 		{
-			if ((context.Operators.Equal(context.Operators.Convert<string>(this.Patient(context)?.GenderElement), "male") ?? false))
+			if ((context.Operators.Equal(context.Operators.Convert<string>(this.Patient()?.GenderElement), "male") ?? false))
 			{
 				string b_ = null;
 
 				return new CqlCode("M", "http://hl7.org/fhir/v3/AdministrativeGender", b_, "Male");
 			}
-			else if ((context.Operators.Equal(context.Operators.Convert<string>(this.Patient(context)?.GenderElement), "female") ?? false))
+			else if ((context.Operators.Equal(context.Operators.Convert<string>(this.Patient()?.GenderElement), "female") ?? false))
 			{
 				string c_ = null;
 
@@ -186,5 +244,9 @@ public class SupplementalDataElementsFHIR4_2_0_000
 
 		return a_();
 	}
+
+    [CqlDeclaration("SDE Sex")]
+	public CqlCode SDE_Sex() => 
+		__SDE_Sex?.Value;
 
 }

--- a/Demo/Measures/TJCOverallFHIR-1.8.000.cs
+++ b/Demo/Measures/TJCOverallFHIR-1.8.000.cs
@@ -14,79 +14,189 @@ using Task = Hl7.Fhir.Model.Task;
 public class TJCOverallFHIR_1_8_000
 {
 
-    public static TJCOverallFHIR_1_8_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Comfort_Measures;
+    internal Lazy<CqlValueSet> __Discharge_To_Acute_Care_Facility;
+    internal Lazy<CqlValueSet> __Discharged_to_Health_Care_Facility_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Discharged_to_Home_for_Hospice_Care;
+    internal Lazy<CqlValueSet> __Emergency_Department_Visit;
+    internal Lazy<CqlValueSet> __Encounter_Inpatient;
+    internal Lazy<CqlValueSet> __Hemorrhagic_Stroke;
+    internal Lazy<CqlValueSet> __Ischemic_Stroke;
+    internal Lazy<CqlValueSet> __Left_Against_Medical_Advice;
+    internal Lazy<CqlValueSet> __Non_Elective_Inpatient;
+    internal Lazy<CqlValueSet> __Observation_Services;
+    internal Lazy<CqlValueSet> __Patient_Expired;
+    internal Lazy<CqlValueSet> __Ticagrelor_Therapy;
+    internal Lazy<CqlCode> __Birth_date;
+    internal Lazy<CqlCode[]> __LOINC;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+    internal Lazy<IEnumerable<Encounter>> __Non_Elective_Inpatient_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __All_Stroke_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Principal_Diagnosis_and_Age;
+    internal Lazy<IEnumerable<Encounter>> __Ischemic_Stroke_Encounter;
+    internal Lazy<IEnumerable<Encounter>> __Ischemic_Stroke_Encounters_with_Discharge_Disposition;
+    internal Lazy<IEnumerable<object>> __Intervention_Comfort_Measures;
+    internal Lazy<IEnumerable<Encounter>> __Comfort_Measures_during_Hospitalization;
+    internal Lazy<IEnumerable<Encounter>> __Encounter_with_Comfort_Measures_during_Hospitalization;
+
+    #endregion
+    public TJCOverallFHIR_1_8_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Comfort_Measures = new Lazy<CqlValueSet>(this.Comfort_Measures_Value(context));
+        __Discharge_To_Acute_Care_Facility = new Lazy<CqlValueSet>(this.Discharge_To_Acute_Care_Facility_Value(context));
+        __Discharged_to_Health_Care_Facility_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(context));
+        __Discharged_to_Home_for_Hospice_Care = new Lazy<CqlValueSet>(this.Discharged_to_Home_for_Hospice_Care_Value(context));
+        __Emergency_Department_Visit = new Lazy<CqlValueSet>(this.Emergency_Department_Visit_Value(context));
+        __Encounter_Inpatient = new Lazy<CqlValueSet>(this.Encounter_Inpatient_Value(context));
+        __Hemorrhagic_Stroke = new Lazy<CqlValueSet>(this.Hemorrhagic_Stroke_Value(context));
+        __Ischemic_Stroke = new Lazy<CqlValueSet>(this.Ischemic_Stroke_Value(context));
+        __Left_Against_Medical_Advice = new Lazy<CqlValueSet>(this.Left_Against_Medical_Advice_Value(context));
+        __Non_Elective_Inpatient = new Lazy<CqlValueSet>(this.Non_Elective_Inpatient_Value(context));
+        __Observation_Services = new Lazy<CqlValueSet>(this.Observation_Services_Value(context));
+        __Patient_Expired = new Lazy<CqlValueSet>(this.Patient_Expired_Value(context));
+        __Ticagrelor_Therapy = new Lazy<CqlValueSet>(this.Ticagrelor_Therapy_Value(context));
+        __Birth_date = new Lazy<CqlCode>(this.Birth_date_Value(context));
+        __LOINC = new Lazy<CqlCode[]>(this.LOINC_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+        __Non_Elective_Inpatient_Encounter = new Lazy<IEnumerable<Encounter>>(this.Non_Elective_Inpatient_Encounter_Value(context));
+        __All_Stroke_Encounter = new Lazy<IEnumerable<Encounter>>(this.All_Stroke_Encounter_Value(context));
+        __Encounter_with_Principal_Diagnosis_and_Age = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Principal_Diagnosis_and_Age_Value(context));
+        __Ischemic_Stroke_Encounter = new Lazy<IEnumerable<Encounter>>(this.Ischemic_Stroke_Encounter_Value(context));
+        __Ischemic_Stroke_Encounters_with_Discharge_Disposition = new Lazy<IEnumerable<Encounter>>(this.Ischemic_Stroke_Encounters_with_Discharge_Disposition_Value(context));
+        __Intervention_Comfort_Measures = new Lazy<IEnumerable<object>>(this.Intervention_Comfort_Measures_Value(context));
+        __Comfort_Measures_during_Hospitalization = new Lazy<IEnumerable<Encounter>>(this.Comfort_Measures_during_Hospitalization_Value(context));
+        __Encounter_with_Comfort_Measures_during_Hospitalization = new Lazy<IEnumerable<Encounter>>(this.Encounter_with_Comfort_Measures_during_Hospitalization_Value(context));
+    }
+    #region Dependencies
+
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Comfort_Measures_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
 
     [CqlDeclaration("Comfort Measures")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45")]
-	public CqlValueSet Comfort_Measures(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/1.3.6.1.4.1.33895.1.3.0.45", null);
+	public CqlValueSet Comfort_Measures() => 
+		__Comfort_Measures?.Value;
+
+	private CqlValueSet Discharge_To_Acute_Care_Facility_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
 
     [CqlDeclaration("Discharge To Acute Care Facility")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87")]
-	public CqlValueSet Discharge_To_Acute_Care_Facility(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.87", null);
+	public CqlValueSet Discharge_To_Acute_Care_Facility() => 
+		__Discharge_To_Acute_Care_Facility?.Value;
+
+	private CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
 
     [CqlDeclaration("Discharged to Health Care Facility for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207")]
-	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.207", null);
+	public CqlValueSet Discharged_to_Health_Care_Facility_for_Hospice_Care() => 
+		__Discharged_to_Health_Care_Facility_for_Hospice_Care?.Value;
+
+	private CqlValueSet Discharged_to_Home_for_Hospice_Care_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
 
     [CqlDeclaration("Discharged to Home for Hospice Care")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209")]
-	public CqlValueSet Discharged_to_Home_for_Hospice_Care(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.209", null);
+	public CqlValueSet Discharged_to_Home_for_Hospice_Care() => 
+		__Discharged_to_Home_for_Hospice_Care?.Value;
+
+	private CqlValueSet Emergency_Department_Visit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
 
     [CqlDeclaration("Emergency Department Visit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292")]
-	public CqlValueSet Emergency_Department_Visit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+	public CqlValueSet Emergency_Department_Visit() => 
+		__Emergency_Department_Visit?.Value;
+
+	private CqlValueSet Encounter_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
 
     [CqlDeclaration("Encounter Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307")]
-	public CqlValueSet Encounter_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+	public CqlValueSet Encounter_Inpatient() => 
+		__Encounter_Inpatient?.Value;
+
+	private CqlValueSet Hemorrhagic_Stroke_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
 
     [CqlDeclaration("Hemorrhagic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212")]
-	public CqlValueSet Hemorrhagic_Stroke(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.212", null);
+	public CqlValueSet Hemorrhagic_Stroke() => 
+		__Hemorrhagic_Stroke?.Value;
+
+	private CqlValueSet Ischemic_Stroke_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
 
     [CqlDeclaration("Ischemic Stroke")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247")]
-	public CqlValueSet Ischemic_Stroke(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.247", null);
+	public CqlValueSet Ischemic_Stroke() => 
+		__Ischemic_Stroke?.Value;
+
+	private CqlValueSet Left_Against_Medical_Advice_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
 
     [CqlDeclaration("Left Against Medical Advice")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308")]
-	public CqlValueSet Left_Against_Medical_Advice(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.308", null);
+	public CqlValueSet Left_Against_Medical_Advice() => 
+		__Left_Against_Medical_Advice?.Value;
+
+	private CqlValueSet Non_Elective_Inpatient_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
 
     [CqlDeclaration("Non-Elective Inpatient")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424")]
-	public CqlValueSet Non_Elective_Inpatient(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.424", null);
+	public CqlValueSet Non_Elective_Inpatient() => 
+		__Non_Elective_Inpatient?.Value;
+
+	private CqlValueSet Observation_Services_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
 
     [CqlDeclaration("Observation Services")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143")]
-	public CqlValueSet Observation_Services(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+	public CqlValueSet Observation_Services() => 
+		__Observation_Services?.Value;
+
+	private CqlValueSet Patient_Expired_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
 
     [CqlDeclaration("Patient Expired")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309")]
-	public CqlValueSet Patient_Expired(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.309", null);
+	public CqlValueSet Patient_Expired() => 
+		__Patient_Expired?.Value;
+
+	private CqlValueSet Ticagrelor_Therapy_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", null);
 
     [CqlDeclaration("Ticagrelor Therapy")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39")]
-	public CqlValueSet Ticagrelor_Therapy(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1110.39", null);
+	public CqlValueSet Ticagrelor_Therapy() => 
+		__Ticagrelor_Therapy?.Value;
 
-    [CqlDeclaration("Birth date")]
-	public CqlCode Birth_date(CqlContext context) => 
+	private CqlCode Birth_date_Value(CqlContext context) => 
 		new CqlCode("21112-8", "http://loinc.org", null, null);
 
-    [CqlDeclaration("LOINC")]
-	public CqlCode[] LOINC(CqlContext context)
+    [CqlDeclaration("Birth date")]
+	public CqlCode Birth_date() => 
+		__Birth_date?.Value;
+
+	private CqlCode[] LOINC_Value(CqlContext context)
 	{
 		var a_ = new CqlCode[]
 		{
@@ -96,8 +206,11 @@ public class TJCOverallFHIR_1_8_000
 		return a_;
 	}
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    [CqlDeclaration("LOINC")]
+	public CqlCode[] LOINC() => 
+		__LOINC?.Value;
+
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -108,8 +221,11 @@ public class TJCOverallFHIR_1_8_000
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -117,18 +233,21 @@ public class TJCOverallFHIR_1_8_000
 		return b_;
 	}
 
-    [CqlDeclaration("Non Elective Inpatient Encounter")]
-	public IEnumerable<Encounter> Non_Elective_Inpatient_Encounter(CqlContext context)
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
+	private IEnumerable<Encounter> Non_Elective_Inpatient_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Non_Elective_Inpatient(context);
+		var a_ = this.Non_Elective_Inpatient();
 		var b_ = context.Operators.RetrieveByValueSet<Encounter>(a_, null);
 		bool? c_(Encounter NonElectiveEncounter)
 		{
-			var e_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, NonElectiveEncounter?.Period);
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.LengthInDays(context, e_);
+			var e_ = FHIRHelpers_4_0_001.ToInterval(NonElectiveEncounter?.Period);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.LengthInDays(e_);
 			var g_ = context.Operators.LessOrEqual(f_, (int?)120);
 			var i_ = context.Operators.End(e_);
-			var j_ = this.Measurement_Period(context);
+			var j_ = this.Measurement_Period();
 			var k_ = context.Operators.ElementInInterval<CqlDateTime>(i_, j_, "day");
 			var l_ = context.Operators.And(g_, k_);
 
@@ -139,18 +258,21 @@ public class TJCOverallFHIR_1_8_000
 		return d_;
 	}
 
-    [CqlDeclaration("All Stroke Encounter")]
-	public IEnumerable<Encounter> All_Stroke_Encounter(CqlContext context)
+    [CqlDeclaration("Non Elective Inpatient Encounter")]
+	public IEnumerable<Encounter> Non_Elective_Inpatient_Encounter() => 
+		__Non_Elective_Inpatient_Encounter?.Value;
+
+	private IEnumerable<Encounter> All_Stroke_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Non_Elective_Inpatient_Encounter(context);
+		var a_ = this.Non_Elective_Inpatient_Encounter();
 		bool? b_(Encounter NonElectiveEncounter)
 		{
-			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.PrincipalDiagnosis(context, NonElectiveEncounter);
-			var e_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, d_?.Code);
-			var f_ = this.Hemorrhagic_Stroke(context);
+			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.PrincipalDiagnosis(NonElectiveEncounter);
+			var e_ = FHIRHelpers_4_0_001.ToConcept(d_?.Code);
+			var f_ = this.Hemorrhagic_Stroke();
 			var g_ = context.Operators.ConceptInValueSet(e_, f_);
-			var i_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, d_?.Code);
-			var j_ = this.Ischemic_Stroke(context);
+			var i_ = FHIRHelpers_4_0_001.ToConcept(d_?.Code);
+			var j_ = this.Ischemic_Stroke();
 			var k_ = context.Operators.ConceptInValueSet(i_, j_);
 			var l_ = context.Operators.Or(g_, k_);
 
@@ -161,18 +283,21 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
-    [CqlDeclaration("Encounter with Principal Diagnosis and Age")]
-	public IEnumerable<Encounter> Encounter_with_Principal_Diagnosis_and_Age(CqlContext context)
+    [CqlDeclaration("All Stroke Encounter")]
+	public IEnumerable<Encounter> All_Stroke_Encounter() => 
+		__All_Stroke_Encounter?.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Principal_Diagnosis_and_Age_Value(CqlContext context)
 	{
-		var a_ = this.All_Stroke_Encounter(context);
+		var a_ = this.All_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter AllStrokeEncounter)
 		{
 			var d_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 			bool? e_(Patient BirthDate)
 			{
-				var i_ = this.Patient(context);
+				var i_ = this.Patient();
 				var j_ = context.Operators.ConvertStringToDateTime(i_?.BirthDateElement?.Value);
-				var k_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, AllStrokeEncounter?.Period);
+				var k_ = FHIRHelpers_4_0_001.ToInterval(AllStrokeEncounter?.Period);
 				var l_ = context.Operators.Start(k_);
 				var m_ = context.Operators.CalculateAgeAt(j_, l_, "year");
 				var n_ = context.Operators.GreaterOrEqual(m_, (int?)18);
@@ -191,15 +316,18 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
-    [CqlDeclaration("Ischemic Stroke Encounter")]
-	public IEnumerable<Encounter> Ischemic_Stroke_Encounter(CqlContext context)
+    [CqlDeclaration("Encounter with Principal Diagnosis and Age")]
+	public IEnumerable<Encounter> Encounter_with_Principal_Diagnosis_and_Age() => 
+		__Encounter_with_Principal_Diagnosis_and_Age?.Value;
+
+	private IEnumerable<Encounter> Ischemic_Stroke_Encounter_Value(CqlContext context)
 	{
-		var a_ = this.Encounter_with_Principal_Diagnosis_and_Age(context);
+		var a_ = this.Encounter_with_Principal_Diagnosis_and_Age();
 		bool? b_(Encounter EncounterWithAge)
 		{
-			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.PrincipalDiagnosis(context, EncounterWithAge);
-			var e_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, d_?.Code);
-			var f_ = this.Ischemic_Stroke(context);
+			var d_ = MATGlobalCommonFunctionsFHIR4_6_1_000.PrincipalDiagnosis(EncounterWithAge);
+			var e_ = FHIRHelpers_4_0_001.ToConcept(d_?.Code);
+			var f_ = this.Ischemic_Stroke();
 			var g_ = context.Operators.ConceptInValueSet(e_, f_);
 
 			return g_;
@@ -209,25 +337,28 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
-    [CqlDeclaration("Ischemic Stroke Encounters with Discharge Disposition")]
-	public IEnumerable<Encounter> Ischemic_Stroke_Encounters_with_Discharge_Disposition(CqlContext context)
+    [CqlDeclaration("Ischemic Stroke Encounter")]
+	public IEnumerable<Encounter> Ischemic_Stroke_Encounter() => 
+		__Ischemic_Stroke_Encounter?.Value;
+
+	private IEnumerable<Encounter> Ischemic_Stroke_Encounters_with_Discharge_Disposition_Value(CqlContext context)
 	{
-		var a_ = this.Ischemic_Stroke_Encounter(context);
+		var a_ = this.Ischemic_Stroke_Encounter();
 		bool? b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, IschemicStrokeEncounter?.Hospitalization?.DischargeDisposition);
-			var e_ = this.Discharge_To_Acute_Care_Facility(context);
+			var d_ = FHIRHelpers_4_0_001.ToConcept(IschemicStrokeEncounter?.Hospitalization?.DischargeDisposition);
+			var e_ = this.Discharge_To_Acute_Care_Facility();
 			var f_ = context.Operators.ConceptInValueSet(d_, e_);
-			var h_ = this.Left_Against_Medical_Advice(context);
+			var h_ = this.Left_Against_Medical_Advice();
 			var i_ = context.Operators.ConceptInValueSet(d_, h_);
 			var j_ = context.Operators.Or(f_, i_);
-			var l_ = this.Patient_Expired(context);
+			var l_ = this.Patient_Expired();
 			var m_ = context.Operators.ConceptInValueSet(d_, l_);
 			var n_ = context.Operators.Or(j_, m_);
-			var p_ = this.Discharged_to_Home_for_Hospice_Care(context);
+			var p_ = this.Discharged_to_Home_for_Hospice_Care();
 			var q_ = context.Operators.ConceptInValueSet(d_, p_);
 			var r_ = context.Operators.Or(n_, q_);
-			var t_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care(context);
+			var t_ = this.Discharged_to_Health_Care_Facility_for_Hospice_Care();
 			var u_ = context.Operators.ConceptInValueSet(d_, t_);
 			var v_ = context.Operators.Or(r_, u_);
 
@@ -238,10 +369,13 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
-    [CqlDeclaration("Intervention Comfort Measures")]
-	public IEnumerable<object> Intervention_Comfort_Measures(CqlContext context)
+    [CqlDeclaration("Ischemic Stroke Encounters with Discharge Disposition")]
+	public IEnumerable<Encounter> Ischemic_Stroke_Encounters_with_Discharge_Disposition() => 
+		__Ischemic_Stroke_Encounters_with_Discharge_Disposition?.Value;
+
+	private IEnumerable<object> Intervention_Comfort_Measures_Value(CqlContext context)
 	{
-		var a_ = this.Comfort_Measures(context);
+		var a_ = this.Comfort_Measures();
 		var b_ = context.Operators.RetrieveByValueSet<ServiceRequest>(a_, null);
 		bool? c_(ServiceRequest P)
 		{
@@ -270,19 +404,22 @@ public class TJCOverallFHIR_1_8_000
 		return i_;
 	}
 
-    [CqlDeclaration("Comfort Measures during Hospitalization")]
-	public IEnumerable<Encounter> Comfort_Measures_during_Hospitalization(CqlContext context)
+    [CqlDeclaration("Intervention Comfort Measures")]
+	public IEnumerable<object> Intervention_Comfort_Measures() => 
+		__Intervention_Comfort_Measures?.Value;
+
+	private IEnumerable<Encounter> Comfort_Measures_during_Hospitalization_Value(CqlContext context)
 	{
-		var a_ = this.Ischemic_Stroke_Encounter(context);
+		var a_ = this.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Intervention_Comfort_Measures(context);
+			var d_ = this.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
 				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
 				var j_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
-				var k_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, ((i_ as FhirDateTime) ?? j_));
-				var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, IschemicStrokeEncounter);
+				var k_ = FHIRHelpers_4_0_001.ToDateTime(((i_ as FhirDateTime) ?? j_));
+				var l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
 				var m_ = context.Operators.ElementInInterval<CqlDateTime>(k_, l_, null);
 
 				return m_;
@@ -299,21 +436,24 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
-    [CqlDeclaration("Encounter with Comfort Measures during Hospitalization")]
-	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization(CqlContext context)
+    [CqlDeclaration("Comfort Measures during Hospitalization")]
+	public IEnumerable<Encounter> Comfort_Measures_during_Hospitalization() => 
+		__Comfort_Measures_during_Hospitalization?.Value;
+
+	private IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization_Value(CqlContext context)
 	{
-		var a_ = this.Ischemic_Stroke_Encounter(context);
+		var a_ = this.Ischemic_Stroke_Encounter();
 		IEnumerable<Encounter> b_(Encounter IschemicStrokeEncounter)
 		{
-			var d_ = this.Intervention_Comfort_Measures(context);
+			var d_ = this.Intervention_Comfort_Measures();
 			bool? e_(object ComfortMeasure)
 			{
 				var i_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "performed");
-				var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, i_);
+				var j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Normalize_Interval(i_);
 				var k_ = context.Operators.Start(j_);
 				var l_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
-				var m_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, l_);
-				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, IschemicStrokeEncounter);
+				var m_ = FHIRHelpers_4_0_001.ToDateTime(l_);
+				var n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(IschemicStrokeEncounter);
 				var o_ = context.Operators.ElementInInterval<CqlDateTime>((k_ ?? m_), n_, null);
 
 				return o_;
@@ -330,8 +470,12 @@ public class TJCOverallFHIR_1_8_000
 		return c_;
 	}
 
+    [CqlDeclaration("Encounter with Comfort Measures during Hospitalization")]
+	public IEnumerable<Encounter> Encounter_with_Comfort_Measures_during_Hospitalization() => 
+		__Encounter_with_Comfort_Measures_during_Hospitalization?.Value;
+
     [CqlDeclaration("CalendarDayOfOrDayAfter")]
-	public CqlInterval<CqlDate> CalendarDayOfOrDayAfter(CqlContext context, CqlDateTime StartValue)
+	public CqlInterval<CqlDate> CalendarDayOfOrDayAfter(CqlDateTime StartValue)
 	{
 		var a_ = context.Operators.DateFrom(StartValue);
 		var b_ = context.Operators.Quantity(1m, "day");

--- a/Demo/Measures/VTEFHIR4-4.8.000.cs
+++ b/Demo/Measures/VTEFHIR4-4.8.000.cs
@@ -14,15 +14,42 @@ using Task = Hl7.Fhir.Model.Task;
 public class VTEFHIR4_4_8_000
 {
 
-    public static VTEFHIR4_4_8_000 Instance { get; }  = new();
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<CqlValueSet> __Intensive_Care_Unit;
+    internal Lazy<CqlInterval<CqlDateTime>> __Measurement_Period;
+    internal Lazy<Patient> __Patient;
+
+    #endregion
+    public VTEFHIR4_4_8_000(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+        MATGlobalCommonFunctionsFHIR4_6_1_000 = new MATGlobalCommonFunctionsFHIR4_6_1_000(context);
+        FHIRHelpers_4_0_001 = new FHIRHelpers_4_0_001(context);
+
+        __Intensive_Care_Unit = new Lazy<CqlValueSet>(this.Intensive_Care_Unit_Value(context));
+        __Measurement_Period = new Lazy<CqlInterval<CqlDateTime>>(this.Measurement_Period_Value(context));
+        __Patient = new Lazy<Patient>(this.Patient_Value(context));
+    }
+    #region Dependencies
+
+    public MATGlobalCommonFunctionsFHIR4_6_1_000 MATGlobalCommonFunctionsFHIR4_6_1_000 { get; }
+    public FHIRHelpers_4_0_001 FHIRHelpers_4_0_001 { get; }
+
+    #endregion
+
+	private CqlValueSet Intensive_Care_Unit_Value(CqlContext context) => 
+		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", null);
 
     [CqlDeclaration("Intensive Care Unit")]
     [CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206")]
-	public CqlValueSet Intensive_Care_Unit(CqlContext context) => 
-		new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1029.206", null);
+	public CqlValueSet Intensive_Care_Unit() => 
+		__Intensive_Care_Unit?.Value;
 
-    [CqlDeclaration("Measurement Period")]
-	public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+	private CqlInterval<CqlDateTime> Measurement_Period_Value(CqlContext context)
 	{
 		var a_ = context.Operators.ConvertIntegerToDecimal(default);
 		var b_ = context.Operators.DateTime((int?)2019, (int?)1, (int?)1, (int?)0, (int?)0, (int?)0, (int?)0, a_);
@@ -33,8 +60,11 @@ public class VTEFHIR4_4_8_000
 		return (CqlInterval<CqlDateTime>)f_;
 	}
 
-    [CqlDeclaration("Patient")]
-	public Patient Patient(CqlContext context)
+    [CqlDeclaration("Measurement Period")]
+	public CqlInterval<CqlDateTime> Measurement_Period() => 
+		__Measurement_Period?.Value;
+
+	private Patient Patient_Value(CqlContext context)
 	{
 		var a_ = context.Operators.RetrieveByValueSet<Patient>(null, null);
 		var b_ = context.Operators.SingleOrNull<Patient>(a_);
@@ -42,23 +72,27 @@ public class VTEFHIR4_4_8_000
 		return b_;
 	}
 
+    [CqlDeclaration("Patient")]
+	public Patient Patient() => 
+		__Patient?.Value;
+
     [CqlDeclaration("FirstInpatientIntensiveCareUnit")]
-	public Encounter.LocationComponent FirstInpatientIntensiveCareUnit(CqlContext context, Encounter Encounter)
+	public Encounter.LocationComponent FirstInpatientIntensiveCareUnit(Encounter Encounter)
 	{
 		bool? a_(Encounter.LocationComponent HospitalLocation)
 		{
-			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.GetLocation(context, HospitalLocation?.Location);
+			var f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.GetLocation(HospitalLocation?.Location);
 			CqlConcept g_(CodeableConcept X)
 			{
-				var o_ = FHIRHelpers_4_0_001.Instance.ToConcept(context, X);
+				var o_ = FHIRHelpers_4_0_001.ToConcept(X);
 
 				return o_;
 			};
 			var h_ = context.Operators.SelectOrNull<CodeableConcept, CqlConcept>((f_?.Type as IEnumerable<CodeableConcept>), g_);
-			var i_ = this.Intensive_Care_Unit(context);
+			var i_ = this.Intensive_Care_Unit();
 			var j_ = context.Operators.ConceptsInValueSet(h_, i_);
-			var k_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
-			var l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, HospitalLocation?.Period);
+			var k_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
+			var l_ = FHIRHelpers_4_0_001.ToInterval(HospitalLocation?.Period);
 			var m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, l_, null);
 			var n_ = context.Operators.And(j_, m_);
 
@@ -67,7 +101,7 @@ public class VTEFHIR4_4_8_000
 		var b_ = context.Operators.WhereOrNull<Encounter.LocationComponent>((Encounter?.Location as IEnumerable<Encounter.LocationComponent>), a_);
 		object c_(Encounter.LocationComponent @this)
 		{
-			var p_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, @this?.Period);
+			var p_ = FHIRHelpers_4_0_001.ToInterval(@this?.Period);
 			var q_ = context.Operators.Start(p_);
 
 			return q_;
@@ -79,25 +113,25 @@ public class VTEFHIR4_4_8_000
 	}
 
     [CqlDeclaration("FirstICULocationPeriod")]
-	public Period FirstICULocationPeriod(CqlContext context, Encounter Encounter)
+	public Period FirstICULocationPeriod(Encounter Encounter)
 	{
-		var a_ = this.FirstInpatientIntensiveCareUnit(context, Encounter);
+		var a_ = this.FirstInpatientIntensiveCareUnit(Encounter);
 
 		return a_?.Period;
 	}
 
     [CqlDeclaration("StartOfFirstICU")]
-	public CqlDateTime StartOfFirstICU(CqlContext context, Encounter Encounter)
+	public CqlDateTime StartOfFirstICU(Encounter Encounter)
 	{
-		var a_ = this.FirstICULocationPeriod(context, Encounter);
-		var b_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, a_);
+		var a_ = this.FirstICULocationPeriod(Encounter);
+		var b_ = FHIRHelpers_4_0_001.ToInterval(a_);
 		var c_ = context.Operators.Start(b_);
 
 		return c_;
 	}
 
     [CqlDeclaration("CalendarDayOfOrDayAfter")]
-	public CqlInterval<CqlDate> CalendarDayOfOrDayAfter(CqlContext context, CqlDateTime StartValue)
+	public CqlInterval<CqlDate> CalendarDayOfOrDayAfter(CqlDateTime StartValue)
 	{
 		var a_ = context.Operators.DateFrom(StartValue);
 		var c_ = context.Operators.Quantity(1m, "day");
@@ -108,12 +142,12 @@ public class VTEFHIR4_4_8_000
 	}
 
     [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterAdmission")]
-	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterAdmission(CqlContext context, Encounter Encounter)
+	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterAdmission(Encounter Encounter)
 	{
-		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, Encounter);
+		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(Encounter);
 		var b_ = context.Operators.Start(a_);
 		var c_ = context.Operators.DateFrom(b_);
-		var d_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, Encounter?.Period);
+		var d_ = FHIRHelpers_4_0_001.ToInterval(Encounter?.Period);
 		var e_ = context.Operators.Start(d_);
 		var f_ = context.Operators.DateFrom(e_);
 		var g_ = context.Operators.Quantity(1m, "day");
@@ -124,12 +158,12 @@ public class VTEFHIR4_4_8_000
 	}
 
     [CqlDeclaration("FromDayOfStartOfHospitalizationToDayAfterFirstICU")]
-	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterFirstICU(CqlContext context, Encounter Encounter)
+	public CqlInterval<CqlDate> FromDayOfStartOfHospitalizationToDayAfterFirstICU(Encounter Encounter)
 	{
-		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, Encounter);
+		var a_ = MATGlobalCommonFunctionsFHIR4_6_1_000.HospitalizationWithObservation(Encounter);
 		var b_ = context.Operators.Start(a_);
 		var c_ = context.Operators.DateFrom(b_);
-		var d_ = this.StartOfFirstICU(context, Encounter);
+		var d_ = this.StartOfFirstICU(Encounter);
 		var e_ = context.Operators.DateFrom(d_);
 		var f_ = context.Operators.Quantity(1m, "day");
 		var g_ = context.Operators.Add(e_, f_);


### PR DESCRIPTION
- restore the lazy loading and constructors but only for measures with context defined
- add lazy null handling
- addresses #588

Current 1.0

ADD-E: Duration: 3h 32m 35s
CRE: Duration: 2h 46m 1s
PND-E: Duration: 10h 48m 39s
SPD: Duration: 3h 10m 21s

Time to run 80 HEDIS measures with multiple configurations using current develop 1.0 branch
![image](https://github.com/user-attachments/assets/0acdef5d-36f3-4a34-a0b0-529a9d57e517)

With these updates, same build pipeline

ADD-E: Duration: 38m 0s
CRE: Duration: 57m 4s
PND-E: Duration: 53m 39s
SPD: Duration: 1h 36m 22s

![image](https://github.com/user-attachments/assets/9a7a566b-a161-43a1-b37a-d7006c0ac49a)
