### PR TITLE
ignore fluent assertions version 8.0 and higher in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,3 +30,5 @@ updates:
         update-types: ["version-update:semver-patch"]
       - dependency-name: coverlet.collector
         update-types: ["version-update:semver-patch"]
+      - dependency-name: FluentAssertions
+        versions: [">=8.0.0"]


### PR DESCRIPTION
Decided to ignore moving to 8.0.0 of FluentAssertions for now since they have updated their license to a commercial one:
https://github.com/fluentassertions/fluentassertions/pull/2943