### PR TITLE
831 when selecting results from invocationtoolkit allow callback before each

### DIFF
--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
@@ -10,7 +10,6 @@ using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Hl7.Cql.CodeGeneration.NET.Toolkit.Internal;
 using Hl7.Cql.Compiler;
-using Hl7.Cql.Elm;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.Toolkit;
 using Microsoft.Extensions.DependencyInjection;

--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkitConversionRecord.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkitConversionRecord.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using Hl7.Cql.Elm;
 using Hl7.Cql.Runtime;
 
 namespace Hl7.Cql.CodeGeneration.NET.Toolkit;

--- a/Cql/CoreTests/InvocationToolkitTests.cs
+++ b/Cql/CoreTests/InvocationToolkitTests.cs
@@ -31,7 +31,7 @@ public class InvocationToolkitTests
 
         // Act
         var result = librarySetInvoker
-                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"), TODO)
+                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"))
                      .SelectResults(ctx)
                      .ToDictionary(t => t.definitionInvoker.DefinitionName);
 

--- a/Cql/CoreTests/InvocationToolkitTests.cs
+++ b/Cql/CoreTests/InvocationToolkitTests.cs
@@ -31,8 +31,8 @@ public class InvocationToolkitTests
 
         // Act
         var result = librarySetInvoker
-                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"))
-                     .SelectResults(ctx, null)
+                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"), TODO)
+                     .SelectResults(ctx)
                      .ToDictionary(t => t.definitionInvoker.DefinitionName);
 
         // Assert

--- a/Cql/CoreTests/QueriesTest.cs
+++ b/Cql/CoreTests/QueriesTest.cs
@@ -1,16 +1,13 @@
 ﻿#nullable enable
 using Hl7.Cql.CodeGeneration.NET.Toolkit;
 using Hl7.Cql.CodeGeneration.NET.Toolkit.Extensions;
-using Hl7.Cql.CodeGeneration.NET.Toolkit.Internal;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Primitives;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;
 using Hl7.Fhir.Model;
-using Hl7.Cql.Compiler;
 using Hl7.Cql.Invocation.Toolkit;
 using Hl7.Cql.Invocation.Toolkit.Extensions;
-using Hl7.Cql.Runtime.Hosting;
 
 namespace CoreTests
 {

--- a/Cql/CoreTests/Tuples/CqlTupleTests.cs
+++ b/Cql/CoreTests/Tuples/CqlTupleTests.cs
@@ -114,7 +114,7 @@ public class CqlTupleTests
 
         // Act
         var result = librarySetInvoker
-                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"), TODO)
+                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"))
                      .SelectResults(ctx)
                      .ToDictionary(t => t.definitionInvoker.DefinitionName, t => t.invocationResult);
         Assert.IsNotNull(result);

--- a/Cql/CoreTests/Tuples/CqlTupleTests.cs
+++ b/Cql/CoreTests/Tuples/CqlTupleTests.cs
@@ -114,8 +114,8 @@ public class CqlTupleTests
 
         // Act
         var result = librarySetInvoker
-                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"))
-                     .SelectResults(ctx, null)
+                     .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.Parse("CqlNestedTupleTest-1.0.0"), TODO)
+                     .SelectResults(ctx)
                      .ToDictionary(t => t.definitionInvoker.DefinitionName, t => t.invocationResult);
         Assert.IsNotNull(result);
         result.TryGetValue("Result", out var obj);

--- a/Cql/Cql.Compiler/ExpressionBuilderContext.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilderContext.LibraryDefs.cs
@@ -6,10 +6,8 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Hl7.Cql.Compiler.Expressions;
-using Hl7.Cql.Compiler.Infrastructure;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Primitives;
 

--- a/Cql/Cql.Compiler/LibraryExpressionBuilderContext.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/LibraryExpressionBuilderContext.LibraryDefs.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Exceptions;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Primitives;

--- a/Cql/Cql.Invocation/Toolkit/Extensions/DefinitionInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/DefinitionInvokerExtensions.cs
@@ -18,48 +18,41 @@ namespace Hl7.Cql.Invocation.Toolkit.Extensions;
 public static class DefinitionInvokerExtensions
 {
     /// <summary>
-    /// Enumerates library expression invocations.
+    /// Invokes the definitions in the provided collection of <see cref="DefinitionInvoker"/> instances
+    /// and returns their results along with the corresponding invokers.
     /// </summary>
     ///
-    /// <param name="definitionInvokers">The definition invokers to get results from.</param>
-    /// <param name="cqlContext">The CQL context used for invocation.</param>
-    /// <param name="definitionInvocationExceptionCallback">
-    /// <para>
-    /// An optional callback right after an exception is caught, and before it rethrown or ignored,
-    /// based on the currently selected
-    /// <see cref="LibrarySetInvoker.BatchProcessExceptionContinuation">LibrarySetInvoker.BatchProcessExceptionContinuation</see>.
-    /// </para>
-    /// <para>
-    /// In most cases this is only necessary when the selected strategy is set to Ignore exceptions and when the caller
-    /// has a special use case for it, e.g. to keep track of these exceptions.
-    /// </para>
-    /// <para>
-    /// Otherwise, it's best to just catch the exception the normal way.
-    /// </para>
+    /// <param name="definitionInvokers">
+    /// A collection of <see cref="DefinitionInvoker"/> instances to be invoked.
     /// </param>
-    /// <returns>An enumeration of tuples containing the definition invoker and the result.</returns>
     ///
-    /// <remarks>
-    /// <para>
-    /// Exceptions are enriched such that the last <see cref="DefinitionInvoker"/> that caused
-    /// the exception is available when inspecting the <see cref="Exception.Data">Exception.Data["Current"]</see> property.
-    /// </para>
+    /// <param name="cqlContext">
+    /// The <see cref="CqlContext"/> used during the invocation of the definitions.
+    /// </param>
     ///
-    /// <para>
-    /// From the <see cref="DefinitionInvoker"/> the name of the
-    /// <see cref="DefinitionInvoker.LibraryIdentifier"/> and <see cref="DefinitionInvoker.DefinitionName"/> are available.
-    /// </para>
-    /// </remarks>
+    /// <param name="selectResultsOptions">
+    /// An optional <see cref="SelectResultsOptions"/> instance that provides callbacks for customizing behavior.
+    /// </param>
+    ///
+    /// <returns>
+    /// An enumerable of tuples where each tuple contains a <see cref="DefinitionInvoker"/> and its
+    /// corresponding invocation result.
+    /// </returns>
     public static IEnumerable<(DefinitionInvoker definitionInvoker, object? invocationResult)> SelectResults(
         this IEnumerable<DefinitionInvoker> definitionInvokers,
         CqlContext cqlContext,
-        ValueExceptionHandler<DefinitionInvoker>? definitionInvocationExceptionCallback = null)
+        SelectResultsOptions? selectResultsOptions = null)
     {
+        selectResultsOptions ??= SelectResultsOptions.Default;
+
+        var (
+            argumentsProviderCallback,
+            invocationExceptionCallback,
+            preInvokeHandler,
+            postInvokeHandler) = selectResultsOptions;
+
         if (definitionInvokers.TryGetNonEnumeratedCount(out int count) && count == 0)
             return [];
-
-        // We can only invoke definitions with no additional parameters besides the CqlContext.
-        definitionInvokers = definitionInvokers.Where(definitionInvoker => definitionInvoker.ParameterTypes.Length == 0);
 
         // We need to enumerate twice, which isn't a problem in the case of collections.
         if (definitionInvokers is not IReadOnlyCollection<DefinitionInvoker> or ICollection<DefinitionInvoker>)
@@ -80,13 +73,133 @@ public static class DefinitionInvokerExtensions
         // ReSharper disable once PossibleMultipleEnumeration
         return definitionInvokers
             .TrySelect(
-                definitionInvoker => (definitionInvoker, definitionInvoker.Invoke(cqlContext)),
+                definitionInvoker =>
+                {
+                    object?[] args = [];
+                    if (definitionInvoker.ParameterTypes.Length > 0)
+                    {
+                        if (argumentsProviderCallback is null)
+                            throw new ArgumentException($"The definition {definitionInvoker} has parameters, but no arguments were provided.");
+                        args = argumentsProviderCallback(definitionInvoker, cqlContext);
+                        if (args.Length != definitionInvoker.ParameterTypes.Length)
+                            throw new ArgumentException($"The number of arguments ({args.Length}) does not match the number of parameters ({definitionInvoker.ParameterTypes.Length}) for definition {definitionInvoker}.");
+                    }
+
+                    preInvokeHandler?.Invoke(definitionInvoker, cqlContext, args);
+                    (DefinitionInvoker definitionInvoker, object? invocationResult) result = (definitionInvoker, definitionInvoker.Invoke(cqlContext, args));
+                    postInvokeHandler?.Invoke(definitionInvoker, cqlContext, args, result.invocationResult);
+                    return result;
+                },
                 errorStrategy => errorStrategy
                                  .SetContinuation(continuation)
                                  .AddLoggerExceptionHandler(
                                      logger,
                                      (definitionInvoker, logMessage) => logMessage("Could not invoke definition {definition}", definitionInvoker))
-                                 .AddExceptionHandler(definitionInvocationExceptionCallback)
+                                 .AddExceptionHandler(invocationExceptionCallback)
             );
     }
 }
+
+/// <summary>
+/// Represents a delegate that is invoked before the execution of a CQL definition.
+/// </summary>
+/// <param name="definitionInvoker">
+/// The <see cref="DefinitionInvoker"/> responsible for invoking the CQL definition.
+/// </param>
+/// <param name="cqlContext">
+/// The <see cref="CqlContext"/> providing the execution context for the CQL definition.
+/// </param>
+/// <param name="definitionArguments">
+/// An array of arguments to be passed to the CQL definition.
+/// </param>
+public delegate void PreInvokeDefinitionHandler(
+    DefinitionInvoker definitionInvoker,
+    CqlContext cqlContext,
+    object?[] definitionArguments);
+
+/// <summary>
+/// Represents a callback delegate that provides arguments for a CQL definition invocation.
+/// </summary>
+/// <param name="definitionInvoker">
+/// The <see cref="DefinitionInvoker"/> instance responsible for invoking the CQL definition.
+/// </param>
+/// <param name="cqlContext">
+/// The <see cref="CqlContext"/> representing the execution context for the CQL definition.
+/// </param>
+/// <returns>
+/// An array of objects representing the arguments to be passed to the CQL definition.
+/// </returns>
+public delegate object?[] DefinitionArgumentsProviderCallback(
+    DefinitionInvoker definitionInvoker,
+    CqlContext cqlContext);
+
+/// <summary>
+/// Represents a delegate that is invoked after the execution of a CQL definition.
+/// </summary>
+/// <param name="definitionInvoker">
+/// The <see cref="DefinitionInvoker"/> responsible for invoking the CQL definition.
+/// </param>
+/// <param name="cqlContext">
+/// The <see cref="CqlContext"/> providing the execution context for the CQL definition.
+/// </param>
+/// <param name="definitionArguments">
+/// An array of arguments passed to the CQL definition during invocation.
+/// </param>
+/// <param name="definitionResult">
+/// The result produced by the execution of the CQL definition.
+/// </param>
+public delegate void PostInvokeDefinitionHandler(
+    DefinitionInvoker definitionInvoker,
+    CqlContext cqlContext,
+    object?[] definitionArguments,
+    object? definitionResult);
+
+/// <summary>
+/// Represents the options for selecting results during the invocation of CQL definitions.
+/// </summary>
+///
+/// <remarks>
+/// This record provides callbacks for customizing the behavior of definition invocations,
+/// including argument provision, pre-invocation actions, and exception handling.
+/// </remarks>
+///
+/// <param name="DefinitionArgumentsProviderCallback">
+/// A callback function that provides arguments for each <see cref="DefinitionInvoker"/>
+/// that have more than one parameter. When selecting definitions from SelectExpressions, the
+/// default behavior is to not include definitions with parameters, unless includeDefinitionsWithParameters
+/// was set to <c>true</c>. If this is the case, you must provide a callback to supply the arguments,
+/// otherwise it is not needed.
+/// </param>
+///
+/// <param name="PreInvokeDefinitionCallback">
+/// A callback invoked before the execution of a definition.
+/// </param>
+///
+/// <param name="PostInvokeDefinitionCallback">
+/// A callback invoked after the execution of a definition, containing the result of the invocation.
+/// </param>
+///
+/// <param name="DefinitionInvocationExceptionCallback">
+/// A callback for handling exceptions that occur during the definition invocation.
+/// It takes the <see cref="DefinitionInvoker"/>, the exception, and a continuation strategy as parameters.
+/// </param>
+public record SelectResultsOptions(
+    DefinitionArgumentsProviderCallback? DefinitionArgumentsProviderCallback = null,
+    ValueExceptionHandler<DefinitionInvoker>? DefinitionInvocationExceptionCallback = null,
+    PreInvokeDefinitionHandler? PreInvokeDefinitionCallback = null,
+    PostInvokeDefinitionHandler? PostInvokeDefinitionCallback = null)
+{
+    /// <summary>
+    /// Gets the default instance of <see cref="SelectResultsOptions"/> with no custom callbacks or exception handlers.
+    /// </summary>
+    /// <remarks>
+    /// This property provides a pre-configured instance of <see cref="SelectResultsOptions"/> with all optional
+    /// callbacks and exception handlers set to <c>null</c>. It can be used as a baseline configuration
+    /// when no specific customization is required.
+    /// </remarks>
+    /// <value>
+    /// A default instance of <see cref="SelectResultsOptions"/>.
+    /// </value>
+    public static SelectResultsOptions Default { get; } = new();
+}
+

--- a/Cql/Cql.Invocation/Toolkit/Extensions/DefinitionInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/DefinitionInvokerExtensions.cs
@@ -47,9 +47,8 @@ public static class DefinitionInvokerExtensions
 
         var (
             argumentsProviderCallback,
-            invocationExceptionCallback,
             preInvokeHandler,
-            postInvokeHandler) = selectResultsOptions;
+            postInvokeHandler, invocationExceptionCallback) = selectResultsOptions;
 
         if (definitionInvokers.TryGetNonEnumeratedCount(out int count) && count == 0)
             return [];
@@ -163,7 +162,7 @@ public delegate void PostInvokeDefinitionHandler(
 /// including argument provision, pre-invocation actions, and exception handling.
 /// </remarks>
 ///
-/// <param name="DefinitionArgumentsProviderCallback">
+/// <param name="ProviderArgumentsCallback">
 /// A callback function that provides arguments for each <see cref="DefinitionInvoker"/>
 /// that have more than one parameter. When selecting definitions from SelectExpressions, the
 /// default behavior is to not include definitions with parameters, unless includeDefinitionsWithParameters
@@ -179,15 +178,15 @@ public delegate void PostInvokeDefinitionHandler(
 /// A callback invoked after the execution of a definition, containing the result of the invocation.
 /// </param>
 ///
-/// <param name="DefinitionInvocationExceptionCallback">
+/// <param name="InvocationExceptionCallback">
 /// A callback for handling exceptions that occur during the definition invocation.
 /// It takes the <see cref="DefinitionInvoker"/>, the exception, and a continuation strategy as parameters.
 /// </param>
 public record SelectResultsOptions(
-    DefinitionArgumentsProviderCallback? DefinitionArgumentsProviderCallback = null,
-    ValueExceptionHandler<DefinitionInvoker>? DefinitionInvocationExceptionCallback = null,
+    DefinitionArgumentsProviderCallback? ProviderArgumentsCallback = null,
     PreInvokeDefinitionHandler? PreInvokeDefinitionCallback = null,
-    PostInvokeDefinitionHandler? PostInvokeDefinitionCallback = null)
+    PostInvokeDefinitionHandler? PostInvokeDefinitionCallback = null,
+    ValueExceptionHandler<DefinitionInvoker>? InvocationExceptionCallback = null)
 {
     /// <summary>
     /// Gets the default instance of <see cref="SelectResultsOptions"/> with no custom callbacks or exception handlers.

--- a/Cql/Cql.Invocation/Toolkit/Extensions/LibraryInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/LibraryInvokerExtensions.cs
@@ -18,11 +18,14 @@ namespace Hl7.Cql.Invocation.Toolkit.Extensions;
 public static class LibraryInvokerExtensions
 {
     /// <summary>
-    /// Enumerates the expressions in the library.
+    /// 
     /// </summary>
-    /// <param name="libraryInvoker">The library invoker.</param>
+    /// <param name="libraryInvoker"></param>
+    /// <param name="includeDefinitionsWithParameters"></param>
+    /// <returns></returns>
     public static IEnumerable<DefinitionInvoker> SelectExpressions(
-        this LibraryInvoker libraryInvoker) =>
+        this LibraryInvoker libraryInvoker,
+        bool includeDefinitionsWithParameters = false) =>
         libraryInvoker
             .Definitions.Values
             .Where(definitionInvoker =>
@@ -37,7 +40,8 @@ public static class LibraryInvokerExtensions
         this LibraryInvoker libraryInvoker) =>
         libraryInvoker
             .Definitions.Values
-            .Where(definitionInvoker => definitionInvoker.CqlDefinitionAttribute.GetType() == typeof(CqlFunctionDefinitionAttribute));
+            .Where(definitionInvoker =>
+                       definitionInvoker.CqlDefinitionAttribute.GetType() == typeof(CqlFunctionDefinitionAttribute));
 
     /// <summary>
     /// Enumerates the value sets in the library.

--- a/Cql/Cql.Invocation/Toolkit/Extensions/LibrarySetInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/LibrarySetInvokerExtensions.cs
@@ -17,19 +17,28 @@ namespace Hl7.Cql.Invocation.Toolkit.Extensions;
 public static class LibrarySetInvokerExtensions
 {
     /// <summary>
-    /// Enumerates the expressions in the library set.
+    /// 
     /// </summary>
-    /// <param name="librarySetInvoker">The library set invoker of which to enumerate expressions for all libraries.</param>
+    /// <param name="librarySetInvoker"></param>
+    /// <param name="includeDefinitionsWithParameters"></param>
+    /// <returns></returns>
     public static IEnumerable<DefinitionInvoker> SelectExpressions(
-        this LibrarySetInvoker librarySetInvoker) =>
+        this LibrarySetInvoker librarySetInvoker,
+        bool includeDefinitionsWithParameters = false) =>
         librarySetInvoker
             .LibraryInvokers.Values
-            .SelectMany(libraryInvoker => libraryInvoker.SelectExpressions());
+            .SelectMany(libraryInvoker => libraryInvoker.SelectExpressions(includeDefinitionsWithParameters));
 
     /// <summary>
-    /// Enumerates the functions in the library set.
+    /// Retrieves all function definitions from the libraries within the specified <see cref="LibrarySetInvoker"/>.
     /// </summary>
-    /// <param name="librarySetInvoker">The library set invoker of which to enumerate functions for all libraries.</param>
+    /// <param name="librarySetInvoker">
+    /// The <see cref="LibrarySetInvoker"/> instance containing the libraries to search for function definitions.
+    /// </param>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="DefinitionInvoker"/> representing the function definitions
+    /// found in the libraries.
+    /// </returns>
     public static IEnumerable<DefinitionInvoker> SelectFunctions(
         this LibrarySetInvoker librarySetInvoker) =>
         librarySetInvoker
@@ -37,26 +46,56 @@ public static class LibrarySetInvokerExtensions
             .SelectMany(libraryInvoker => libraryInvoker.SelectFunctions());
 
     /// <summary>
-    /// Enumerates the definitions in the library set.
+    /// Selects the expressions defined in the specified library from the <see cref="LibrarySetInvoker"/>.
     /// </summary>
-    /// <param name="librarySetInvoker">The library set invoker.</param>
-    /// <param name="libraryIdentifier">The library on which definitions enumerated.</param>
+    /// <param name="librarySetInvoker">
+    /// The <see cref="LibrarySetInvoker"/> containing the library invokers.
+    /// </param>
+    /// <param name="libraryIdentifier">
+    /// The identifier of the library whose expressions are to be selected.
+    /// </param>
+    /// <param name="includeDefinitionsWithParameters">
+    /// A boolean value indicating whether to include definitions that have parameters.
+    /// Defaults to <c>false</c>.
+    /// </param>
+    /// <returns>
+    /// A collection of <see cref="DefinitionInvoker"/> instances representing the selected expressions.
+    /// If the specified library is not found, an empty collection is returned.
+    /// </returns>
     public static IEnumerable<DefinitionInvoker> SelectExpressionsForLibrary(
         this LibrarySetInvoker librarySetInvoker,
-        CqlVersionedLibraryIdentifier libraryIdentifier) =>
+        CqlVersionedLibraryIdentifier libraryIdentifier,
+        bool includeDefinitionsWithParameters = false) =>
         librarySetInvoker.LibraryInvokers.TryGetValue(libraryIdentifier, out var libraryInvoker)
-            ? libraryInvoker.SelectExpressions()
+            ? libraryInvoker.SelectExpressions(includeDefinitionsWithParameters)
             : [];
 
     /// <summary>
-    /// Gets the result of a specific definition in a specific library.
+    /// Invokes a library definition within the specified library set using the provided context, library identifier, 
+    /// definition signature, and arguments.
     /// </summary>
-    /// <param name="librarySetInvoker">The library set invoker.</param>
-    /// <param name="cqlContext">The CQL context.</param>
-    /// <param name="libraryIdentifier">The identifier of the library.</param>
-    /// <param name="definitionSignature">The name of the definition with its associated parameter types.</param>
-    /// <param name="args">Any additional arguments for the invocation (typically when calling a function definition).</param>
-    /// <returns>The result of the definition invocation.</returns>
+    /// <param name="librarySetInvoker">
+    /// The <see cref="LibrarySetInvoker"/> instance that contains the library set to invoke the definition from.
+    /// </param>
+    /// <param name="cqlContext">
+    /// The <see cref="CqlContext"/> representing the execution context for the invocation.
+    /// </param>
+    /// <param name="libraryIdentifier">
+    /// The <see cref="CqlVersionedLibraryIdentifier"/> identifying the library containing the definition to invoke.
+    /// </param>
+    /// <param name="definitionSignature">
+    /// The <see cref="DefinitionSignature"/> representing the signature of the definition to invoke.
+    /// </param>
+    /// <param name="args">
+    /// The arguments to pass to the definition during invocation.
+    /// </param>
+    /// <returns>
+    /// The result of the library definition invocation, or <c>null</c> if the invocation does not produce a result.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the number of provided arguments does not match the number of parameters in the definition signature,
+    /// or when the arguments do not match the expected parameter types.
+    /// </exception>
     [DebuggerStepperBoundary]
     public static object? InvokeLibraryDefinition(
         this LibrarySetInvoker librarySetInvoker,

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.3.0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.3.0.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using System.Runtime.CompilerServices;
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Hl7.Cql.CodeGeneration.NET;

--- a/Cql/CqlToElmTests/(tests)/FHIRHelpersTest.cs
+++ b/Cql/CqlToElmTests/(tests)/FHIRHelpersTest.cs
@@ -1,5 +1,4 @@
 using Hl7.Cql.Elm;
-using Hl7.Cql.Runtime;
 
 namespace Hl7.Cql.CqlToElm.Test
 {

--- a/Cql/CqlToElmTests/(tests)/RefTest.cs
+++ b/Cql/CqlToElmTests/(tests)/RefTest.cs
@@ -1,7 +1,6 @@
 using Hl7.Cql.Elm;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Primitives;
-using Hl7.Cql.Runtime;
 using M = Hl7.Fhir.Model;
 
 namespace Hl7.Cql.CqlToElm.Test

--- a/Cql/Elm/Elm.cs
+++ b/Cql/Elm/Elm.cs
@@ -6,7 +6,6 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
-using System.Threading;
 using Hl7.Cql.Abstractions.Exceptions;
 using Hl7.Cql.Runtime;
 

--- a/Demo/CLI/LibraryRunner.cs
+++ b/Demo/CLI/LibraryRunner.cs
@@ -1,14 +1,9 @@
 ﻿using CLI.Helpers;
-using Dumpify;
-using Hl7.Cql.Abstractions;
 using Hl7.Cql.CodeGeneration.NET;
-using Hl7.Cql.Fhir;
 using Hl7.Cql.Invocation.Toolkit;
 using Hl7.Cql.Invocation.Toolkit.Extensions;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.ValueSets;
-using Hl7.Fhir.Model;
-using Hl7.Fhir.Serialization;
 
 namespace CLI
 {

--- a/Demo/CqlApiExamples/Program.cs
+++ b/Demo/CqlApiExamples/Program.cs
@@ -31,21 +31,21 @@ internal static class Program
         // Create a logger factory via the Microsoft.Extensions.Logging API
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
-        // AddDuplicates(loggerFactory);
-        // Add3And2Example(loggerFactory);
-        // InvokeCqlExample(loggerFactory);
+        AddDuplicates(loggerFactory);
+        Add3And2Example(loggerFactory);
+        InvokeCqlExample(loggerFactory);
         InvokeCqlFromExamplesFolder(loggerFactory);
-        // PackageFromExamplesFolder(loggerFactory);
-        //
-        // string[] exampleSetNames = ["CMS", "Authoring", "CMS", "Demo", "Tests", "RR23"];
-        // foreach (var exampleSetName in exampleSetNames)
-        // {
-        //     Directories dirs = Directories.Create(exampleSetName);
-        //     //PackageCqlToFhirExample(loggerFactory, dirs);
-        //     PackageElmToFhirExample(loggerFactory, dirs);
-        //     dirs = dirs with { FhirInDirectory = dirs.FhirOutDirectory };
-        //     InvokeResourceExample(loggerFactory, dirs);
-        // }
+        PackageFromExamplesFolder(loggerFactory);
+
+        string[] exampleSetNames = ["CMS", "Authoring", "CMS", "Demo", "Tests", "RR23"];
+        foreach (var exampleSetName in exampleSetNames)
+        {
+            Directories dirs = Directories.Create(exampleSetName);
+            //PackageCqlToFhirExample(loggerFactory, dirs);
+            PackageElmToFhirExample(loggerFactory, dirs);
+            dirs = dirs with { FhirInDirectory = dirs.FhirOutDirectory };
+            InvokeResourceExample(loggerFactory, dirs);
+        }
     }
 
     private static void AddDuplicates(ILoggerFactory loggerFactory)

--- a/Demo/CqlApiExamples/Program.cs
+++ b/Demo/CqlApiExamples/Program.cs
@@ -31,21 +31,21 @@ internal static class Program
         // Create a logger factory via the Microsoft.Extensions.Logging API
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
-        AddDuplicates(loggerFactory);
-        Add3And2Example(loggerFactory);
-        InvokeCqlExample(loggerFactory);
+        // AddDuplicates(loggerFactory);
+        // Add3And2Example(loggerFactory);
+        // InvokeCqlExample(loggerFactory);
         InvokeCqlFromExamplesFolder(loggerFactory);
-        PackageFromExamplesFolder(loggerFactory);
-
-        string[] exampleSetNames = ["CMS", "Authoring", "CMS", "Demo", "Tests", "RR23"];
-        foreach (var exampleSetName in exampleSetNames)
-        {
-            Directories dirs = Directories.Create(exampleSetName);
-            //PackageCqlToFhirExample(loggerFactory, dirs);
-            PackageElmToFhirExample(loggerFactory, dirs);
-            dirs = dirs with { FhirInDirectory = dirs.FhirOutDirectory };
-            InvokeResourceExample(loggerFactory, dirs);
-        }
+        // PackageFromExamplesFolder(loggerFactory);
+        //
+        // string[] exampleSetNames = ["CMS", "Authoring", "CMS", "Demo", "Tests", "RR23"];
+        // foreach (var exampleSetName in exampleSetNames)
+        // {
+        //     Directories dirs = Directories.Create(exampleSetName);
+        //     //PackageCqlToFhirExample(loggerFactory, dirs);
+        //     PackageElmToFhirExample(loggerFactory, dirs);
+        //     dirs = dirs with { FhirInDirectory = dirs.FhirOutDirectory };
+        //     InvokeResourceExample(loggerFactory, dirs);
+        // }
     }
 
     private static void AddDuplicates(ILoggerFactory loggerFactory)
@@ -229,10 +229,33 @@ internal static class Program
                                                 .AddCqlLibrariesFromDirectory(dirs.CqlFromDirectory)
                                                 .CreateLibrarySetInvoker(name: "Examples");
 
-        logger.LogInformation("{dump}", librarySetInvoker.DumpLibraryDefinitions());
+        //logger.LogInformation("{dump}", librarySetInvoker.DumpLibraryDefinitions());
+
+        // Calling invocations individually
         Trace.Assert(Invoke("CqlAggregateFunctionsTest-1.0.000", "Count.CountTestTime") is 3);
         Trace.Assert(Invoke("CqlAggregateFunctionsTest-1.0.000", "Count.CountTestNull") is 0);
         Trace.Assert(Invoke("CqlStringOperatorsTest-1.0.000", "Combine.CombineABCSepDash") is "a-b-c");
+
+        // Invoking all expressions in a library
+        var results = librarySetInvoker
+                      .SelectExpressions()
+                      .SelectResults(
+                          cqlContext,
+                          SelectResultsOptions.Default with
+                          {
+                              PreInvokeDefinitionCallback = (
+                                      invoker,
+                                      context,
+                                      arguments) =>
+                                  logger.LogInformation("Invoking definition {definition} with arguments [{arguments}]", invoker, arguments),
+                              PostInvokeDefinitionCallback = (
+                                      invoker,
+                                      context,
+                                      arguments,
+                                      result) =>
+                                  logger.LogInformation("Invoked definition {definition} with result {result}", invoker, result),
+                          })
+                      .ToList(); // Important to enumerate the results here, otherwise nothing will be invoked
 
         object? Invoke(string libraryName, string declarationName)
         {
@@ -403,7 +426,7 @@ file static class Extensions
                   .Select(definitionInvoker => (definitionInvoker, default(object)))
                 : librarySetInvoker
                   .SelectExpressions()
-                  .SelectResults(cqlContext, null);
+                  .SelectResults(cqlContext);
 
         foreach (var groupedByLibrary in
                  definitions.GroupBy(o => o.definitionInvoker.LibraryIdentifier))

--- a/Demo/Test.Measures.Demo/MeasuresTest.cs
+++ b/Demo/Test.Measures.Demo/MeasuresTest.cs
@@ -52,7 +52,7 @@ namespace Test
             var ctx = FhirCqlContext.ForBundle(patientEverything, MY2023, valueSets);
 
             var results = scope
-                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, version))
+                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, version), TODO)
                           .SelectResults(ctx)
                           .ToDictionary(t => t.definitionInvoker.DefinitionName, t => t.invocationResult);
 

--- a/Demo/Test.Measures.Demo/MeasuresTest.cs
+++ b/Demo/Test.Measures.Demo/MeasuresTest.cs
@@ -52,7 +52,7 @@ namespace Test
             var ctx = FhirCqlContext.ForBundle(patientEverything, MY2023, valueSets);
 
             var results = scope
-                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, version), TODO)
+                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, version))
                           .SelectResults(ctx)
                           .ToDictionary(t => t.definitionInvoker.DefinitionName, t => t.invocationResult);
 


### PR DESCRIPTION
⚠️  Also review [Integration Runner](https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/pull/44)

Updates the invocation toolkit:
* Allows `SelectExpressions` to include expressions which contains parameters. Default is to exclude.
* Callbacks added for `SelectResults` wrapped in `SelectResultsOptions`:
  * `ProviderArgumentsCallback`: A callback for providing arguments for expressions with parameters
  * `PreInvokeDefinitionCallback`: A callback just before invoking the expression
  * `PostInvokeDefinitionCallback`: A callback just after invoking the expression which contains the result
  * `InvocationExceptionCallback`: A callback for fail invocations