### PR TITLE
Add capability to invoke CQL functions to the InvocationToolkit

### DIFF
--- a/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
+++ b/Cql/CodeGeneration.NET/LibrarySetCSharpCodeGenerator.cs
@@ -318,6 +318,7 @@ internal partial class LibrarySetCSharpCodeGenerator
             LambdaExpression overload = Overload;
             TupleMetadataBuilder tupleMetadataBuilder = LibraryWriter.LibrarySetWriter.TupleMetadataBuilder;
             var isDef = IsDefinition(overload);
+            var isFunc = IsFunction(overload);
 
             var vng = new VariableNameGenerator(Enumerable.Empty<string>(), postfix: "_");
 
@@ -334,7 +335,7 @@ internal partial class LibrarySetCSharpCodeGenerator
 
             overload = Expression.Lambda(visitedBody, parameters);
 
-            if (isDef)
+            if (isDef || isFunc)
             {
                 IndentedTextWriter.WriteLine($"[CqlDeclaration({CqlName.QuoteString()})]");
                 WriteTags();
@@ -375,6 +376,10 @@ internal partial class LibrarySetCSharpCodeGenerator
 
         private static bool IsDefinition(LambdaExpression overload) =>
             overload.Parameters.Count == 1
+            && overload.Parameters[0].Type == typeof(CqlContext);
+
+        private static bool IsFunction(LambdaExpression overload) =>
+            overload.Parameters.Count > 1
             && overload.Parameters[0].Type == typeof(CqlContext);
 
         private static Expression Transform(Expression body, params ExpressionVisitor[] visitors)

--- a/Cql/CoreTests/InvocationToolkitTests.cs
+++ b/Cql/CoreTests/InvocationToolkitTests.cs
@@ -105,4 +105,27 @@ public class InvocationToolkitTests
                                  { "description", ["Patients in the IP"] }
                              });
     }
+
+    [TestMethod]
+    public void TestFunctionInvocation()
+    {
+        const int arg1 = 2;
+        const int arg2 = 3;
+        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
+        var cqlLibraryString = CqlLibraryString.Parse(
+            """
+            library FunctionTest version '1.0.0'
+            define function Add(a Integer, b Integer): a + b
+            """);
+        var cqlToolkit = new CqlToolkit(config: cqlToElmProcessorSettings)
+            .AddCqlLibraries(cqlLibraryString);
+
+        using var librarySetInvoker = cqlToolkit.CreateLibrarySetInvoker();
+
+        var cqlContext = FhirCqlContext.ForBundle();
+        var result =
+            librarySetInvoker.GetLibraryFunctionResult(cqlContext, cqlLibraryString.LibraryIdentifier, "Add", arg1, arg2);
+
+        result.Should().Be(arg1+arg2, "The function should return the sum of the two arguments.");
+    }
 }

--- a/Cql/Cql.Invocation/Toolkit/Extensions/LibrarySetInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/LibrarySetInvokerExtensions.cs
@@ -144,4 +144,19 @@ public static class LibrarySetInvokerExtensions
         var result = libraryDefinitionInvoker.Invoke(cqlContext);
         return result;
     }
+
+    [DebuggerStepperBoundary]
+    public static object? GetLibraryFunctionResult(
+        this LibrarySetInvoker librarySetInvoker,
+        CqlContext cqlContext,
+        CqlVersionedLibraryIdentifier libraryIdentifier,
+        string functionName,
+        params object[] functionArguments)
+    {
+        var libraryInvoker = librarySetInvoker.LibraryInvokers[libraryIdentifier];
+        var libraryFunctionInvoker = libraryInvoker.Functions[functionName];
+        var result = libraryFunctionInvoker.Invoke(cqlContext, functionArguments);
+
+        return result;
+    }
 }

--- a/Cql/Cql.Invocation/Toolkit/FunctionInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/FunctionInvoker.cs
@@ -1,0 +1,74 @@
+﻿using Hl7.Cql.Runtime;
+using static Hl7.Cql.Invocation.Toolkit.StringBuilderExtensions;
+
+namespace Hl7.Cql.Invocation.Toolkit;
+
+/// <summary>
+/// Abstract base class representing a function invoker.
+/// </summary>
+/// <param name="libraryInvoker">The library invoker that created this instance.</param>
+/// <param name="functionName">The name of the function.</param>
+/// <param name="methodInfo">The method information for the definition.</param>
+/// <param name="tagValuesByName">The tag values associated with the definition.</param>
+/// <param name="valueSetId">The value set identifier, if any.</param>
+public abstract class FunctionInvoker(
+    LibraryInvoker libraryInvoker,
+    string functionName,
+    MethodInfo methodInfo,
+    IReadOnlyDictionary<string, IReadOnlySet<string>> tagValuesByName,
+    string? valueSetId)
+{
+    /// <summary>
+    /// The library invoker that created this instance.
+    /// </summary>
+    private LibraryInvoker LibraryInvoker { get; } = libraryInvoker;
+
+    /// <summary>
+    /// Gets the name of the function.
+    /// </summary>
+    public string FunctionName { get;  } = functionName;
+
+    protected MethodInfo MethodInfo { get; } = methodInfo;
+
+    /// <summary>
+    /// Gets the tag values by tag name that is associated with the definition.
+    /// Where there duplicate tags by name, their values will be combined into a set.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlySet<string>> TagValuesByName { get; } = tagValuesByName;
+
+    /// <summary>
+    /// Gets the return type of the function.
+    /// </summary>
+    public Type ReturnType => MethodInfo.ReturnType;
+
+    /// <summary>
+    /// A convenience property to get the library identifier of the library that contains this definition.
+    /// </summary>
+    public CqlVersionedLibraryIdentifier LibraryIdentifier => LibraryInvoker.LibraryIdentifier;
+
+    /// <summary>
+    /// A convenience property to get the library set name.
+    /// </summary>
+    public string LibrarySetName => LibraryInvoker.LibrarySetName;
+
+    /// <summary>
+    /// Gets the value set identifier, if any.
+    /// </summary>
+    public string? ValueSetId { get; } = valueSetId;
+
+    /// <summary>
+    /// Invokes the function with the given CQL context and the given arguments.
+    /// </summary>
+    /// <param name="cqlContext">The CQL context.</param>
+    /// <param name="args">Additional arguments of the function.</param>
+    /// <returns>The result of the invocation.</returns>
+    public abstract object? Invoke(CqlContext cqlContext, params object[] args);
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        StartBrace()
+            .AppendMemberIf(LibrarySetName, LibrarySetName is { Length: > 0 })
+            .AppendMember(LibraryIdentifier)
+            .AppendMember(FunctionName)
+            .EndBrace();
+}

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.2_0_8_0.cs
@@ -51,12 +51,29 @@ internal sealed class LibraryInvoker_2_0_8_0 : LibraryInvokerOnInstance
                                                && o.Method.GetParameters() is [{ } p0]
                                                && p0.ParameterType == typeof(CqlContext)
                                                    ? (DefinitionInvoker)new DefinitionInvoker_2_0_8_0(
-                                                       this, declarationName, Library, o.Method, o.TagValuesByName, o.ValueSetId)
+                                                       this, declarationName, Library, o.Method, o.TagValuesByName,
+                                                       o.ValueSetId)
                                                    : null)
                       .ToImmutableDictionary(o => o.DefinitionName);
+
+        Functions = libraryMethodInfos
+            .SelectWhereNotNull(o => o.DeclarationName is { } functionName
+                                             && o.Method.GetParameters().Length > 1
+                                             && o.Method.GetParameters()[0].ParameterType == typeof(CqlContext)
+                                            //&& o.Method.GetParameters() is [{ } p0, .. var pRest]
+                                            //&& p0.ParameterType == typeof(CqlContext)
+                                            //&& pRest.Length > 0
+                                                ? (FunctionInvoker)new FunctionInvoker_2_0_8_0(
+                                                     this, functionName, Library, o.Method, o.TagValuesByName,
+                                                     o.ValueSetId)
+                                                : null)
+                    .ToImmutableDictionary(o => o.FunctionName);
     }
 
     public override IReadOnlyDictionary<string, DefinitionInvoker> Definitions { get; }
+
+    public override IReadOnlyDictionary<string, FunctionInvoker> Functions { get; }
+
 
     private static object GetLibraryFromStaticInstanceProperty(Type libraryType)
     {
@@ -104,4 +121,17 @@ file class DefinitionInvoker_2_0_8_0
 {
     public override object? Invoke(CqlContext cqlContext) =>
         MethodInfo.Invoke(library, BindingFlags.DoNotWrapExceptions, null, [cqlContext], CultureInfo.InvariantCulture);
+}
+
+file class FunctionInvoker_2_0_8_0(
+    LibraryInvoker libraryInvoker,
+    string functionName,
+    ILibrary library,
+    MethodInfo methodInfo,
+    IReadOnlyDictionary<string, IReadOnlySet<string>> tagValuesByName,
+    string? valueSetId) : FunctionInvoker(libraryInvoker, functionName, methodInfo, tagValuesByName, valueSetId)
+{
+    public override object? Invoke(CqlContext cqlContext, params object[] args) =>
+        MethodInfo.Invoke(library, BindingFlags.DoNotWrapExceptions, null, [cqlContext, ..args], CultureInfo.InvariantCulture);
+
 }

--- a/Cql/Cql.Invocation/Toolkit/LibraryInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/LibraryInvoker.cs
@@ -71,6 +71,11 @@ public abstract class LibraryInvoker
     public abstract IReadOnlyDictionary<string, DefinitionInvoker> Definitions { get; }
 
     /// <summary>
+    /// Gets the dictionary of function invokers for the CQL library.
+    /// </summary>
+    public abstract IReadOnlyDictionary<string, FunctionInvoker> Functions { get; }
+
+    /// <summary>
     /// Tries to create a <see cref="LibraryInvoker"/> instance from the specified type.
     /// </summary>
     /// <param name="librarySetInvoker">The library set invoker that created the <see cref="LibraryInvoker"/>.</param>


### PR DESCRIPTION
Implement feature request #824 

- Adds new method `GetLibraryFunctionResult(...)` to the InvocationToolkit's `LibrarySetInvoker` (-> `LibrarySetInvocationExtensions.cs`)
- Adds a new abstract base class `FunctionInvoker` (-> `FunctionInvoker.cs`)
- Adds an implementation for the FunctionInvoker in the `LibraryInvokcer.2_0_8_0` class (-> `LibraryInvoker.2_0_8_0.cs`)
- Extends the `LibrarySetCSharpCodeGenerator` to ensure that functions receive the `[CqlDeclaration()]` attribute (-> `LibrarySetCSharpCodeGenerator.cs`)
- Adds a small unit test to demonstrate and test the expected behaviour (-> `InvocationToolkitTests.cs`) 

The whole implementation is very much inspired and basically identical to the implementation for the invocation of definitions.