### PR TITLE
Support string based unit definition in convert-statement

### DIFF
--- a/Cql/Cql.CqlToElm/Visitors/UnaryExpressionVisitor.cs
+++ b/Cql/Cql.CqlToElm/Visitors/UnaryExpressionVisitor.cs
@@ -131,7 +131,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
 
             if (!typeSpecifier.IsOrderedType())
                 expression.AddError($"Can only determine {extent} for types that are ordered.");
-            
+
             return expression
                 .WithId()
                 .WithLocator(context.Locator());
@@ -148,7 +148,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
                 .WithLocator(context.Locator());
         }
 
-        //   expression ('is' | 'as') typeSpecifier  
+        //   expression ('is' | 'as') typeSpecifier
         public override Expression VisitTypeExpression([NotNull] cqlParser.TypeExpressionContext context)
         {
             var operand = Visit(context.expression());
@@ -165,7 +165,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
                     operand = operand,
                     isTypeSpecifier = typeSpecifier,
                     isType = typeSpecifier is NamedTypeSpecifier nts ? typeSpecifier.resultTypeName : null
-                }.WithResultType(SystemTypes.BooleanType);                
+                }.WithResultType(SystemTypes.BooleanType);
             }
             else if (@operator == "as")
             {
@@ -251,14 +251,24 @@ namespace Hl7.Cql.CqlToElm.Visitors
             else
             {
                 var unit = context.unit();
-                DateTimePrecision dtp;
+                Literal literal;
                 if (unit.dateTimePrecision() is { } dtpc)
-                    dtp = dtpc.Parse();
+                {
+                    var parsedDtpc = dtpc.Parse();
+                    literal = ElmFactory.Literal(parsedDtpc);
+                }
                 else if (unit.pluralDateTimePrecision() is { } pdtpc)
-                    dtp = pdtpc.Parse();
+                {
+                    var parsedPdtpc = pdtpc.Parse();
+                    literal = ElmFactory.Literal(parsedPdtpc);
+                }
+                else if (unit.STRING() is { } unitString)
+                {
+                    var parsedUnitString = unitString.ParseString() ?? unitString.GetText();
+                    literal = ElmFactory.Literal(parsedUnitString);
+                }
                 else
                     throw new InvalidOperationException("Syntax error; expected unit.");
-                var literal = ElmFactory.Literal(dtp);
                 return new ConvertQuantity { operand = [expression, literal] }
                     .WithId()
                     .WithLocator(context.Locator())

--- a/Cql/CqlToElmTests/(tests)/ConvertTest.cs
+++ b/Cql/CqlToElmTests/(tests)/ConvertTest.cs
@@ -47,5 +47,28 @@ namespace Hl7.Cql.CqlToElm.Test
 
         }
 
+        [TestMethod]
+        public void Convert_Meters_to_Centimeters()
+        {
+            var library = CreateCqlToolkit().MakeLibraryFromExpression("convert 5 'm' to 'cm'");
+            var quantity = library.Should().BeACorrectlyInitializedLibraryWithStatementOfType<ConvertQuantity>();
+            var result = Run(quantity, library);
+            var q = result.Should().BeOfType<CqlQuantity>().Subject;
+            q.value.Should().Be(500m);
+            q.unit.Should().Be("cm");
+        }
+
+        /* Mass units are not yet defined and respective conversions not yet implemented, see UcumUnits.cs and UnitConverter.cs
+        [TestMethod]
+        public void Convert_Grams_to_Kilograms()
+        {
+            var library = CreateCqlToolkit().MakeLibraryFromExpression("convert 500 'g' to 'kg'");
+            var quantity = library.Should().BeACorrectlyInitializedLibraryWithStatementOfType<ConvertQuantity>();
+            var result = Run(quantity, library);
+            var q = result.Should().BeOfType<CqlQuantity>().Subject;
+            q.value.Should().Be(0.5m);
+            q.unit.Should().Be("kg");
+        }
+        */
     }
 }

--- a/Cql/CqlToElmTests/(tests)/ConvertTest.cs
+++ b/Cql/CqlToElmTests/(tests)/ConvertTest.cs
@@ -58,8 +58,8 @@ namespace Hl7.Cql.CqlToElm.Test
             q.unit.Should().Be("cm");
         }
 
-        /* Mass units are not yet defined and respective conversions not yet implemented, see UcumUnits.cs and UnitConverter.cs
         [TestMethod]
+        [Ignore("Mass units are not yet defined and respective conversions not yet implemented, see UcumUnits.cs and UnitConverter.cs")]
         public void Convert_Grams_to_Kilograms()
         {
             var library = CreateCqlToolkit().MakeLibraryFromExpression("convert 500 'g' to 'kg'");
@@ -69,6 +69,5 @@ namespace Hl7.Cql.CqlToElm.Test
             q.value.Should().Be(0.5m);
             q.unit.Should().Be("kg");
         }
-        */
     }
 }


### PR DESCRIPTION
Fixes #793 

Handle case for a unit given as a string in `VisitConversionExpressionTerm()` via additional `else if`-statement

Adding unit test for meter to centimeter conversion. 