### PR TITLE
834 Add ElmR1 and Fhir401 models by default to CqlToolkitConfig

### DIFF
--- a/Cql/CoreTests/InvocationToolkitTests.cs
+++ b/Cql/CoreTests/InvocationToolkitTests.cs
@@ -62,10 +62,7 @@ public class InvocationToolkitTests
                               """;
 
         var cqlToolkit =
-            new CqlToolkit(config: CqlToolkitConfig.Default with
-                {
-                    Models = [CqlModel.ElmR1, CqlModel.Fhir401],
-                })
+            new CqlToolkit()
                 .AddCqlLibraries(cqlMeasuresExample)
                 .TranslateToElm();
 
@@ -112,13 +109,12 @@ public class InvocationToolkitTests
     {
         const int arg1 = 2;
         const int arg2 = 3;
-        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
         var cqlLibraryString = CqlLibraryString.Parse(
             """
             library FunctionTest version '1.0.0'
             define function Add(a Integer, b Integer): a + b
             """);
-        var cqlToolkit = new CqlToolkit(config: cqlToElmProcessorSettings)
+        var cqlToolkit = new CqlToolkit()
             .AddCqlLibraries(cqlLibraryString);
 
         using var librarySetInvoker = cqlToolkit.CreateLibrarySetInvoker();

--- a/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
@@ -71,7 +71,6 @@ Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.AmbiguousTypeBehavior.get -> Hl7.Cql.C
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.AmbiguousTypeBehavior.init -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.CqlToolkitConfig(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig! original) -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.CqlToolkitConfig(System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>? Models = null, System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.Model.ModelInfo!>? ModelInfos = null, Hl7.Cql.CqlToElm.AmbiguousTypeBehavior AmbiguousTypeBehavior = Hl7.Cql.CqlToElm.AmbiguousTypeBehavior.Error, string? SystemElmModelUri = "urn:hl7-org:elm-types:r1", string? SystemElmModelVersion = "1.0.0", bool EnableListDemotion = false, bool EnableListPromotion = false, bool EnableIntervalDemotion = false, bool EnableIntervalPromotion = false, bool AllowNullIntervals = false, bool ValidateIntervals = true, bool LongsRequireSuffix = true, bool ValidateLiterals = true) -> void
-Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Deconstruct(out System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>? Models, out System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.Model.ModelInfo!>? ModelInfos, out Hl7.Cql.CqlToElm.AmbiguousTypeBehavior AmbiguousTypeBehavior, out string? SystemElmModelUri, out string? SystemElmModelVersion, out bool EnableListDemotion, out bool EnableListPromotion, out bool EnableIntervalDemotion, out bool EnableIntervalPromotion, out bool AllowNullIntervals, out bool ValidateIntervals, out bool LongsRequireSuffix, out bool ValidateLiterals) -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalDemotion.get -> bool
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalDemotion.init -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalPromotion.get -> bool
@@ -115,9 +114,6 @@ Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.LibraryIdentifier.get -> Hl7.Cql
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.LibraryIdentifier.init -> void
 Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions
 override Hl7.Cql.CqlToElm.CqlLibraryString.GetHashCode() -> int
-override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Equals(object? obj) -> bool
-override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.GetHashCode() -> int
-override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.ToString() -> string!
 override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.GetHashCode() -> int
 override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.GetHashCode() -> int
 static Hl7.Cql.CqlToElm.CqlLibraryString.explicit operator Hl7.Cql.CqlToElm.CqlLibraryString(string! cqlLibraryString) -> Hl7.Cql.CqlToElm.CqlLibraryString
@@ -139,8 +135,8 @@ static Hl7.Cql.CqlToElm.ModelProvider.ToElm(this Hl7.Cql.Model.TupleTypeSpecifie
 static Hl7.Cql.CqlToElm.ModelProvider.ToElm(this Hl7.Cql.Model.TypeSpecifier! ts, Hl7.Cql.CqlToElm.IModelProvider! provider) -> Hl7.Cql.Elm.TypeSpecifier!
 static Hl7.Cql.CqlToElm.ModelProvider.TryGetTypeInfoFor(this Hl7.Cql.Model.ModelInfo! model, string! name, out Hl7.Cql.Model.TypeInfo? result) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Default.get -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig!
-static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? right) -> bool
-static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.operator ==(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? right) -> bool
+static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.DefaultCqlModels.get -> System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>!
+static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.DefaultCqlModels.set -> void
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord right) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.operator ==(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord right) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord right) -> bool
@@ -151,10 +147,7 @@ static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.AddCqlLibraryFil
 static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.GetCqlToolkitResults(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit) -> System.Collections.Generic.IEnumerable<Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord>!
 static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.SaveElmFilesToDirectory(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit, System.IO.DirectoryInfo! directory, bool writeIndented = false, Hl7.Cql.Runtime.IO.DirectoryInfoHandler? directoryPreparationStrategy = null) -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkit!
 static readonly Hl7.Cql.CqlToElm.CqlToElmOptions.Default -> Hl7.Cql.CqlToElm.CqlToElmOptions!
-virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.<Clone>$() -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig!
 virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EqualityContract.get -> System.Type!
-virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Equals(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? other) -> bool
-virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.PrintMembers(System.Text.StringBuilder! builder) -> bool
 ~override Hl7.Cql.CqlToElm.CqlLibraryString.Equals(object obj) -> bool
 ~override Hl7.Cql.CqlToElm.CqlLibraryString.ToString() -> string
 ~override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.Equals(object obj) -> bool

--- a/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
@@ -71,6 +71,7 @@ Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.AmbiguousTypeBehavior.get -> Hl7.Cql.C
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.AmbiguousTypeBehavior.init -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.CqlToolkitConfig(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig! original) -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.CqlToolkitConfig(System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>? Models = null, System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.Model.ModelInfo!>? ModelInfos = null, Hl7.Cql.CqlToElm.AmbiguousTypeBehavior AmbiguousTypeBehavior = Hl7.Cql.CqlToElm.AmbiguousTypeBehavior.Error, string? SystemElmModelUri = "urn:hl7-org:elm-types:r1", string? SystemElmModelVersion = "1.0.0", bool EnableListDemotion = false, bool EnableListPromotion = false, bool EnableIntervalDemotion = false, bool EnableIntervalPromotion = false, bool AllowNullIntervals = false, bool ValidateIntervals = true, bool LongsRequireSuffix = true, bool ValidateLiterals = true) -> void
+Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Deconstruct(out System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>? Models, out System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.Model.ModelInfo!>? ModelInfos, out Hl7.Cql.CqlToElm.AmbiguousTypeBehavior AmbiguousTypeBehavior, out string? SystemElmModelUri, out string? SystemElmModelVersion, out bool EnableListDemotion, out bool EnableListPromotion, out bool EnableIntervalDemotion, out bool EnableIntervalPromotion, out bool AllowNullIntervals, out bool ValidateIntervals, out bool LongsRequireSuffix, out bool ValidateLiterals) -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalDemotion.get -> bool
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalDemotion.init -> void
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EnableIntervalPromotion.get -> bool
@@ -114,6 +115,9 @@ Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.LibraryIdentifier.get -> Hl7.Cql
 Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.LibraryIdentifier.init -> void
 Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions
 override Hl7.Cql.CqlToElm.CqlLibraryString.GetHashCode() -> int
+override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Equals(object? obj) -> bool
+override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.GetHashCode() -> int
+override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.ToString() -> string!
 override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.GetHashCode() -> int
 override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.GetHashCode() -> int
 static Hl7.Cql.CqlToElm.CqlLibraryString.explicit operator Hl7.Cql.CqlToElm.CqlLibraryString(string! cqlLibraryString) -> Hl7.Cql.CqlToElm.CqlLibraryString
@@ -137,6 +141,8 @@ static Hl7.Cql.CqlToElm.ModelProvider.TryGetTypeInfoFor(this Hl7.Cql.Model.Model
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Default.get -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig!
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.DefaultCqlModels.get -> System.Collections.Immutable.ImmutableHashSet<Hl7.Cql.CqlToElm.Toolkit.CqlModel>!
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.DefaultCqlModels.set -> void
+static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? right) -> bool
+static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.operator ==(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? right) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord right) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.operator ==(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord right) -> bool
 static Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord.operator !=(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord left, Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord right) -> bool
@@ -147,7 +153,10 @@ static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.AddCqlLibraryFil
 static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.GetCqlToolkitResults(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit) -> System.Collections.Generic.IEnumerable<Hl7.Cql.CqlToElm.Toolkit.CqlToolkitResultRecord>!
 static Hl7.Cql.CqlToElm.Toolkit.Extensions.CqlToolkitExtensions.SaveElmFilesToDirectory(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit, System.IO.DirectoryInfo! directory, bool writeIndented = false, Hl7.Cql.Runtime.IO.DirectoryInfoHandler? directoryPreparationStrategy = null) -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkit!
 static readonly Hl7.Cql.CqlToElm.CqlToElmOptions.Default -> Hl7.Cql.CqlToElm.CqlToElmOptions!
+virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.<Clone>$() -> Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig!
 virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.EqualityContract.get -> System.Type!
+virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.Equals(Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig? other) -> bool
+virtual Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConfig.PrintMembers(System.Text.StringBuilder! builder) -> bool
 ~override Hl7.Cql.CqlToElm.CqlLibraryString.Equals(object obj) -> bool
 ~override Hl7.Cql.CqlToElm.CqlLibraryString.ToString() -> string
 ~override Hl7.Cql.CqlToElm.Toolkit.CqlToolkitConversionRecord.Equals(object obj) -> bool

--- a/Cql/Cql.CqlToElm/Toolkit/CqlToolkitConfig.cs
+++ b/Cql/Cql.CqlToElm/Toolkit/CqlToolkitConfig.cs
@@ -135,6 +135,11 @@ public record CqlToolkitConfig(
     )
 {
     /// <summary>
+    /// Gets or sets the default set of CQL models to use when translating CQL to ELM.
+    /// </summary>
+    public static ImmutableHashSet<CqlModel> DefaultCqlModels { get; set; } = [CqlModel.ElmR1, CqlModel.Fhir401];
+
+    /// <summary>
     /// The default configuration for the CQL toolkit.
     /// </summary>
     public static CqlToolkitConfig Default { get; } = new();
@@ -142,7 +147,7 @@ public record CqlToolkitConfig(
     /// <summary>
     /// The model information to use when translating CQL to ELM.
     /// </summary>
-    public ImmutableHashSet<CqlModel> Models { get; init; } = Models ?? [];
+    public ImmutableHashSet<CqlModel> Models { get; init; } = Models ?? DefaultCqlModels;
 
     /// <summary>
     /// The model information to use when translating CQL to ELM.

--- a/Cql/Cql.Invocation/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Invocation/PublicAPI.Unshipped.txt
@@ -14,11 +14,26 @@ Hl7.Cql.Invocation.Toolkit.DefinitionInvoker.ParameterTypes.get -> System.Type![
 Hl7.Cql.Invocation.Toolkit.DefinitionInvoker.ReturnType.get -> System.Type!
 Hl7.Cql.Invocation.Toolkit.DefinitionInvoker.TagValuesByName.get -> System.Collections.Generic.IReadOnlyDictionary<string!, System.Collections.Generic.IReadOnlySet<string!>!>!
 Hl7.Cql.Invocation.Toolkit.Extensions.CqlToolkitInvocationExtensions
+Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionArgumentsProviderCallback
 Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionInvokerExtensions
 Hl7.Cql.Invocation.Toolkit.Extensions.ElmToolkitInvocationExtensions
 Hl7.Cql.Invocation.Toolkit.Extensions.InvocationToolkitExtensions
 Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions
 Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions
+Hl7.Cql.Invocation.Toolkit.Extensions.PostInvokeDefinitionHandler
+Hl7.Cql.Invocation.Toolkit.Extensions.PreInvokeDefinitionHandler
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.Deconstruct(out Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionArgumentsProviderCallback? ProviderArgumentsCallback, out Hl7.Cql.Invocation.Toolkit.Extensions.PreInvokeDefinitionHandler? PreInvokeDefinitionCallback, out Hl7.Cql.Invocation.Toolkit.Extensions.PostInvokeDefinitionHandler? PostInvokeDefinitionCallback, out Hl7.Cql.Runtime.ValueExceptionHandler<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>? InvocationExceptionCallback) -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.InvocationExceptionCallback.get -> Hl7.Cql.Runtime.ValueExceptionHandler<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>?
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.InvocationExceptionCallback.init -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.PostInvokeDefinitionCallback.get -> Hl7.Cql.Invocation.Toolkit.Extensions.PostInvokeDefinitionHandler?
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.PostInvokeDefinitionCallback.init -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.PreInvokeDefinitionCallback.get -> Hl7.Cql.Invocation.Toolkit.Extensions.PreInvokeDefinitionHandler?
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.PreInvokeDefinitionCallback.init -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.ProviderArgumentsCallback.get -> Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionArgumentsProviderCallback?
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.ProviderArgumentsCallback.init -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.SelectResultsOptions(Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionArgumentsProviderCallback? ProviderArgumentsCallback = null, Hl7.Cql.Invocation.Toolkit.Extensions.PreInvokeDefinitionHandler? PreInvokeDefinitionCallback = null, Hl7.Cql.Invocation.Toolkit.Extensions.PostInvokeDefinitionHandler? PostInvokeDefinitionCallback = null, Hl7.Cql.Runtime.ValueExceptionHandler<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>? InvocationExceptionCallback = null) -> void
+Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.SelectResultsOptions(Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions! original) -> void
 Hl7.Cql.Invocation.Toolkit.InvocationToolkit
 Hl7.Cql.Invocation.Toolkit.InvocationToolkit.AddAssemblyBinaries(System.Collections.Generic.IEnumerable<Hl7.Cql.CodeGeneration.NET.AssemblyBinary!>! assemblyBinary) -> Hl7.Cql.Invocation.Toolkit.InvocationToolkit!
 Hl7.Cql.Invocation.Toolkit.InvocationToolkit.AssemblyBinaries.get -> System.Collections.Generic.IReadOnlySet<Hl7.Cql.CodeGeneration.NET.AssemblyBinary!>!
@@ -43,12 +58,15 @@ Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.LibrarySetName.get -> string!
 Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.LoggerFactory.get -> Microsoft.Extensions.Logging.ILoggerFactory!
 Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.SetBatchProcessExceptionContinuation(Hl7.Cql.Runtime.BatchProcessExceptionContinuation continuation) -> Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!
 override Hl7.Cql.Invocation.Toolkit.DefinitionInvoker.ToString() -> string!
+override Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.Equals(object? obj) -> bool
+override Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.GetHashCode() -> int
+override Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.ToString() -> string!
 override Hl7.Cql.Invocation.Toolkit.LibraryInstanceInvoker.DependencyLibraryIdentifiers.get -> System.Collections.Generic.IReadOnlyCollection<Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier>!
 override Hl7.Cql.Invocation.Toolkit.LibraryInstanceInvoker.LibraryIdentifier.get -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 override Hl7.Cql.Invocation.Toolkit.LibraryInvoker.ToString() -> string!
 override Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.ToString() -> string?
 static Hl7.Cql.Invocation.Toolkit.Extensions.CqlToolkitInvocationExtensions.CreateLibrarySetInvoker(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit, Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig? elmToolkitConfig = null, string! name = "") -> Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!
-static Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionInvokerExtensions.SelectResults(this System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>! definitionInvokers, Hl7.Cql.Runtime.CqlContext! cqlContext, Hl7.Cql.Runtime.ValueExceptionHandler<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>? definitionInvocationExceptionCallback = null) -> System.Collections.Generic.IEnumerable<(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definitionInvoker, object? invocationResult)>!
+static Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionInvokerExtensions.SelectResults(this System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>! definitionInvokers, Hl7.Cql.Runtime.CqlContext! cqlContext, Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? selectResultsOptions = null) -> System.Collections.Generic.IEnumerable<(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definitionInvoker, object? invocationResult)>!
 static Hl7.Cql.Invocation.Toolkit.Extensions.ElmToolkitInvocationExtensions.CreateInvocationToolkit(this Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkit! elmToolkit) -> Hl7.Cql.Invocation.Toolkit.InvocationToolkit!
 static Hl7.Cql.Invocation.Toolkit.Extensions.ElmToolkitInvocationExtensions.CreateLibrarySetInvoker(this Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkit! elmToolkit, string! name = "") -> Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!
 static Hl7.Cql.Invocation.Toolkit.Extensions.ElmToolkitInvocationExtensions.UseLibrarySetInvoker(this Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkit! elmToolkit, System.Action<Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!>! useLibrarySetInvoker, string! librarySetName = "") -> void
@@ -58,10 +76,20 @@ static Hl7.Cql.Invocation.Toolkit.Extensions.InvocationToolkitExtensions.AddAsse
 static Hl7.Cql.Invocation.Toolkit.Extensions.InvocationToolkitExtensions.AddAssemblyBinaryFilesFromDirectory(this Hl7.Cql.Invocation.Toolkit.InvocationToolkit! invocationToolkit, System.IO.DirectoryInfo! directory, System.IO.EnumerationOptions? options = null, System.Func<System.IO.FileInfo!, bool>? filePredicate = null) -> Hl7.Cql.Invocation.Toolkit.InvocationToolkit!
 static Hl7.Cql.Invocation.Toolkit.Extensions.InvocationToolkitExtensions.UseLibrarySetInvoker(this Hl7.Cql.Invocation.Toolkit.InvocationToolkit! invocationToolkit, System.Action<Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!>! useLibrarySetInvoker, string! librarySetName = "") -> void
 static Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions.SelectCodes(this Hl7.Cql.Invocation.Toolkit.LibraryInvoker! libraryInvoker) -> System.Collections.Generic.IEnumerable<(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definition, Hl7.Cql.Primitives.CqlCode! code)>!
-static Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions.SelectExpressions(this Hl7.Cql.Invocation.Toolkit.LibraryInvoker! libraryInvoker) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
+static Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions.SelectExpressions(this Hl7.Cql.Invocation.Toolkit.LibraryInvoker! libraryInvoker, bool includeDefinitionsWithParameters = false) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
 static Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions.SelectFunctions(this Hl7.Cql.Invocation.Toolkit.LibraryInvoker! libraryInvoker) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
 static Hl7.Cql.Invocation.Toolkit.Extensions.LibraryInvokerExtensions.SelectValueSets(this Hl7.Cql.Invocation.Toolkit.LibraryInvoker! libraryInvoker) -> System.Collections.Generic.IEnumerable<(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definition, Hl7.Cql.Primitives.CqlValueSet! valueSet)>!
 static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.InvokeLibraryDefinition(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker, Hl7.Cql.Runtime.CqlContext! cqlContext, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier libraryIdentifier, Hl7.Cql.Runtime.DefinitionSignature! definitionSignature, params object?[]! args) -> object?
-static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.SelectExpressions(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
-static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.SelectExpressionsForLibrary(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier libraryIdentifier) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
+static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.SelectExpressions(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker, bool includeDefinitionsWithParameters = false) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
+static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.SelectExpressionsForLibrary(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier libraryIdentifier, bool includeDefinitionsWithParameters = false) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
 static Hl7.Cql.Invocation.Toolkit.Extensions.LibrarySetInvokerExtensions.SelectFunctions(this Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker! librarySetInvoker) -> System.Collections.Generic.IEnumerable<Hl7.Cql.Invocation.Toolkit.DefinitionInvoker!>!
+static Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.Default.get -> Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions!
+static Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.operator !=(Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? left, Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? right) -> bool
+static Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.operator ==(Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? left, Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? right) -> bool
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.DefinitionArgumentsProviderCallback.Invoke(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definitionInvoker, Hl7.Cql.Runtime.CqlContext! cqlContext) -> object?[]!
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.PostInvokeDefinitionHandler.Invoke(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definitionInvoker, Hl7.Cql.Runtime.CqlContext! cqlContext, object?[]! definitionArguments, object? definitionResult) -> void
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.PreInvokeDefinitionHandler.Invoke(Hl7.Cql.Invocation.Toolkit.DefinitionInvoker! definitionInvoker, Hl7.Cql.Runtime.CqlContext! cqlContext, object?[]! definitionArguments) -> void
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.<Clone>$() -> Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions!
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.EqualityContract.get -> System.Type!
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.Equals(Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions? other) -> bool
+virtual Hl7.Cql.Invocation.Toolkit.Extensions.SelectResultsOptions.PrintMembers(System.Text.StringBuilder! builder) -> bool

--- a/Cql/Cql.Invocation/Toolkit/Extensions/LibraryInvokerExtensions.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/LibraryInvokerExtensions.cs
@@ -18,7 +18,7 @@ namespace Hl7.Cql.Invocation.Toolkit.Extensions;
 public static class LibraryInvokerExtensions
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="libraryInvoker"></param>
     /// <param name="includeDefinitionsWithParameters"></param>

--- a/Cql/CqlToElmTests/Base.cs
+++ b/Cql/CqlToElmTests/Base.cs
@@ -206,18 +206,21 @@ namespace Hl7.Cql.CqlToElm.Test
             bool EnableListDemotion = false,
             bool EnableIntervalPromotion = false,
             bool EnableIntervalDemotion = false,
-            bool AllowNullIntervals = false) =>
-            new(LoggerFactory,
-                new CqlToolkitConfig(
-                    Models: Models ?? [CqlModel.ElmR1, CqlModel.Fhir401],
-                    ModelInfos: ModelInfos,
-                    AmbiguousTypeBehavior: AmbiguousTypeBehavior,
-                    EnableListDemotion: EnableListDemotion,
-                    EnableListPromotion: EnableListPromotion,
-                    EnableIntervalDemotion: EnableIntervalDemotion,
-                    EnableIntervalPromotion: EnableIntervalPromotion,
-                    AllowNullIntervals: AllowNullIntervals
-                ));
+            bool AllowNullIntervals = false)
+        {
+            Debug.Assert(CqlToolkitConfig.DefaultCqlModels.SetEquals([CqlModel.ElmR1, CqlModel.Fhir401]));
+            return new CqlToolkit(LoggerFactory,
+                                  new CqlToolkitConfig(
+                                      Models: Models,
+                                      ModelInfos: ModelInfos,
+                                      AmbiguousTypeBehavior: AmbiguousTypeBehavior,
+                                      EnableListDemotion: EnableListDemotion,
+                                      EnableListPromotion: EnableListPromotion,
+                                      EnableIntervalDemotion: EnableIntervalDemotion,
+                                      EnableIntervalPromotion: EnableIntervalPromotion,
+                                      AllowNullIntervals: AllowNullIntervals
+                                  ));
+        }
 
         internal static ElmToolkit CreateElmToolkit(
             ImmutableHashSet<CqlModel>? models = null,

--- a/Demo/CqlApiExamples/Program.cs
+++ b/Demo/CqlApiExamples/Program.cs
@@ -28,6 +28,9 @@ internal static class Program
 
     private static void Main(string[] args)
     {
+        // Confirm that the CqlToolkitConfig is set to use these models by default
+        Debug.Assert(CqlToolkitConfig.DefaultCqlModels.SetEquals([CqlModel.ElmR1, CqlModel.Fhir401]));
+
         // Create a logger factory via the Microsoft.Extensions.Logging API
         using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
@@ -116,8 +119,7 @@ internal static class Program
     private static void PackageFromExamplesFolder(ILoggerFactory loggerFactory)
     {
         // Create fluent cql toolkit
-        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
-        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory, cqlToElmProcessorSettings);
+        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory);
 
         // "Directories" is not a part of the API, but a helper class for this example
         var dirs = Directories.Create("Demo");
@@ -137,8 +139,7 @@ internal static class Program
         ILoggerFactory loggerFactory)
     {
         // Create fluent cql toolkit
-        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
-        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory, cqlToElmProcessorSettings);
+        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory);
 
         var cqlLibraryString = CqlLibraryString.Parse(
             """
@@ -218,8 +219,7 @@ internal static class Program
         var dirs = Directories.Create("Tests");
 
         // Create fluent cql toolkit
-        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
-        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory, cqlToElmProcessorSettings);
+        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory);
 
         // We can write extensions to make it even easier to change exception handling
         var cqlContext = FhirCqlContext.ForBundle();
@@ -277,8 +277,7 @@ internal static class Program
         dirs.GeneratedDirectory.Delete(recursive: true);
 
         // Create fluent cql toolkit
-        var config = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
-        var cqlToolkit = new CqlToolkit(loggerFactory, config);
+        var cqlToolkit = new CqlToolkit(loggerFactory);
         _ =
             cqlToolkit
                 .SetIgnoreEnumerationExceptions()
@@ -329,9 +328,8 @@ internal static class Program
         dirs.GeneratedDirectory.Delete(recursive: true);
 
         // Create fluent cql toolkit
-        var config = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
         CqlToolkit cqlToolkit =
-            new CqlToolkit(loggerFactory, config)
+            new CqlToolkit(loggerFactory)
                 .SetIgnoreEnumerationExceptions()
                 .AddCqlLibrariesFromDirectory(dirs.CqlFromDirectory);
 
@@ -368,8 +366,7 @@ internal static class Program
         ILoggerFactory loggerFactory)
     {
         // Create fluent cql toolkit
-        var cqlToElmProcessorSettings = new CqlToolkitConfig(Models: [CqlModel.ElmR1, CqlModel.Fhir401]);
-        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory, cqlToElmProcessorSettings);
+        CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory);
 
         // Add CQL libraries from a directory and process them to ELM, then save the ELM files to a directory
         cqlToolkit


### PR DESCRIPTION
Add static property `CqlToolkitConfig.DefaultCqlModels` and add `ElmR1` and `Fhir401` as defaults.
The default `CqlToolkitConfig` will use the values from this static property when models are not explicitly set
