### PR TITLE
Fix CqlToolkit to use correct BatchProcessExceptionContinuation

### DIFF
--- a/Cql/Cql.CqlToElm/Toolkit/CqlToolkit.cs
+++ b/Cql/Cql.CqlToElm/Toolkit/CqlToolkit.cs
@@ -134,7 +134,7 @@ public sealed class CqlToolkit : IToolkit<CqlToolkit>
                         conversions[r.LibraryIdentifier] = newConversionRecord;
                     },
                     errorStrategy => errorStrategy
-                                     .SetContinuation(BatchProcessExceptionContinuation.Continue)
+                                     .SetContinuation(BatchProcessExceptionContinuation)
                                      .AddLoggerExceptionHandler(_services.Logger,
                                                                 (conversion, messageBuilder) =>
                                                                     messageBuilder("Could not translate CQL to ELM: {lib}", conversion.LibraryIdentifier))


### PR DESCRIPTION
When translating cql to elm, the exception strategy was always `BatchProcessExceptionContinuation.Continue`. Instead it should have been `BatchProcessExceptionContinuation`, which is the configured value on the toolkit