### PR TITLE
Add support for bind a value in a valueset where the valueset is an expression

### DIFF
--- a/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.6.0")]
+[CqlLibrary("ValueSetExprExample", "1.0.0")]
+public partial class ValueSetExprExample_1_0_0 : ILibrary, ISingleton<ValueSetExprExample_1_0_0>
+{
+    private ValueSetExprExample_1_0_0() {}
+
+    public static ValueSetExprExample_1_0_0 Instance { get; } = new();
+
+    #region Library Members
+    public string Name => "ValueSetExprExample";
+    public string Version => "1.0.0";
+    public ILibrary[] Dependencies => [];
+    #endregion Library Members
+
+    [CqlDeclaration("ValueSet-A-1")]
+    [CqlValueSet("http://fire.ly/ValueSet/ValueSet-A-1")]
+    public CqlValueSet ValueSet_A_1(CqlContext context) => 
+        new CqlValueSet("http://fire.ly/ValueSet/ValueSet-A-1", default);
+
+
+    [CqlDeclaration("ValueSet-A-2")]
+    [CqlValueSet("http://fire.ly/ValueSet/ValueSet-A-2")]
+    public CqlValueSet ValueSet_A_2(CqlContext context) => 
+        new CqlValueSet("http://fire.ly/ValueSet/ValueSet-A-2", default);
+
+
+    [CqlDeclaration("ValueSet-B-1")]
+    [CqlValueSet("http://fire.ly/ValueSet/ValueSet-B-1")]
+    public CqlValueSet ValueSet_B_1(CqlContext context) => 
+        new CqlValueSet("http://fire.ly/ValueSet/ValueSet-B-1", default);
+
+
+    [CqlDeclaration("ValueSet-B-2")]
+    [CqlValueSet("http://fire.ly/ValueSet/ValueSet-B-2")]
+    public CqlValueSet ValueSet_B_2(CqlContext context) => 
+        new CqlValueSet("http://fire.ly/ValueSet/ValueSet-B-2", default);
+
+
+    [CqlDeclaration("ChosenSubCategory")]
+    public string ChosenSubCategory(CqlContext context)
+    {
+        object a_ = context.ResolveParameter("ValueSetExprExample-1.0.0", "ChosenSubCategory", "1");
+
+        return (string)a_;
+    }
+
+
+    [CqlDeclaration("ChosenCode")]
+    public CqlCode ChosenCode(CqlContext context)
+    {
+        object a_ = context.ResolveParameter("ValueSetExprExample-1.0.0", "ChosenCode", new CqlCode("A-1-A", "http://fire.ly/CodeSystem/Test", null, null));
+
+        return (CqlCode)a_;
+    }
+
+
+    [CqlDeclaration("ValueSetA")]
+    public CqlValueSet ValueSetA(CqlContext context)
+    {
+        CqlValueSet a_()
+        {
+            bool b_()
+            {
+                string d_ = this.ChosenSubCategory(context);
+                bool? e_ = context.Operators.Equal(d_, "1");
+
+                return e_ ?? false;
+            };
+            bool c_()
+            {
+                string f_ = this.ChosenSubCategory(context);
+                bool? g_ = context.Operators.Equal(f_, "2");
+
+                return g_ ?? false;
+            };
+            if (b_())
+            {
+                CqlValueSet h_ = this.ValueSet_A_1(context);
+
+                return h_;
+            }
+            else if (c_())
+            {
+                CqlValueSet i_ = this.ValueSet_A_2(context);
+
+                return i_;
+            }
+            else
+            {
+                return default;
+            }
+        };
+
+        return a_();
+    }
+
+
+    [CqlDeclaration("ValueSetB")]
+    public CqlValueSet ValueSetB(CqlContext context)
+    {
+        CqlValueSet a_()
+        {
+            bool b_()
+            {
+                string d_ = this.ChosenSubCategory(context);
+                bool? e_ = context.Operators.Equal(d_, "1");
+
+                return e_ ?? false;
+            };
+            bool c_()
+            {
+                string f_ = this.ChosenSubCategory(context);
+                bool? g_ = context.Operators.Equal(f_, "2");
+
+                return g_ ?? false;
+            };
+            if (b_())
+            {
+                CqlValueSet h_ = this.ValueSet_B_1(context);
+
+                return h_;
+            }
+            else if (c_())
+            {
+                CqlValueSet i_ = this.ValueSet_B_2(context);
+
+                return i_;
+            }
+            else
+            {
+                return default;
+            }
+        };
+
+        return a_();
+    }
+
+
+    [CqlDeclaration("Result")]
+    public string Result(CqlContext context)
+    {
+        string a_()
+        {
+            bool b_()
+            {
+                CqlCode d_ = this.ChosenCode(context);
+                CqlValueSet e_ = this.ValueSetA(context);
+                bool? f_ = context.Operators.CodeInValueSet(d_, e_);
+
+                return f_ ?? false;
+            };
+            bool c_()
+            {
+                CqlCode g_ = this.ChosenCode(context);
+                CqlValueSet h_ = this.ValueSetB(context);
+                bool? i_ = context.Operators.CodeInValueSet(g_, h_);
+
+                return i_ ?? false;
+            };
+            if (b_())
+            {
+                return "a";
+            }
+            else if (c_())
+            {
+                return "b";
+            }
+            else
+            {
+                return default;
+            }
+        };
+
+        return a_();
+    }
+
+}

--- a/Cql/CoreTests/CoreTests.csproj
+++ b/Cql/CoreTests/CoreTests.csproj
@@ -72,4 +72,8 @@
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Content Include="Input\ELM\HL7\ValueSetExprExample-1.0.0.cql" />
+	</ItemGroup>
 </Project>

--- a/Cql/CoreTests/Input/ELM/HL7/ValueSetExprExample-1.0.0.cql
+++ b/Cql/CoreTests/Input/ELM/HL7/ValueSetExprExample-1.0.0.cql
@@ -1,0 +1,36 @@
+library ValueSetExprExample version '1.0.0'
+
+using FHIR version '4.0.1'
+
+valueset "ValueSet-A-1": 'http://fire.ly/ValueSet/ValueSet-A-1'
+valueset "ValueSet-A-2": 'http://fire.ly/ValueSet/ValueSet-A-2'
+valueset "ValueSet-B-1": 'http://fire.ly/ValueSet/ValueSet-B-1'
+valueset "ValueSet-B-2": 'http://fire.ly/ValueSet/ValueSet-B-2'
+
+parameter "ChosenSubCategory" String default '1'
+
+parameter "ChosenCode" Code default Code {
+    code: 'A-1-A',
+    system: 'http://fire.ly/CodeSystem/Test'
+}
+
+define "ValueSetA":
+    case "ChosenSubCategory"
+      when '1' then "ValueSet-A-1"
+      when '2' then "ValueSet-A-2"
+    else null
+end
+
+define "ValueSetB":
+    case "ChosenSubCategory"
+        when '1' then "ValueSet-B-1"
+        when '2' then "ValueSet-B-2"
+    else null
+end
+
+define "Result":
+    case
+        when "ChosenCode" in "ValueSetA" then 'a'
+        when "ChosenCode" in "ValueSetB" then 'b'
+    else null
+end

--- a/Cql/CoreTests/Input/ELM/HL7/ValueSetExprExample-1.0.0.json
+++ b/Cql/CoreTests/Input/ELM/HL7/ValueSetExprExample-1.0.0.json
@@ -1,0 +1,321 @@
+{
+   "library" : {
+      "annotation" : [ {
+         "translatorVersion" : "3.1.0",
+         "translatorOptions" : "EnableLocators,EnableResultTypes",
+         "type" : "CqlToElmInfo"
+      } ],
+      "identifier" : {
+         "id" : "ValueSetExprExample",
+         "version" : "1.0.0"
+      },
+      "schemaIdentifier" : {
+         "id" : "urn:hl7-org:elm",
+         "version" : "r1"
+      },
+      "usings" : {
+         "def" : [ {
+            "localIdentifier" : "System",
+            "uri" : "urn:hl7-org:elm-types:r1"
+         }, {
+            "locator" : "3:1-3:26",
+            "localIdentifier" : "FHIR",
+            "uri" : "http://hl7.org/fhir",
+            "version" : "4.0.1"
+         } ]
+      },
+      "parameters" : {
+         "def" : [ {
+            "locator" : "10:1-10:48",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+            "name" : "ChosenSubCategory",
+            "accessLevel" : "Public",
+            "default" : {
+               "locator" : "10:46-10:48",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "valueType" : "{urn:hl7-org:elm-types:r1}String",
+               "value" : "1",
+               "type" : "Literal"
+            },
+            "parameterTypeSpecifier" : {
+               "locator" : "10:31-10:36",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "name" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "NamedTypeSpecifier"
+            }
+         }, {
+            "locator" : "12:1-15:1",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+            "name" : "ChosenCode",
+            "accessLevel" : "Public",
+            "default" : {
+               "locator" : "12:37-15:1",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+               "classType" : "{urn:hl7-org:elm-types:r1}Code",
+               "type" : "Instance",
+               "element" : [ {
+                  "name" : "code",
+                  "value" : {
+                     "locator" : "13:11-13:17",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "A-1-A",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "name" : "system",
+                  "value" : {
+                     "locator" : "14:13-14:44",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "http://fire.ly/CodeSystem/Test",
+                     "type" : "Literal"
+                  }
+               } ]
+            },
+            "parameterTypeSpecifier" : {
+               "locator" : "12:24-12:27",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+               "name" : "{urn:hl7-org:elm-types:r1}Code",
+               "type" : "NamedTypeSpecifier"
+            }
+         } ]
+      },
+      "valueSets" : {
+         "def" : [ {
+            "locator" : "5:1-5:63",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSet-A-1",
+            "id" : "http://fire.ly/ValueSet/ValueSet-A-1",
+            "accessLevel" : "Public"
+         }, {
+            "locator" : "6:1-6:63",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSet-A-2",
+            "id" : "http://fire.ly/ValueSet/ValueSet-A-2",
+            "accessLevel" : "Public"
+         }, {
+            "locator" : "7:1-7:63",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSet-B-1",
+            "id" : "http://fire.ly/ValueSet/ValueSet-B-1",
+            "accessLevel" : "Public"
+         }, {
+            "locator" : "8:1-8:63",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSet-B-2",
+            "id" : "http://fire.ly/ValueSet/ValueSet-B-2",
+            "accessLevel" : "Public"
+         } ]
+      },
+      "statements" : {
+         "def" : [ {
+            "locator" : "17:1-22:3",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSetA",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "locator" : "18:5-22:3",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+               "type" : "Case",
+               "comparand" : {
+                  "locator" : "18:10-18:28",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "name" : "ChosenSubCategory",
+                  "type" : "ParameterRef"
+               },
+               "caseItem" : [ {
+                  "locator" : "19:7-19:34",
+                  "when" : {
+                     "locator" : "19:12-19:14",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "then" : {
+                     "locator" : "19:21-19:34",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "ValueSet-A-1",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
+                  }
+               }, {
+                  "locator" : "20:7-20:34",
+                  "when" : {
+                     "locator" : "20:12-20:14",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "2",
+                     "type" : "Literal"
+                  },
+                  "then" : {
+                     "locator" : "20:21-20:34",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "ValueSet-A-2",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
+                  }
+               } ],
+               "else" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "As",
+                  "operand" : {
+                     "locator" : "21:10-21:13",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  }
+               }
+            }
+         }, {
+            "locator" : "24:1-29:3",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+            "name" : "ValueSetB",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "locator" : "25:5-29:3",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+               "type" : "Case",
+               "comparand" : {
+                  "locator" : "25:10-25:28",
+                  "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                  "name" : "ChosenSubCategory",
+                  "type" : "ParameterRef"
+               },
+               "caseItem" : [ {
+                  "locator" : "26:9-26:36",
+                  "when" : {
+                     "locator" : "26:14-26:16",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "1",
+                     "type" : "Literal"
+                  },
+                  "then" : {
+                     "locator" : "26:23-26:36",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "ValueSet-B-1",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
+                  }
+               }, {
+                  "locator" : "27:9-27:36",
+                  "when" : {
+                     "locator" : "27:14-27:16",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "2",
+                     "type" : "Literal"
+                  },
+                  "then" : {
+                     "locator" : "27:23-27:36",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                     "name" : "ValueSet-B-2",
+                     "preserve" : true,
+                     "type" : "ValueSetRef"
+                  }
+               } ],
+               "else" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                  "type" : "As",
+                  "operand" : {
+                     "locator" : "28:10-28:13",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  }
+               }
+            }
+         }, {
+            "locator" : "31:1-36:3",
+            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+            "name" : "Result",
+            "context" : "Patient",
+            "accessLevel" : "Public",
+            "expression" : {
+               "locator" : "32:5-36:3",
+               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+               "type" : "Case",
+               "caseItem" : [ {
+                  "locator" : "33:9-33:49",
+                  "when" : {
+                     "locator" : "33:14-33:40",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "InValueSet",
+                     "signature" : [ {
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }, {
+                        "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "code" : {
+                        "locator" : "33:14-33:25",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "ChosenCode",
+                        "type" : "ParameterRef"
+                     },
+                     "valuesetExpression" : {
+                        "locator" : "33:30-33:40",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "name" : "ValueSetA",
+                        "type" : "ExpressionRef"
+                     }
+                  },
+                  "then" : {
+                     "locator" : "33:47-33:49",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "a",
+                     "type" : "Literal"
+                  }
+               }, {
+                  "locator" : "34:9-34:49",
+                  "when" : {
+                     "locator" : "34:14-34:40",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Boolean",
+                     "type" : "InValueSet",
+                     "signature" : [ {
+                        "name" : "{urn:hl7-org:elm-types:r1}Code",
+                        "type" : "NamedTypeSpecifier"
+                     }, {
+                        "name" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "type" : "NamedTypeSpecifier"
+                     } ],
+                     "code" : {
+                        "locator" : "34:14-34:25",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}Code",
+                        "name" : "ChosenCode",
+                        "type" : "ParameterRef"
+                     },
+                     "valuesetExpression" : {
+                        "locator" : "34:30-34:40",
+                        "resultTypeName" : "{urn:hl7-org:elm-types:r1}ValueSet",
+                        "name" : "ValueSetB",
+                        "type" : "ExpressionRef"
+                     }
+                  },
+                  "then" : {
+                     "locator" : "34:47-34:49",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
+                     "valueType" : "{urn:hl7-org:elm-types:r1}String",
+                     "value" : "b",
+                     "type" : "Literal"
+                  }
+               } ],
+               "else" : {
+                  "asType" : "{urn:hl7-org:elm-types:r1}String",
+                  "type" : "As",
+                  "operand" : {
+                     "locator" : "35:10-35:13",
+                     "resultTypeName" : "{urn:hl7-org:elm-types:r1}Any",
+                     "type" : "Null"
+                  }
+               }
+            }
+         } ]
+      }
+   }
+}
+

--- a/Cql/CoreTests/ValueSetExpressionTests.cs
+++ b/Cql/CoreTests/ValueSetExpressionTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using FluentAssertions;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.ValueSets;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests;
+
+[TestClass]
+public class ValueSetExpressionTests
+
+{
+    private Dictionary<string, object> _parameters;
+    private CqlContext ctx;
+    private static IValueSetDictionary _valueSets = null!;
+
+
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _parameters = new();
+        ctx = FhirCqlContext.ForBundle(
+            valueSets: _valueSets,
+            parameters: _parameters);
+    }
+
+    [TestMethod]
+    public void ChoseCodeIsA1A_And_SubCategory1_ResultShouldBeA()
+    {
+        var lib = ValueSetExprExample_1_0_0.Instance;
+        lib.ChosenSubCategory(ctx).Should().Be("1");
+        lib.ChosenCode(ctx)?.code.Should().Be("A-1-A");
+        lib.ValueSetA(ctx)?.id.Should().Be(ValueSetIdFor("A", "1"));
+        lib.ValueSetB(ctx)?.id.Should().Be(ValueSetIdFor("B", "1"));
+        lib.Result(ctx).Should().Be("a");
+    }
+
+    [TestMethod]
+    public void ChosenCodeIsA1C_And_SubCategory1_ResultShouldBeNull()
+    {
+        _parameters["ChosenCode"] = new CqlCode { code = "A-1-C" }; ;
+
+        var lib = ValueSetExprExample_1_0_0.Instance;
+        lib.ChosenSubCategory(ctx).Should().Be("1");
+        lib.ChosenCode(ctx)?.code.Should().Be("A-1-C");
+        lib.ValueSetA(ctx)?.id.Should().Be(ValueSetIdFor("A", "1"));
+        lib.ValueSetB(ctx)?.id.Should().Be(ValueSetIdFor("B", "1"));
+        lib.Result(ctx).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void ChosenCodeIsB2A_And_SubCategory2_ResultShouldBeB()
+    {
+        _parameters["ChosenSubCategory"] = "2";
+        _parameters["ChosenCode"] = new CqlCode { code = "B-2-A" }; ;
+
+        var lib = ValueSetExprExample_1_0_0.Instance;
+        lib.ChosenSubCategory(ctx).Should().Be("2");
+        lib.ChosenCode(ctx)?.code.Should().Be("B-2-A");
+        lib.ValueSetA(ctx)?.id.Should().Be(ValueSetIdFor("A", "2"));
+        lib.ValueSetB(ctx)?.id.Should().Be(ValueSetIdFor("B", "2"));
+        lib.Result(ctx).Should().Be("b");
+    }
+
+    [ClassInitialize]
+    public static void ClassInitialize(TestContext _)
+    {
+        _valueSets = new[]
+        {
+            ValueSet("A", "1"),
+            ValueSet("A", "2"),
+            ValueSet("B", "1"),
+            ValueSet("B", "2"),
+        }.ToValueSetDictionary();
+    }
+
+    private static ValueSet ValueSet(string category, string subCategory) =>
+        new()
+        {
+            Id = ValueSetIdFor(category, subCategory),
+            Url = ValueSetIdFor(category, subCategory),
+            Expansion = new ValueSet.ExpansionComponent
+            {
+                Contains =
+                [
+                    new()
+                    {
+                        Code = $"{category}-{subCategory}-A",
+                        System = "http://fire.ly/CodeSystem/Test"
+                    },
+                    new()
+                    {
+                        Code = $"{category}-{subCategory}-B",
+                        System = "http://fire.ly/CodeSystem/Test"
+                    },
+                ]
+            }
+        };
+
+    private static string ValueSetIdFor(string category, string subCategory) =>
+        $"http://fire.ly/ValueSet/ValueSet-{category}-{subCategory}";
+
+}

--- a/Cql/Cql.Compiler/ExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilderContext.cs
@@ -179,15 +179,15 @@ partial class ExpressionBuilderContext(
                     FunctionRef e => FunctionRef(e),
 
                     // InvokeDefinitionThroughRuntimeContext
-                    CodeRef e => CodeRef(e),
+                    CodeRef e       => CodeRef(e),
                     CodeSystemRef e => CodeSystemRef(e),
-                    ConceptRef e => ConceptRef(e),
+                    ConceptRef e    => ConceptRef(e),
                     ExpressionRef e => ExpressionRef(e),
-                    AnyInValueSet e => ProcessValueSet(e.valueset, e.codes, isList: true),
-                    InValueSet e => ProcessValueSet(e.valueset!, e.code, isList: false),
-                    Retrieve e => Retrieve(e),
-                    ValueSetRef e => ValueSetRef(e),
-                    ParameterRef e => ParameterRef(e),
+                    AnyInValueSet e => BindValueInValueSet(valueExpr: TranslateArg(e.codes), valueSetExpr: TranslateValueSet(e.valueset, e.valuesetExpression), isList: true),
+                    InValueSet e    => BindValueInValueSet(valueExpr: TranslateArg(e.code), valueSetExpr: TranslateValueSet(e.valueset, e.valuesetExpression), isList: false),
+                    Retrieve e      => Retrieve(e),
+                    ValueSetRef e   => ValueSetRef(e),
+                    ParameterRef e  => ParameterRef(e),
 
                     // NOTE: Do not rename ICqlOperators.CreateValueSetFacade to ExpandValueSet
                     ExpandValueSet e => _cqlOperatorsBinder.BindToMethod(nameof(ICqlOperators.CreateValueSetFacade), TranslateArgs(GetBindArgs(element)), TranslateTypes(GetTypeArgs(element))),
@@ -1196,23 +1196,35 @@ partial class ExpressionBuilderContext(
         return new DefinitionCallExpression(CqlExpressions.Definitions_PropertyExpression, libraryName, name, CqlExpressions.ParameterExpression, funcType);
     }
 
-    private Expression ProcessValueSet(ValueSetRef valueSetRef, Elm.Expression valueExpr, bool isList)
+    private Expression BindValueInValueSet(
+        Expression valueExpr,
+        Expression valueSetExpr,
+        bool isList)
     {
-        Expression expr = TranslateArg(valueExpr);
+        var codeType = isList ? _typeResolver.GetListElementType(valueExpr.Type, throwError: true)! : valueExpr.Type;
 
-        var codeType = isList ? _typeResolver.GetListElementType(expr.Type, throwError: true)! : expr.Type;
-
-        var valueSet = InvokeDefinitionThroughRuntimeContext(valueSetRef.name!, valueSetRef.libraryName, typeof(CqlValueSet));
         if (codeType == _typeResolver.CodeType)
-            return BindCqlOperator(isList ? nameof(ICqlOperators.CodesInValueSet) : nameof(ICqlOperators.CodeInValueSet), expr, valueSet);
+            return BindCqlOperator(isList ? nameof(ICqlOperators.CodesInValueSet) : nameof(ICqlOperators.CodeInValueSet), valueExpr, valueSetExpr);
 
         if (codeType == _typeResolver.ConceptType)
-            return BindCqlOperator(isList ? nameof(ICqlOperators.ConceptsInValueSet) : nameof(ICqlOperators.ConceptInValueSet), expr, valueSet);
+            return BindCqlOperator(isList ? nameof(ICqlOperators.ConceptsInValueSet) : nameof(ICqlOperators.ConceptInValueSet), valueExpr, valueSetExpr);
 
         if (codeType == typeof(string))
-            return BindCqlOperator(isList ? nameof(ICqlOperators.StringsInValueSet) : nameof(ICqlOperators.StringInValueSet), expr, valueSet);
+            return BindCqlOperator(isList ? nameof(ICqlOperators.StringsInValueSet) : nameof(ICqlOperators.StringInValueSet), valueExpr, valueSetExpr);
 
         throw new NotImplementedException().WithContext(this);
+    }
+
+    private Expression TranslateValueSet(ValueSetRef valueSetRef, Elm.Expression valueSetExpression)
+    {
+        var valueSet =
+            (valueSetRef, valueSetExpression) switch
+            {
+                ({} r, null) => InvokeDefinitionThroughRuntimeContext(r.name!, r.libraryName, typeof(CqlValueSet)),
+                (null, {} e) => TranslateElement(e),
+                _            => throw this.NewExpressionBuildingException("Expected either a ValueSetRef or a ValueSetExpression")
+            };
+        return valueSet;
     }
 }
 


### PR DESCRIPTION
Work for
- #630

When binding an in operator to a valueset, that valueset could either be a valueset reference as it is currently implemented, but missing was that it could be a valueset expression.

Unit tests added as well