### PR TITLE
634 adopt standard extension for input parameters that are a list

### DIFF
--- a/Cql/Cql.Packaging/Constants.cs
+++ b/Cql/Cql.Packaging/Constants.cs
@@ -10,7 +10,7 @@ namespace Hl7.Cql.Packaging
 {
     internal static class Constants
     {
-        public const string ParameterElementTypeExtensionUri = "https://ncqa.org/fhir/StructureDefinition/ext-parameter.list-element-type";
-        public const string ParameterAccessLevel = "http://hl7.org/fhir/StructureDefinition/cqf-cqlAccessLevel";
+        public const string Hl7FhirStructureDefinitionCqlAccessLevel = "http://hl7.org/fhir/StructureDefinition/cqf-cqlAccessLevel";
+        public const string Hl7FhirStructureDefinitionCqlType = "http://hl7.org/fhir/StructureDefinition/cqf-cqlType";
     }
 }

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -262,31 +262,36 @@ namespace Hl7.Cql.Packaging
         {
             if (resultTypeSpecifier is null)
                 return null;
+
             switch (resultTypeSpecifier)
             {
                 case IntervalTypeSpecifier interval:
-                    {
-                        if (interval.pointType is null)
-                            return null;
-                        var pointType = TypeEntryFor(interval.pointType);
-                        return TypeEntryFor(CqlPrimitiveType.Interval, pointType);
-                    }
+                    if (interval.pointType is null)
+                        return null;
+
+                    var pointType = TypeEntryFor(interval.pointType);
+                    return TypeEntryFor(CqlPrimitiveType.Interval, pointType);
+
                 case ListTypeSpecifier list:
                     if (list.elementType is null)
                         return null;
+
                     var elementType = TypeEntryFor(list.elementType);
                     if (elementType is null)
                         return null;
+
                     return TypeEntryFor(CqlPrimitiveType.List, elementType);
+
                 case NamedTypeSpecifier named:
                     return TypeEntryFor(named.name.Name);
+
                 case ChoiceTypeSpecifier:
                 case TupleTypeSpecifier:
                     return new CqlTypeToFhirMapping(FHIRAllTypes.Basic, CqlPrimitiveType.Tuple);
+
                 default:
-                    break;
+                    return null;
             }
-            return null;
         }
 
         /// <summary>

--- a/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
+++ b/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
@@ -25,9 +25,13 @@ internal class WriteToFileFhirResourcePostProcessor(
 
     public override void ProcessResource(Resource resource)
     {
+        var outDirectory = _fhirResourceWriterOptions.OutDirectory;
+        if (outDirectory is null)
+            return;
+
         var resourceType = resource.GetType().Name; // e.g. Library or Measure
         var resourceFileName = ResourceFileName.Create(resourceType, resource.Id, resource.VersionId);
-        var file = new FileInfo(resourceFileName.FileName);
+        var file = new FileInfo(Path.Combine(outDirectory.FullName, resourceFileName.FileName));
         _logger.LogInformation("Writing FHIR Resource file: '{file}'", file.FullName);
 
         if (resource is Library library

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -12,11 +12,13 @@ using Hl7.Cql.Compiler;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Iso8601;
 using Hl7.Cql.Packaging.PostProcessors;
+using Hl7.Cql.Primitives;
 using Hl7.Fhir.Model;
 using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Hl7.Fhir.Utility;
+using String = Hl7.Fhir.ElementModel.Types.String;
 
 namespace Hl7.Cql.Packaging;
 
@@ -351,15 +353,16 @@ internal class ResourcePackager(
         var typeSpecifier = elmParameter.resultTypeSpecifier ?? elmParameter.parameterTypeSpecifier;
         if (typeSpecifier is null)
             throw new ArgumentException($"{typeSpecifier} is missing on parameter: {elmParameter.name}", nameof(elmParameter));
+
         var type = typeCrosswalk.TypeEntryFor(typeSpecifier);
-        if (type is null || type.FhirType is null)
+        if (type?.FhirType is null)
             throw new ArgumentException($"Unable to identify a valid FHIR type for this parameter.", nameof(elmParameter));
 
-        var annotations = (elmParameter.annotation?
-                               .OfType<Elm.Annotation>()
-                               .SelectMany(a => a.t ?? [])
-                           ?? [])
-            .ToArray();
+        // var annotations = (elmParameter.annotation?
+        //                        .OfType<Elm.Annotation>()
+        //                        .SelectMany(a => a.t ?? [])
+        //                    ?? [])
+        //     .ToArray();
 
         var parameterDefinition = new ParameterDefinition
         {
@@ -382,9 +385,11 @@ internal class ResourcePackager(
             {
                 name = definition.resultTypeName
             };
+
         var type = typeCrosswalk.TypeEntryFor(resultTypeSpecifier);
-        if (type is null || type.FhirType is null)
+        if (type?.FhirType is null)
             throw new ArgumentException($"Unable to identify a valid FHIR type for this definition.", nameof(definition));
+
         var parameterDefinition = new ParameterDefinition
         {
             Name = definition.name!,
@@ -393,14 +398,23 @@ internal class ResourcePackager(
             Max = "1",
             Type = type.FhirType!,
         };
-        if (type.ElementType is not null && type.ElementType.FhirType is not null)
+
+        if (
+            type is
+            {
+                CqlType: { } cqlType and CqlPrimitiveType.List,
+                ElementType.FhirType: { } elementFhirType
+            })
         {
+            parameterDefinition.Type = elementFhirType;
+            parameterDefinition.Max = "*";
+
             parameterDefinition.Extension =
             [
                 new Extension
                 {
-                    Value = new Code<FHIRAllTypes>(type.ElementType.FhirType),
-                    Url = Constants.ParameterElementTypeExtensionUri
+                    Url = Constants.Hl7FhirStructureDefinitionCqlType,
+                    Value = new FhirString(cqlType.ToString()),// e.g. List
                 }
             ];
         }
@@ -410,7 +424,7 @@ internal class ResourcePackager(
             parameterDefinition.Extension.Add(new Extension
             {
                 Value = new Hl7.Fhir.Model.Code("private"),
-                Url = Constants.ParameterAccessLevel,
+                Url = Constants.Hl7FhirStructureDefinitionCqlAccessLevel,
             });
         }
 


### PR DESCRIPTION
Work for 
* #634 

# Fixes
* Correctly output List out parameters to Library resources. 
* Change max cadinality from "1" to  "*"
![image](https://github.com/user-attachments/assets/20b72b85-80f8-430e-8943-363020086978)
* Fix not using the OutDirectory when writing resource files, causing resource files to be generated directly in the project file folders