### PR TITLE
553 no mapping for cql long to fhir v43 integer64   throw exception

### DIFF
--- a/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
+++ b/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
@@ -1,0 +1,70 @@
+using System;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Packaging;
+using Hl7.Cql.Primitives;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.Packaging;
+
+[TestClass]
+public class CqlTypeToFhirTypeMapperTests
+{
+    [TestMethod]
+    public void TypeEntryFor_CqlPrimitiveTypeBoolean_ReturnsFhirBoolean()
+    {
+        // Arrange
+        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
+
+        // Act
+        var result = mapper.TypeEntryFor(CqlPrimitiveType.Boolean);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(FHIRAllTypes.Boolean, result.FhirType);
+        Assert.AreEqual(CqlPrimitiveType.Boolean, result.CqlType);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(ArgumentNullException))]
+    public void TypeEntryFor_CqlPrimitiveTypeListWithoutElementType_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
+
+        // Act
+        mapper.TypeEntryFor(CqlPrimitiveType.List);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(NotSupportedException))]
+    public void TypeEntryFor_CqlPrimitiveTypeLong_ThrowsNotSupportedException()
+    {
+        // Arrange
+        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
+
+        // Act
+        mapper.TypeEntryFor(CqlPrimitiveType.Long);
+    }
+
+    [TestMethod]
+    public void TypeEntryFor_CqlPrimitiveTypeListWithElementType_ReturnsFhirList()
+    {
+        // Arrange
+        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+        var elementType = new CqlTypeToFhirMapping(FHIRAllTypes.String, CqlPrimitiveType.String);
+        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
+
+        // Act
+        var result = mapper.TypeEntryFor(CqlPrimitiveType.List, elementType);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(FHIRAllTypes.List, result.FhirType);
+        Assert.AreEqual(CqlPrimitiveType.List, result.CqlType);
+        Assert.AreEqual(elementType, result.ElementType);
+    }
+}

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -130,6 +130,13 @@ namespace Hl7.Cql.Packaging
                     return new CqlTypeToFhirMapping(FHIRAllTypes.Date, cqlType);
                 case CqlPrimitiveType.DateTime:
                     return new CqlTypeToFhirMapping(FHIRAllTypes.DateTime, cqlType);
+                case CqlPrimitiveType.Long:
+#if FhirReleaseR4
+                    // integer64 only supported in R5. Compare https://hl7.org/fhir/R4/datatypes.html vs https://hl7.org/fhir/R5/datatypes.html
+                    throw new NotSupportedException("No mapping from CQL Long to FHIR in release 4 (see https://hl7.org/fhir/R4/datatypes.html)");
+//#else FhirReleaseR5
+//                    return new CqlTypeToFhirMapping(FHIRAllTypes.Integer64, cqlType);
+#endif
                 case CqlPrimitiveType.Decimal:
                     return new CqlTypeToFhirMapping(FHIRAllTypes.Decimal, cqlType);
                 case CqlPrimitiveType.List:

--- a/cql-base.props
+++ b/cql-base.props
@@ -7,7 +7,15 @@
 	<PropertyGroup>
 		<!-- Keep this in sync between cql-base.props and cql-demo.props -->
 		<FirelySdkVersion>5.10.3</FirelySdkVersion>
+
+		<!-- https://hl7.org/fhir/R4/ -->
+		<FhirRelease>R4</FhirRelease>
 	</PropertyGroup>
+
+	<PropertyGroup>
+		<DefineConstants Condition="'$(FhirRelease)'!=''">$(DefineConstants);FhirRelease$(FhirRelease)</DefineConstants>
+	</PropertyGroup>
+
 
 	<!-- Solution-wide properties for NuGet packaging -->
 	<PropertyGroup>


### PR DESCRIPTION
Fix for 
* #553 

Work
* Throw `NotSupportedException` when mapping CQL Long to FHIR R4
* Partial unit tests added for `CqlTypeToFhirTypeMapper`
* Added build property `FhirRelease` = `R4` in `cql-base.props`