### PR TITLE
Adding unit tests and fix for issue to read Parameter type from ResultTypeName or ParameterType entries

### DIFF
--- a/Cql/CoreTests/Input/ELM/Test/ParameterTest.cql
+++ b/Cql/CoreTests/Input/ELM/Test/ParameterTest.cql
@@ -1,0 +1,5 @@
+library ParameterTest version '1.0.0'
+
+parameter param default 5
+
+define Output: param

--- a/Cql/CoreTests/Input/ELM/Test/ParameterTest_ParameterType.json
+++ b/Cql/CoreTests/Input/ELM/Test/ParameterTest_ParameterType.json
@@ -1,0 +1,90 @@
+{
+  "library": {
+    "identifier": {
+      "id": "ParameterTest",
+      "system": "",
+      "version": "1.0.0"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "includes": {
+      "def": []
+    },
+    "parameters": {
+      "def": [
+        {
+          "default": {
+            "type": "Literal",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "2",
+            "locator": "3:24-3:24",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "param",
+          "parameterType": "{urn:hl7-org:elm-types:r1}Integer",
+          "accessLevel": "Public",
+          "localId": "1",
+          "locator": "3:0-3:24"
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": []
+    },
+    "valueSets": {
+      "def": []
+    },
+    "codes": {
+      "def": []
+    },
+    "concepts": {
+      "def": []
+    },
+    "contexts": {
+      "def": []
+    },
+    "statements": {
+      "def": [
+        {
+          "expression": {
+            "type": "ParameterRef",
+            "name": "param",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "20",
+            "locator": "5:15-5:15",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "Output",
+          "accessLevel": "Public",
+          "resultTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "localId": "21",
+          "locator": "5:0-5:15",
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+        }
+      ]
+    },
+    "annotation": []
+  }
+}

--- a/Cql/CoreTests/Input/ELM/Test/ParameterTest_ParameterTypeSpecifier.json
+++ b/Cql/CoreTests/Input/ELM/Test/ParameterTest_ParameterTypeSpecifier.json
@@ -1,0 +1,93 @@
+{
+  "library": {
+    "identifier": {
+      "id": "ParameterTest",
+      "system": "",
+      "version": "1.0.0"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "includes": {
+      "def": []
+    },
+    "parameters": {
+      "def": [
+        {
+          "default": {
+            "type": "Literal",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "2",
+            "locator": "3:24-3:24",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "parameterTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "param",
+          "accessLevel": "Public",
+          "localId": "1",
+          "locator": "3:0-3:24"
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": []
+    },
+    "valueSets": {
+      "def": []
+    },
+    "codes": {
+      "def": []
+    },
+    "concepts": {
+      "def": []
+    },
+    "contexts": {
+      "def": []
+    },
+    "statements": {
+      "def": [
+        {
+          "expression": {
+            "type": "ParameterRef",
+            "name": "param",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "20",
+            "locator": "5:15-5:15",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "Output",
+          "accessLevel": "Public",
+          "resultTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "localId": "21",
+          "locator": "5:0-5:15",
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+        }
+      ]
+    },
+    "annotation": []
+  }
+}

--- a/Cql/CoreTests/Input/ELM/Test/ParameterTest_ResultTypeName.json
+++ b/Cql/CoreTests/Input/ELM/Test/ParameterTest_ResultTypeName.json
@@ -1,0 +1,90 @@
+{
+  "library": {
+    "identifier": {
+      "id": "ParameterTest",
+      "system": "",
+      "version": "1.0.0"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "includes": {
+      "def": []
+    },
+    "parameters": {
+      "def": [
+        {
+          "default": {
+            "type": "Literal",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "2",
+            "locator": "3:24-3:24",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "param",
+          "accessLevel": "Public",
+          "localId": "1",
+          "locator": "3:0-3:24",
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": []
+    },
+    "valueSets": {
+      "def": []
+    },
+    "codes": {
+      "def": []
+    },
+    "concepts": {
+      "def": []
+    },
+    "contexts": {
+      "def": []
+    },
+    "statements": {
+      "def": [
+        {
+          "expression": {
+            "type": "ParameterRef",
+            "name": "param",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "20",
+            "locator": "5:15-5:15",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "Output",
+          "accessLevel": "Public",
+          "resultTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "localId": "21",
+          "locator": "5:0-5:15",
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+        }
+      ]
+    },
+    "annotation": []
+  }
+}

--- a/Cql/CoreTests/Input/ELM/Test/ParameterTest_ResultTypeSpecifier.json
+++ b/Cql/CoreTests/Input/ELM/Test/ParameterTest_ResultTypeSpecifier.json
@@ -1,0 +1,93 @@
+{
+  "library": {
+    "identifier": {
+      "id": "ParameterTest",
+      "system": "",
+      "version": "1.0.0"
+    },
+    "schemaIdentifier": {
+      "id": "urn:hl7-org:elm",
+      "version": "r1"
+    },
+    "usings": {
+      "def": [
+        {
+          "localIdentifier": "System",
+          "uri": "urn:hl7-org:elm-types:r1",
+          "version": "1.0.0"
+        }
+      ]
+    },
+    "includes": {
+      "def": []
+    },
+    "parameters": {
+      "def": [
+        {
+          "default": {
+            "type": "Literal",
+            "valueType": "{urn:hl7-org:elm-types:r1}Integer",
+            "value": "5",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "2",
+            "locator": "3:24-3:24",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "param",
+          "accessLevel": "Public",
+          "resultTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "localId": "1",
+          "locator": "3:0-3:24"
+        }
+      ]
+    },
+    "codeSystems": {
+      "def": []
+    },
+    "valueSets": {
+      "def": []
+    },
+    "codes": {
+      "def": []
+    },
+    "concepts": {
+      "def": []
+    },
+    "contexts": {
+      "def": []
+    },
+    "statements": {
+      "def": [
+        {
+          "expression": {
+            "type": "ParameterRef",
+            "name": "param",
+            "resultTypeSpecifier": {
+              "type": "NamedTypeSpecifier",
+              "name": "{urn:hl7-org:elm-types:r1}Integer"
+            },
+            "localId": "20",
+            "locator": "5:15-5:15",
+            "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "name": "Output",
+          "accessLevel": "Public",
+          "resultTypeSpecifier": {
+            "type": "NamedTypeSpecifier",
+            "name": "{urn:hl7-org:elm-types:r1}Integer"
+          },
+          "localId": "21",
+          "locator": "5:0-5:15",
+          "resultTypeName": "{urn:hl7-org:elm-types:r1}Integer"
+        }
+      ]
+    },
+    "annotation": []
+  }
+}

--- a/Cql/CoreTests/Packaging/LibraryPackagerTests.cs
+++ b/Cql/CoreTests/Packaging/LibraryPackagerTests.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Hl7.Cql.CodeGeneration.NET;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Packaging;
+using Hl7.Fhir.Model;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace CoreTests.Packaging;
+
+[TestClass]
+public class LibraryPackagerTests
+{
+    private static readonly FhirTypeResolver TypeResolver = new (ModelInfo.ModelInspector);
+    private readonly AssemblyData _assemblyData = new ([], new Dictionary<string, string>());
+    private readonly CqlTypeToFhirTypeMapper _mapper = new (TypeResolver);
+
+    [DataTestMethod]
+    [DataRow("Input/ELM/Test/ParameterTest_ResultTypeSpecifier.json", FHIRAllTypes.Integer)]
+    [DataRow("Input/ELM/Test/ParameterTest_ParameterTypeSpecifier.json", FHIRAllTypes.Integer)]
+    [DataRow("Input/ELM/Test/ParameterTest_ResultTypeName.json", FHIRAllTypes.Integer)]
+    [DataRow("Input/ELM/Test/ParameterTest_ParameterType.json", FHIRAllTypes.Integer)]
+    public void ElmParameterToFhir_ParameterTypeCanBeDerivedFromDifferentSources(string filename, FHIRAllTypes expectedType)
+    {
+        // Arrange
+        var elmFile = new FileInfo(filename);
+
+        // Act
+        var library = LibraryPackager.CreateLibraryResource(
+            elmFile,
+            null,
+            null,
+            _assemblyData,
+            _mapper);
+
+        // Assert
+        Assert.IsNotNull(library);
+        var inputParameter = library.Parameter.Single(pd => pd.Use == OperationParameterUse.In);
+        Assert.AreEqual("param", inputParameter.Name);
+        Assert.AreEqual(expectedType, inputParameter.Type);
+    }
+}

--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -268,7 +268,7 @@ file static class MeasurePackager
     }
 }
 
-file static class LibraryPackager
+internal static class LibraryPackager
 {
     public static FhirLibrary CreateLibraryResource(
         FileInfo elmFile,
@@ -301,7 +301,7 @@ file static class LibraryPackager
         if (fhirParameters.Any())
             AddCQLOptions(fhirLibrary, fhirParameters);
 
-        if (cqlFile!.Exists)
+        if (cqlFile?.Exists == true)
             AddCqlAttachment(elmLibrary, fhirLibrary, cqlFile);
 
         AddDllAttachment(elmLibrary, fhirLibrary, assemblyData);
@@ -530,9 +530,13 @@ file static class LibraryPackager
         ParameterDef elmParameter,
         CqlTypeToFhirTypeMapper typeCrosswalk)
     {
-        var typeSpecifier = elmParameter.resultTypeSpecifier ?? elmParameter.parameterTypeSpecifier;
+        var typeSpecifier = elmParameter.resultTypeSpecifier
+                            ?? elmParameter.parameterTypeSpecifier
+                            ?? (elmParameter.resultTypeName is not null ? new NamedTypeSpecifier { name = elmParameter.resultTypeName } : null)
+                            ?? (elmParameter.parameterType is not null ? new NamedTypeSpecifier { name = elmParameter.parameterType } : null);
+
         if (typeSpecifier is null)
-            throw new ArgumentException($"{typeSpecifier} is missing on parameter: {elmParameter.name}",
+            throw new ArgumentException($"TypeSpecifier is missing on parameter: {elmParameter.name}",
                                         nameof(elmParameter));
 
         var type = typeCrosswalk.TypeEntryFor(typeSpecifier);


### PR DESCRIPTION
Fixes #710 

- The main fix is in Cql/Cql.Packaging/ResourcePackager.cs
- Adding some unit tests and testdata to reproduce the bug and verify the fix