### PR TITLE
698 public api use semantic versioning on the generated libraries

### DIFF
--- a/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
+++ b/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
@@ -22,6 +22,12 @@ namespace Hl7.Cql.CodeGeneration.NET;
 /// </summary>
 internal partial class LibrarySetCSharpCodeGenerator
 {
+    /// <summary>
+    /// Gets the product of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear
+    /// in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Tool"/>.
+    /// </summary>
+    internal static string GeneratorToolName { get; } = GetGeneratorToolNameFromAssemblyProductName();
+
     private readonly TypeToCSharpConverter _typeToCSharpConverter;
 
     /// <summary>

--- a/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
+++ b/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
@@ -20,7 +20,7 @@ namespace Hl7.Cql.CodeGeneration.NET;
 /// <summary>
 /// Processes a definition dictionary of <see cref="LambdaExpression"/> into a .NET classes per library.
 /// </summary>
-internal class LibrarySetCSharpCodeGenerator
+internal partial class LibrarySetCSharpCodeGenerator
 {
     private readonly TypeToCSharpConverter _typeToCSharpConverter;
 
@@ -38,30 +38,22 @@ internal class LibrarySetCSharpCodeGenerator
     /// </summary>
     private readonly IReadOnlyList<(string alias, string type)> _aliasedUsings;
 
-    /// <summary>
-    /// Gets the version of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Version"/>.
-    /// </summary>
-    private readonly string _generatorToolVersion;
-
-    /// <summary>
-    /// Gets the product of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Tool"/>.
-    /// </summary>
-    private readonly string _generatorToolName;
-
     public LibrarySetCSharpCodeGenerator(
         TypeResolver typeResolver,
         TypeToCSharpConverter typeToCSharpConverter)
     {
         _typeToCSharpConverter = typeToCSharpConverter;
         _usings = BuildUsings(typeResolver);
-        var thisAssembly = GetType().Assembly;
-        _generatorToolVersion = thisAssembly.GetName().Version?.ToString() ?? "1.0.0";
-        _generatorToolName = thisAssembly.GetCustomAttributes(false)
-                                         .OfType<AssemblyProductAttribute>()
-                                         .SingleOrDefault()?
-                                         .Product ?? "ELM-to-CSharp";
         _aliasedUsings = typeResolver.Aliases.ToList();
     }
+
+    private static string GetGeneratorToolNameFromAssemblyProductName() =>
+        typeof(LibrarySetCSharpCodeGenerator)
+            .Assembly
+            .GetCustomAttributes(false)
+            .OfType<AssemblyProductAttribute>()
+            .SingleOrDefault()?
+            .Product ?? "ELM-to-CSharp";
 
     private static HashSet<string> BuildUsings(TypeResolver typeResolver)
     {
@@ -104,8 +96,6 @@ internal class LibrarySetCSharpCodeGenerator
         DefinitionDictionary<LambdaExpression> Definitions)
     {
         public TupleMetadataBuilder TupleMetadataBuilder { get; } = new();
-        public string GeneratorToolName => Processor._generatorToolName;
-        public string GeneratorToolVersion => Processor._generatorToolVersion;
         public TypeToCSharpConverter TypeToCSharpConverter => Processor._typeToCSharpConverter;
         public IReadOnlyList<(string alias, string type)> AliasedUsings => Processor._aliasedUsings;
         public HashSet<string> Usings => Processor._usings;
@@ -259,7 +249,7 @@ internal class LibrarySetCSharpCodeGenerator
         private void WriteClass()
         {
             IndentedTextWriter.WriteLine(
-                $"[System.CodeDom.Compiler.GeneratedCode({LibrarySetWriter.GeneratorToolName.QuoteString()}, {LibrarySetWriter.GeneratorToolVersion.QuoteString()})]");
+                $"[System.CodeDom.Compiler.GeneratedCode({GeneratorToolName.QuoteString()}, {GeneratorToolVersion.QuoteString()})]");
 
             IndentedTextWriter.WriteLine(
                 LibraryVersionedIdentifier.version is { } version && Version.TryParse(version, out _)

--- a/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
+++ b/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
@@ -3,20 +3,16 @@
 internal partial class LibrarySetCSharpCodeGenerator
 {
     /// <summary>
-    /// Gets the version of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Version"/>.
+    /// Gets the version of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear
+    /// in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Version"/>.
     /// </summary>
     /// <remarks>
     /// This version must be MANUALLY updated whenever the code generation logic changes.
-    /// The version should be updated according to the Semantic Versioning specification.
+    /// The version should be updated according to the Semantic Versioning specification (although text is not allowed, e.g. alpha).
     /// This version does not correlate to the version of the CQL SDK.
     /// When the version is updated, the libraries must be regenerated as well as part of the pull request.
     /// Also, it is important to ensure the library invoker toolkit is updated to support the new version,
     /// for this you need to update the LibraryInvoker.SupportsVersion method, or create a new version of the LibraryInvoker.
     /// </remarks>
-    private const string GeneratorToolVersion = "2.1";
-
-    /// <summary>
-    /// Gets the product of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Tool"/>.
-    /// </summary>
-    private static string GeneratorToolName { get; } = GetGeneratorToolNameFromAssemblyProductName();
+    internal const string GeneratorToolVersion = "2.1.0.0";
 }

--- a/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
+++ b/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
@@ -9,6 +9,9 @@ internal partial class LibrarySetCSharpCodeGenerator
     /// This version must be MANUALLY updated whenever the code generation logic changes.
     /// The version should be updated according to the Semantic Versioning specification.
     /// This version does not correlate to the version of the CQL SDK.
+    /// When the version is updated, the libraries must be regenerated as well as part of the pull request.
+    /// Also, it is important to ensure the library invoker toolkit is updated to support the new version,
+    /// for this you need to update the LibraryInvoker.SupportsVersion method, or create a new version of the LibraryInvoker.
     /// </remarks>
     private const string GeneratorToolVersion = "2.1";
 

--- a/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
+++ b/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
@@ -1,0 +1,19 @@
+﻿namespace Hl7.Cql.CodeGeneration.NET;
+
+internal partial class LibrarySetCSharpCodeGenerator
+{
+    /// <summary>
+    /// Gets the version of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Version"/>.
+    /// </summary>
+    /// <remarks>
+    /// This version must be MANUALLY updated whenever the code generation logic changes.
+    /// The version should be updated according to the Semantic Versioning specification.
+    /// This version does not correlate to the version of the CQL SDK.
+    /// </remarks>
+    private const string GeneratorToolVersion = "2.1";
+
+    /// <summary>
+    /// Gets the product of this <see cref="LibrarySetCSharpCodeGenerator"/> as will appear in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Tool"/>.
+    /// </summary>
+    private static string GeneratorToolName { get; } = GetGeneratorToolNameFromAssemblyProductName();
+}

--- a/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
+++ b/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CqlBooleanTest", "1.0.000")]
 public partial class CqlBooleanTest_1_0_000 : ILibrary, ISingleton<CqlBooleanTest_1_0_000>
 {

--- a/Cql/CoreTests/CSharp/CqlNestedTupleTest-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/CqlNestedTupleTest-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CqlNestedTupleTest", "1.0.0")]
 public partial class CqlNestedTupleTest_1_0_0 : ILibrary, ISingleton<CqlNestedTupleTest_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIRConversionTest", "2023.0.0")]
 public partial class FHIRConversionTest_2023_0_0 : ILibrary, ISingleton<FHIRConversionTest_2023_0_0>
 {

--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIRHelpers", "4.0.1")]
 public partial class FHIRHelpers_4_0_1 : ILibrary, ISingleton<FHIRHelpers_4_0_1>
 {

--- a/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("RR23", "1.0.0")]
 public partial class RR23_1_0_0 : ILibrary, ISingleton<RR23_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("TestRetrieve", "1.0.1")]
 public partial class TestRetrieve_1_0_1 : ILibrary, ISingleton<TestRetrieve_1_0_1>
 {

--- a/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("TestRetrieveInclude", "1.0.1")]
 public partial class TestRetrieveInclude_1_0_1 : ILibrary, ISingleton<TestRetrieveInclude_1_0_1>
 {

--- a/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ValueSetExprExample", "1.0.0")]
 public partial class ValueSetExprExample_1_0_0 : ILibrary, ISingleton<ValueSetExprExample_1_0_0>
 {

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
@@ -83,8 +83,8 @@ internal sealed class LibraryInvoker_2_0_8_0 : LibraryInvokerOnInstance
     /// The current CQL tool version can be referenced by <see cref="LibrarySetCSharpCodeGenerator.GeneratorToolVersion"/>.
     /// </summary>
     public static bool SupportsVersion(Version cqlToolVersion) =>
-        cqlToolVersion >= new Version(2, 0, 8)
-        && cqlToolVersion <= new Version(2, 1);
+        cqlToolVersion >= new Version(2, 0, 8, 0)
+        && cqlToolVersion <= new Version(2, 1, 0, 0);
 }
 
 file class DefinitionInvoker_2_0_8_0(

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
@@ -8,6 +8,7 @@
 
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.Toolkit;
 
@@ -77,10 +78,13 @@ internal sealed class LibraryInvoker_2_0_8_0 : LibraryInvokerOnInstance
         return true;
     }
 
-    public static bool SupportsVersion(Version cqlToolVersion)
-    {
-        return cqlToolVersion >= new Version(2, 0, 8);
-    }
+    /// <summary>
+    /// Determines whether the specified CQL tool version is supported.
+    /// The current CQL tool version can be referenced by <see cref="LibrarySetCSharpCodeGenerator.GeneratorToolVersion"/>.
+    /// </summary>
+    public static bool SupportsVersion(Version cqlToolVersion) =>
+        cqlToolVersion >= new Version(2, 0, 8)
+        && cqlToolVersion <= new Version(2, 1);
 }
 
 file class DefinitionInvoker_2_0_8_0(

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DocumentationofCurrentMedicationsFHIR", "0.2.000")]
 public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, ISingleton<DocumentationofCurrentMedicationsFHIR_0_2_000>
 {

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIRHelpers", "4.3.000")]
 public partial class FHIRHelpers_4_3_000 : ILibrary, ISingleton<FHIRHelpers_4_3_000>
 {

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("MultipleResourcesExample", "0.0.1")]
 public partial class MultipleResourcesExample_0_0_1 : ILibrary, ISingleton<MultipleResourcesExample_0_0_1>
 {

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ParametersExample", "0.0.1")]
 public partial class ParametersExample_0_0_1 : ILibrary, ISingleton<ParametersExample_0_0_1>
 {

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("QICoreCommon", "2.0.000")]
 public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_0_000>
 {

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Status", "1.6.000")]
 public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
 {

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SupplementalDataElements", "3.4.000")]
 public partial class SupplementalDataElements_3_4_000 : ILibrary, ISingleton<SupplementalDataElements_3_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/AHAOverall-2.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AHAOverall-2.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AHAOverall", "2.8.000")]
 public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_000>
 {

--- a/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ALARACTOQRFHIR-0.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ALARACTOQRFHIR", "0.4.000")]
 public partial class ALARACTOQRFHIR_0_4_000 : ILibrary, ISingleton<ALARACTOQRFHIR_0_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdultOutpatientEncounters-4.11.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AdultOutpatientEncounters", "4.11.000")]
 public partial class AdultOutpatientEncounters_4_11_000 : ILibrary, ISingleton<AdultOutpatientEncounters_4_11_000>
 {

--- a/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.16.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AdvancedIllnessandFrailty-1.16.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AdvancedIllnessandFrailty", "1.16.000")]
 public partial class AdvancedIllnessandFrailty_1_16_000 : ILibrary, ISingleton<AdvancedIllnessandFrailty_1_16_000>
 {

--- a/Demo/Measures.CMS/CSharp/AlaraCTClinicalFHIR-0.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTClinicalFHIR-0.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AlaraCTClinicalFHIR", "0.4.000")]
 public partial class AlaraCTClinicalFHIR_0_4_000 : ILibrary, ISingleton<AlaraCTClinicalFHIR_0_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCTIQRFHIR-0.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AlaraCTIQRFHIR", "0.4.000")]
 public partial class AlaraCTIQRFHIR_0_4_000 : ILibrary, ISingleton<AlaraCTIQRFHIR_0_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/AlaraCommonFunctions-1.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AlaraCommonFunctions-1.5.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AlaraCommonFunctions", "1.5.000")]
 public partial class AlaraCommonFunctions_1_5_000 : ILibrary, ISingleton<AlaraCommonFunctions_1_5_000>
 {

--- a/Demo/Measures.CMS/CSharp/Antibiotic-1.7.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Antibiotic-1.7.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Antibiotic", "1.7.000")]
 public partial class Antibiotic_1_7_000 : ILibrary, ISingleton<Antibiotic_1_7_000>
 {

--- a/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AnticoagulationTherapyforAtrialFibrillationFlutterFHIR", "0.3.000")]
 public partial class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000 : ILibrary, ISingleton<AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_000>
 {

--- a/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AntidepressantMedicationManagementFHIR-0.1.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AntidepressantMedicationManagementFHIR", "0.1.001")]
 public partial class AntidepressantMedicationManagementFHIR_0_1_001 : ILibrary, ISingleton<AntidepressantMedicationManagementFHIR_0_1_001>
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.2.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateDXAScansForWomenUnder65FHIR-0.2.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AppropriateDXAScansForWomenUnder65FHIR", "0.2.001")]
 public partial class AppropriateDXAScansForWomenUnder65FHIR_0_2_001 : ILibrary, ISingleton<AppropriateDXAScansForWomenUnder65FHIR_0_2_001>
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTestingforPharyngitisFHIR-0.1.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AppropriateTestingforPharyngitisFHIR", "0.1.001")]
 public partial class AppropriateTestingforPharyngitisFHIR_0_1_001 : ILibrary, ISingleton<AppropriateTestingforPharyngitisFHIR_0_1_001>
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforSTEMIFHIR-1.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AppropriateTreatmentforSTEMIFHIR", "1.2.000")]
 public partial class AppropriateTreatmentforSTEMIFHIR_1_2_000 : ILibrary, ISingleton<AppropriateTreatmentforSTEMIFHIR_1_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR-0.1.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR", "0.1.001")]
 public partial class AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_001 : ILibrary, ISingleton<AppropriateTreatmentforUpperRespiratoryInfectionURIFHIR_0_1_001>
 {

--- a/Demo/Measures.CMS/CSharp/BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR-1.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR-1.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR", "1.4.000")]
 public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4_000 : ILibrary, ISingleton<BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/BreastCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/BreastCancerScreeningFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("BreastCancerScreeningFHIR", "0.0.001")]
 public partial class BreastCancerScreeningFHIR_0_0_001 : ILibrary, ISingleton<BreastCancerScreeningFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/CQMCommon-2.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CQMCommon-2.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CQMCommon", "2.2.000")]
 public partial class CQMCommon_2_2_000 : ILibrary, ISingleton<CQMCommon_2_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CRLReceiptofSpecialistReportFHIR-0.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CRLReceiptofSpecialistReportFHIR", "0.3.000")]
 public partial class CRLReceiptofSpecialistReportFHIR_0_3_000 : ILibrary, ISingleton<CRLReceiptofSpecialistReportFHIR_0_3_000>
 {

--- a/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Cataracts2040BCVAwithin90DaysFHIR", "0.1.000")]
 public partial class Cataracts2040BCVAwithin90DaysFHIR_0_1_000 : ILibrary, ISingleton<Cataracts2040BCVAwithin90DaysFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/CervicalCancerScreeningFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CervicalCancerScreeningFHIR", "0.0.001")]
 public partial class CervicalCancerScreeningFHIR_0_0_001 : ILibrary, ISingleton<CervicalCancerScreeningFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CesareanBirthFHIR", "0.2.000")]
 public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBirthFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR", "0.1.000")]
 public partial class ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR_0_1_000 : ILibrary, ISingleton<ChildandAdolescentMajorDepressiveDisorderMDDSuicideRiskAssessmentFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildhoodImmunizationStatusFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ChildhoodImmunizationStatusFHIR", "0.1.000")]
 public partial class ChildhoodImmunizationStatusFHIR_0_1_000 : ILibrary, ISingleton<ChildhoodImmunizationStatusFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChildrenWhoHaveDentalDecayOrCavitiesFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ChildrenWhoHaveDentalDecayOrCavitiesFHIR", "0.0.001")]
 public partial class ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001 : ILibrary, ISingleton<ChildrenWhoHaveDentalDecayOrCavitiesFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ChlamydiaScreeninginWomenFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ChlamydiaScreeninginWomenFHIR", "0.1.000")]
 public partial class ChlamydiaScreeninginWomenFHIR_0_1_000 : ILibrary, ISingleton<ChlamydiaScreeninginWomenFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ColonCancerScreeningFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ColonCancerScreeningFHIR", "0.1.000")]
 public partial class ColonCancerScreeningFHIR_0_1_000 : ILibrary, ISingleton<ColonCancerScreeningFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/ControllingHighBloodPressureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ControllingHighBloodPressureFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ControllingHighBloodPressureFHIR", "0.1.000")]
 public partial class ControllingHighBloodPressureFHIR_0_1_000 : ILibrary, ISingleton<ControllingHighBloodPressureFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/CumulativeMedicationDuration-4.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CumulativeMedicationDuration", "4.1.000")]
 public partial class CumulativeMedicationDuration_4_1_000 : ILibrary, ISingleton<CumulativeMedicationDuration_4_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.1.000")]
 public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000 : ILibrary, ISingleton<DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DementiaCognitiveAssessmentFHIR", "0.1.000")]
 public partial class DementiaCognitiveAssessmentFHIR_0_1_000 : ILibrary, ISingleton<DementiaCognitiveAssessmentFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/DepressionRemissionatTwelveMonthsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DepressionRemissionatTwelveMonthsFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DepressionRemissionatTwelveMonthsFHIR", "0.2.000")]
 public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, ISingleton<DepressionRemissionatTwelveMonthsFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesEyeExamFHIR-0.0.002.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DiabetesEyeExamFHIR", "0.0.002")]
 public partial class DiabetesEyeExamFHIR_0_0_002 : ILibrary, ISingleton<DiabetesEyeExamFHIR_0_0_002>
 {

--- a/Demo/Measures.CMS/CSharp/DiabetesGlycemicStatusAssessmentGreaterThan9PercentFHIR-0.1.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/DiabetesGlycemicStatusAssessmentGreaterThan9PercentFHIR-0.1.002.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DiabetesGlycemicStatusAssessmentGreaterThan9PercentFHIR", "0.1.002")]
 public partial class DiabetesGlycemicStatusAssessmentGreaterThan9PercentFHIR_0_1_002 : ILibrary, ISingleton<DiabetesGlycemicStatusAssessmentGreaterThan9PercentFHIR_0_1_002>
 {

--- a/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DischargedonAntithromboticTherapyFHIR-0.9.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.9.000")]
 public partial class DischargedonAntithromboticTherapyFHIR_0_9_000 : ILibrary, ISingleton<DischargedonAntithromboticTherapyFHIR_0_9_000>
 {

--- a/Demo/Measures.CMS/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DocumentationofCurrentMedicationsFHIR", "0.2.000")]
 public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, ISingleton<DocumentationofCurrentMedicationsFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/FHIRHelpers-4.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FHIRHelpers-4.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIRHelpers", "4.4.000")]
 public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.2.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/FallsScreeningForFutureFallRiskFHIR-0.2.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FallsScreeningForFutureFallRiskFHIR", "0.2.001")]
 public partial class FallsScreeningForFutureFallRiskFHIR_0_2_001 : ILibrary, ISingleton<FallsScreeningForFutureFallRiskFHIR_0_2_001>
 {

--- a/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR-0.1.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR", "0.1.001")]
 public partial class FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_001 : ILibrary, ISingleton<FollowUpCareforChildrenPrescribedADHDMedicationADDFHIR_0_1_001>
 {

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FunctionalStatusAssessmentforTotalHipReplacementFHIR", "0.0.008")]
 public partial class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008 : ILibrary, ISingleton<FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_008>
 {

--- a/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/FunctionalStatusAssessmentsforHeartFailureFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FunctionalStatusAssessmentsforHeartFailureFHIR", "0.1.000")]
 public partial class FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000 : ILibrary, ISingleton<FunctionalStatusAssessmentsforHeartFailureFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/GlobalMalnutritionCompositeFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("GlobalMalnutritionCompositeFHIR", "0.2.000")]
 public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingleton<GlobalMalnutritionCompositeFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/HFACEIorARBorARNIforLVSDFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFACEIorARBorARNIforLVSDFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HFACEIorARBorARNIforLVSDFHIR", "0.2.000")]
 public partial class HFACEIorARBorARNIforLVSDFHIR_0_2_000 : ILibrary, ISingleton<HFACEIorARBorARNIforLVSDFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HFBetaBlockerTherapyforLVSDFHIR", "1.4.000")]
 public partial class HFBetaBlockerTherapyforLVSDFHIR_1_4_000 : ILibrary, ISingleton<HFBetaBlockerTherapyforLVSDFHIR_1_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HIVRetentionFHIR", "0.1.000")]
 public partial class HIVRetentionFHIR_0_1_000 : ILibrary, ISingleton<HIVRetentionFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/HIVSTITestingFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVSTITestingFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HIVSTITestingFHIR", "0.2.000")]
 public partial class HIVSTITestingFHIR_0_2_000 : ILibrary, ISingleton<HIVSTITestingFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/HIVScreeningFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVScreeningFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HIVScreeningFHIR", "0.2.000")]
 public partial class HIVScreeningFHIR_0_2_000 : ILibrary, ISingleton<HIVScreeningFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HIVViralSuppressionFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HIVViralSuppressionFHIR", "0.1.000")]
 public partial class HIVViralSuppressionFHIR_0_1_000 : ILibrary, ISingleton<HIVViralSuppressionFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/Hospice-6.12.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Hospice-6.12.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Hospice", "6.12.000")]
 public partial class Hospice_6_12_000 : ILibrary, ISingleton<Hospice_6_12_000>
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmFallsWithInjuryFHIR-0.0.024.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmFallsWithInjuryFHIR-0.0.024.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmFallsWithInjuryFHIR", "0.0.024")]
 public partial class HospitalHarmFallsWithInjuryFHIR_0_0_024 : ILibrary, ISingleton<HospitalHarmFallsWithInjuryFHIR_0_0_024>
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR", "0.1.000")]
 public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000 : ILibrary, ISingleton<HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmOpioidRelatedAdverseEventsFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmOpioidRelatedAdverseEventsFHIR", "0.1.000")]
 public partial class HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000 : ILibrary, ISingleton<HospitalHarmOpioidRelatedAdverseEventsFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmPressureInjuryFHIR", "0.1.000")]
 public partial class HospitalHarmPressureInjuryFHIR_0_1_000 : ILibrary, ISingleton<HospitalHarmPressureInjuryFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.1.000")]
 public partial class HospitalHarmSevereHypoglycemiaFHIR_0_1_000 : ILibrary, ISingleton<HospitalHarmSevereHypoglycemiaFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HybridHospitalWideMortalityFHIR", "0.0.001")]
 public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingleton<HybridHospitalWideMortalityFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HybridHospitalWideReadmissionFHIR", "0.0.001")]
 public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISingleton<HybridHospitalWideReadmissionFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR", "1.4.000")]
 public partial class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_000 : ILibrary, ISingleton<IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("KidneyHealthEvaluationFHIR", "0.1.000")]
 public partial class KidneyHealthEvaluationFHIR_0_1_000 : ILibrary, ISingleton<KidneyHealthEvaluationFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/OncologyPainIntensityQuantifiedFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("OncologyPainIntensityQuantifiedFHIR", "0.1.000")]
 public partial class OncologyPainIntensityQuantifiedFHIR_0_1_000 : ILibrary, ISingleton<OncologyPainIntensityQuantifiedFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/PCMaternal-5.19.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCMaternal-5.19.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PCMaternal", "5.19.000")]
 public partial class PCMaternal_5_19_000 : ILibrary, ISingleton<PCMaternal_5_19_000>
 {

--- a/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PCSBPScreeningFollowUpFHIR", "0.2.000")]
 public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<PCSBPScreeningFollowUpFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("POAGOpticNerveEvaluationFHIR", "0.1.000")]
 public partial class POAGOpticNerveEvaluationFHIR_0_1_000 : ILibrary, ISingleton<POAGOpticNerveEvaluationFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/PalliativeCare-1.11.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/PalliativeCare-1.11.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PalliativeCare", "1.11.000")]
 public partial class PalliativeCare_1_11_000 : ILibrary, ISingleton<PalliativeCare_1_11_000>
 {

--- a/Demo/Measures.CMS/CSharp/PreventiveCareAndTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/PreventiveCareAndTobaccoUseScreeningAndCessationInterventionFHIR-0.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PreventiveCareAndTobaccoUseScreeningAndCessationInterventionFHIR", "0.0.001")]
 public partial class PreventiveCareAndTobaccoUseScreeningAndCessationInterventionFHIR_0_0_001 : ILibrary, ISingleton<PreventiveCareAndTobaccoUseScreeningAndCessationInterventionFHIR_0_0_001>
 {

--- a/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
+++ b/Demo/Measures.CMS/CSharp/PrimaryCariesPreventionasOfferedbyDentistsFHIR-0.0.002.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PrimaryCariesPreventionasOfferedbyDentistsFHIR", "0.0.002")]
 public partial class PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002 : ILibrary, ISingleton<PrimaryCariesPreventionasOfferedbyDentistsFHIR_0_0_002>
 {

--- a/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.3.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ProstateCaAvoidanceBoneScanOveruseFHIR", "0.3.000")]
 public partial class ProstateCaAvoidanceBoneScanOveruseFHIR_0_3_000 : ILibrary, ISingleton<ProstateCaAvoidanceBoneScanOveruseFHIR_0_3_000>
 {

--- a/Demo/Measures.CMS/CSharp/QICoreCommon-2.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/QICoreCommon-2.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("QICoreCommon", "2.1.000")]
 public partial class QICoreCommon_2_1_000 : ILibrary, ISingleton<QICoreCommon_2_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SafeUseofOpioidsConcurrentPrescribingFHIR", "0.2.000")]
 public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_2_000 : ILibrary, ISingleton<SafeUseofOpioidsConcurrentPrescribingFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SevereObstetricComplicationsFHIR-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SevereObstetricComplicationsFHIR", "0.1.000")]
 public partial class SevereObstetricComplicationsFHIR_0_1_000 : ILibrary, ISingleton<SevereObstetricComplicationsFHIR_0_1_000>
 {

--- a/Demo/Measures.CMS/CSharp/StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR", "0.2.000")]
 public partial class StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR_0_2_000 : ILibrary, ISingleton<StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR_0_2_000>
 {

--- a/Demo/Measures.CMS/CSharp/Status-1.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/Status-1.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Status", "1.8.000")]
 public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
 {

--- a/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.5.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/SupplementalDataElements-3.5.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SupplementalDataElements", "3.5.000")]
 public partial class SupplementalDataElements_3_5_000 : ILibrary, ISingleton<SupplementalDataElements_3_5_000>
 {

--- a/Demo/Measures.CMS/CSharp/TJCOverall-8.14.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/TJCOverall-8.14.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("TJCOverall", "8.14.000")]
 public partial class TJCOverall_8_14_000 : ILibrary, ISingleton<TJCOverall_8_14_000>
 {

--- a/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.4.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR", "1.4.000")]
 public partial class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_4_000 : ILibrary, ISingleton<UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR_1_4_000>
 {

--- a/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.2.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/UseofHighRiskMedicationsintheElderlyFHIR-0.2.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("UseofHighRiskMedicationsintheElderlyFHIR", "0.2.001")]
 public partial class UseofHighRiskMedicationsintheElderlyFHIR_0_2_001 : ILibrary, ISingleton<UseofHighRiskMedicationsintheElderlyFHIR_0_2_001>
 {

--- a/Demo/Measures.CMS/CSharp/VTE-8.8.000.g.cs
+++ b/Demo/Measures.CMS/CSharp/VTE-8.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("VTE", "8.8.000")]
 public partial class VTE_8_8_000 : ILibrary, ISingleton<VTE_8_8_000>
 {

--- a/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.001.g.cs
+++ b/Demo/Measures.CMS/CSharp/WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR-0.1.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR", "0.1.001")]
 public partial class WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR_0_1_001 : ILibrary, ISingleton<WeightAssessmentandCounselingforNutritionandPhysicalActivityforChildrenandAdolescentsFHIR_0_1_001>
 {

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AdultOutpatientEncountersFHIR4", "2.2.000")]
 public partial class AdultOutpatientEncountersFHIR4_2_2_000 : ILibrary, ISingleton<AdultOutpatientEncountersFHIR4_2_2_000>
 {

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("AdvancedIllnessandFrailtyExclusionECQMFHIR4", "5.17.000")]
 public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILibrary, ISingleton<AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000>
 {

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("BCSEHEDISMY2022", "1.0.0")]
 public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY2022_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("BreastCancerScreeningsFHIR", "0.0.009")]
 public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<BreastCancerScreeningsFHIR_0_0_009>
 {

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CervicalCancerScreeningFHIR", "0.0.005")]
 public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<CervicalCancerScreeningFHIR_0_0_005>
 {

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("ColorectalCancerScreeningsFHIR", "0.0.003")]
 public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISingleton<ColorectalCancerScreeningsFHIR_0_0_003>
 {

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("CumulativeMedicationDurationFHIR4", "1.0.000")]
 public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISingleton<CumulativeMedicationDurationFHIR4_1_0_000>
 {

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.0.004")]
 public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : ILibrary, ISingleton<DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004>
 {

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DevDays", "2023.0.0")]
 public partial class DevDays_2023_0_0 : ILibrary, ISingleton<DevDays_2023_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR", "0.0.015")]
 public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibrary, ISingleton<DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015>
 {

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.0.010")]
 public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, ISingleton<DischargedonAntithromboticTherapyFHIR_0_0_010>
 {

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Exam125FHIR", "0.0.009")]
 public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_009>
 {

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("Exam130FHIR", "0.0.003")]
 public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_003>
 {

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIR347", "0.1.021")]
 public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
 {

--- a/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("FHIRHelpers", "4.0.001")]
 public partial class FHIRHelpers_4_0_001 : ILibrary, ISingleton<FHIRHelpers_4_0_001>
 {

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospiceFHIR4", "2.3.000")]
 public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_3_000>
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR", "0.0.006")]
 public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006 : ILibrary, ISingleton<HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006>
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.0.012")]
 public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISingleton<HospitalHarmSevereHypoglycemiaFHIR_0_0_012>
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HybridHWMFHIR", "0.102.005")]
 public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHIR_0_102_005>
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("HybridHWRFHIR", "1.3.005")]
 public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_1_3_005>
 {

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("MATGlobalCommonFunctionsFHIR4", "6.1.000")]
 public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleton<MATGlobalCommonFunctionsFHIR4_6_1_000>
 {

--- a/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
+++ b/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("MeasureExample", "0.0.1")]
 public partial class MeasureExample_0_0_1 : ILibrary, ISingleton<MeasureExample_0_0_1>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAAdvancedIllnessandFrailty", "1.0.0")]
 public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<NCQAAdvancedIllnessandFrailty_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQACQLBase", "1.0.0")]
 public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAClaims", "1.0.0")]
 public partial class NCQAClaims_1_0_0 : ILibrary, ISingleton<NCQAClaims_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAEncounter", "1.0.0")]
 public partial class NCQAEncounter_1_0_0 : ILibrary, ISingleton<NCQAEncounter_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAFHIRBase", "1.0.0")]
 public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAHealthPlanEnrollment", "1.0.0")]
 public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAHealthPlanEnrollment_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAHospice", "1.0.0")]
 public partial class NCQAHospice_1_0_0 : ILibrary, ISingleton<NCQAHospice_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAPalliativeCare", "1.0.0")]
 public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliativeCare_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQAStatus", "1.0.0")]
 public partial class NCQAStatus_1_0_0 : ILibrary, ISingleton<NCQAStatus_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("NCQATerminology", "1.0.0")]
 public partial class NCQATerminology_1_0_0 : ILibrary, ISingleton<NCQATerminology_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PalliativeCareFHIR", "0.6.000")]
 public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<PalliativeCareFHIR_0_6_000>
 {

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR", "0.0.008")]
 public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008 : ILibrary, ISingleton<PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008>
 {

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SafeUseofOpioidsConcurrentPrescribingFHIR", "0.0.012")]
 public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrary, ISingleton<SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012>
 {

--- a/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("SupplementalDataElementsFHIR4", "2.0.000")]
 public partial class SupplementalDataElementsFHIR4_2_0_000 : ILibrary, ISingleton<SupplementalDataElementsFHIR4_2_0_000>
 {

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("TJCOverallFHIR", "1.8.000")]
 public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHIR_1_8_000>
 {

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.0.11.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "2.1.0.0")]
 [CqlLibrary("VTEFHIR4", "4.8.000")]
 public partial class VTEFHIR4_4_8_000 : ILibrary, ISingleton<VTEFHIR4_4_8_000>
 {


### PR DESCRIPTION
* Detach versioning between CQL SDK and generated C# library output
* When the code generating logic changes, the version must be manually incremented in `_CODE GENERATOR VERSION_.cs`, and any library invokers must be updated accordingly
* Updated c# generated code

Related submodule PR's
* [Integration.Runner](https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/pull/33)
* [Ncqa.DQIC](https://github.com/FirelyTeam/Ncqa.DQIC/pull/15)