### PR TITLE
Adding tests to demonstrate issue around tuples respresented as ValueTuples

### DIFF
--- a/Cql/CoreTests/CSharp/CqlTupleTest-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/CqlTupleTest-1.0.0.g.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.4.0")]
+[CqlLibrary("CqlTupleTest", "1.0.0")]
+public class CqlTupleTest_1_0_0
+{
+
+
+    internal CqlContext context;
+
+    #region Cached values
+
+    internal Lazy<(string status, string result)?> __Result;
+
+    #endregion
+    public CqlTupleTest_1_0_0(CqlContext context)
+    {
+        this.context = context ?? throw new ArgumentNullException("context");
+
+
+        __Result = new Lazy<(string status, string result)?>(this.Result_Value);
+    }
+	private (string status, string result)? Result_Value()
+	{
+		(string status, string result)? a_ = ("success", "some result");
+
+		return a_;
+	}
+
+    [CqlDeclaration("Result")]
+	public (string status, string result)? Result() => 
+		__Result.Value;
+
+}

--- a/Cql/CoreTests/CoreTests.csproj
+++ b/Cql/CoreTests/CoreTests.csproj
@@ -21,8 +21,8 @@
 		<PackageReference Include="MSTest.TestFramework" Version="3.6.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.6.0" />
 		<PackageReference Include="coverlet.collector" Version="6.0.2">
-		  <PrivateAssets>all</PrivateAssets>
-		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
 		<PackageReference Remove="Microsoft.CodeAnalysis.PublicApiAnalyzers" />
@@ -43,6 +43,7 @@
 		<LibrarySet>CoreTests.HL7</LibrarySet>
 		<CqlDirectory>$(MSBuildProjectDirectory)/input/elm/hl7</CqlDirectory>
 		<ElmDirectory>$(MSBuildProjectDirectory)/input/elm/hl7</ElmDirectory>
+		<DllDirectory>$(MSBuildProjectDirectory)/Assemblies</DllDirectory>
 		<!-- <ResourcesDirectory>$(MSBuildProjectDirectory)/Resources</ResourcesDirectory> -->
 		<!-- <TestResultsDirectory>$(MSBuildProjectDirectory)/input/tests/results</TestResultsDirectory> -->
 	</PropertyGroup>
@@ -64,6 +65,9 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 		<None Update="Input\ValueSets\*.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+		<None Include="Assemblies\*.dll">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>

--- a/Cql/CoreTests/CqlTupleTest.cs
+++ b/Cql/CoreTests/CqlTupleTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Runtime;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests;
+
+[TestClass]
+public class CqlTupleTest
+{
+    [TestMethod]
+    public void Result_ShouldBeTupleWithNamedItems()
+    {
+        CqlContext ctx = FhirCqlContext.ForBundle();
+        var lib = new CqlTupleTest_1_0_0(ctx);
+        var result = lib.Result();
+
+        Assert.IsNotNull(result);
+        var resultValue = result.Value;
+
+        Assert.AreEqual("success", resultValue.status); // works only because the compiler replaces resultValue.status with resultValue.Item1
+        Assert.AreEqual("some result", resultValue.result); // works only because the compiler replaces resultValue.result with resultValue.Item2
+
+        Assert.IsNotNull(resultValue.GetType().GetField("Item1")); // works
+        Assert.IsNotNull(resultValue.GetType().GetField("Item2"));
+        Assert.IsNotNull(resultValue.GetType().GetField("status")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
+        Assert.IsNotNull(resultValue.GetType().GetField("result")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
+        // see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples#tuple-field-names
+    }
+}

--- a/Cql/CoreTests/CqlTupleTest.cs
+++ b/Cql/CoreTests/CqlTupleTest.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Runtime;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,5 +26,8 @@ public class CqlTupleTest
         Assert.IsNotNull(resultValue.GetType().GetField("status")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
         Assert.IsNotNull(resultValue.GetType().GetField("result")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
         // see https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/value-tuples#tuple-field-names
+
+        var str = JsonSerializer.Serialize(resultValue);
+        Assert.AreEqual("{\"status\":\"success\",\"result\":\"some result\"}", str); //fails, because a tuple without field names can't be serialized to JSON
     }
 }

--- a/Cql/CoreTests/Input/ELM/HL7/CqlTupleTest.cql
+++ b/Cql/CoreTests/Input/ELM/HL7/CqlTupleTest.cql
@@ -1,0 +1,7 @@
+library CqlTupleTest version '1.0.0'
+
+define "Result":
+  Tuple{
+    status: 'success',
+    result: 'some result'
+  }

--- a/Cql/CoreTests/Input/ELM/HL7/CqlTupleTest.json
+++ b/Cql/CoreTests/Input/ELM/HL7/CqlTupleTest.json
@@ -1,0 +1,87 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "2.11.0",
+         "translatorOptions" : "EnableLocators,EnableResultTypes",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "CqlTupleTest",
+         "version" : "1.0.0"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "3:1-7:3",
+            "name" : "Result",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "resultTypeSpecifier" : {
+               "type" : "TupleTypeSpecifier",
+               "element" : [ {
+                  "name" : "status",
+                  "elementType" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               }, {
+                  "name" : "result",
+                  "elementType" : {
+                     "name" : "{urn:hl7-org:elm-types:r1}String",
+                     "type" : "NamedTypeSpecifier"
+                  }
+               } ]
+            },
+            "expression" : {
+               "locator" : "4:3-7:3",
+               "type" : "Tuple",
+               "resultTypeSpecifier" : {
+                  "type" : "TupleTypeSpecifier",
+                  "element" : [ {
+                     "name" : "status",
+                     "elementType" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  }, {
+                     "name" : "result",
+                     "elementType" : {
+                        "name" : "{urn:hl7-org:elm-types:r1}String",
+                        "type" : "NamedTypeSpecifier"
+                     }
+                  } ]
+               },
+               "element" : [ {
+                  "name" : "status",
+                  "value" : {
+                     "locator" : "5:13-5:21",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "success",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "name" : "result",
+                  "value" : {
+                     "locator" : "6:13-6:25",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "some result",
+                     "type" : "Literal"
+                  }
+               } ]
+            }
+         } ]
+      }
+   }
+}
+

--- a/Cql/CoreTests/TupleAssemblyOutputTest.cs
+++ b/Cql/CoreTests/TupleAssemblyOutputTest.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.Loader;
+using System.Text.Json;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Packaging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -31,5 +32,8 @@ public class TupleAssemblyOutputTest
         //Assert.AreEqual("success", valueTuple.status); //doesn't compile because the compiler replaces valueTuple.status with valueTuple.Item1
         Assert.IsNotNull(valueTuple.GetType().GetField("status")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
         Assert.IsNotNull(valueTuple.GetType().GetField("result")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
+
+        var str = JsonSerializer.Serialize(valueTuple);
+        Assert.AreEqual("{\"status\":\"success\",\"result\":\"some result\"}", str); //fails, because a tuple without field names can't be serialized to JSON
     }
 }

--- a/Cql/CoreTests/TupleAssemblyOutputTest.cs
+++ b/Cql/CoreTests/TupleAssemblyOutputTest.cs
@@ -28,7 +28,7 @@ public class TupleAssemblyOutputTest
         Assert.IsNotNull(value);
         Assert.IsInstanceOfType(value, typeof(ValueTuple<string, string>));
         var valueTuple = (ValueTuple<string, string>)value;
-        Assert.AreEqual("success", valueTuple.status); //doesn't compile because the compiler replaces valueTuple.status with valueTuple.Item1
+        //Assert.AreEqual("success", valueTuple.status); //doesn't compile because the compiler replaces valueTuple.status with valueTuple.Item1
         Assert.IsNotNull(valueTuple.GetType().GetField("status")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
         Assert.IsNotNull(valueTuple.GetType().GetField("result")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
     }

--- a/Cql/CoreTests/TupleAssemblyOutputTest.cs
+++ b/Cql/CoreTests/TupleAssemblyOutputTest.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.Loader;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Packaging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests;
+
+[TestClass]
+public class TupleAssemblyOutputTest
+{
+    [TestMethod]
+    public void ReturnsTupleWithNamedFields()
+    {
+        var file = @"Assemblies/CqlTupleTest-1.0.0.dll";
+        var filePath = Path.GetFullPath(file);
+
+        var asm = new AssemblyLoadContext("CqlTupleTest");
+        asm.LoadFromAssemblyPath(filePath);
+
+        var ctx = FhirCqlContext.ForBundle();
+        var result = asm.Run("CqlTupleTest", "1.0.0", ctx);
+        Assert.IsNotNull(result);
+
+        result.TryGetValue("Result", out var value);
+        Assert.IsNotNull(value);
+        Assert.IsInstanceOfType(value, typeof(ValueTuple<string, string>));
+        var valueTuple = (ValueTuple<string, string>)value;
+        Assert.AreEqual("success", valueTuple.status); //doesn't compile because the compiler replaces valueTuple.status with valueTuple.Item1
+        Assert.IsNotNull(valueTuple.GetType().GetField("status")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
+        Assert.IsNotNull(valueTuple.GetType().GetField("result")); // fails, because the compiler replaced all custom names with default names, the custom names are not part of the runtime type information
+    }
+}

--- a/Demo/Cql/Build/ElmToCSharp.Targets.xml
+++ b/Demo/Cql/Build/ElmToCSharp.Targets.xml
@@ -38,6 +38,7 @@
 			<PackagerCLIArgs Condition="'$(CSharpDirectory)'!=''">$(PackagerCLIArgs) --cs "$(CSharpDirectory)"</PackagerCLIArgs>
 			<PackagerCLIArgs Condition="'$(ResourcesDirectory)'!=''">$(PackagerCLIArgs) --fhir "$(ResourcesDirectory)"</PackagerCLIArgs>
 			<PackagerCLIArgs Condition="'$(CSharpTypeFormat)'!=''">$(PackagerCLIArgs) --cs-typeformat "$(CSharpTypeFormat)"</PackagerCLIArgs>
+			<PackagerCliArgs Condition="'$(DllDirectory)'!=''">$(PackagerCLIArgs) --dll "$(DllDirectory)"</PackagerCliArgs>
 			<PackagerCLICommand>$(PackagerCLI) $(PackagerClIArgs)</PackagerCLICommand>
 			<!-- <PackagerCLICommand>$(PackagerCLI) $(PackagerClIArgs) &gt; NUL 2&gt; NUL</PackagerCLICommand> -->
 		</PropertyGroup>


### PR DESCRIPTION
Demonstrating Issue #592 

Adds some testdata and two unit-tests to demonstrate an issue representing CQL Tuple Types as C# ValueTuples.
See #592 for a detailed description of the issue.

**Summary**

Adding test data to `Input/ELM/HL7/`:

* `CqlTupleTest.cql`: CQL file that returns a simple tuple
* `CqlTupleTest.json`: ELM representation of CqlTupleTest.cql

`Demo/Cql/Build/ElmToSharp.Targets.xml`:

* Add additional packager cli argument to export the assemblies to the configured directory (`DllDirectory`)

`Cql/CoreTests/CoreTests.csproj`:

* Define `DllDirectory` property to let the packager export C# assemblies to new `Assemblies` directory
* Copy new `Assemblies` directory to the build output, to be able to load the generated assembly in tests

`Cql/CoreTest/CSharp/CqlTupleTest-1.0.0.g.cs`:

* auto-generated from `Input/ELM/HL7/CqlTupleTest.json` during build step

`Cql/CoreTests/CqlTupleTest.cs`:

* Works on `Cql/CoreTest/CSharp/CqlTupleTest-1.0.0.g.cs` which is compiled into the `CoreTests.dll`  assembly during the build step
* Demonstrates the issue with the tuple (and that some aspects work as long as the test code and the tuple code reside in the same assembly and are compiled together)

`Cql/CoreTests/TupleAssemblyOutputTest.cs`:

* Works on the `CqlTupleTest-1.0.0.dll` assembly which is created by the packager during the build step
* Demonstrates the issue, especially across assembly boundaries
