### PR TITLE
Handle retrieve filter with code and respective unit test

### DIFF
--- a/Cql/Cql.CqlToElm/Visitors/ExpressionVisitor.cs
+++ b/Cql/Cql.CqlToElm/Visitors/ExpressionVisitor.cs
@@ -12,7 +12,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
             ModelProvider = services.GetRequiredService<IModelProvider>();
             CoercionProvider = services.GetRequiredService<CoercionProvider>();
             ElmFactory = services.GetRequiredService<ElmFactory>();
-            Messaging = services.GetRequiredService<MessageProvider>(); 
+            Messaging = services.GetRequiredService<MessageProvider>();
             Options = services.GetRequiredService<IOptions<CqlToElmOptions>>().Value;
             TypeSpecifierVisitor = new TypeSpecifierVisitor(services, builder);
             InvocationBuilder = services.GetRequiredService<InvocationBuilder>();
@@ -60,7 +60,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
             // When enabled, allow Interval<Any> to be created for Interval[null, null].
             // This is normally disabled.
             if ((Options.AllowNullIntervals ?? false)
-                && low is Null 
+                && low is Null
                 && low.resultTypeSpecifier == SystemTypes.AnyType
                 && high is Null
                 && high.resultTypeSpecifier == SystemTypes.AnyType)
@@ -70,14 +70,13 @@ namespace Hl7.Cql.CqlToElm.Visitors
                     .WithResultType(SystemTypes.AnyType.ToIntervalType());
             }
 
-            var intervalSelector = InvocationBuilder.MatchSignature(SystemLibrary.Interval, 
-                low, 
-                high, 
+            var intervalSelector = InvocationBuilder.MatchSignature(SystemLibrary.Interval,
+                low,
+                high,
                 ElmFactory.Literal(lowClosed), ElmFactory.Literal(highClosed));
 
             if (intervalSelector.Compatible)
             {
-                
                 var interval = InvocationBuilder.Invoke(intervalSelector);
                 // TODO: this should be incorporated in the validation framework
                 // The validation framework is static and can't accept configuration options :(
@@ -185,6 +184,16 @@ namespace Hl7.Cql.CqlToElm.Visitors
                 { } => new ExpressionRef { name = contextName },
                 _ => null
             };
+
+            if (terminology?.GetType() == typeof(CodeRef))
+            {
+                codeComparator = "~";
+                codePath = "code";
+                terminology = new ToList
+                {
+                    operand = terminology
+                };
+            }
 
             var retrieve = new Retrieve
             {

--- a/Cql/CqlToElmTests/(tests)/RetrieveTest.cs
+++ b/Cql/CqlToElmTests/(tests)/RetrieveTest.cs
@@ -108,5 +108,88 @@ namespace Hl7.Cql.CqlToElm.Test
             }
         }
 
+
+        [TestMethod]
+        public void Retrieve_FilteredByCode()
+        {
+            var cqlToolkit = CreateCqlToolkit();
+            var cqlLibraryString = CqlLibraryString.Parse("""
+                library FilteredRetrieve version '1.0.0'
+
+                using FHIR version '4.0.1'
+                codesystem LOINC: 'http://loinc.org'
+                code "Body height": '8302-2' from LOINC
+
+                define "Body height observations":
+                    [Observation: "Body height"]
+                """);
+            var lib = cqlToolkit.MakeLibrary(cqlLibraryString.Cql);
+
+            var r = lib.Should().BeACorrectlyInitializedLibraryWithStatementOfType<Retrieve>();
+            r.Should().NotBeNull();
+
+            Assert.AreEqual(1, lib.codeSystems.Length);
+            Assert.AreEqual(1, lib.codes.Length);
+            Assert.AreEqual(1, lib.statements.Length);
+            Assert.IsInstanceOfType(lib.statements[0].expression, typeof(Retrieve));
+
+            var retrieve = (Retrieve)lib.statements[0].expression;
+            Assert.AreEqual("code", retrieve.codeProperty);
+            Assert.AreEqual("~", retrieve.codeComparator);
+            Assert.IsNotNull(retrieve.codes);
+            Assert.IsInstanceOfType(retrieve.codes, typeof(ToList));
+
+            var toList = (ToList)retrieve.codes;
+            Assert.IsInstanceOfType(toList.operand, typeof(CodeRef));
+
+            var codeRef = (CodeRef)toList.operand;
+            Assert.AreEqual("Body height", codeRef.name);
+
+            using var librarySetInvoker = cqlToolkit.CreateLibrarySetInvoker();
+
+            var bundle = new Bundle
+            {
+                Entry = new List<Bundle.EntryComponent>
+                {
+                    new Bundle.EntryComponent
+                    {
+                        Resource = new Observation
+                        {
+                            Id = "1",
+                            Code = new CodeableConcept
+                            {
+                                Coding = new List<Coding>
+                                {
+                                    new Coding { Code = "8302-2",  System = "http://loinc.org" }
+                                }
+                            }
+                        }
+                    },
+                    new Bundle.EntryComponent
+                    {
+                        Resource = new Observation
+                        {
+                            Id = "2",
+                            Code = new CodeableConcept
+                            {
+                                Coding = new List<Coding>
+                                {
+                                    new Coding { Code = "29463-7",  System = "http://loinc.org" }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = librarySetInvoker.GetLibraryDefinitionResult(
+                FhirCqlContext.ForBundle(bundle),
+                cqlLibraryString.LibraryIdentifier, "Body height observations");
+
+            result.Should().NotBeNull();
+            Assert.IsInstanceOfType(result, typeof(IEnumerable<Observation>));
+            var observations = (IEnumerable<Observation>)result;
+            Assert.AreEqual(1, observations.Count());
+        }
     }
 }


### PR DESCRIPTION
Fix for #789 
Add some code to check if the terminology is just a CodeRef and handle accordingly. 

The implementation is heavily inspired by the ELM created via the java toolchain and tries to mimic the respective result. 