### PR TITLE
635 ensure that cqltype extension is added to all library input parameters

### DIFF
--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -493,6 +493,7 @@ file static class LibraryPackager
     private static void AddParameterCqlTypeExtension(CqlTypeToFhirMapping type, ParameterDefinition parameterDefinition)
     {
         var cqlType = type.CqlType;
+        var cqlElementType = type.ElementType?.CqlType;
         switch (cqlType)
         {
             case null:
@@ -505,12 +506,20 @@ file static class LibraryPackager
                 break;
         }
 
+        var cqlTypeName =
+            cqlElementType switch
+            {
+                null => cqlType.ToString(),
+                CqlPrimitiveType.Fhir => $"{cqlType}<{cqlElementType}.{type.ElementType!.FhirType}>",
+                { } => $"{cqlType}<{cqlElementType}>",
+            };
+
         parameterDefinition.Extension =
         [
             new Extension
             {
                 Url = Constants.Hl7FhirStructureDefinitionCqlType,
-                Value = new FhirString(cqlType.ToString()),
+                Value = new FhirString(cqlTypeName),
             }
         ];
     }

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -16,11 +16,14 @@ using Hl7.Cql.Packaging.PostProcessors;
 using Hl7.Cql.Primitives;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Utility;
-using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
 using Code = Hl7.Fhir.Model.Code;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
-using Library = Hl7.Cql.Elm.Library;
+
+using ElmLibrary = Hl7.Cql.Elm.Library;
+using FhirLibrary = Hl7.Fhir.Model.Library;
+using FhirResource = Hl7.Fhir.Model.Resource;
+using FhirMeasure = Hl7.Fhir.Model.Measure;
 
 namespace Hl7.Cql.Packaging;
 
@@ -34,17 +37,17 @@ internal class ResourcePackager(
     private readonly TypeResolver _typeResolver = typeResolver;
     private readonly FhirResourcePostProcessor? _fhirResourcePostProcessor = fhirResourcePostProcessor;
 
-    public IReadOnlyCollection<Resource> PackageResources(
+    public IReadOnlyCollection<FhirResource> PackageResources(
         DirectoryInfo elmDirectory,
         DirectoryInfo cqlDirectory,
         string? resourceCanonicalRootUrl,
-        LibrarySet librarySet,
+        LibrarySet elmLibrarySet,
         IReadOnlyDictionary<string, AssemblyData> assembliesByLibraryName)
     {
-        var resources = new List<Resource>();
+        var resources = new List<FhirResource>();
         var librariesByVersionedIdentifier = new Dictionary<string, FhirLibrary>();
 
-        void OnResourceCreated(Resource resource)
+        void OnResourceCreated(FhirResource resource)
         {
             _fhirResourcePostProcessor?.ProcessResource(resource);
             resources!.Add(resource);
@@ -54,7 +57,7 @@ internal class ResourcePackager(
 
         foreach (var (name, asmData) in assembliesByLibraryName)
         {
-            var library = librarySet.GetLibrary(name)!;
+            var library = elmLibrarySet.GetLibrary(name)!;
             var elmFile = new FileInfo(Path.Combine(elmDirectory.FullName, $"{library.GetVersionedIdentifier()}.json"));
             if (!elmFile.Exists)
                 elmFile = new FileInfo(Path.Combine(elmDirectory.FullName,
@@ -83,17 +86,17 @@ internal class ResourcePackager(
             librariesByVersionedIdentifier.Add(library.GetVersionedIdentifier()!, fhirLibrary);
 
             // Analyze datarequirements and add to the FHIR Library resource.
-            var dataRequirementsAnalyzer = new DataRequirementsAnalyzer(librarySet, library);
+            var dataRequirementsAnalyzer = new DataRequirementsAnalyzer(elmLibrarySet, library);
             var dataRequirements = dataRequirementsAnalyzer.Analyze();
             fhirLibrary.DataRequirement.AddRange(dataRequirements);
 
             OnResourceCreated(fhirLibrary);
         }
 
-        foreach (var library in librarySet)
+        foreach (var elmLibrary in elmLibrarySet)
         {
-            var elmFile = new FileInfo(Path.Combine(elmDirectory.FullName, $"{library.GetVersionedIdentifier()}.json"));
-            foreach (var def in library.statements ?? [])
+            var elmFile = new FileInfo(Path.Combine(elmDirectory.FullName, $"{elmLibrary.GetVersionedIdentifier()}.json"));
+            foreach (var def in elmLibrary.statements ?? [])
             {
                 if (def.annotation == null)
                     continue;
@@ -119,7 +122,7 @@ internal class ResourcePackager(
                     && !string.IsNullOrWhiteSpace(yearAnnotation.value)
                     && int.TryParse(yearAnnotation.value, out var measureYear))
                 {
-                    Measure measure = MeasurePackager.CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByVersionedIdentifier, library);
+                    FhirMeasure measure = MeasurePackager.CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByVersionedIdentifier, elmLibrary);
                     OnResourceCreated(measure);
                 }
             }
@@ -131,15 +134,15 @@ internal class ResourcePackager(
 
 file static class MeasurePackager
 {
-    public static Measure CreateMeasureResource(
+    public static FhirMeasure CreateMeasureResource(
         FileInfo elmFile,
         string? resourceCanonicalRootUrl,
         Tag measureAnnotation,
         int measureYear,
         Dictionary<string, FhirLibrary> librariesByVersionedIdentifier,
-        Library elmLibrary)
+        ElmLibrary elmLibrary)
     {
-        var measure = new Measure();
+        var measure = new FhirMeasure();
         measure.Name = measureAnnotation.value;
         measure.Id = elmLibrary.identifier?.id!;
         measure.Version = elmLibrary.identifier?.version!;
@@ -172,14 +175,14 @@ file static class LibraryPackager
         string? resourceCanonicalRootUrl,
         AssemblyData assemblyData,
         CqlTypeToFhirTypeMapper typeCrosswalk,
-        Library? elmLibrary = null)
+        ElmLibrary? elmLibrary = null)
     {
         if (!elmFile.Exists)
             throw new ArgumentException($"Couldn't find library {elmFile.FullName}", nameof(elmFile));
 
         if (elmLibrary is null)
         {
-            elmLibrary = Library.LoadFromJson(elmFile);
+            elmLibrary = ElmLibrary.LoadFromJson(elmFile);
             if (elmLibrary is null)
                 throw new ArgumentException($"File at {elmFile.FullName} is not valid ELM");
         }
@@ -208,7 +211,7 @@ file static class LibraryPackager
     }
 
     private static void AddElmAttachment(
-        Library elmLibrary,
+        ElmLibrary elmLibrary,
         FileInfo elmFile,
         FhirLibrary fhirLibrary)
     {
@@ -216,14 +219,14 @@ file static class LibraryPackager
         var attachment = new Attachment
         {
             ElementId = $"{elmLibrary.GetVersionedIdentifier()}+elm",
-            ContentType = Library.JsonMimeType,
+            ContentType = ElmLibrary.JsonMimeType,
             Data = bytes,
         };
         fhirLibrary.Content.Add(attachment);
     }
 
     private static FhirLibrary CreateFhirLibrary(
-        Library elmLibrary,
+        ElmLibrary elmLibrary,
         FileInfo elmFile,
         string? resourceCanonicalRootUrl)
     {
@@ -239,14 +242,15 @@ file static class LibraryPackager
     }
 
     private static void AddRelatedArtefacts(
-        Library elmLibrary,
+        ElmLibrary elmLibrary,
         FhirLibrary library,
         string? resourceCanonicalRootUrl)
     {
         foreach (var include in elmLibrary?.includes ?? [])
         {
             string includeVersionString = string.IsNullOrEmpty(include.version) ? string.Empty : $"|{include.version}";
-            string includeIdMaybeVersion = $"{resourceCanonicalRootUrl.EnsureEndsWith("/")}Library/{include.path}{includeVersionString}";
+            string includeIdMaybeVersion =
+                $"{resourceCanonicalRootUrl.EnsureEndsWith("/")}Library/{include.path}{includeVersionString}";
             library.RelatedArtifact.Add(new RelatedArtifact
             {
                 Type = RelatedArtifact.RelatedArtifactType.DependsOn,
@@ -256,7 +260,7 @@ file static class LibraryPackager
     }
 
     private static void AddOutParameters(
-        Library elmLibrary,
+        ElmLibrary elmLibrary,
         List<ParameterDefinition> parameters,
         CqlTypeToFhirTypeMapper typeCrosswalk)
     {
@@ -268,7 +272,7 @@ file static class LibraryPackager
     }
 
     private static void AddInParameters(
-        Library elmLibrary,
+        ElmLibrary elmLibrary,
         List<ParameterDefinition> parameters,
         CqlTypeToFhirTypeMapper typeCrosswalk)
     {
@@ -295,7 +299,7 @@ file static class LibraryPackager
     }
 
     private static void AddCqlAttachment(
-        Library? elmLibrary,
+        ElmLibrary? elmLibrary,
         FhirLibrary fhirLibrary,
         FileInfo cqlFile)
     {
@@ -310,7 +314,9 @@ file static class LibraryPackager
         fhirLibrary.Content.Add(attachment);
     }
 
-    private static void AddCQLOptions(FhirLibrary fhirLibrary, IReadOnlyList<Parameters.ParameterComponent> fhirParameters)
+    private static void AddCQLOptions(
+        FhirLibrary fhirLibrary,
+        IReadOnlyList<Parameters.ParameterComponent> fhirParameters)
     {
         // Adding CQL Options as a contained resource
         // See: https://build.fhir.org/domainresource-definitions.html#DomainResource.contained
@@ -348,7 +354,7 @@ file static class LibraryPackager
     }
 
     private static void AddDllAttachment(
-        Library? elmLibrary,
+        ElmLibrary? elmLibrary,
         FhirLibrary library,
         AssemblyData assemblyData)
     {
@@ -362,14 +368,17 @@ file static class LibraryPackager
         library.Content.Add(attachment);
     }
 
-    private static void AddFhirParameterIfNotNull(List<Parameters.ParameterComponent> parameters, string name, string? value)
+    private static void AddFhirParameterIfNotNull(
+        List<Parameters.ParameterComponent> parameters,
+        string name,
+        string? value)
     {
         //TODO: use mapper when values in CqlToElmInfo results anything but strings
         if (!string.IsNullOrEmpty(value))
             parameters.Add(new Parameters.ParameterComponent { Name = name, Value = new FhirString(value) });
     }
 
-    private static IReadOnlyList<Parameters.ParameterComponent> CreateFhirParameters(Library elmLibrary)
+    private static IReadOnlyList<Parameters.ParameterComponent> CreateFhirParameters(ElmLibrary elmLibrary)
     {
         var fhirParameters = new List<Parameters.ParameterComponent>();
         foreach (var annotation in elmLibrary?.annotation ?? [])
@@ -378,7 +387,8 @@ file static class LibraryPackager
                 continue;
 
             // translatorVersion
-            AddFhirParameterIfNotNull(fhirParameters, nameof(cqlOptions.translatorVersion), cqlOptions.translatorVersion);
+            AddFhirParameterIfNotNull(fhirParameters, nameof(cqlOptions.translatorVersion),
+                                      cqlOptions.translatorVersion);
 
             // translatorOptions
             if (!string.IsNullOrEmpty(cqlOptions.translatorOptions))
@@ -399,6 +409,7 @@ file static class LibraryPackager
             // format
             AddFhirParameterIfNotNull(fhirParameters, "format", "JSON");
         }
+
         return fhirParameters;
     }
 
@@ -420,11 +431,13 @@ file static class LibraryPackager
     {
         var typeSpecifier = elmParameter.resultTypeSpecifier ?? elmParameter.parameterTypeSpecifier;
         if (typeSpecifier is null)
-            throw new ArgumentException($"{typeSpecifier} is missing on parameter: {elmParameter.name}", nameof(elmParameter));
+            throw new ArgumentException($"{typeSpecifier} is missing on parameter: {elmParameter.name}",
+                                        nameof(elmParameter));
 
         var type = typeCrosswalk.TypeEntryFor(typeSpecifier);
         if (type?.FhirType is null)
-            throw new ArgumentException("Unable to identify a valid FHIR type for this parameter.", nameof(elmParameter));
+            throw new ArgumentException("Unable to identify a valid FHIR type for this parameter.",
+                                        nameof(elmParameter));
 
         var parameterDefinition = new ParameterDefinition
         {
@@ -434,6 +447,7 @@ file static class LibraryPackager
             Max = "1",
             Type = type.FhirType,
         };
+        AddParameterCqlTypeExtension(type, parameterDefinition);
         return parameterDefinition;
     }
 
@@ -450,7 +464,8 @@ file static class LibraryPackager
 
         var type = typeCrosswalk.TypeEntryFor(resultTypeSpecifier);
         if (type?.FhirType is null)
-            throw new ArgumentException("Unable to identify a valid FHIR type for this definition.", nameof(definition));
+            throw new ArgumentException("Unable to identify a valid FHIR type for this definition.",
+                                        nameof(definition));
 
         var parameterDefinition = new ParameterDefinition
         {
@@ -461,23 +476,7 @@ file static class LibraryPackager
             Type = type.FhirType!,
         };
 
-        if (type is
-            {
-                CqlType: { } cqlType and CqlPrimitiveType.List,
-                ElementType.FhirType: { } elementFhirType
-            })
-        {
-            parameterDefinition.Type = elementFhirType;
-            parameterDefinition.Max = "*";
-            parameterDefinition.Extension =
-            [
-                new Extension
-                {
-                    Url = Constants.Hl7FhirStructureDefinitionCqlType,
-                    Value = new FhirString(cqlType.ToString()),// e.g. List
-                }
-            ];
-        }
+        AddParameterCqlTypeExtension(type, parameterDefinition);
 
         if (definition.accessLevel == AccessModifier.Private)
         {
@@ -489,5 +488,30 @@ file static class LibraryPackager
         }
 
         return parameterDefinition;
+    }
+
+    private static void AddParameterCqlTypeExtension(CqlTypeToFhirMapping type, ParameterDefinition parameterDefinition)
+    {
+        var cqlType = type.CqlType;
+        switch (cqlType)
+        {
+            case null:
+                return;
+
+            case CqlPrimitiveType.List
+                when type.ElementType?.FhirType is { } elementFhirType:
+                parameterDefinition.Type = elementFhirType;
+                parameterDefinition.Max = "*";
+                break;
+        }
+
+        parameterDefinition.Extension =
+        [
+            new Extension
+            {
+                Url = Constants.Hl7FhirStructureDefinitionCqlType,
+                Value = new FhirString(cqlType.ToString()),
+            }
+        ];
     }
 }

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -25,6 +25,7 @@ using Library = Hl7.Cql.Elm.Library;
 namespace Hl7.Cql.Packaging;
 
 #pragma warning disable CS1591
+
 internal class ResourcePackager(
     TypeResolver typeResolver,
     FhirResourcePostProcessor? fhirResourcePostProcessor
@@ -125,6 +126,41 @@ internal class ResourcePackager(
         }
 
         return resources;
+    }
+}
+
+file static class MeasurePackager
+{
+    public static Measure CreateMeasureResource(
+        FileInfo elmFile,
+        string? resourceCanonicalRootUrl,
+        Tag measureAnnotation,
+        int measureYear,
+        Dictionary<string, FhirLibrary> librariesByVersionedIdentifier,
+        Library elmLibrary)
+    {
+        var measure = new Measure();
+        measure.Name = measureAnnotation.value;
+        measure.Id = elmLibrary.identifier?.id!;
+        measure.Version = elmLibrary.identifier?.version!;
+        measure.Status = PublicationStatus.Active;
+        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
+            .ToString();
+        measure.EffectivePeriod = new Period
+        {
+            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
+            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
+        };
+        measure.Group = [];
+        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
+        if (elmLibrary.GetVersionedIdentifier() is null)
+            throw new InvalidOperationException("Library VersionedIdentifier should not be null.");
+
+        if (!librariesByVersionedIdentifier.TryGetValue(elmLibrary.GetVersionedIdentifier()!, out var libForMeasure))
+            throw new InvalidOperationException(
+                $"We didn't create a measure for library {libForMeasure}");
+        measure.Library = new List<string> { libForMeasure!.Url };
+        return measure;
     }
 }
 
@@ -453,40 +489,5 @@ file static class LibraryPackager
         }
 
         return parameterDefinition;
-    }
-}
-
-file static class MeasurePackager
-{
-    public static Measure CreateMeasureResource(
-        FileInfo elmFile,
-        string? resourceCanonicalRootUrl,
-        Tag measureAnnotation,
-        int measureYear,
-        Dictionary<string, FhirLibrary> librariesByVersionedIdentifier,
-        Library elmLibrary)
-    {
-        var measure = new Measure();
-        measure.Name = measureAnnotation.value;
-        measure.Id = elmLibrary.identifier?.id!;
-        measure.Version = elmLibrary.identifier?.version!;
-        measure.Status = PublicationStatus.Active;
-        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
-            .ToString();
-        measure.EffectivePeriod = new Period
-        {
-            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
-            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
-        };
-        measure.Group = [];
-        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
-        if (elmLibrary.GetVersionedIdentifier() is null)
-            throw new InvalidOperationException("Library VersionedIdentifier should not be null.");
-
-        if (!librariesByVersionedIdentifier.TryGetValue(elmLibrary.GetVersionedIdentifier()!, out var libForMeasure))
-            throw new InvalidOperationException(
-                $"We didn't create a measure for library {libForMeasure}");
-        measure.Library = new List<string> { libForMeasure!.Url };
-        return measure;
     }
 }

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -18,7 +18,8 @@ using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
 using Hl7.Fhir.Utility;
-using String = Hl7.Fhir.ElementModel.Types.String;
+using Library = Hl7.Cql.Elm.Library;
+using DateTime = System.DateTime;
 
 namespace Hl7.Cql.Packaging;
 
@@ -70,13 +71,13 @@ internal class ResourcePackager(
             }
 
             if (cqlFiles.Length > 1)
-                throw new InvalidOperationException($"More than 1 CQL file found.");
+                throw new InvalidOperationException("More than 1 CQL file found.");
 
             var cqlFile = cqlFiles[0];
             if (library.GetVersionedIdentifier() is null)
                 throw new InvalidOperationException("Library VersionedIdentifier should not be null.");
 
-            var fhirLibrary = CreateLibraryResource(elmFile, cqlFile, resourceCanonicalRootUrl, asmData, typeCrosswalk, library);
+            var fhirLibrary = LibraryPackager.CreateLibraryResource(elmFile, cqlFile, resourceCanonicalRootUrl, asmData, typeCrosswalk, library);
             librariesByVersionedIdentifier.Add(library.GetVersionedIdentifier()!, fhirLibrary);
 
             // Analyze datarequirements and add to the FHIR Library resource.
@@ -116,7 +117,7 @@ internal class ResourcePackager(
                     && !string.IsNullOrWhiteSpace(yearAnnotation.value)
                     && int.TryParse(yearAnnotation.value, out var measureYear))
                 {
-                    Measure measure = CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByVersionedIdentifier, library);
+                    Measure measure = MeasurePackager.CreateMeasureResource(elmFile, resourceCanonicalRootUrl, measureAnnotation, measureYear, librariesByVersionedIdentifier, library);
                     OnResourceCreated(measure);
                 }
             }
@@ -124,46 +125,17 @@ internal class ResourcePackager(
 
         return resources;
     }
+}
 
-    private static Measure CreateMeasureResource(
-        FileInfo elmFile,
-        string? resourceCanonicalRootUrl,
-        Tag measureAnnotation,
-        int measureYear,
-        Dictionary<string, FhirLibrary> librariesByVersionedIdentifier,
-        Elm.Library elmLibrary)
-    {
-        var measure = new Measure();
-        measure.Name = measureAnnotation.value;
-        measure.Id = elmLibrary.identifier?.id!;
-        measure.Version = elmLibrary.identifier?.version!;
-        measure.Status = PublicationStatus.Active;
-        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
-            .ToString();
-        measure.EffectivePeriod = new Period
-        {
-            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
-            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
-        };
-        measure.Group = [];
-        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
-        if (elmLibrary.GetVersionedIdentifier() is null)
-            throw new InvalidOperationException("Library VersionedIdentifier should not be null.");
-
-        if (!librariesByVersionedIdentifier.TryGetValue(elmLibrary.GetVersionedIdentifier()!, out var libForMeasure))
-            throw new InvalidOperationException(
-                $"We didn't create a measure for library {libForMeasure}");
-        measure.Library = new List<string> { libForMeasure!.Url };
-        return measure;
-    }
-
-    private static FhirLibrary CreateLibraryResource(
+file static class LibraryPackager
+{
+    public static FhirLibrary CreateLibraryResource(
         FileInfo elmFile,
         FileInfo? cqlFile,
         string? resourceCanonicalRootUrl,
         AssemblyData assembly,
         CqlTypeToFhirTypeMapper typeCrosswalk,
-        Elm.Library? elmLibrary = null)
+        Library? elmLibrary = null)
     {
         if (!elmFile.Exists)
             throw new ArgumentException($"Couldn't find library {elmFile.FullName}", nameof(elmFile));
@@ -175,6 +147,31 @@ internal class ResourcePackager(
                 throw new ArgumentException($"File at {elmFile.FullName} is not valid ELM");
         }
 
+        var fhirLibrary = CreateFhirLibrary(resourceCanonicalRootUrl, elmLibrary, elmFile.LastWriteTimeUtc);
+        AddElmAttachment(elmFile, elmLibrary, fhirLibrary);
+        var parameters = new List<ParameterDefinition>();
+        AddInParameters(parameters, typeCrosswalk, elmLibrary);
+        AddOutParameters(parameters, typeCrosswalk, elmLibrary);
+        fhirLibrary.Parameter = parameters.Count > 0 ? parameters : null!;
+
+        AddRelatedArtefacts(resourceCanonicalRootUrl, elmLibrary, fhirLibrary);
+
+        var cqlOptions = CqlToElmInfoToFhir(elmLibrary!);
+        if (cqlOptions.Any())
+            AddCQLOptions(cqlOptions, fhirLibrary);
+
+        if (cqlFile!.Exists)
+            AddCqlAttachment(cqlFile, elmLibrary, fhirLibrary);
+
+        AddDllAttachment(assembly, elmLibrary, fhirLibrary);
+        foreach (var kvp in assembly.SourceCode)
+            AddCSharpAttachment(fhirLibrary, kvp);
+
+        return fhirLibrary;
+    }
+
+    private static void AddElmAttachment(FileInfo elmFile, Library elmLibrary, FhirLibrary fhirLibrary)
+    {
         var bytes = File.ReadAllBytes(elmFile.FullName);
         var attachment = new Attachment
         {
@@ -182,26 +179,64 @@ internal class ResourcePackager(
             ContentType = Elm.Library.JsonMimeType,
             Data = bytes,
         };
-        var library = new FhirLibrary();
-        library.Content.Add(attachment);
-        library.Type = LogicLibraryCodeableConcept;
-        string libraryId = $"{elmLibrary!.identifier.id}";
-        library.Id = libraryId!;
-        library.Version = elmLibrary!.identifier?.version!;
-        library.Name = elmLibrary!.identifier?.id!;
-        library.Status = PublicationStatus.Active;
-        library.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, Iso8601.DateTimePrecision.Millisecond).ToString();
-        library.Url = library.CanonicalUri(resourceCanonicalRootUrl);
-        var parameters = new List<ParameterDefinition>();
-        var inParams = elmLibrary.parameters?
-            .Select(pd => ElmParameterToFhir(pd, typeCrosswalk));
-        if (inParams is not null)
-            parameters.AddRange(inParams);
+        fhirLibrary.Content.Add(attachment);
+    }
+
+    private static FhirLibrary CreateFhirLibrary(
+        string? resourceCanonicalRootUrl,
+        Library elmLibrary,
+        DateTime elmFileLastWriteTimeUtc)
+    {
+        var fhirLibrary = new FhirLibrary
+        {
+            Type = LogicLibraryCodeableConcept,
+            Id = $"{elmLibrary.identifier.id}",
+            Version = elmLibrary.identifier?.version!,
+            Name = elmLibrary.identifier?.id!,
+            Status = PublicationStatus.Active,
+            Date = new DateTimeIso8601(elmFileLastWriteTimeUtc, Iso8601.DateTimePrecision.Millisecond).ToString()
+        };
+        fhirLibrary.Url = fhirLibrary.CanonicalUri(resourceCanonicalRootUrl);
+        return fhirLibrary;
+    }
+
+    private static void AddRelatedArtefacts(string? resourceCanonicalRootUrl, Library elmLibrary, FhirLibrary library)
+    {
+        foreach (var include in elmLibrary?.includes ?? [])
+        {
+            string includeVersionString = string.IsNullOrEmpty(include.version) ? string.Empty : $"|{include.version}";
+            string includeIdMaybeVersion = $"{resourceCanonicalRootUrl.EnsureEndsWith("/")}Library/{include.path}{includeVersionString}";
+            library.RelatedArtifact.Add(new RelatedArtifact
+            {
+                Type = RelatedArtifact.RelatedArtifactType.DependsOn,
+                Resource = includeIdMaybeVersion,
+            });
+        }
+    }
+
+    private static void AddOutParameters(
+        List<ParameterDefinition> parameters,
+        CqlTypeToFhirTypeMapper typeCrosswalk,
+        Library elmLibrary)
+    {
         var outParams = elmLibrary.statements?
-            .Where(def => def.name != "Patient" && def is not FunctionDef)
-            .Select(def => ElmDefinitionToParameter(def, typeCrosswalk));
+                                  .Where(def => def.name != "Patient" && def is not FunctionDef)
+                                  .Select(def => ElmDefinitionToParameter(def, typeCrosswalk));
         if (outParams is not null)
             parameters.AddRange(outParams);
+    }
+
+    private static void AddInParameters(
+        List<ParameterDefinition> parameters,
+        CqlTypeToFhirTypeMapper typeCrosswalk,
+        Library elmLibrary)
+    {
+        var inParams = elmLibrary.parameters?
+            .Select(pd => ElmParameterToFhir(pd, typeCrosswalk));
+
+        if (inParams is not null)
+            parameters.AddRange(inParams);
+
         var valueSetParameterDefinitions = new List<ParameterDefinition>();
         foreach (var valueSet in elmLibrary.valueSets ?? [])
         {
@@ -215,83 +250,83 @@ internal class ResourcePackager(
         }
 
         parameters.AddRange(valueSetParameterDefinitions);
-        library.Parameter = parameters.Count > 0 ? parameters : null!;
 
-        foreach (var include in elmLibrary?.includes ?? [])
-        {
-            string includeVersionString = string.IsNullOrEmpty(include.version) ? string.Empty : $"|{include.version}";
-            string includeIdMaybeVersion = $"{resourceCanonicalRootUrl.EnsureEndsWith("/")}Library/{include.path}{includeVersionString}";
-            library.RelatedArtifact.Add(new RelatedArtifact
-            {
-                Type = RelatedArtifact.RelatedArtifactType.DependsOn,
-                Resource = includeIdMaybeVersion,
-            });
-        }
-
-        var cqlOptions = CqlToElmInfoToFhir(elmLibrary!, typeCrosswalk);
-        if (cqlOptions.Any())
-        {
-            // Adding CQL Options as a contained resource
-            // See: https://build.fhir.org/domainresource-definitions.html#DomainResource.contained
-
-            var p = new Parameters();
-            p.Id = "options";
-            p.Parameter.AddRange(cqlOptions);
-            library.Contained = [p];
-
-            // See requirement for Contained resources: https://build.fhir.org/domainresource.html#invs
-            // dom-3: If the resource is contained in another resource,
-            //        it SHALL be referred to from elsewhere in the resource
-            //        or SHALL refer to the containing resource
-            //
-            // This is done by adding an extension. (Example: https://build.fhir.org/ig/HL7/cql-ig/Library-CQLExample.json.html)
-
-            var extension = new Extension
-            {
-                Url = "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions",
-                Value = new ResourceReference { Reference = "#options" },
-            };
-            library.Extension.Add(extension);
-        }
-
-        if (cqlFile!.Exists)
-        {
-            var cqlBytes = File.ReadAllBytes(cqlFile.FullName);
-
-            var cqlAttachment = new Attachment
-            {
-                ElementId = $"{elmLibrary!.GetVersionedIdentifier()}+cql",
-                ContentType = "text/cql",
-                Data = cqlBytes,
-            };
-            library.Content.Add(cqlAttachment);
-        }
-
-        if (assembly != null)
-        {
-            var assemblyBytes = assembly.Binary;
-            var assemblyAttachment = new Attachment
-            {
-                ElementId = $"{elmLibrary!.GetVersionedIdentifier()}+dll",
-                ContentType = "application/octet-stream",
-                Data = assemblyBytes,
-            };
-            library.Content.Add(assemblyAttachment);
-            foreach (var kvp in assembly.SourceCode)
-            {
-                var sourceBytes = Encoding.UTF8.GetBytes(kvp.Value);
-                //var sourceBase64 = System.Convert.ToBase64String(sourceBytes);
-                var sourceAttachment = new Attachment
-                {
-                    ElementId = $"{kvp.Key}+csharp",
-                    ContentType = "text/plain",
-                    Data = sourceBytes,
-                };
-                library.Content.Add(sourceAttachment);
-            }
-        }
-        return library;
     }
+
+    private static Attachment CreateElmAttachment(FileInfo elmFile, Library elmLibrary)
+    {
+        var bytes = File.ReadAllBytes(elmFile.FullName);
+        var attachment = new Attachment
+        {
+            ElementId = $"{elmLibrary.GetVersionedIdentifier()}+elm",
+            ContentType = Elm.Library.JsonMimeType,
+            Data = bytes,
+        };
+        return attachment;
+    }
+
+    private static void AddCqlAttachment(FileInfo cqlFile, Library? elmLibrary, FhirLibrary library)
+    {
+        var cqlBytes = File.ReadAllBytes(cqlFile.FullName);
+
+        var attachment = new Attachment
+        {
+            ElementId = $"{elmLibrary!.GetVersionedIdentifier()}+cql",
+            ContentType = "text/cql",
+            Data = cqlBytes,
+        };
+        library.Content.Add(attachment);
+    }
+
+    private static void AddCQLOptions(IReadOnlyList<Parameters.ParameterComponent> cqlOptions, FhirLibrary library)
+    {
+        // Adding CQL Options as a contained resource
+        // See: https://build.fhir.org/domainresource-definitions.html#DomainResource.contained
+
+        var p = new Parameters();
+        p.Id = "options";
+        p.Parameter.AddRange(cqlOptions);
+        library.Contained = [p];
+
+        // See requirement for Contained resources: https://build.fhir.org/domainresource.html#invs
+        // dom-3: If the resource is contained in another resource,
+        //        it SHALL be referred to from elsewhere in the resource
+        //        or SHALL refer to the containing resource
+        //
+        // This is done by adding an extension. (Example: https://build.fhir.org/ig/HL7/cql-ig/Library-CQLExample.json.html)
+
+        var extension = new Extension
+        {
+            Url = "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions",
+            Value = new ResourceReference { Reference = "#options" },
+        };
+        library.Extension.Add(extension);
+    }
+
+    private static void AddCSharpAttachment(FhirLibrary library, KeyValuePair<string, string> kvp)
+    {
+        var sourceBytes = Encoding.UTF8.GetBytes(kvp.Value);
+        var attachment = new Attachment
+        {
+            ElementId = $"{kvp.Key}+csharp",
+            ContentType = "text/plain",
+            Data = sourceBytes,
+        };
+        library.Content.Add(attachment);
+    }
+
+    private static void AddDllAttachment(AssemblyData assembly, Library? elmLibrary, FhirLibrary library)
+    {
+        var assemblyBytes = assembly.Binary;
+        var attachment = new Attachment
+        {
+            ElementId = $"{elmLibrary!.GetVersionedIdentifier()}+dll",
+            ContentType = "application/octet-stream",
+            Data = assemblyBytes,
+        };
+        library.Content.Add(attachment);
+    }
+
     private static void AddParameterIfNotNull(List<Parameters.ParameterComponent> parameters, string name, string? value)
     {
         //TODO: use mapper when values in CqlToElmInfo results anything but strings
@@ -301,7 +336,7 @@ internal class ResourcePackager(
         }
     }
 
-    private static IReadOnlyList<Parameters.ParameterComponent> CqlToElmInfoToFhir(Elm.Library elmLibrary, CqlTypeToFhirTypeMapper typeCrosswalk)
+    private static IReadOnlyList<Parameters.ParameterComponent> CqlToElmInfoToFhir(Library elmLibrary)
     {
         var parameters = new List<Parameters.ParameterComponent>();
         foreach (var annotation in elmLibrary?.annotation ?? [])
@@ -340,8 +375,8 @@ internal class ResourcePackager(
         [
             new Coding
             {
-                Code = "logic-library"!,
-                System = "http://terminology.hl7.org/CodeSystem/library-type"!
+                Code = "logic-library",
+                System = "http://terminology.hl7.org/CodeSystem/library-type"
             }
         ]
     };
@@ -369,7 +404,7 @@ internal class ResourcePackager(
             Name = elmParameter.name!,
             Use = OperationParameterUse.In,
             Min = elmParameter.@default is null ? 1 : 0,
-            Max = "1"!,
+            Max = "1",
             Type = type.FhirType,
         };
         return parameterDefinition;
@@ -429,5 +464,40 @@ internal class ResourcePackager(
         }
 
         return parameterDefinition;
+    }
+}
+
+file static class MeasurePackager
+{
+    public static Measure CreateMeasureResource(
+        FileInfo elmFile,
+        string? resourceCanonicalRootUrl,
+        Tag measureAnnotation,
+        int measureYear,
+        Dictionary<string, FhirLibrary> librariesByVersionedIdentifier,
+        Library elmLibrary)
+    {
+        var measure = new Measure();
+        measure.Name = measureAnnotation.value;
+        measure.Id = elmLibrary.identifier?.id!;
+        measure.Version = elmLibrary.identifier?.version!;
+        measure.Status = PublicationStatus.Active;
+        measure.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond)
+            .ToString();
+        measure.EffectivePeriod = new Period
+        {
+            Start = new DateTimeIso8601(measureYear, 1, 1, 0, 0, 0, 0, 0, 0).ToString(),
+            End = new DateTimeIso8601(measureYear, 12, 31, 23, 59, 59, 999, 0, 0).ToString(),
+        };
+        measure.Group = [];
+        measure.Url = measure.CanonicalUri(resourceCanonicalRootUrl);
+        if (elmLibrary.GetVersionedIdentifier() is null)
+            throw new InvalidOperationException("Library VersionedIdentifier should not be null.");
+
+        if (!librariesByVersionedIdentifier.TryGetValue(elmLibrary.GetVersionedIdentifier()!, out var libForMeasure))
+            throw new InvalidOperationException(
+                $"We didn't create a measure for library {libForMeasure}");
+        measure.Library = new List<string> { libForMeasure!.Url };
+        return measure;
     }
 }

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -5,6 +5,7 @@
  * This file is licensed under the BSD 3-Clause license
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
+
 using System.Text;
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET;
@@ -14,12 +15,12 @@ using Hl7.Cql.Iso8601;
 using Hl7.Cql.Packaging.PostProcessors;
 using Hl7.Cql.Primitives;
 using Hl7.Fhir.Model;
+using Hl7.Fhir.Utility;
 using FhirLibrary = Hl7.Fhir.Model.Library;
 using Annotation = Hl7.Cql.Elm.Annotation;
+using Code = Hl7.Fhir.Model.Code;
 using DateTimePrecision = Hl7.Cql.Iso8601.DateTimePrecision;
-using Hl7.Fhir.Utility;
 using Library = Hl7.Cql.Elm.Library;
-using DateTime = System.DateTime;
 
 namespace Hl7.Cql.Packaging;
 
@@ -133,7 +134,7 @@ file static class LibraryPackager
         FileInfo elmFile,
         FileInfo? cqlFile,
         string? resourceCanonicalRootUrl,
-        AssemblyData assembly,
+        AssemblyData assemblyData,
         CqlTypeToFhirTypeMapper typeCrosswalk,
         Library? elmLibrary = null)
     {
@@ -142,65 +143,69 @@ file static class LibraryPackager
 
         if (elmLibrary is null)
         {
-            elmLibrary = Elm.Library.LoadFromJson(elmFile);
+            elmLibrary = Library.LoadFromJson(elmFile);
             if (elmLibrary is null)
                 throw new ArgumentException($"File at {elmFile.FullName} is not valid ELM");
         }
 
-        var fhirLibrary = CreateFhirLibrary(resourceCanonicalRootUrl, elmLibrary, elmFile.LastWriteTimeUtc);
-        AddElmAttachment(elmFile, elmLibrary, fhirLibrary);
+        var fhirLibrary = CreateFhirLibrary(elmLibrary, elmFile, resourceCanonicalRootUrl);
+        AddElmAttachment(elmLibrary, elmFile, fhirLibrary);
         var parameters = new List<ParameterDefinition>();
-        AddInParameters(parameters, typeCrosswalk, elmLibrary);
-        AddOutParameters(parameters, typeCrosswalk, elmLibrary);
+        AddInParameters(elmLibrary, parameters, typeCrosswalk);
+        AddOutParameters(elmLibrary, parameters, typeCrosswalk);
         fhirLibrary.Parameter = parameters.Count > 0 ? parameters : null!;
 
-        AddRelatedArtefacts(resourceCanonicalRootUrl, elmLibrary, fhirLibrary);
+        AddRelatedArtefacts(elmLibrary, fhirLibrary, resourceCanonicalRootUrl);
 
-        var cqlOptions = CqlToElmInfoToFhir(elmLibrary!);
-        if (cqlOptions.Any())
-            AddCQLOptions(cqlOptions, fhirLibrary);
+        var fhirParameters = CreateFhirParameters(elmLibrary);
+        if (fhirParameters.Any())
+            AddCQLOptions(fhirLibrary, fhirParameters);
 
         if (cqlFile!.Exists)
-            AddCqlAttachment(cqlFile, elmLibrary, fhirLibrary);
+            AddCqlAttachment(elmLibrary, fhirLibrary, cqlFile);
 
-        AddDllAttachment(assembly, elmLibrary, fhirLibrary);
-        foreach (var kvp in assembly.SourceCode)
+        AddDllAttachment(elmLibrary, fhirLibrary, assemblyData);
+        foreach (var kvp in assemblyData.SourceCode)
             AddCSharpAttachment(fhirLibrary, kvp);
 
         return fhirLibrary;
     }
 
-    private static void AddElmAttachment(FileInfo elmFile, Library elmLibrary, FhirLibrary fhirLibrary)
+    private static void AddElmAttachment(
+        Library elmLibrary,
+        FileInfo elmFile,
+        FhirLibrary fhirLibrary)
     {
         var bytes = File.ReadAllBytes(elmFile.FullName);
         var attachment = new Attachment
         {
             ElementId = $"{elmLibrary.GetVersionedIdentifier()}+elm",
-            ContentType = Elm.Library.JsonMimeType,
+            ContentType = Library.JsonMimeType,
             Data = bytes,
         };
         fhirLibrary.Content.Add(attachment);
     }
 
     private static FhirLibrary CreateFhirLibrary(
-        string? resourceCanonicalRootUrl,
         Library elmLibrary,
-        DateTime elmFileLastWriteTimeUtc)
+        FileInfo elmFile,
+        string? resourceCanonicalRootUrl)
     {
-        var fhirLibrary = new FhirLibrary
-        {
-            Type = LogicLibraryCodeableConcept,
-            Id = $"{elmLibrary.identifier.id}",
-            Version = elmLibrary.identifier?.version!,
-            Name = elmLibrary.identifier?.id!,
-            Status = PublicationStatus.Active,
-            Date = new DateTimeIso8601(elmFileLastWriteTimeUtc, Iso8601.DateTimePrecision.Millisecond).ToString()
-        };
+        var fhirLibrary = new FhirLibrary();
+        fhirLibrary.Type = LogicLibraryCodeableConcept;
+        fhirLibrary.Id = $"{elmLibrary.identifier.id}";
+        fhirLibrary.Version = elmLibrary.identifier?.version!;
+        fhirLibrary.Name = elmLibrary.identifier?.id!;
+        fhirLibrary.Status = PublicationStatus.Active;
+        fhirLibrary.Date = new DateTimeIso8601(elmFile.LastWriteTimeUtc, DateTimePrecision.Millisecond).ToString();
         fhirLibrary.Url = fhirLibrary.CanonicalUri(resourceCanonicalRootUrl);
         return fhirLibrary;
     }
 
-    private static void AddRelatedArtefacts(string? resourceCanonicalRootUrl, Library elmLibrary, FhirLibrary library)
+    private static void AddRelatedArtefacts(
+        Library elmLibrary,
+        FhirLibrary library,
+        string? resourceCanonicalRootUrl)
     {
         foreach (var include in elmLibrary?.includes ?? [])
         {
@@ -215,9 +220,9 @@ file static class LibraryPackager
     }
 
     private static void AddOutParameters(
+        Library elmLibrary,
         List<ParameterDefinition> parameters,
-        CqlTypeToFhirTypeMapper typeCrosswalk,
-        Library elmLibrary)
+        CqlTypeToFhirTypeMapper typeCrosswalk)
     {
         var outParams = elmLibrary.statements?
                                   .Where(def => def.name != "Patient" && def is not FunctionDef)
@@ -227,9 +232,9 @@ file static class LibraryPackager
     }
 
     private static void AddInParameters(
+        Library elmLibrary,
         List<ParameterDefinition> parameters,
-        CqlTypeToFhirTypeMapper typeCrosswalk,
-        Library elmLibrary)
+        CqlTypeToFhirTypeMapper typeCrosswalk)
     {
         var inParams = elmLibrary.parameters?
             .Select(pd => ElmParameterToFhir(pd, typeCrosswalk));
@@ -253,19 +258,10 @@ file static class LibraryPackager
 
     }
 
-    private static Attachment CreateElmAttachment(FileInfo elmFile, Library elmLibrary)
-    {
-        var bytes = File.ReadAllBytes(elmFile.FullName);
-        var attachment = new Attachment
-        {
-            ElementId = $"{elmLibrary.GetVersionedIdentifier()}+elm",
-            ContentType = Elm.Library.JsonMimeType,
-            Data = bytes,
-        };
-        return attachment;
-    }
-
-    private static void AddCqlAttachment(FileInfo cqlFile, Library? elmLibrary, FhirLibrary library)
+    private static void AddCqlAttachment(
+        Library? elmLibrary,
+        FhirLibrary fhirLibrary,
+        FileInfo cqlFile)
     {
         var cqlBytes = File.ReadAllBytes(cqlFile.FullName);
 
@@ -275,18 +271,18 @@ file static class LibraryPackager
             ContentType = "text/cql",
             Data = cqlBytes,
         };
-        library.Content.Add(attachment);
+        fhirLibrary.Content.Add(attachment);
     }
 
-    private static void AddCQLOptions(IReadOnlyList<Parameters.ParameterComponent> cqlOptions, FhirLibrary library)
+    private static void AddCQLOptions(FhirLibrary fhirLibrary, IReadOnlyList<Parameters.ParameterComponent> fhirParameters)
     {
         // Adding CQL Options as a contained resource
         // See: https://build.fhir.org/domainresource-definitions.html#DomainResource.contained
 
         var p = new Parameters();
         p.Id = "options";
-        p.Parameter.AddRange(cqlOptions);
-        library.Contained = [p];
+        p.Parameter.AddRange(fhirParameters);
+        fhirLibrary.Contained = [p];
 
         // See requirement for Contained resources: https://build.fhir.org/domainresource.html#invs
         // dom-3: If the resource is contained in another resource,
@@ -300,7 +296,7 @@ file static class LibraryPackager
             Url = "http://hl7.org/fhir/StructureDefinition/cqf-cqlOptions",
             Value = new ResourceReference { Reference = "#options" },
         };
-        library.Extension.Add(extension);
+        fhirLibrary.Extension.Add(extension);
     }
 
     private static void AddCSharpAttachment(FhirLibrary library, KeyValuePair<string, string> kvp)
@@ -315,9 +311,12 @@ file static class LibraryPackager
         library.Content.Add(attachment);
     }
 
-    private static void AddDllAttachment(AssemblyData assembly, Library? elmLibrary, FhirLibrary library)
+    private static void AddDllAttachment(
+        Library? elmLibrary,
+        FhirLibrary library,
+        AssemblyData assemblyData)
     {
-        var assemblyBytes = assembly.Binary;
+        var assemblyBytes = assemblyData.Binary;
         var attachment = new Attachment
         {
             ElementId = $"{elmLibrary!.GetVersionedIdentifier()}+dll",
@@ -327,46 +326,44 @@ file static class LibraryPackager
         library.Content.Add(attachment);
     }
 
-    private static void AddParameterIfNotNull(List<Parameters.ParameterComponent> parameters, string name, string? value)
+    private static void AddFhirParameterIfNotNull(List<Parameters.ParameterComponent> parameters, string name, string? value)
     {
         //TODO: use mapper when values in CqlToElmInfo results anything but strings
         if (!string.IsNullOrEmpty(value))
-        {
             parameters.Add(new Parameters.ParameterComponent { Name = name, Value = new FhirString(value) });
-        }
     }
 
-    private static IReadOnlyList<Parameters.ParameterComponent> CqlToElmInfoToFhir(Library elmLibrary)
+    private static IReadOnlyList<Parameters.ParameterComponent> CreateFhirParameters(Library elmLibrary)
     {
-        var parameters = new List<Parameters.ParameterComponent>();
+        var fhirParameters = new List<Parameters.ParameterComponent>();
         foreach (var annotation in elmLibrary?.annotation ?? [])
         {
-            if (annotation is CqlToElmInfo cqlOptions)
+            if (annotation is not CqlToElmInfo cqlOptions)
+                continue;
+
+            // translatorVersion
+            AddFhirParameterIfNotNull(fhirParameters, nameof(cqlOptions.translatorVersion), cqlOptions.translatorVersion);
+
+            // translatorOptions
+            if (!string.IsNullOrEmpty(cqlOptions.translatorOptions))
             {
-                // translatorVersion
-                AddParameterIfNotNull(parameters, nameof(cqlOptions.translatorVersion), cqlOptions.translatorVersion);
-
-                // translatorOptions
-                if (!string.IsNullOrEmpty(cqlOptions.translatorOptions))
+                var optionArray = cqlOptions.translatorOptions.Split(',');
+                foreach (string item in optionArray)
                 {
-                    var optionArray = cqlOptions.translatorOptions.Split(',');
-                    foreach (string item in optionArray)
-                    {
-                        AddParameterIfNotNull(parameters, "option", item);
-                    }
+                    AddFhirParameterIfNotNull(fhirParameters, "option", item);
                 }
-
-                // signatureLevel
-                AddParameterIfNotNull(parameters, nameof(cqlOptions.signatureLevel), cqlOptions.signatureLevel);
-
-                // compatibilityLevel
-                AddParameterIfNotNull(parameters, "compatibilityLevel", "1.5");
-
-                // format
-                AddParameterIfNotNull(parameters, "format", "JSON");
             }
+
+            // signatureLevel
+            AddFhirParameterIfNotNull(fhirParameters, nameof(cqlOptions.signatureLevel), cqlOptions.signatureLevel);
+
+            // compatibilityLevel
+            AddFhirParameterIfNotNull(fhirParameters, "compatibilityLevel", "1.5");
+
+            // format
+            AddFhirParameterIfNotNull(fhirParameters, "format", "JSON");
         }
-        return parameters;
+        return fhirParameters;
     }
 
     private static readonly CodeableConcept LogicLibraryCodeableConcept = new()
@@ -391,13 +388,7 @@ file static class LibraryPackager
 
         var type = typeCrosswalk.TypeEntryFor(typeSpecifier);
         if (type?.FhirType is null)
-            throw new ArgumentException($"Unable to identify a valid FHIR type for this parameter.", nameof(elmParameter));
-
-        // var annotations = (elmParameter.annotation?
-        //                        .OfType<Elm.Annotation>()
-        //                        .SelectMany(a => a.t ?? [])
-        //                    ?? [])
-        //     .ToArray();
+            throw new ArgumentException("Unable to identify a valid FHIR type for this parameter.", nameof(elmParameter));
 
         var parameterDefinition = new ParameterDefinition
         {
@@ -423,7 +414,7 @@ file static class LibraryPackager
 
         var type = typeCrosswalk.TypeEntryFor(resultTypeSpecifier);
         if (type?.FhirType is null)
-            throw new ArgumentException($"Unable to identify a valid FHIR type for this definition.", nameof(definition));
+            throw new ArgumentException("Unable to identify a valid FHIR type for this definition.", nameof(definition));
 
         var parameterDefinition = new ParameterDefinition
         {
@@ -434,8 +425,7 @@ file static class LibraryPackager
             Type = type.FhirType!,
         };
 
-        if (
-            type is
+        if (type is
             {
                 CqlType: { } cqlType and CqlPrimitiveType.List,
                 ElementType.FhirType: { } elementFhirType
@@ -443,7 +433,6 @@ file static class LibraryPackager
         {
             parameterDefinition.Type = elementFhirType;
             parameterDefinition.Max = "*";
-
             parameterDefinition.Extension =
             [
                 new Extension
@@ -454,11 +443,11 @@ file static class LibraryPackager
             ];
         }
 
-        if (definition.accessLevel == Elm.AccessModifier.Private)
+        if (definition.accessLevel == AccessModifier.Private)
         {
             parameterDefinition.Extension.Add(new Extension
             {
-                Value = new Hl7.Fhir.Model.Code("private"),
+                Value = new Code("private"),
                 Url = Constants.Hl7FhirStructureDefinitionCqlAccessLevel,
             });
         }

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -507,11 +507,17 @@ file static class LibraryPackager
         }
 
         var cqlTypeName =
-            cqlElementType switch
+            (cqlType, cqlElementType) switch
             {
-                null => cqlType.ToString(),
-                CqlPrimitiveType.Fhir => $"{cqlType}<{cqlElementType}.{type.ElementType!.FhirType}>",
-                { } => $"{cqlType}<{cqlElementType}>",
+                // Don't show "generic" for List
+                (CqlPrimitiveType.List, _) => cqlType.ToString(),
+
+                // "Generic" display
+                (_, CqlPrimitiveType.Fhir) => $"{cqlType}<{cqlElementType}.{type.ElementType!.FhirType}>",
+                (_, { })                   => $"{cqlType}<{cqlElementType}>",
+
+                // Non-"Generic" display
+                _ => cqlType.ToString(),
             };
 
         parameterDefinition.Extension =

--- a/Cql/Elm/Library-serialization.cs
+++ b/Cql/Elm/Library-serialization.cs
@@ -111,7 +111,7 @@ public partial class Library
             }
         }
 
-        return container.library;
+        return library;
     }
 
     private static void CorrectLegacyConstructs(JsonNode a)


### PR DESCRIPTION
Work for 
* #635 

# Work
* Add cqltype extension on all parameters (boxed in red below). Notice that the previous issue #634 added the same extension but only for list types (boxed in cyan). 
![image](https://github.com/user-attachments/assets/fedd4079-42c6-416f-8141-45da5515da4b)
* Also include the element type if provided, except for List
* Split the library and measure resource packaging into separate types