### PR TITLE
645 bug   fail to create files in missing directory

### DIFF
--- a/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
+++ b/Cql/Cql.Packaging/PostProcessors/WriteToFileFhirResourcePostProcessor.cs
@@ -5,6 +5,8 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
+
+using System.Diagnostics;
 using System.Text.Json;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
@@ -25,13 +27,14 @@ internal class WriteToFileFhirResourcePostProcessor(
 
     public override void ProcessResource(Resource resource)
     {
-        var outDirectory = _fhirResourceWriterOptions.OutDirectory;
-        if (outDirectory is null)
-            return;
+        ResourceFileName resourceFileName = resource switch
+        {
+            Library l => ResourceFileName.Create(nameof(Library), l.Id, l.Version),
+            Measure m => ResourceFileName.Create(nameof(Measure), m.Id, m.Version),
+            _ => throw new UnreachableException("Only expecting Library or Measure.")
+        };
 
-        var resourceType = resource.GetType().Name; // e.g. Library or Measure
-        var resourceFileName = ResourceFileName.Create(resourceType, resource.Id, resource.VersionId);
-        var file = new FileInfo(Path.Combine(outDirectory.FullName, resourceFileName.FileName));
+        var file = new FileInfo($"{Path.Combine(_fhirResourceWriterOptions.OutDirectory!.FullName, resourceFileName.FileName)}");
         _logger.LogInformation("Writing FHIR Resource file: '{file}'", file.FullName);
 
         if (resource is Library library

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -1,31 +1,46 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 using Hl7.Cql.Abstractions.Infrastructure;
-using Hl7.Cql.CodeGeneration.NET;
 using Microsoft.CodeAnalysis;
 
 var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
 	.FindParentDirectoryContaining("*.sln")!;
 
-(string subDir, string measureSubDir)[] iteration = [
-	("Demo", "Measures.Demo"),
-	("CMS", "Measures.CMS")
+(string librarySetSubDir, string measureSubDir, string? cqlSubDirOverride, string? elmSubDirOverride)[] iteration = [
+	("Demo", "Measures.Demo", null, null),
+	("CMS", "Measures.CMS", null, null),
+	("Authoring", "Measures.Authoring", "/Input/cql", "/Elm"),
 ];
 
 bool first = true;
-foreach ((string librarySetSubDir, string measuresSubDir) in iteration)
+foreach ((string librarySetSubDir, string measuresSubDir, string? cqlSubDirOverride, string? elmSubDirOverride) in iteration)
 {
-	string[] arguments =
+	string librarySetsRootDir = $"{solutionDir}/LibrarySets/{librarySetSubDir}";
+	string demoRootDir = $"{solutionDir}/Demo/{measuresSubDir}";
+
+    string elmDir =
+        elmSubDirOverride is null
+            ? $"{librarySetsRootDir}/Elm"
+            : $"{demoRootDir}{elmSubDirOverride}";
+	string cqlDir =
+		cqlSubDirOverride is null
+            ? $"{librarySetsRootDir}/Cql"
+            : $"{demoRootDir}/{cqlSubDirOverride}";
+	string fhirDir = $"{librarySetsRootDir}/Resources";
+	string dllDir = $"{librarySetsRootDir}/Assemblies";
+    string csharpDir = $"{demoRootDir}/CSharp";
+
+    string[] arguments =
 		CommandLineParser
 			.SplitCommandLineIntoArguments(
 				$"""
 					 --override-utc-date-time "1970-01-01T00:00:00.000Z"
 					 --canonical-root-url "https://fire.ly/fhir/"
-					 --elm "{solutionDir}/LibrarySets/{librarySetSubDir}/Elm"
-					 --cql "{solutionDir}/LibrarySets/{librarySetSubDir}/Cql"
-					 --fhir "{solutionDir}/LibrarySets/{librarySetSubDir}/Resources"
-					 --dll "{solutionDir}/LibrarySets/{librarySetSubDir}/Assemblies"
-					 --cs "{solutionDir}/Demo/{measuresSubDir}/CSharp"
+					 --elm "{elmDir}"
+					 --cql "{cqlDir}"
+					 --fhir "{fhirDir}"
+					 --dll "{dllDir}"
+					 --cs "{csharpDir}"
 					 --log-debug true
 					 {(first ? "" : "--log-dont-clear true")}
 					 """.Replace("\n", " "),

--- a/Cql/MultiPackagerCLI/Program.cs
+++ b/Cql/MultiPackagerCLI/Program.cs
@@ -3,44 +3,32 @@
 using Hl7.Cql.Abstractions.Infrastructure;
 using Microsoft.CodeAnalysis;
 
-var solutionDir = new DirectoryInfo(Environment.CurrentDirectory)
-	.FindParentDirectoryContaining("*.sln")!;
-
-(string librarySetSubDir, string measureSubDir, string? cqlSubDirOverride, string? elmSubDirOverride)[] iteration = [
-	("Demo", "Measures.Demo", null, null),
-	("CMS", "Measures.CMS", null, null),
-	("Authoring", "Measures.Authoring", "/Input/cql", "/Elm"),
+MeasuresDirSet[] measureDirSets =
+[
+    new MeasuresDirSet("Demo"),
+    new MeasuresDirSet("CMS"),
+    new MeasuresDirSet("Authoring")
+        .Mutate(m => m with
+        {
+            CqlDir = $"{m.MeasuresProjectRootDir}/Input/cql",
+            ElmDir = $"{m.MeasuresProjectRootDir}/Elm"
+        }),
 ];
 
 bool first = true;
-foreach ((string librarySetSubDir, string measuresSubDir, string? cqlSubDirOverride, string? elmSubDirOverride) in iteration)
+foreach (MeasuresDirSet dirSet in measureDirSets)
 {
-	string librarySetsRootDir = $"{solutionDir}/LibrarySets/{librarySetSubDir}";
-	string demoRootDir = $"{solutionDir}/Demo/{measuresSubDir}";
-
-    string elmDir =
-        elmSubDirOverride is null
-            ? $"{librarySetsRootDir}/Elm"
-            : $"{demoRootDir}{elmSubDirOverride}";
-	string cqlDir =
-		cqlSubDirOverride is null
-            ? $"{librarySetsRootDir}/Cql"
-            : $"{demoRootDir}/{cqlSubDirOverride}";
-	string fhirDir = $"{librarySetsRootDir}/Resources";
-	string dllDir = $"{librarySetsRootDir}/Assemblies";
-    string csharpDir = $"{demoRootDir}/CSharp";
-
     string[] arguments =
 		CommandLineParser
 			.SplitCommandLineIntoArguments(
 				$"""
 					 --override-utc-date-time "1970-01-01T00:00:00.000Z"
 					 --canonical-root-url "https://fire.ly/fhir/"
-					 --elm "{elmDir}"
-					 --cql "{cqlDir}"
-					 --fhir "{fhirDir}"
-					 --dll "{dllDir}"
-					 --cs "{csharpDir}"
+					 --elm "{dirSet.ElmDir}"
+					 --cql "{dirSet.CqlDir}"
+					 --fhir "{dirSet.FhirDir}"
+					 --dll "{dirSet.DllDir}"
+					 --cs "{dirSet.CSharpDir}"
 					 --log-debug true
 					 {(first ? "" : "--log-dont-clear true")}
 					 """.Replace("\n", " "),
@@ -49,4 +37,34 @@ foreach ((string librarySetSubDir, string measuresSubDir, string? cqlSubDirOverr
 
 	Hl7.Cql.Packager.Program.Main(arguments);
 	first = false;
+}
+
+file record MeasuresDirSet
+{
+	public static string SolutionDir { get; } = new DirectoryInfo(Environment.CurrentDirectory)
+        .FindParentDirectoryContaining("*.sln")!
+        .FullName;
+
+
+    public MeasuresDirSet(string Name)
+    {
+        this.Name = Name;
+        LibrarySetsRootDir = $"{SolutionDir}/LibrarySets/{Name}";
+        MeasuresProjectRootDir = $"{SolutionDir}/Demo/Measures.{Name}";
+        ElmDir = $"{LibrarySetsRootDir}/Elm";
+		CqlDir = $"{LibrarySetsRootDir}/Cql";
+		FhirDir = $"{LibrarySetsRootDir}/Resources";
+		DllDir = $"{LibrarySetsRootDir}/Assemblies";
+		CSharpDir = $"{MeasuresProjectRootDir}/CSharp";
+    }
+
+    public string Name { get; }
+    public string LibrarySetsRootDir { get; }
+    public string MeasuresProjectRootDir { get; }
+    public string ElmDir { get; init; }
+    public string CqlDir { get; init; }
+    public string FhirDir { get; }
+    public string DllDir { get; }
+    public string CSharpDir { get; }
+	public MeasuresDirSet Mutate(Func<MeasuresDirSet, MeasuresDirSet> mutator) => mutator(this);
 }


### PR DESCRIPTION
Fix for 
- #645 

Work
- Bugfix - [Missing commit](https://github.com/FirelyTeam/firely-cql-sdk/pull/646/commits/1ac9fd10c75d1a6b52e8e24979fc92a7a958833c) from previous PR #531, which adds versions to resources and fixes file creation to the correct directory
- Feature - [Include Authoring](https://github.com/FirelyTeam/firely-cql-sdk/pull/646/commits/90fa3620164a97686e8e921ba3d443d58a424501) to be run as part of the MultiPackagerCLI. 