### PR TITLE
818 Fix parsing

### DIFF
--- a/Cql/CoreTests/Infrastructure/CqlLibraryStringTests.cs
+++ b/Cql/CoreTests/Infrastructure/CqlLibraryStringTests.cs
@@ -85,8 +85,8 @@ namespace CoreTests.Infrastructure
         public void Parse_ValidQualifierIdentifierAndVersion_ReturnsCqlLibraryString()
         {
             // Arrange
-            string cqlContent = "library Namespace.TestLibrary version '1.0.0'";
-            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"Namespace.TestLibrary-1.0.0";
+            string cqlContent = "library NamespaceA.NamespaceB.TestLibrary version '1.0.0'";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"NamespaceA.NamespaceB.TestLibrary-1.0.0";
 
             // Act
             var result = CqlLibraryString.Parse(cqlContent);
@@ -138,7 +138,7 @@ namespace CoreTests.Infrastructure
 
             // Assert
             var e = Assert.ThrowsException<FormatException>(act);
-            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: extraneous input '<EOF>' expecting {QUOTEDIDENTIFIER, IDENTIFIER, DELIMITEDIDENTIFIER}.", e.Message);
+            Assert.AreEqual("Not a valid Hl7.Cql.CqlToElm.CqlLibraryString: Syntax error: extraneous input '<EOF>' expecting {QUOTEDIDENTIFIER, IDENTIFIER, DELIMITEDIDENTIFIER}.", e.Message);
         }
 
         [TestMethod]
@@ -167,7 +167,7 @@ namespace CoreTests.Infrastructure
 
             // Assert
             var e = Assert.ThrowsException<FormatException>(act);
-            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: missing 'library' at 'invalid'.", e.Message);
+            Assert.AreEqual("Not a valid Hl7.Cql.CqlToElm.CqlLibraryString: Syntax error: missing 'library' at 'invalid'.", e.Message);
         }
 
         [TestMethod]
@@ -181,7 +181,7 @@ namespace CoreTests.Infrastructure
 
             // Assert
             var e = Assert.ThrowsException<FormatException>(act);
-            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: mismatched input '<EOF>' expecting 'library'.", e.Message);
+            Assert.AreEqual("Not a valid Hl7.Cql.CqlToElm.CqlLibraryString: Syntax error: mismatched input '<EOF>' expecting 'library'.", e.Message);
         }
     }
 }

--- a/Cql/CoreTests/Infrastructure/CqlLibraryStringTests.cs
+++ b/Cql/CoreTests/Infrastructure/CqlLibraryStringTests.cs
@@ -7,7 +7,7 @@ namespace CoreTests.Infrastructure
     public class CqlLibraryStringTests
     {
         [TestMethod]
-        public void FromCql_ValidCqlContentWithoutVersion_ReturnsCqlLibraryString()
+        public void Parse_ValidCqlContentWithoutVersion_ReturnsCqlLibraryString()
         {
             // Arrange
             string cqlContent = "library TestLibrary";
@@ -22,7 +22,7 @@ namespace CoreTests.Infrastructure
         }
 
         [TestMethod]
-        public void FromCql_ValidCqlContentSkipCommentsAndWithoutVersion_ReturnsCqlLibraryString()
+        public void Parse_ValidCqlContentSkipCommentsAndWithoutVersion_ReturnsCqlLibraryString()
         {
             // Arrange
             string cqlContent = """
@@ -41,8 +41,7 @@ namespace CoreTests.Infrastructure
 
                 library TestLibrary
                 """;
-            var expectedIdentifier = CqlVersionedLibraryIdentifier.FromNameAndVersion(
-                CqlLibraryIdentifier.Parse("TestLibrary"));
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"TestLibrary";
 
             // Act
             var result = CqlLibraryString.Parse(cqlContent);
@@ -53,7 +52,7 @@ namespace CoreTests.Infrastructure
         }
 
         [TestMethod]
-        public void FromCql_ValidCqlContentWithEmptyLines_ReturnsCqlLibraryString()
+        public void Parse_ValidCqlContentWithEmptyLines_ReturnsCqlLibraryString()
         {
             // Arrange
             string cqlContent = "library TestLibrary version '1.0.0'";
@@ -68,7 +67,7 @@ namespace CoreTests.Infrastructure
         }
 
         [TestMethod]
-        public void FromCql_ValidCqlContent_ReturnsCqlLibraryString()
+        public void Parse_ValidCqlContent_ReturnsCqlLibraryString()
         {
             // Arrange
             string cqlContent = "library TestLibrary version '1.0.0'";
@@ -83,26 +82,106 @@ namespace CoreTests.Infrastructure
         }
 
         [TestMethod]
-        [ExpectedException(typeof(FormatException))]
-        public void FromCql_InvalidCqlContent_ThrowsFormatException()
+        public void Parse_ValidQualifierIdentifierAndVersion_ReturnsCqlLibraryString()
+        {
+            // Arrange
+            string cqlContent = "library Namespace.TestLibrary version '1.0.0'";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"Namespace.TestLibrary-1.0.0";
+
+            // Act
+            var result = CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            Assert.AreEqual(expectedIdentifier, result.LibraryIdentifier);
+            Assert.AreEqual(cqlContent, result.Cql);
+        }
+
+        [TestMethod]
+        public void Parse_ValidQualifierQuotedIdentifierAndVersion_ReturnsCqlLibraryString()
+        {
+            // Arrange
+            string cqlContent = """library Namespace."Test Library" version '1.0.0-alpha'""";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"""Namespace.Test Library-1.0.0-alpha""";
+
+            // Act
+            var result = CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            Assert.AreEqual(expectedIdentifier, result.LibraryIdentifier);
+            Assert.AreEqual(cqlContent, result.Cql);
+        }
+
+        [TestMethod]
+        public void Parse_ValidQualifierDelimitedIdentifierAndVersion_ReturnsCqlLibraryString()
+        {
+            // Arrange
+            string cqlContent = """library Namespace.`Test Library` version '1.0.0-alpha'""";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"""Namespace.Test Library-1.0.0-alpha""";
+
+            // Act
+            var result = CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            Assert.AreEqual(expectedIdentifier, result.LibraryIdentifier);
+            Assert.AreEqual(cqlContent, result.Cql);
+        }
+
+        [TestMethod]
+        public void Parse_ValidQualifierDelimitedIdentifierAndVersionUnbalancedQuote_ThrowFormatException()
+        {
+            // Arrange
+            string cqlContent = """library Namespace.`Test Library version '1.0.0-alpha'""";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"""Namespace.Test Library-1.0.0-alpha""";
+
+            // Act
+            Action act = () => CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            var e = Assert.ThrowsException<FormatException>(act);
+            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: extraneous input '<EOF>' expecting {QUOTEDIDENTIFIER, IDENTIFIER, DELIMITEDIDENTIFIER}.", e.Message);
+        }
+
+        [TestMethod]
+        public void Parse_ValidQualifierDelimitedIdentifierAndVersionWithSpaces_ReturnsCqlLibraryString()
+        {
+            // Arrange
+            string cqlContent = """library `Name space`.`Test Library` version '1.0.0-alpha'""";
+            var expectedIdentifier = (CqlVersionedLibraryIdentifier)"""Name space.Test Library-1.0.0-alpha""";
+
+            // Act
+            var result = CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            Assert.AreEqual(expectedIdentifier, result.LibraryIdentifier);
+            Assert.AreEqual(cqlContent, result.Cql);
+        }
+
+        [TestMethod]
+        public void Parse_InvalidCqlContent_ThrowsFormatException()
         {
             // Arrange
             string cqlContent = "invalid content";
 
             // Act
-            CqlLibraryString.Parse(cqlContent);
+            Action act = () => CqlLibraryString.Parse(cqlContent);
 
-            // Assert is handled by ExpectedException
+            // Assert
+            var e = Assert.ThrowsException<FormatException>(act);
+            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: missing 'library' at 'invalid'.", e.Message);
         }
 
         [TestMethod]
-        public void FromCql_EmptyCqlContent_ThrowsFormatException()
+        public void Parse_EmptyCqlContent_ThrowsFormatException()
         {
             // Arrange
             string cqlContent = "";
 
-            // Act & Assert
-            Assert.ThrowsException<FormatException>(() => CqlLibraryString.Parse(cqlContent));
+            // Act
+            Action act = () => CqlLibraryString.Parse(cqlContent);
+
+            // Assert
+            var e = Assert.ThrowsException<FormatException>(act);
+            Assert.AreEqual("Not a valid Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier: Syntax error: mismatched input '<EOF>' expecting 'library'.", e.Message);
         }
     }
 }

--- a/Cql/CoreTests/Packaging/FhirIdGeneratorTests.cs
+++ b/Cql/CoreTests/Packaging/FhirIdGeneratorTests.cs
@@ -11,6 +11,8 @@ public class FhirIdGeneratorTests
     [DataRow("Status-1.8.000", "c91484f7-status-1.8.000")]
     [DataRow("Status-1.6.000", "ad01ce35-status-1.6.000")]
     [DataRow("FHIR347-0.1.021", "d333e5c3-fhir347-0.1.021")]
+    [DataRow("Namespace.FHIR Helpers-4.0.1-alpha", "33456ffb-namespace-fhir-helpers-4.0.1-alpha")]
+    [DataRow("Namespace.FHIR Helpers-4.3.0-alpha", "b8f5ea8d-namespace-fhir-helpers-4.3.0-alpha")]
     [DataRow("FHIRHelpers-4.0.001", "edde5879-fhir-helpers-4.0.001")]
     [DataRow("FHIRHelpers-4.3.000", "1e1cb65c-fhir-helpers-4.3.000")]
     [DataRow("POAGOpticNerveEvaluationFHIR-0.1.000", "f60da446-poag-optic-nerve-evaluation-fhir-0.1.000")]

--- a/Cql/CoreTests/Packaging/ResourceFileNameTests.cs
+++ b/Cql/CoreTests/Packaging/ResourceFileNameTests.cs
@@ -67,16 +67,6 @@ public class ResourceFileNameTests
     }
 
     [TestMethod]
-    public void Parse_InvalidString_ShouldThrowFormatException()
-    {
-        if (ResourceFileName.AllowUnderscores)
-            return;
-
-        Action act = () => ResourceFileName.Parse("Invalid-Str_ing", null);
-        act.Should().Throw<FormatException>();
-    }
-
-    [TestMethod]
     public void TryParse_ValidStringWithExtension_ShouldReturnTrueAndResourceFileName()
     {
         var result = ResourceFileName.TryParse("Type-Identifier-1.0.0.json", null, out var resourceFileName);
@@ -94,16 +84,5 @@ public class ResourceFileNameTests
         resourceFileName.Type.Should().Be("Type");
         resourceFileName.Identifier.Should().Be("Identifier");
         resourceFileName.Version.Should().Be("1.0.0");
-    }
-
-    [TestMethod]
-    public void TryParse_InvalidString_ShouldReturnFalse()
-    {
-        if (ResourceFileName.AllowUnderscores)
-            return;
-
-        var result = ResourceFileName.TryParse("Invalid-Str_ing", null, out var resourceFileName);
-        result.Should().BeFalse();
-        resourceFileName.Should().Be(default(ResourceFileName));
     }
 }

--- a/Cql/Cql.CqlToElm/CqlLibraryString.cs
+++ b/Cql/Cql.CqlToElm/CqlLibraryString.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Runtime;
+using Hl7.Cql.Runtime.Parsing;
 
 namespace Hl7.Cql.CqlToElm;
 
@@ -14,7 +15,8 @@ namespace Hl7.Cql.CqlToElm;
 /// Represents a CQL library with its content as a string
 /// as well as its library identifier, extracted from the content.
 /// </summary>
-public readonly partial record struct CqlLibraryString
+public readonly record struct CqlLibraryString
+    : IParsable<CqlLibraryString>
 {
     /// <summary>
     /// Creates a new instance of <see cref="CqlLibraryString"/> from the given identifier and content.
@@ -29,36 +31,12 @@ public readonly partial record struct CqlLibraryString
         return new CqlLibraryString(libraryIdentifier, cqlContent);
     }
 
-    /// <summary>
-    /// Regex to extract the library name and optional version from a CQL string.
-    /// The CQL specification for it can be found at https://cql.hl7.org/19-l-cqlsyntaxdiagrams.html#library
-    /// under libraryDefinition.
-    /// </summary>
-    /// <returns>A <see cref="Regex"/> to extract the library name and version.</returns>
-    [GeneratedRegex("""
-                         \A
-                         (?:                # Non-capturing group for block comments, line comments and whitespace
-                           /\*              #   Start of block comment
-                           [\s\S]*?         #   Match any characters (including newlines) non-greedily
-                           \*/              #   End of block comment
-                         |                  # OR
-                           //               #   Start of line comment
-                           [^\r\n]*         #   Match any characters except newlines
-                         |                  # OR
-                           \s               #   Match any whitespace character
-                         )*                 # Zero or more occurrences of the above
-                         library            # until "library" is found
-                         \s+                # at least one space
-                         (?<lib>\S+)        # The name of the library
-                         (?:
-                           \s+              # at least one space
-                           version          # version keyword
-                           \s*              # optional spaces
-                           '(?<ver>[^']+)'  # The version of the library between single quotes
-                         )?                 # Version is optional
-                         """,
-                    RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline)]
-    private static partial Regex LibraryNameAndVersionRegex();
+    #region Parsing
+
+    private static readonly CqlParseErrorHandler OnErrorThrowException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlLibraryIdentifier));
+
+    static CqlLibraryString IParsable<CqlLibraryString>.Parse(string s, IFormatProvider? provider) =>
+        Parse(s);
 
     /// <summary>
     /// Parses a CQL string to create a <see cref="CqlLibraryString"/> instance.
@@ -68,15 +46,72 @@ public readonly partial record struct CqlLibraryString
     /// <exception cref="FormatException">Thrown when the library identifier and version cannot be extracted from the provided CQL string.</exception>
     public static CqlLibraryString Parse(string cqlContent)
     {
-        var match = LibraryNameAndVersionRegex().Match(cqlContent);
-        if (!match.Success)
-            throw new FormatException("Could not get library identifier and version from provided cql string.");
-
-        var lib = match.Groups["lib"].Value;
-        var ver = match.Groups["ver"].Value.NullIfEmpty();
-        var libVer = CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, ver);
-        return new CqlLibraryString(libVer, cqlContent);
+        TryParse(cqlContent, out var result, OnErrorThrowException);
+        return result!.Value;
     }
+
+    static bool IParsable<CqlLibraryString>.TryParse(
+        [NotNullWhen(true)] string? s,
+        IFormatProvider? provider,
+        out CqlLibraryString result)
+    {
+        if (!string.IsNullOrEmpty(s) && TryParse(s, out var nresult))
+        {
+            result = nresult.Value;
+            return true;
+        }
+
+        result = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to parse the provided CQL content into a <see cref="CqlLibraryString"/> instance.
+    /// </summary>
+    /// <param name="cqlContent">
+    /// The CQL content to parse. This must be a valid CQL library definition.
+    /// </param>
+    /// <param name="result">
+    /// When this method returns, contains the parsed <see cref="CqlLibraryString"/> instance if the parsing succeeded;
+    /// otherwise, <c>null</c>.
+    /// </param>
+    /// <param name="onError">
+    /// An optional delegate to handle parse errors. If provided, this delegate will be invoked for each error encountered
+    /// during parsing.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the parsing succeeded; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool TryParse(
+        string cqlContent,
+        [NotNullWhen(true)]out CqlLibraryString? result,
+        CqlParseErrorHandler? onError = null)
+    {
+        if (!cqlContent.TryParseCqlLibraryDefinition(out var ntuple, onError))
+        {
+            result = null;
+            return false;
+        }
+
+        var tuple = ntuple.Value;
+        var qualifiedIdentifier = tuple switch
+        {
+            ({ Length: > 0 } q, { } i, _) => CqlLibraryIdentifier.NewVerbatim($"{q}.{i}"),
+            var (_, i, _)                 => CqlLibraryIdentifier.NewVerbatim(i),
+        };
+
+        CqlLibraryVersion? version = tuple.version switch
+        {
+            ({ Length: > 0 } v) => CqlLibraryVersion.NewVerbatim(v),
+            _                   => null
+        };
+
+        var libVer = CqlVersionedLibraryIdentifier.FromNameAndVersion(qualifiedIdentifier, version);
+        result = new CqlLibraryString(libVer, cqlContent);
+        return true;
+    }
+
+    #endregion
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CqlLibraryString"/> struct.

--- a/Cql/Cql.CqlToElm/CqlLibraryString.cs
+++ b/Cql/Cql.CqlToElm/CqlLibraryString.cs
@@ -33,7 +33,7 @@ public readonly record struct CqlLibraryString
 
     #region Parsing
 
-    private static readonly CqlParseErrorHandler OnErrorThrowException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlLibraryIdentifier));
+    private static readonly CqlParseErrorHandler OnErrorThrowException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlLibraryString));
 
     static CqlLibraryString IParsable<CqlLibraryString>.Parse(string s, IFormatProvider? provider) =>
         Parse(s);
@@ -106,7 +106,7 @@ public readonly record struct CqlLibraryString
             _                   => null
         };
 
-        var libVer = CqlVersionedLibraryIdentifier.FromNameAndVersion(qualifiedIdentifier, version);
+        var libVer = CqlVersionedLibraryIdentifier.FromIdentifierAndVersion(qualifiedIdentifier, version);
         result = new CqlLibraryString(libVer, cqlContent);
         return true;
     }

--- a/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.CqlToElm/PublicAPI.Unshipped.txt
@@ -127,6 +127,7 @@ static Hl7.Cql.CqlToElm.CqlLibraryString.implicit operator string!(Hl7.Cql.CqlTo
 static Hl7.Cql.CqlToElm.CqlLibraryString.operator !=(Hl7.Cql.CqlToElm.CqlLibraryString left, Hl7.Cql.CqlToElm.CqlLibraryString right) -> bool
 static Hl7.Cql.CqlToElm.CqlLibraryString.operator ==(Hl7.Cql.CqlToElm.CqlLibraryString left, Hl7.Cql.CqlToElm.CqlLibraryString right) -> bool
 static Hl7.Cql.CqlToElm.CqlLibraryString.Parse(string! cqlContent) -> Hl7.Cql.CqlToElm.CqlLibraryString
+static Hl7.Cql.CqlToElm.CqlLibraryString.TryParse(string! cqlContent, out Hl7.Cql.CqlToElm.CqlLibraryString? result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
 static Hl7.Cql.CqlToElm.ModelProvider.GetBaseType(Hl7.Cql.CqlToElm.IModelProvider! provider, Hl7.Cql.Elm.TypeSpecifier! type) -> Hl7.Cql.Elm.NamedTypeSpecifier?
 static Hl7.Cql.CqlToElm.ModelProvider.GetModelFromName(this Hl7.Cql.CqlToElm.IModelProvider! provider, string! name, string? version = null) -> Hl7.Cql.Model.ModelInfo!
 static Hl7.Cql.CqlToElm.ModelProvider.ToElm(this Hl7.Cql.Model.ChoiceTypeSpecifier! cts, Hl7.Cql.CqlToElm.IModelProvider! provider) -> Hl7.Cql.Elm.ChoiceTypeSpecifier!

--- a/Cql/Cql.CqlToElm/Toolkit/Internal/LibraryBuilderProvider.cs
+++ b/Cql/Cql.CqlToElm/Toolkit/Internal/LibraryBuilderProvider.cs
@@ -27,7 +27,7 @@ internal sealed class LibraryBuilderProvider(
         string libraryName,
         string? version,
         [NotNullWhen(true)] out LibraryBuilder? libraryBuilder,
-        out string? error) => TryResolveLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(libraryName, version), out libraryBuilder, out error);
+        out string? error) => TryResolveLibrary(CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(libraryName, version), out libraryBuilder, out error);
 
     public bool TryResolveLibrary(
         CqlVersionedLibraryIdentifier libVer,

--- a/Cql/Cql.CqlToElm/Visitors/TerminalParsers.cs
+++ b/Cql/Cql.CqlToElm/Visitors/TerminalParsers.cs
@@ -139,8 +139,8 @@ namespace Hl7.Cql.CqlToElm.Visitors
         public static (string qualifier, string id) Parse(this cqlParser.QualifiedIdentifierContext context)
         {
             var qualifiers = context.qualifier().Select(q => q.identifier().Parse()!).ToArray();
-
-             return (string.Join(CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter, qualifiers), context.identifier().Parse()!);
+            var qualifier = CqlVersionedLibraryIdentifierFormatting.FormatSystem(qualifiers) ?? "";
+            return (qualifier, context.identifier().Parse()!);
         }
 
         // : (libraryIdentifier '.')? identifier

--- a/Cql/Cql.CqlToElm/Visitors/TerminalParsers.cs
+++ b/Cql/Cql.CqlToElm/Visitors/TerminalParsers.cs
@@ -1,6 +1,7 @@
 ﻿using Antlr4.Runtime.Tree;
 using Hl7.Cql.CqlToElm.Grammar;
 using Hl7.Cql.Elm;
+using Hl7.Cql.Runtime;
 
 namespace Hl7.Cql.CqlToElm.Visitors
 {
@@ -139,15 +140,7 @@ namespace Hl7.Cql.CqlToElm.Visitors
         {
             var qualifiers = context.qualifier().Select(q => q.identifier().Parse()!).ToArray();
 
-            if (qualifiers.Any())
-            {
-                if (qualifiers.Length > 1)
-                    throw new InvalidOperationException($"Multiple qualifiers not supported.");
-
-                return (qualifiers.Single(), context.identifier().Parse()!);
-            }
-            else
-                return (string.Empty, context.identifier().Parse()!);
+             return (string.Join(CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter, qualifiers), context.identifier().Parse()!);
         }
 
         // : (libraryIdentifier '.')? identifier

--- a/Cql/Cql.Invocation/Toolkit/Extensions/InvocationToolkitExtensions.FhirLibraryAdding.cs
+++ b/Cql/Cql.Invocation/Toolkit/Extensions/InvocationToolkitExtensions.FhirLibraryAdding.cs
@@ -48,7 +48,7 @@ partial class InvocationToolkitExtensions
                                             logger,
                                             (fhirLibrary, logMessage) =>
                                                 logMessage("Could not extract assembly binary from FHIR library resource: {id}",
-                                                           CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(fhirLibrary.Name, fhirLibrary.Version))))
+                                                           CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(fhirLibrary.Name, fhirLibrary.Version))))
                                .ToList()
             ;
 

--- a/Cql/Cql.Invocation/Toolkit/LibraryInstanceInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/LibraryInstanceInvoker.cs
@@ -29,11 +29,11 @@ public abstract class LibraryInstanceInvoker(
     /// Gets the versioned identifier of the CQL library.
     /// </summary>
     public override CqlVersionedLibraryIdentifier LibraryIdentifier { get; } =
-        CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(library.Name, library.Version);
+        CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(library.Name, library.Version);
 
     /// <inheritdoc />
     public override IReadOnlyCollection<CqlVersionedLibraryIdentifier> DependencyLibraryIdentifiers { get; } =
         library.Dependencies
-               .Select(dep => CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(dep.Name, dep.Version))
+               .Select(dep => CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(dep.Name, dep.Version))
                .ToList();
 }

--- a/Cql/Cql.Packaging/FhirIdGenerator.cs
+++ b/Cql/Cql.Packaging/FhirIdGenerator.cs
@@ -74,7 +74,7 @@ internal static partial class FhirIdGenerator
 
     private static string GetMd5Hash(CqlVersionedLibraryIdentifier input)
     {
-        var text = input.ToString('*');
+        var text = input.FormatDelimited('*');
         byte[] hashBytes = MD5.ComputeHash(Encoding.UTF8.GetBytes(text));
         StringBuilder sb = new StringBuilder();
         foreach (byte b in hashBytes)

--- a/Cql/Cql.Packaging/FhirIdGenerator.cs
+++ b/Cql/Cql.Packaging/FhirIdGenerator.cs
@@ -74,7 +74,7 @@ internal static partial class FhirIdGenerator
 
     private static string GetMd5Hash(CqlVersionedLibraryIdentifier input)
     {
-        var text = input.ToString("*");
+        var text = input.ToString('*');
         byte[] hashBytes = MD5.ComputeHash(Encoding.UTF8.GetBytes(text));
         StringBuilder sb = new StringBuilder();
         foreach (byte b in hashBytes)

--- a/Cql/Cql.Packaging/ResourceCanonicalBuilderFactory.cs
+++ b/Cql/Cql.Packaging/ResourceCanonicalBuilderFactory.cs
@@ -26,7 +26,7 @@ internal static class ResourceCanonicalBuilderFactory
             string includeVersionString = string.IsNullOrEmpty(version) ? string.Empty : $"|{version}";
             var resultCanonical = fixedLibraryCanonicals is { Count: > 0 }
                                   && CqlLibraryIdentifier.TryParse(identifier, out var cqlLibraryIdentifier)
-                                  && fixedLibraryCanonicals.TryGetValue(cqlLibraryIdentifier, out var canonical)
+                                  && fixedLibraryCanonicals.TryGetValue(cqlLibraryIdentifier.Value, out var canonical)
                                       ? $"{canonical}{includeVersionString}"
                                       : $"{rootUrl}{resourceType}/{identifier}{includeVersionString}";
             return resultCanonical;

--- a/Cql/Cql.Packaging/ResourceFileName.cs
+++ b/Cql/Cql.Packaging/ResourceFileName.cs
@@ -34,7 +34,7 @@ public readonly record struct ResourceFileName : IParsable<ResourceFileName>
         string type,
         string identifier,
         string? version = null) =>
-        (Type, Identifier, Version) = (type, identifier, version);
+        (Type, Identifier, Version) = (type ?? throw new ArgumentNullException(nameof(type)), identifier ?? throw new ArgumentNullException(nameof(identifier)), version);
 
     /// <summary>
     /// Creates a new instance of <see cref="ResourceFileName"/>.

--- a/Cql/Cql.Packaging/ResourceFileName.cs
+++ b/Cql/Cql.Packaging/ResourceFileName.cs
@@ -17,13 +17,8 @@ public readonly record struct ResourceFileName : IParsable<ResourceFileName>
     // Should not contain underscores - https://build.fhir.org/ig/HL7/cql-ig/conformance.html#library-name-and-url
     // !! Special handling around hyphens as it is used to delimit between resource type, identifier and version
 
-    internal const bool AllowUnderscores = false; // Allowed for now, since NCQA cql files use underscores
-
 #pragma warning disable CS0162 // Unreachable code detected
-    private static readonly char[] InvalidChars =
-        AllowUnderscores
-            ? (char[])['-'/*, '_'*/]
-            : (char[])['-', '_'];
+    private static readonly char[] InvalidChars = ['-'];
 #pragma warning restore CS0162 // Unreachable code detected
 
     private static readonly ArgValidator<string> ValidateType = Arg.IsRequired().And(Arg.ShouldNotContain(InvalidChars));

--- a/Cql/Cql.Runtime/Cql.Runtime.csproj
+++ b/Cql/Cql.Runtime/Cql.Runtime.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Cql.Abstractions\Cql.Abstractions.csproj" />
+		<ProjectReference Include="..\Cql.Grammar\Cql.Grammar.csproj" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 		<PackageReference Include="Fhir.Metrics" Version="1.3.0" />
 	</ItemGroup>

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -1,5 +1,13 @@
 ﻿#nullable enable
-const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.IdentifierVersionDelimiter = "-" -> string!
+const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.IdentifierVersionDelimiter = '-' -> char
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.CannotSplitIdentifierAndVersionByDash = "Cannot split identifier and version by dash." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.ExpectedTokenNotFound_1 = "Expected {0} token not found." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.MoreTokensAfterEndOfInput = "More tokens after expected end of input." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.MultipleQualifiersNotSupported = "Multiple qualifiers not supported." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.NullOrEmpty = "Input is null or empty." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.SyntaxErrorFound = "Syntax error found." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.SyntaxError_1 = "Syntax error: {0}." -> string!
+const Hl7.Cql.Runtime.Parsing.CqlParseErrors.TextOpenedButNotClosed = "Text is opened with a special character, but not closed." -> string!
 Hl7.Cql.Conversion.ITypeConverterEntry
 Hl7.Cql.Conversion.ITypeConverterEntry.Convert(object? instance, System.Type! to) -> object?
 Hl7.Cql.Conversion.ITypeConverterEntry.Handles(System.Type! from, System.Type! to) -> bool
@@ -579,6 +587,17 @@ Hl7.Cql.Runtime.DefinitionSignature.Name.get -> string!
 Hl7.Cql.Runtime.DefinitionSignature.ParameterTypes.get -> System.Type![]!
 Hl7.Cql.Runtime.IO.DirectoryInfoHandler
 Hl7.Cql.Runtime.IO.DirectoryPreparationStrategy
+Hl7.Cql.Runtime.Parsing.CqlParseError
+Hl7.Cql.Runtime.Parsing.CqlParseError.Arguments.get -> object?[]!
+Hl7.Cql.Runtime.Parsing.CqlParseError.CqlParseError() -> void
+Hl7.Cql.Runtime.Parsing.CqlParseError.CqlParseError(System.FormattableString! FormattableString) -> void
+Hl7.Cql.Runtime.Parsing.CqlParseError.Deconstruct(out System.FormattableString! FormattableString) -> void
+Hl7.Cql.Runtime.Parsing.CqlParseError.Equals(Hl7.Cql.Runtime.Parsing.CqlParseError other) -> bool
+Hl7.Cql.Runtime.Parsing.CqlParseError.Format.get -> string!
+Hl7.Cql.Runtime.Parsing.CqlParseError.FormattableString.get -> System.FormattableString!
+Hl7.Cql.Runtime.Parsing.CqlParseError.FormattableString.init -> void
+Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler
+Hl7.Cql.Runtime.Parsing.CqlParseErrors
 Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter
 Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter.CqlValueTupleJsonConverter() -> void
 Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverterFactory
@@ -628,6 +647,8 @@ override Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.GetHashCode() -> int
 override Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.ToString() -> string!
 override Hl7.Cql.Runtime.DefinitionSignature.Equals(object? other) -> bool
 override Hl7.Cql.Runtime.DefinitionSignature.GetHashCode() -> int
+override Hl7.Cql.Runtime.Parsing.CqlParseError.GetHashCode() -> int
+override Hl7.Cql.Runtime.Parsing.CqlParseError.ToString() -> string!
 override Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter.Read(ref System.Text.Json.Utf8JsonReader reader, System.Type! typeToConvert, System.Text.Json.JsonSerializerOptions! options) -> System.Runtime.CompilerServices.ITuple!
 override Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter.Write(System.Text.Json.Utf8JsonWriter! writer, System.Runtime.CompilerServices.ITuple! value, System.Text.Json.JsonSerializerOptions! options) -> void
 override Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverterFactory.CanConvert(System.Type! typeToConvert) -> bool
@@ -642,14 +663,14 @@ static Hl7.Cql.Runtime.CqlLibraryIdentifier.implicit operator string!(Hl7.Cql.Ru
 static Hl7.Cql.Runtime.CqlLibraryIdentifier.operator !=(Hl7.Cql.Runtime.CqlLibraryIdentifier left, Hl7.Cql.Runtime.CqlLibraryIdentifier right) -> bool
 static Hl7.Cql.Runtime.CqlLibraryIdentifier.operator ==(Hl7.Cql.Runtime.CqlLibraryIdentifier left, Hl7.Cql.Runtime.CqlLibraryIdentifier right) -> bool
 static Hl7.Cql.Runtime.CqlLibraryIdentifier.Parse(string! s) -> Hl7.Cql.Runtime.CqlLibraryIdentifier
-static Hl7.Cql.Runtime.CqlLibraryIdentifier.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryIdentifier result) -> bool
+static Hl7.Cql.Runtime.CqlLibraryIdentifier.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryIdentifier? result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
 static Hl7.Cql.Runtime.CqlLibraryVersion.explicit operator Hl7.Cql.Runtime.CqlLibraryVersion(string! version) -> Hl7.Cql.Runtime.CqlLibraryVersion
 static Hl7.Cql.Runtime.CqlLibraryVersion.implicit operator string!(Hl7.Cql.Runtime.CqlLibraryVersion version) -> string!
 static Hl7.Cql.Runtime.CqlLibraryVersion.operator !=(Hl7.Cql.Runtime.CqlLibraryVersion left, Hl7.Cql.Runtime.CqlLibraryVersion right) -> bool
 static Hl7.Cql.Runtime.CqlLibraryVersion.operator ==(Hl7.Cql.Runtime.CqlLibraryVersion left, Hl7.Cql.Runtime.CqlLibraryVersion right) -> bool
 static Hl7.Cql.Runtime.CqlLibraryVersion.Parse(string! s) -> Hl7.Cql.Runtime.CqlLibraryVersion
-static Hl7.Cql.Runtime.CqlLibraryVersion.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryVersion result) -> bool
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! identifier, string? version = null, string! delimiter = "-") -> string?
+static Hl7.Cql.Runtime.CqlLibraryVersion.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryVersion? result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
+static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! identifier, string? version = null, char delimiter = '-') -> string?
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.explicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(string! versionedIdentifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.FromNameAndVersion(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier, Hl7.Cql.Runtime.CqlLibraryVersion? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.implicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
@@ -658,13 +679,20 @@ static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.operator !=(Hl7.Cql.Runtime
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.operator ==(Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier left, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier right) -> bool
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.Parse(string! s) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(string! identifier, string? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.TryParse(string? s, out Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier result) -> bool
+static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.TryParse(string? s, out Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
 static Hl7.Cql.Runtime.DefinitionSignature.implicit operator Hl7.Cql.Runtime.DefinitionSignature!(string! name) -> Hl7.Cql.Runtime.DefinitionSignature!
 static Hl7.Cql.Runtime.DefinitionSignature.operator !=(Hl7.Cql.Runtime.DefinitionSignature? left, Hl7.Cql.Runtime.DefinitionSignature? right) -> bool
 static Hl7.Cql.Runtime.DefinitionSignature.operator ==(Hl7.Cql.Runtime.DefinitionSignature? left, Hl7.Cql.Runtime.DefinitionSignature? right) -> bool
 static Hl7.Cql.Runtime.IO.DirectoryPreparationStrategy.CreateFileDeletionDirectoryHandler(string! searchPattern = "*", System.IO.EnumerationOptions? enumerationOptions = null, System.Func<System.IO.FileInfo!, bool>? fileSelector = null) -> Hl7.Cql.Runtime.IO.DirectoryInfoHandler!
 static Hl7.Cql.Runtime.IO.DirectoryPreparationStrategy.CreateIfNotExists.get -> Hl7.Cql.Runtime.IO.DirectoryInfoHandler!
 static Hl7.Cql.Runtime.IO.DirectoryPreparationStrategy.Recreate.get -> Hl7.Cql.Runtime.IO.DirectoryInfoHandler!
+static Hl7.Cql.Runtime.Parsing.CqlParseError.implicit operator Hl7.Cql.Runtime.Parsing.CqlParseError((string! format, object! arg) message) -> Hl7.Cql.Runtime.Parsing.CqlParseError
+static Hl7.Cql.Runtime.Parsing.CqlParseError.implicit operator Hl7.Cql.Runtime.Parsing.CqlParseError((string! format, object! arg1, object! args2) message) -> Hl7.Cql.Runtime.Parsing.CqlParseError
+static Hl7.Cql.Runtime.Parsing.CqlParseError.implicit operator Hl7.Cql.Runtime.Parsing.CqlParseError((string! format, object![]! args) message) -> Hl7.Cql.Runtime.Parsing.CqlParseError
+static Hl7.Cql.Runtime.Parsing.CqlParseError.implicit operator Hl7.Cql.Runtime.Parsing.CqlParseError(string! message) -> Hl7.Cql.Runtime.Parsing.CqlParseError
+static Hl7.Cql.Runtime.Parsing.CqlParseError.implicit operator Hl7.Cql.Runtime.Parsing.CqlParseError(System.FormattableString! message) -> Hl7.Cql.Runtime.Parsing.CqlParseError
+static Hl7.Cql.Runtime.Parsing.CqlParseError.operator !=(Hl7.Cql.Runtime.Parsing.CqlParseError left, Hl7.Cql.Runtime.Parsing.CqlParseError right) -> bool
+static Hl7.Cql.Runtime.Parsing.CqlParseError.operator ==(Hl7.Cql.Runtime.Parsing.CqlParseError left, Hl7.Cql.Runtime.Parsing.CqlParseError right) -> bool
 static Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter.Default.get -> Hl7.Cql.Runtime.Serialization.CqlValueTupleJsonConverter!
 static Hl7.Cql.Toolkit.ToolkitExtensions.SetIgnoreEnumerationExceptions<TSelf>(this Hl7.Cql.Toolkit.IToolkit<TSelf>! toolkit, bool breakAfterFirstException = false) -> TSelf
 static Hl7.Cql.Toolkit.ToolkitExtensions.SetThrowEnumerationExceptions<TSelf>(this Hl7.Cql.Toolkit.IToolkit<TSelf>! toolkit) -> TSelf
@@ -678,7 +706,9 @@ virtual Hl7.Cql.Operators.RetrieveParameters.Equals(Hl7.Cql.Operators.RetrievePa
 virtual Hl7.Cql.Operators.RetrieveParameters.PrintMembers(System.Text.StringBuilder! builder) -> bool
 virtual Hl7.Cql.Runtime.BaseTypeResolver.GetPropertyCore(System.Type! type, string! propertyName) -> System.Reflection.PropertyInfo?
 virtual Hl7.Cql.Runtime.IO.DirectoryInfoHandler.Invoke(System.IO.DirectoryInfo! directory) -> void
+virtual Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler.Invoke(Hl7.Cql.Runtime.Parsing.CqlParseError parseError) -> void
 virtual Hl7.Cql.Runtime.ValueExceptionHandler<T>.Invoke(T value, System.Exception! exception, Hl7.Cql.Runtime.BatchProcessExceptionContinuation continuation = Hl7.Cql.Runtime.BatchProcessExceptionContinuation.Throw) -> void
 ~override Hl7.Cql.Runtime.CqlLibraryIdentifier.Equals(object obj) -> bool
 ~override Hl7.Cql.Runtime.CqlLibraryVersion.Equals(object obj) -> bool
 ~override Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.Equals(object obj) -> bool
+~override Hl7.Cql.Runtime.Parsing.CqlParseError.Equals(object obj) -> bool

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -1,6 +1,4 @@
 ﻿#nullable enable
-const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.IdentifierVersionDelimiter = '-' -> char
-const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter = '.' -> char
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.CannotSplitIdentifierAndVersionByDash = "Cannot split identifier and version by dash." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.ExpectedTokenNotFound_1 = "Expected {0} token not found." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.MoreTokensAfterEndOfInput = "More tokens after expected end of input." -> string!
@@ -670,8 +668,6 @@ static Hl7.Cql.Runtime.CqlLibraryVersion.operator !=(Hl7.Cql.Runtime.CqlLibraryV
 static Hl7.Cql.Runtime.CqlLibraryVersion.operator ==(Hl7.Cql.Runtime.CqlLibraryVersion left, Hl7.Cql.Runtime.CqlLibraryVersion right) -> bool
 static Hl7.Cql.Runtime.CqlLibraryVersion.Parse(string! s) -> Hl7.Cql.Runtime.CqlLibraryVersion
 static Hl7.Cql.Runtime.CqlLibraryVersion.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryVersion? result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! identifier, string? version = null, char delimiter = '-') -> string?
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! system, string! identifier, string? version = null, char systemDelimiter = '.', char versionDelimiter = '-') -> string?
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.explicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(string! versionedIdentifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.FromIdentifierAndVersion(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier, Hl7.Cql.Runtime.CqlLibraryVersion? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.implicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -1,9 +1,9 @@
 ﻿#nullable enable
 const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.IdentifierVersionDelimiter = '-' -> char
+const Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter = '.' -> char
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.CannotSplitIdentifierAndVersionByDash = "Cannot split identifier and version by dash." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.ExpectedTokenNotFound_1 = "Expected {0} token not found." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.MoreTokensAfterEndOfInput = "More tokens after expected end of input." -> string!
-const Hl7.Cql.Runtime.Parsing.CqlParseErrors.MultipleQualifiersNotSupported = "Multiple qualifiers not supported." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.NullOrEmpty = "Input is null or empty." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.SyntaxErrorFound = "Syntax error found." -> string!
 const Hl7.Cql.Runtime.Parsing.CqlParseErrors.SyntaxError_1 = "Syntax error: {0}." -> string!
@@ -671,14 +671,15 @@ static Hl7.Cql.Runtime.CqlLibraryVersion.operator ==(Hl7.Cql.Runtime.CqlLibraryV
 static Hl7.Cql.Runtime.CqlLibraryVersion.Parse(string! s) -> Hl7.Cql.Runtime.CqlLibraryVersion
 static Hl7.Cql.Runtime.CqlLibraryVersion.TryParse(string? s, out Hl7.Cql.Runtime.CqlLibraryVersion? result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! identifier, string? version = null, char delimiter = '-') -> string?
+static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.BuildString(string! system, string! identifier, string? version = null, char systemDelimiter = '.', char versionDelimiter = '-') -> string?
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.explicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(string! versionedIdentifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.FromNameAndVersion(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier, Hl7.Cql.Runtime.CqlLibraryVersion? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
+static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.FromIdentifierAndVersion(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier, Hl7.Cql.Runtime.CqlLibraryVersion? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.implicit operator Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier(Hl7.Cql.Runtime.CqlLibraryIdentifier identifier) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.implicit operator string!(Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier versionedIdentifier) -> string!
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.operator !=(Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier left, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier right) -> bool
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.operator ==(Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier left, Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier right) -> bool
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.Parse(string! s) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
-static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(string! identifier, string? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
+static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(string! identifier, string? version = null) -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 static Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier.TryParse(string? s, out Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier result, Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler? onError = null) -> bool
 static Hl7.Cql.Runtime.DefinitionSignature.implicit operator Hl7.Cql.Runtime.DefinitionSignature!(string! name) -> Hl7.Cql.Runtime.DefinitionSignature!
 static Hl7.Cql.Runtime.DefinitionSignature.operator !=(Hl7.Cql.Runtime.DefinitionSignature? left, Hl7.Cql.Runtime.DefinitionSignature? right) -> bool

--- a/Cql/Cql.Runtime/Runtime/CqlLibraryIdentifier.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlLibraryIdentifier.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using Hl7.Cql.Runtime.Parsing;
 using Hl7.Cql.Runtime.Serialization;
 
 namespace Hl7.Cql.Runtime;
@@ -40,11 +41,7 @@ public readonly record struct CqlLibraryIdentifier :
     /// Initializes a new instance of the <see cref="CqlLibraryIdentifier"/> struct.
     /// </summary>
     /// <param name="value">The string value of the identifier.</param>
-    private CqlLibraryIdentifier(string value) => _value = value; // TryParse will already do validation
-
-    internal static bool IsValid([NotNullWhen(true)]string? value) =>
-        value is not null
-        && !value.Contains('_');
+    private CqlLibraryIdentifier(string value) => _value = value ?? throw new ArgumentNullException(nameof(value)); // TryParse will already do validation
 
     /// <summary>
     /// Returns the string representation of the identifier.
@@ -53,6 +50,8 @@ public readonly record struct CqlLibraryIdentifier :
     public override string ToString() => _value;
 
     #region Parsing
+
+    private static readonly CqlParseErrorHandler OnErrorThrowException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlLibraryIdentifier));
 
     /// <summary>
     /// Parses the specified string to a <see cref="CqlLibraryIdentifier"/>.
@@ -73,9 +72,8 @@ public readonly record struct CqlLibraryIdentifier :
     /// <exception cref="FormatException">Thrown when the string is not a valid identifier.</exception>
     public static CqlLibraryIdentifier Parse(string s)
     {
-        return TryParse(s, out var result)
-                   ? result
-                   : throw new FormatException($"Not a valid {nameof(CqlLibraryIdentifier)}");
+        TryParse(s, out var nresult, OnErrorThrowException);
+        return nresult!.Value;
     }
 
     /// <summary>
@@ -90,7 +88,14 @@ public readonly record struct CqlLibraryIdentifier :
         IFormatProvider? provider,
         out CqlLibraryIdentifier result)
     {
-        return TryParse(s, out result);
+        if (TryParse(s, out var nresult))
+        {
+            result = nresult.Value;
+            return true;
+        }
+
+        result = default;
+        return false;
     }
 
     /// <summary>
@@ -98,17 +103,25 @@ public readonly record struct CqlLibraryIdentifier :
     /// </summary>
     /// <param name="s">The string to parse.</param>
     /// <param name="result">The parsed <see cref="CqlLibraryIdentifier"/>.</param>
+    /// <param name="onError">An optional callback containing details about a failed parse attempt.</param>
     /// <returns><c>true</c> if the string was successfully parsed; otherwise, <c>false</c>.</returns>
-    public static bool TryParse(string? s, out CqlLibraryIdentifier result)
+    public static bool TryParse(
+        string? s,
+        [NotNullWhen(true)] out CqlLibraryIdentifier? result,
+        CqlParseErrorHandler? onError = null)
+
     {
-        if (IsValid(s))
+        result = default(CqlLibraryIdentifier);
+
+        if (string.IsNullOrEmpty(s))
         {
-            result = new CqlLibraryIdentifier(s);
-            return true;
+            onError?.Invoke(CqlParseErrors.NullOrEmpty);
+            return false;
         }
 
-        result = default;
-        return false;
+
+        result = NewVerbatim(s);
+        return true;
     }
 
     #endregion
@@ -141,4 +154,6 @@ public readonly record struct CqlLibraryIdentifier :
     }
 
     #endregion
+
+    internal static CqlLibraryIdentifier NewVerbatim(string value) => new(value);
 }

--- a/Cql/Cql.Runtime/Runtime/CqlLibraryVersion.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlLibraryVersion.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using Hl7.Cql.Runtime.Parsing;
 using Hl7.Cql.Runtime.Serialization;
 
 namespace Hl7.Cql.Runtime;
@@ -48,6 +49,9 @@ public readonly record struct CqlLibraryVersion :
 
     #region Parsing
 
+    private static readonly CqlParseErrorHandler OnErrorThrowException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlLibraryVersion));
+
+
     /// <summary>
     /// Parses the specified string to a <see cref="CqlLibraryVersion"/>.
     /// </summary>
@@ -64,12 +68,11 @@ public readonly record struct CqlLibraryVersion :
     /// </summary>
     /// <param name="s">The string to parse.</param>
     /// <returns>The parsed <see cref="CqlLibraryVersion"/>.</returns>
-    /// <exception cref="FormatException">Thrown when the string is not a valid CQL library version.</exception>
+    /// <exception cref="FormatException">Thrown when the string is not a valid identifier.</exception>
     public static CqlLibraryVersion Parse(string s)
     {
-        return TryParse(s, out var result)
-                   ? result
-                   : throw new FormatException("Not a valid ElmLibraryVersion");
+        TryParse(s, out var nresult, OnErrorThrowException);
+        return nresult!.Value;
     }
 
     /// <summary>
@@ -84,7 +87,14 @@ public readonly record struct CqlLibraryVersion :
         IFormatProvider? provider,
         out CqlLibraryVersion result)
     {
-        return TryParse(s, out result);
+        if (TryParse(s, out var nresult))
+        {
+            result = nresult.Value;
+            return true;
+        }
+
+        result = default;
+        return false;
     }
 
     /// <summary>
@@ -92,18 +102,28 @@ public readonly record struct CqlLibraryVersion :
     /// </summary>
     /// <param name="s">The string to parse.</param>
     /// <param name="result">The parsed <see cref="CqlLibraryVersion"/>.</param>
+    /// <param name="onError">An optional callback containing details about a failed parse attempt.</param>
     /// <returns><c>true</c> if the string was successfully parsed; otherwise, <c>false</c>.</returns>
-    public static bool TryParse(string? s, out CqlLibraryVersion result)
+    public static bool TryParse(
+        string? s,
+        [NotNullWhen(true)] out CqlLibraryVersion? result,
+        CqlParseErrorHandler? onError = null)
+
     {
+        result = default(CqlLibraryVersion);
+
         if (string.IsNullOrEmpty(s))
         {
-            result = default;
+            onError?.Invoke(CqlParseErrors.NullOrEmpty);
             return false;
         }
 
-        result = new CqlLibraryVersion(s);
+
+        result = NewVerbatim(s);
         return true;
     }
 
     #endregion
+
+    internal static CqlLibraryVersion NewVerbatim(string value) => new(value);
 }

--- a/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
@@ -6,6 +6,7 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using Hl7.Cql.Runtime.Parsing;
 using Hl7.Cql.Runtime.Serialization;
 
 namespace Hl7.Cql.Runtime;
@@ -16,15 +17,16 @@ namespace Hl7.Cql.Runtime;
 /// <param name="Identifier">The identifier of the CQL library.</param>
 /// <param name="Version">The version of the CQL library.</param>
 [JsonConverter(typeof(StringEncapsulatedValueJsonConverter<CqlVersionedLibraryIdentifier>))]
-public readonly record struct CqlVersionedLibraryIdentifier(
+public readonly partial record struct CqlVersionedLibraryIdentifier(
     CqlLibraryIdentifier Identifier,
     CqlLibraryVersion? Version = null) : IParsable<CqlVersionedLibraryIdentifier>
 {
+    private static readonly CqlParseErrorHandler OnErrorThrowFormatException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlVersionedLibraryIdentifier));
+
     /// <summary>
     /// The delimiter to use between the identifier and version part in the string representation.
     /// </summary>
-    [UsedImplicitly]
-    public const string IdentifierVersionDelimiter = "-";
+    [UsedImplicitly] public const char IdentifierVersionDelimiter = '-';
 
     /// <summary>
     /// Implicitly converts a <see cref="CqlVersionedLibraryIdentifier"/> to a <see cref="string"/>.
@@ -78,7 +80,7 @@ public readonly record struct CqlVersionedLibraryIdentifier(
     /// Returns a string representation of the CQL versioned library identifier.
     /// </summary>
     /// <returns>A string representation of the CQL versioned library identifier.</returns>
-    internal string ToString(string delimiter)
+    internal string ToString(char delimiter)
     {
         return BuildString(Identifier, Version, delimiter)!;
     }
@@ -95,7 +97,7 @@ public readonly record struct CqlVersionedLibraryIdentifier(
     public static string? BuildString(
         string identifier,
         string? version = null,
-        string delimiter = IdentifierVersionDelimiter) =>
+        char delimiter = IdentifierVersionDelimiter) =>
         (identifier, version) switch
         {
             ({ Length:>0 } id, { Length: > 0 } ver) => $"{id}{delimiter}{ver}",
@@ -111,10 +113,8 @@ public readonly record struct CqlVersionedLibraryIdentifier(
     /// <param name="s">The string to parse.</param>
     /// <param name="provider">The format provider (optional).</param>
     /// <returns>A <see cref="CqlVersionedLibraryIdentifier"/> instance.</returns>
-    static CqlVersionedLibraryIdentifier IParsable<CqlVersionedLibraryIdentifier>.Parse(string s, IFormatProvider? provider)
-    {
-        return Parse(s);
-    }
+    static CqlVersionedLibraryIdentifier IParsable<CqlVersionedLibraryIdentifier>.Parse(string s, IFormatProvider? provider) =>
+        Parse(s);
 
     /// <summary>
     /// Parses a CQL versioned library identifier from the given string.
@@ -124,9 +124,8 @@ public readonly record struct CqlVersionedLibraryIdentifier(
     /// <exception cref="FormatException">Thrown when the string is not a valid CQL versioned library identifier.</exception>
     public static CqlVersionedLibraryIdentifier Parse(string s)
     {
-        return TryParse(s, out var result)
-                   ? result
-                   : throw new FormatException("Not a valid CqlVersionedLibraryIdentifier");
+        TryParse(s, out var result, OnErrorThrowFormatException);
+        return result!;
     }
 
     /// <summary>
@@ -139,40 +138,152 @@ public readonly record struct CqlVersionedLibraryIdentifier(
     static bool IParsable<CqlVersionedLibraryIdentifier>.TryParse(
         [NotNullWhen(true)] string? s,
         IFormatProvider? provider,
-        out CqlVersionedLibraryIdentifier result)
-    {
-        return TryParse(s, out result);
-    }
+        out CqlVersionedLibraryIdentifier result) =>
+        TryParse(s, out result);
 
     /// <summary>
-    /// Tries to parse a CQL versioned library identifier from the given string.
+    /// Attempts to parse the specified string into a <see cref="CqlVersionedLibraryIdentifier"/>.
     /// </summary>
-    /// <param name="s">The string to parse.</param>
-    /// <param name="result">When this method returns, contains the parsed CQL versioned library identifier, if the parsing succeeded.</param>
-    /// <returns><c>true</c> if the parsing succeeded; otherwise, <c>false</c>.</returns>
-    public static bool TryParse(string? s, out CqlVersionedLibraryIdentifier result)
+    /// <param name="s">
+    /// The string to parse. This should represent a versioned library identifier, optionally including a version.
+    /// </param>
+    /// <param name="result">
+    /// When this method returns, contains the parsed <see cref="CqlVersionedLibraryIdentifier"/> if the parsing succeeded;
+    /// otherwise, contains the default value of <see cref="CqlVersionedLibraryIdentifier"/>.
+    /// </param>
+    /// <param name="onError">
+    /// An optional error handler to invoke if parsing fails. If not provided, no error handling will occur.
+    /// </param>
+    /// <returns>
+    /// <c>true</c> if the string was successfully parsed into a <see cref="CqlVersionedLibraryIdentifier"/>; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool TryParse(
+        string? s,
+        out CqlVersionedLibraryIdentifier result,
+        CqlParseErrorHandler? onError = null)
     {
-        if (s is not null)
+        if (!string.IsNullOrEmpty(s))
         {
-            var tokens = s.Split('-', 2);
-            if (CqlLibraryIdentifier.TryParse(tokens[0], out var name))
+            if (TrySplitIdentifierAndVersion(s, out var npair, CqlParseErrorHandlerStrategies.OnErrorIgnore))
             {
-                switch (tokens.Length)
+                var (identifierPart, versionPart) = npair.Value;
+                if (string.IsNullOrEmpty(versionPart)
+                    && CqlLibraryIdentifier.TryParse(identifierPart, out var nidentifier))
                 {
-                    case 1:
-                        result = FromNameAndVersion(name);
-                        return true;
+                    result = FromNameAndVersion(nidentifier.Value);
+                    return true;
+                }
 
-                    case 2 when CqlLibraryVersion.TryParse(tokens[1], out var version):
-                        result = FromNameAndVersion(name, version);
-                        return true;
+                if (CqlLibraryIdentifier.TryParse(identifierPart, out nidentifier)
+                    && CqlLibraryVersion.TryParse(versionPart, out var nversion))
+                {
+                    result = FromNameAndVersion(nidentifier.Value, nversion.Value);
+                    return true;
                 }
             }
         }
 
+        onError?.Invoke(CqlParseErrors.CannotSplitIdentifierAndVersionByDash);
         result = default;
         return false;
     }
+
+    private static bool TrySplitIdentifierAndVersion(
+        string s,
+        [NotNullWhen(true)] out (string identifier, string? version)? value,
+        CqlParseErrorHandler? onError = null)
+    {
+        Debug.Assert(s.Length > 0, "Span must not be empty.");
+        value = null;
+
+        // Stack allocated array of int with length 2
+        int indicesCount = 0;
+        Span<int> indices = stackalloc int[2];
+        var span = s.AsSpan();
+
+        for (int i = span.Length - 1; i >= 0; i--)
+        {
+            if (span[i] == IdentifierVersionDelimiter)
+            {
+                indices[indicesCount] = i;
+                indicesCount++;
+                if (indicesCount == 2)
+                {
+                    // We found the second delimiter, so we can stop searching
+                    break;
+                }
+            }
+        }
+
+        if (indicesCount == 0)
+        {
+            // No version part, just an identifier
+            value = (s, null);
+            return true;
+        }
+
+        if (indicesCount == 1)
+        {
+            var version = span[(indices[0] + 1)..];
+            if (version.Length == 0)
+            {
+                // Version part is empty, so assume last dash is part of the identifier
+                value = (s, null);
+                return true;
+            }
+
+            var identifier = span[..indices[0]];
+            if (identifier.Length == 0)
+            {
+                onError?.Invoke(CqlParseErrors.NullOrEmpty);
+                return false;
+            }
+
+            value = (identifier.ToString(), version.ToString());
+            return true;
+        }
+
+        // We have two or more delimiters. Both identifier and version parts may contain the delimiter itself
+        // for example: "my-lib-1.0.0" or "my-lib-1.0.0-beta" or "my-lib-v1.0.0-beta".
+        // In this case we do a regex on the end part for a semantic version pattern.
+        //
+        // NOTE: Version part doesn't have to be a valid semantic version, it can be any string,
+        // in this case we can't detect the correct split.
+
+        var matches = RegexForSemanticVersionAtEnd().Matches(s);
+        if (matches.Count == 1)
+        {
+            var match = matches[0];
+            var identifier = s[..match.Index];
+            var version = s[(match.Index+1)..]; // +1 to skip the delimiter
+            value = (identifier, version);
+            return true;
+        }
+
+        onError?.Invoke(CqlParseErrors.CannotSplitIdentifierAndVersionByDash);
+        return false;
+    }
+    [GeneratedRegex(
+        """
+        -          # Match a literal hyphen before the version
+        [vV]?      # Optional 'v' or 'V' prefix
+        \d+        # Major version (one or more digits)
+        \.         # Dot separator
+        \d+        # Minor version
+        (?:        # Optional non-capturing group for patch
+         \.         #  Dot separator
+         \d+        #  Patch version
+        )?
+        (?:        # Optional non-capturing group for pre-release
+         \-[\w.-]+  # Hyphen followed by one or more word chars, dots, or hyphens
+        )?
+        (?:        # Optional non-capturing group for build metadata
+         \+[\w.-]+  # Plus sign followed by one or more word chars, dots, or hyphens
+        )?
+        $          # End of string
+        """, RegexOptions.IgnorePatternWhitespace
+    )]
+    private static partial Regex RegexForSemanticVersionAtEnd();
 
     #endregion
 

--- a/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
@@ -24,6 +24,11 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     private static readonly CqlParseErrorHandler OnErrorThrowFormatException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlVersionedLibraryIdentifier));
 
     /// <summary>
+    /// The delimiter to use between the qualifier and identifier part in the string representation.
+    /// </summary>
+    [UsedImplicitly] public const char SystemIdentifierDelimiter = '.';
+
+    /// <summary>
     /// The delimiter to use between the identifier and version part in the string representation.
     /// </summary>
     [UsedImplicitly] public const char IdentifierVersionDelimiter = '-';
@@ -49,11 +54,11 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     /// <param name="identifier">The identifier string.</param>
     /// <param name="version">The version string (optional).</param>
     /// <returns>A <see cref="CqlVersionedLibraryIdentifier"/> instance.</returns>
-    public static CqlVersionedLibraryIdentifier ParseFromNameAndVersion(string identifier, string? version = null)
+    public static CqlVersionedLibraryIdentifier ParseFromIdentifierAndVersion(string identifier, string? version = null)
     {
         CqlLibraryIdentifier cqlLibraryIdentifier = (CqlLibraryIdentifier)identifier;
         CqlLibraryVersion? cqlLibraryVersion = version is null ? null : (CqlLibraryVersion?)version;
-        return FromNameAndVersion(cqlLibraryIdentifier, cqlLibraryVersion);
+        return FromIdentifierAndVersion(cqlLibraryIdentifier, cqlLibraryVersion);
     }
 
     /// <summary>
@@ -62,7 +67,7 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     /// <param name="identifier">The CQL library identifier.</param>
     /// <param name="version">The CQL library version (optional).</param>
     /// <returns>A <see cref="CqlVersionedLibraryIdentifier"/> instance.</returns>
-    public static CqlVersionedLibraryIdentifier FromNameAndVersion(CqlLibraryIdentifier identifier, CqlLibraryVersion? version = null)
+    public static CqlVersionedLibraryIdentifier FromIdentifierAndVersion(CqlLibraryIdentifier identifier, CqlLibraryVersion? version = null)
     {
         return new CqlVersionedLibraryIdentifier(identifier, version);
     }
@@ -80,9 +85,9 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     /// Returns a string representation of the CQL versioned library identifier.
     /// </summary>
     /// <returns>A string representation of the CQL versioned library identifier.</returns>
-    internal string ToString(char delimiter)
+    internal string ToString(char identifierVersionDelimiter)
     {
-        return BuildString(Identifier, Version, delimiter)!;
+        return BuildString(Identifier, Version, identifierVersionDelimiter)!;
     }
 
     /// <summary>
@@ -100,9 +105,33 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
         char delimiter = IdentifierVersionDelimiter) =>
         (identifier, version) switch
         {
-            ({ Length:>0 } id, { Length: > 0 } ver) => $"{id}{delimiter}{ver}",
-            ({ Length: > 0 } id, _)     => id,
+            ({ Length: > 0 } id, { Length: > 0 } ver) => $"{id}{delimiter}{ver}",
+            ({ Length: > 0 } id, _)                   => id,
             _ => null
+        };
+
+    /// <summary>
+    /// Constructs a string representation of a CQL versioned library identifier.
+    /// </summary>
+    /// <param name="system">The system of the CQL library.</param>
+    /// <param name="identifier">The identifier of the CQL library.</param>
+    /// <param name="version">The version of the CQL library. This parameter is optional.</param>
+    /// <param name="systemDelimiter">The delimiter used to separate the system and identifier. Defaults to '.'.</param>
+    /// <param name="versionDelimiter">The delimiter used to separate the identifier and version. Defaults to '-'.</param>
+    /// <returns>A string combining the system, identifier and version, separated by the specified delimiters.</returns>
+    public static string? BuildString(
+        string system,
+        string identifier,
+        string? version = null,
+        char systemDelimiter = SystemIdentifierDelimiter,
+        char versionDelimiter = IdentifierVersionDelimiter) =>
+        (system, identifier, version) switch
+        {
+            ({ Length: > 0 } sys, { Length: > 0 } id, { Length: > 0 } ver) => $"{sys}{systemDelimiter}{id}{versionDelimiter}{ver}",
+            ({ Length: > 0 } sys, { Length: > 0 } id, _)                   => $"{sys}{systemDelimiter}{id}",
+            (_, { Length: > 0 } id, { Length: > 0 } ver)                   => $"{id}{versionDelimiter}{ver}",
+            (_, { Length: > 0 } id, _)                                     => id,
+            _                                                              => null
         };
 
     #region Parsing
@@ -170,14 +199,14 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
                 if (string.IsNullOrEmpty(versionPart)
                     && CqlLibraryIdentifier.TryParse(identifierPart, out var nidentifier))
                 {
-                    result = FromNameAndVersion(nidentifier.Value);
+                    result = FromIdentifierAndVersion(nidentifier.Value);
                     return true;
                 }
 
                 if (CqlLibraryIdentifier.TryParse(identifierPart, out nidentifier)
                     && CqlLibraryVersion.TryParse(versionPart, out var nversion))
                 {
-                    result = FromNameAndVersion(nidentifier.Value, nversion.Value);
+                    result = FromIdentifierAndVersion(nidentifier.Value, nversion.Value);
                     return true;
                 }
             }
@@ -293,7 +322,7 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     /// Implicitly converts a <see cref="CqlLibraryIdentifier"/> to a <see cref="CqlVersionedLibraryIdentifier"/>.
     /// </summary>
     /// <param name="identifier">The CQL library identifier.</param>
-    public static implicit operator CqlVersionedLibraryIdentifier(CqlLibraryIdentifier identifier) => FromNameAndVersion(identifier);
+    public static implicit operator CqlVersionedLibraryIdentifier(CqlLibraryIdentifier identifier) => FromIdentifierAndVersion(identifier);
 
     #endregion
 

--- a/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifier.cs
@@ -24,16 +24,6 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     private static readonly CqlParseErrorHandler OnErrorThrowFormatException = CqlParseErrorHandlerStrategies.OnErrorThrowException(typeof(CqlVersionedLibraryIdentifier));
 
     /// <summary>
-    /// The delimiter to use between the qualifier and identifier part in the string representation.
-    /// </summary>
-    [UsedImplicitly] public const char SystemIdentifierDelimiter = '.';
-
-    /// <summary>
-    /// The delimiter to use between the identifier and version part in the string representation.
-    /// </summary>
-    [UsedImplicitly] public const char IdentifierVersionDelimiter = '-';
-
-    /// <summary>
     /// Implicitly converts a <see cref="CqlVersionedLibraryIdentifier"/> to a <see cref="string"/>.
     /// </summary>
     /// <param name="versionedIdentifier">The <see cref="CqlVersionedLibraryIdentifier"/> to convert.</param>
@@ -78,61 +68,17 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
     /// <returns>A string representation of the CQL versioned library identifier.</returns>
     public override string ToString()
     {
-        return ToString(IdentifierVersionDelimiter);
+        return FormatDelimited(CqlVersionedLibraryIdentifierFormatting.IdentifierVersionDelimiter);
     }
 
     /// <summary>
     /// Returns a string representation of the CQL versioned library identifier.
     /// </summary>
     /// <returns>A string representation of the CQL versioned library identifier.</returns>
-    internal string ToString(char identifierVersionDelimiter)
+    internal string FormatDelimited(char identifierVersionDelimiter)
     {
-        return BuildString(Identifier, Version, identifierVersionDelimiter)!;
+        return CqlVersionedLibraryIdentifierFormatting.FormatIdentifierVersion(Identifier, Version, identifierVersionDelimiter)!;
     }
-
-    /// <summary>
-    /// Constructs a string representation of a CQL versioned library identifier.
-    /// </summary>
-    /// <param name="identifier">The identifier of the CQL library.</param>
-    /// <param name="version">The version of the CQL library. This parameter is optional.</param>
-    /// <param name="delimiter">The delimiter used to separate the identifier and version. Defaults to "-".</param>
-    /// <returns>A string combining the identifier and version, separated by the specified delimiter.
-    /// If the version is not provided, only the identifier is returned.
-    /// If the identifier is not provided, null is returned.</returns>
-    public static string? BuildString(
-        string identifier,
-        string? version = null,
-        char delimiter = IdentifierVersionDelimiter) =>
-        (identifier, version) switch
-        {
-            ({ Length: > 0 } id, { Length: > 0 } ver) => $"{id}{delimiter}{ver}",
-            ({ Length: > 0 } id, _)                   => id,
-            _ => null
-        };
-
-    /// <summary>
-    /// Constructs a string representation of a CQL versioned library identifier.
-    /// </summary>
-    /// <param name="system">The system of the CQL library.</param>
-    /// <param name="identifier">The identifier of the CQL library.</param>
-    /// <param name="version">The version of the CQL library. This parameter is optional.</param>
-    /// <param name="systemDelimiter">The delimiter used to separate the system and identifier. Defaults to '.'.</param>
-    /// <param name="versionDelimiter">The delimiter used to separate the identifier and version. Defaults to '-'.</param>
-    /// <returns>A string combining the system, identifier and version, separated by the specified delimiters.</returns>
-    public static string? BuildString(
-        string system,
-        string identifier,
-        string? version = null,
-        char systemDelimiter = SystemIdentifierDelimiter,
-        char versionDelimiter = IdentifierVersionDelimiter) =>
-        (system, identifier, version) switch
-        {
-            ({ Length: > 0 } sys, { Length: > 0 } id, { Length: > 0 } ver) => $"{sys}{systemDelimiter}{id}{versionDelimiter}{ver}",
-            ({ Length: > 0 } sys, { Length: > 0 } id, _)                   => $"{sys}{systemDelimiter}{id}",
-            (_, { Length: > 0 } id, { Length: > 0 } ver)                   => $"{id}{versionDelimiter}{ver}",
-            (_, { Length: > 0 } id, _)                                     => id,
-            _                                                              => null
-        };
 
     #region Parsing
 
@@ -232,7 +178,7 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
 
         for (int i = span.Length - 1; i >= 0; i--)
         {
-            if (span[i] == IdentifierVersionDelimiter)
+            if (span[i] == CqlVersionedLibraryIdentifierFormatting.IdentifierVersionDelimiter)
             {
                 indices[indicesCount] = i;
                 indicesCount++;
@@ -292,6 +238,7 @@ public readonly partial record struct CqlVersionedLibraryIdentifier(
         onError?.Invoke(CqlParseErrors.CannotSplitIdentifierAndVersionByDash);
         return false;
     }
+
     [GeneratedRegex(
         """
         -          # Match a literal hyphen before the version

--- a/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifierFormatting.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlVersionedLibraryIdentifierFormatting.cs
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+namespace Hl7.Cql.Runtime;
+
+internal static class CqlVersionedLibraryIdentifierFormatting
+{
+    /// <summary>
+    /// The delimiter to use between the qualifier and identifier part in the string representation.
+    /// </summary>
+    [UsedImplicitly] public const char SystemIdentifierDelimiter = '.';
+
+    /// <summary>
+    /// The delimiter to use between the identifier and version part in the string representation.
+    /// </summary>
+    [UsedImplicitly] public const char IdentifierVersionDelimiter = '-';
+
+    /// <summary>
+    /// Constructs a string representation of a system identifier using the specified qualifiers.
+    /// </summary>
+    /// <param name="qualifiers">
+    /// An array of strings representing the qualifiers that make up the system identifier.
+    /// Each element in the array corresponds to a part of the system identifier.
+    /// </param>
+    /// <param name="delimiter">
+    /// The character used to separate the qualifiers in the resulting string.
+    /// Defaults to <see cref="SystemIdentifierDelimiter"/>.
+    /// </param>
+    /// <returns>
+    /// A string representation of the system identifier, with qualifiers separated by the specified delimiter.
+    /// If the <paramref name="qualifiers"/> array is empty, returns <c>null</c>.
+    /// </returns>
+    internal static string? FormatSystem(
+        string[] qualifiers,
+        char delimiter = SystemIdentifierDelimiter)
+    {
+        return qualifiers switch
+        {
+            { Length: > 0 } q => string.Join(delimiter, q),
+            _                 => null,
+        };
+    }
+
+    /// <summary>
+    /// Constructs a string representation of a CQL versioned library identifier.
+    /// </summary>
+    /// <param name="identifier">The identifier of the CQL library.</param>
+    /// <param name="version">The version of the CQL library. This parameter is optional.</param>
+    /// <param name="delimiter">The delimiter used to separate the identifier and version. Defaults to "-".</param>
+    /// <returns>A string combining the identifier and version, separated by the specified delimiter.
+    /// If the version is not provided, only the identifier is returned.
+    /// If the identifier is not provided, null is returned.</returns>
+    internal static string? FormatIdentifierVersion(
+        string identifier,
+        string? version = null,
+        char delimiter = IdentifierVersionDelimiter) =>
+        (identifier, version) switch
+        {
+            ({ Length: > 0 } id, { Length: > 0 } ver) => $"{id}{delimiter}{ver}",
+            ({ Length: > 0 } id, _)                   => id,
+            _                                         => null
+        };
+
+    /// <summary>
+    /// Constructs a string representation of a CQL versioned library identifier.
+    /// </summary>
+    /// <param name="system">The system of the CQL library.</param>
+    /// <param name="identifier">The identifier of the CQL library.</param>
+    /// <param name="version">The version of the CQL library. This parameter is optional.</param>
+    /// <param name="systemDelimiter">The delimiter used to separate the system and identifier. Defaults to '.'.</param>
+    /// <param name="versionDelimiter">The delimiter used to separate the identifier and version. Defaults to '-'.</param>
+    /// <returns>A string combining the system, identifier and version, separated by the specified delimiters.</returns>
+    internal static string? FormatSystemIdentifierVersion(
+        string system,
+        string identifier,
+        string? version = null,
+        char systemDelimiter = SystemIdentifierDelimiter,
+        char versionDelimiter = IdentifierVersionDelimiter) =>
+        (system, identifier, version) switch
+        {
+            ({ Length: > 0 } sys, { Length: > 0 } id, { Length: > 0 } ver) => $"{sys}{systemDelimiter}{id}{versionDelimiter}{ver}",
+            ({ Length: > 0 } sys, { Length: > 0 } id, _)                   => $"{sys}{systemDelimiter}{id}",
+            (_, { Length: > 0 } id, { Length: > 0 } ver)                   => $"{id}{versionDelimiter}{ver}",
+            (_, { Length: > 0 } id, _)                                     => id,
+            _                                                              => null
+        };
+}

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParseError.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParseError.cs
@@ -1,0 +1,47 @@
+﻿namespace Hl7.Cql.Runtime.Parsing;
+
+/// <summary>
+/// Represents a parse error in CQL (Clinical Quality Language).
+/// </summary>
+/// <param name="FormattableString">The formattable string containing the error message.</param>
+public readonly record struct CqlParseError(FormattableString FormattableString)
+{
+    /// <summary>
+    /// Gets the format string of the error message.
+    /// </summary>
+    public string Format => FormattableString.Format;
+    /// <summary>
+    /// Gets the arguments used in the format string of the error message.
+    /// </summary>
+    public object?[] Arguments => FormattableString.GetArguments();
+    /// <summary>
+    /// Returns the string representation of the error message.
+    /// </summary>
+    /// <returns>The formatted error message as a string.</returns>
+    public override string ToString() => FormattableString.ToString(null);
+    /// <summary>
+    /// Implicitly converts a string to a <see cref="CqlParseError"/>.
+    /// </summary>
+    /// <param name="message">The error message as a string.</param>
+    public static implicit operator CqlParseError(string message) => new(FormattableStringFactory.Create(message));
+    /// <summary>
+    /// Implicitly converts a tuple containing a format string and a single argument to a <see cref="CqlParseError"/>.
+    /// </summary>
+    /// <param name="message">A tuple containing the format string and argument.</param>
+    public static implicit operator CqlParseError((string format, object arg) message) => new(FormattableStringFactory.Create(message.format, message.arg));
+    /// <summary>
+    /// Implicitly converts a tuple containing a format string and two arguments to a <see cref="CqlParseError"/>.
+    /// </summary>
+    /// <param name="message">A tuple containing the format string and two arguments.</param>
+    public static implicit operator CqlParseError((string format, object arg1, object args2) message) => new(FormattableStringFactory.Create(message.format, message.arg1, message.args2));
+    /// <summary>
+    /// Implicitly converts a tuple containing a format string and an array of arguments to a <see cref="CqlParseError"/>.
+    /// </summary>
+    /// <param name="message">A tuple containing the format string and arguments array.</param>
+    public static implicit operator CqlParseError((string format, object[] args) message) => new(FormattableStringFactory.Create(message.format, message.args));
+    /// <summary>
+    /// Implicitly converts a <see cref="FormattableString"/> to a <see cref="CqlParseError"/>.
+    /// </summary>
+    /// <param name="message">The formattable string containing the error message.</param>
+    public static implicit operator CqlParseError(FormattableString message) => new(message);
+}

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrorHandler.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrorHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Hl7.Cql.Runtime.Parsing;
+
+/// <summary>
+/// Represents a handler for CQL parse errors.
+/// </summary>
+/// <param name="parseError">The CQL parse error that occurred.</param>
+public delegate void CqlParseErrorHandler(CqlParseError parseError);

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrorHandlerStrategies.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrorHandlerStrategies.cs
@@ -1,0 +1,19 @@
+namespace Hl7.Cql.Runtime.Parsing;
+
+internal static class CqlParseErrorHandlerStrategies
+{
+
+    public static CqlParseErrorHandler OnErrorThrowException(Type TargetType) =>
+        e =>
+            throw (e.Format switch
+           {
+               CqlParseErrors.NullOrEmpty => new ArgumentNullException(),
+               _                          => new FormatException($"Not a valid {TargetType}: {e}")
+           });
+
+    public static CqlParseErrorHandler OnErrorThrowInvalidOperationException =>
+        error => throw new InvalidOperationException(error.ToString());
+
+    public static CqlParseErrorHandler OnErrorIgnore =>
+        error => { };
+}

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrors.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrors.cs
@@ -1,0 +1,47 @@
+﻿namespace Hl7.Cql.Runtime.Parsing;
+
+/// <summary>
+/// Provides a collection of predefined error messages for parsing operations in the CQL runtime.
+/// </summary>
+public static class CqlParseErrors
+{
+    /// <summary>
+    /// Represents an error message indicating that additional tokens were found after the expected end of input.
+    /// </summary>
+    public const string MoreTokensAfterEndOfInput = "More tokens after expected end of input.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found.
+    /// </summary>
+    public const string ExpectedTokenNotFound_1 = "Expected {0} token not found.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
+    /// </summary>
+    public const string TextOpenedButNotClosed = "Text is opened with a special character, but not closed.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
+    /// </summary>
+    public const string MultipleQualifiersNotSupported = "Multiple qualifiers not supported.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
+    /// </summary>
+    public const string SyntaxErrorFound = "Syntax error found.";
+
+    /// <summary>
+    /// Represents an error message indicating a syntax error with a specific message.
+    /// </summary>
+    public const string SyntaxError_1 = "Syntax error: {0}.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
+    /// </summary>
+    public const string NullOrEmpty = "Input is null or empty.";
+
+    /// <summary>
+    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
+    /// </summary>
+    public const string CannotSplitIdentifierAndVersionByDash = "Cannot split identifier and version by dash.";
+}

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrors.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParseErrors.cs
@@ -23,11 +23,6 @@ public static class CqlParseErrors
     /// <summary>
     /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
     /// </summary>
-    public const string MultipleQualifiersNotSupported = "Multiple qualifiers not supported.";
-
-    /// <summary>
-    /// Represents an error message indicating that a specific token was expected but not found, with a suggestion to use a different token.
-    /// </summary>
     public const string SyntaxErrorFound = "Syntax error found.";
 
     /// <summary>

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
@@ -1,0 +1,129 @@
+﻿using Hl7.Cql.CqlToElm.Grammar;
+
+namespace Hl7.Cql.Runtime.Parsing;
+
+internal static class CqlParserExtensions
+{
+    internal static bool TryParseLibraryDefinition(
+        this cqlParser p,
+        [NotNullWhen(true)] out (string qualifier, string identifier, string version)? result,
+        CqlParseErrorHandler onError)
+    {
+        result = null;
+
+        if (p.libraryDefinition() is not { } libraryDefinition)
+        {
+            onError((CqlParseErrors.ExpectedTokenNotFound_1, "libraryDefinition"));
+            return false;
+        }
+
+        if (libraryDefinition.qualifiedIdentifier() is not { } qualifiedIdentifier)
+        {
+            onError((CqlParseErrors.ExpectedTokenNotFound_1, "qualifiedIdentifier"));
+            return false;
+        }
+
+        string qualifierPart = "";
+        switch (qualifiedIdentifier.qualifier())
+        {
+            case null:
+                onError((CqlParseErrors.ExpectedTokenNotFound_1, "qualifier"));
+                return false;
+
+            case { Length: > 1 }:
+                onError(CqlParseErrors.MultipleQualifiersNotSupported);
+                return false;
+
+            case [{} qualifier]:
+            {
+                var qualifierText = qualifier.identifier().GetText();
+                if (!TryUnquote(qualifierText, out qualifierPart, onError, '\"', '`'))
+                {
+                    return false;
+                }
+                break;
+            }
+        }
+
+        string? identifierText;
+        switch (qualifiedIdentifier.identifier()?.GetText())
+        {
+            case null:
+                onError((CqlParseErrors.ExpectedTokenNotFound_1, "identifier"));
+                return false;
+            case { } text:
+                identifierText = text;
+                break;
+        }
+
+        if (!TryUnquote(identifierText, out var identifierPart, onError, '\"', '`'))
+        {
+            return false;
+        }
+
+        var versionText = libraryDefinition.versionSpecifier()?.GetText() ?? string.Empty;
+        if (!TryUnquote(versionText, out var versionPart, onError, '\''))
+        {
+            return false;
+        }
+
+        result = (qualifierPart, identifierPart, versionPart);
+        return true;
+    }
+
+    private static bool TryUnquote(
+        string input,
+        out string result,
+        CqlParseErrorHandler onError,
+        params char[] allowedQuotationChars)
+    {
+        result = input;
+        if (string.IsNullOrEmpty(input))
+            return true;
+
+        for (int i = 0; i < allowedQuotationChars.Length; i++)
+        {
+            char quoteChar = allowedQuotationChars[i];
+            if (input.StartsWith(quoteChar))
+            {
+                if (input.Length == 1
+                    || !input.EndsWith(quoteChar))
+                {
+                    onError((CqlParseErrors.TextOpenedButNotClosed));
+                    return false;
+                }
+                result = input[1..^1];
+                result = Regex.Unescape(result);
+                break;
+            }
+        }
+
+        return true;
+    }
+
+    internal static bool EnsureAtEndOfInput(
+        this cqlParser p,
+        CqlParseErrorHandler onError)
+    {
+        if (p.CurrentToken.Type != cqlParser.Eof)
+        {
+            onError(CqlParseErrors.MoreTokensAfterEndOfInput);
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool EnsureNoSyntaxErrors(
+        this cqlParser p,
+        CqlParseErrorHandler onError)
+    {
+        if (p.NumberOfSyntaxErrors != 0)
+        {
+            onError(CqlParseErrors.SyntaxErrorFound);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
@@ -30,17 +30,24 @@ internal static class CqlParserExtensions
                 onError((CqlParseErrors.ExpectedTokenNotFound_1, "qualifier"));
                 return false;
 
-            case { Length: > 1 }:
-                onError(CqlParseErrors.MultipleQualifiersNotSupported);
-                return false;
-
-            case [{} qualifier]:
+            case {} qualifiers:
             {
-                var qualifierText = qualifier.identifier().GetText();
-                if (!TryUnquote(qualifierText, out qualifierPart, onError, '\"', '`'))
+                StringBuilder sbQualifierPart = new StringBuilder();
+                for (int i = 0; i < qualifiers.Length; i++)
                 {
-                    return false;
+                    var qualifier = qualifiers[i];
+                    var qualifierText = qualifier.identifier().GetText();
+                    if (!TryUnquote(qualifierText, out qualifierPart, onError, '\"', '`'))
+                    {
+                        return false;
+                    }
+
+                    if (sbQualifierPart.Length > 0)
+                        sbQualifierPart.Append(CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter);
+
+                    sbQualifierPart.Append(qualifierPart);
                 }
+                qualifierPart = sbQualifierPart.ToString();
                 break;
             }
         }
@@ -51,6 +58,7 @@ internal static class CqlParserExtensions
             case null:
                 onError((CqlParseErrors.ExpectedTokenNotFound_1, "identifier"));
                 return false;
+            
             case { } text:
                 identifierText = text;
                 break;

--- a/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/CqlParserExtensions.cs
@@ -43,7 +43,7 @@ internal static class CqlParserExtensions
                     }
 
                     if (sbQualifierPart.Length > 0)
-                        sbQualifierPart.Append(CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter);
+                        sbQualifierPart.Append(CqlVersionedLibraryIdentifierFormatting.SystemIdentifierDelimiter);
 
                     sbQualifierPart.Append(qualifierPart);
                 }

--- a/Cql/Cql.Runtime/Runtime/Parsing/StringCqlParseExtensions.cs
+++ b/Cql/Cql.Runtime/Runtime/Parsing/StringCqlParseExtensions.cs
@@ -1,0 +1,46 @@
+﻿using Antlr4.Runtime;
+using Hl7.Cql.CqlToElm.Grammar;
+
+namespace Hl7.Cql.Runtime.Parsing;
+
+internal static class StringCqlParseExtensions
+{
+    public static bool TryParseCqlLibraryDefinition(
+        this string cql,
+        [NotNullWhen(true)] out (string qualifier, string identifier, string version)? result,
+        CqlParseErrorHandler? onError = null,
+        bool ensureAtEndOfInput = false)
+    {
+        onError ??= CqlParseErrorHandlerStrategies.OnErrorIgnore;
+        var cqlParser = cql.ToCqlParser(onError);
+        return cqlParser.TryParseLibraryDefinition(out result, onError)
+               && (!ensureAtEndOfInput || cqlParser.EnsureAtEndOfInput(onError));
+    }
+
+    public static cqlParser ToCqlParser(
+        this string cql,
+        CqlParseErrorHandler? onError = null)
+    {
+        var stringReader = new StringReader(cql);
+        var antlrInputStream = new AntlrInputStream(stringReader);
+        var cqlLexer = new cqlLexer(antlrInputStream);
+        var cqlParser = new cqlParser(new CommonTokenStream(cqlLexer));
+        cqlParser.RemoveErrorListeners();
+        if (onError is { } fn)
+            cqlParser.AddErrorListener(new DelegatedAntlrErrorListener(fn));
+        return cqlParser;
+    }
+
+    private class DelegatedAntlrErrorListener(CqlParseErrorHandler onError) : IAntlrErrorListener<IToken>
+    {
+        public void SyntaxError(
+            TextWriter output,
+            IRecognizer recognizer,
+            IToken offendingSymbol,
+            int line,
+            int charPositionInLine,
+            string msg,
+            RecognitionException e) =>
+            onError((CqlParseErrors.SyntaxError_1, msg));
+    }
+}

--- a/Cql/Elm/Elm.cs
+++ b/Cql/Elm/Elm.cs
@@ -87,7 +87,7 @@ partial class Library : IGetVersionedIdentifier
         {
             if (identifier is not { id.Length: > 0 })
                 throw new MissingIdentifierError(this).ToException();
-            return CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(identifier.id, identifier.version);
+            return CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(identifier.id, identifier.version);
         }
     }
 
@@ -116,7 +116,7 @@ partial class IncludeDef : IGetVersionedIdentifier
         {
             if (path is not { Length: > 0 })
                 throw new MissingIdentifierError(this).ToException();
-            return CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(path, version);
+            return CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(path, version);
         }
     }
 
@@ -128,7 +128,7 @@ partial class IncludeDef : IGetVersionedIdentifier
 partial class VersionedIdentifier : IGetVersionedIdentifier
 {
     internal string? GetVersionedLibraryIdentifierString() =>
-        CqlVersionedLibraryIdentifier.BuildString(id, version);
+        CqlVersionedLibraryIdentifier.BuildString(system, id, version);
 
     /// <inheritdoc />
     (VersionedIdentifier? Result, Exception? Error) IGetVersionedIdentifier.VersionedIdentifier => (this, null);
@@ -140,9 +140,13 @@ partial class VersionedIdentifier : IGetVersionedIdentifier
     {
         get
         {
-            if (id is not { Length: > 0 })
+            if (id is not { Length: > 0 } qualifiedIdentifier)
                 throw new MissingIdentifierError(this).ToException();
-            return CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(id, version);
+
+            if (system is { Length: > 0 } sys)
+                qualifiedIdentifier = $"{sys}{CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter}{qualifiedIdentifier}";
+
+            return CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(qualifiedIdentifier, version);
         }
     }
 

--- a/Cql/Elm/Elm.cs
+++ b/Cql/Elm/Elm.cs
@@ -128,7 +128,7 @@ partial class IncludeDef : IGetVersionedIdentifier
 partial class VersionedIdentifier : IGetVersionedIdentifier
 {
     internal string? GetVersionedLibraryIdentifierString() =>
-        CqlVersionedLibraryIdentifier.BuildString(system, id, version);
+        CqlVersionedLibraryIdentifierFormatting.FormatSystemIdentifierVersion(system, id, version);
 
     /// <inheritdoc />
     (VersionedIdentifier? Result, Exception? Error) IGetVersionedIdentifier.VersionedIdentifier => (this, null);
@@ -144,7 +144,7 @@ partial class VersionedIdentifier : IGetVersionedIdentifier
                 throw new MissingIdentifierError(this).ToException();
 
             if (system is { Length: > 0 } sys)
-                qualifiedIdentifier = $"{sys}{CqlVersionedLibraryIdentifier.SystemIdentifierDelimiter}{qualifiedIdentifier}";
+                qualifiedIdentifier = $"{sys}{CqlVersionedLibraryIdentifierFormatting.SystemIdentifierDelimiter}{qualifiedIdentifier}";
 
             return CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(qualifiedIdentifier, version);
         }

--- a/Demo/CLI/LibraryRunner.cs
+++ b/Demo/CLI/LibraryRunner.cs
@@ -37,7 +37,7 @@ namespace CLI
         {
             //run using Library Resource files - production scenario, no debugging inline with measures project
             Console.WriteLine($"Loading resources for Library: {_opts.Library}");
-            var librarySetName = CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(_opts.LibraryName, _opts.LibraryVersion);
+            var librarySetName = CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(_opts.LibraryName, _opts.LibraryVersion);
             using var librarySetInvoker = new InvocationToolkit()
                                           .AddAssemblyBinariesInFhirLibrariesFromDirectory(new (_opts.ResourcesDirectory))
                                           .CreateLibrarySetInvoker(librarySetName);

--- a/Demo/Test.Measures.Demo/MeasuresTest.cs
+++ b/Demo/Test.Measures.Demo/MeasuresTest.cs
@@ -52,7 +52,7 @@ namespace Test
             var ctx = FhirCqlContext.ForBundle(patientEverything, MY2023, valueSets);
 
             var results = scope
-                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromNameAndVersion(lib, version))
+                          .SelectExpressionsForLibrary(CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion(lib, version))
                           .SelectResults(ctx)
                           .ToDictionary(t => t.definitionInvoker.DefinitionName, t => t.invocationResult);
 

--- a/Examples/CqlSdkExamples/500 Extending Functionality - Log Statements per Library/Program.cs
+++ b/Examples/CqlSdkExamples/500 Extending Functionality - Log Statements per Library/Program.cs
@@ -1,5 +1,7 @@
+using Hl7.Cql.CqlToElm;
 using Hl7.Cql.CqlToElm.Toolkit;
 using Hl7.Cql.CqlToElm.Toolkit.Extensions;
+using Hl7.Cql.Runtime;
 using Microsoft.Extensions.Logging;
 
 partial class Program
@@ -14,10 +16,13 @@ partial class Program
         var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
         // Add CQL libraries from directory
-        var cqlDirectory = new DirectoryInfo("input/cql");
+        //var cqlDirectory = new DirectoryInfo("input/cql");
+        var cql = """
+                  library System.Identifier version 'Version'
+                  """;
         var cqlToolkit = new CqlToolkit(loggerFactory);
-
-        cqlToolkit.AddCqlLibrariesFromDirectory(cqlDirectory);
+        var cqlLibraryString = CqlLibraryString.Parse(cql);
+        cqlToolkit.AddCqlLibraries(cqlLibraryString);
 
         // Translate CQL to ELM0
         cqlToolkit.TranslateToElm();

--- a/Examples/CqlSdkExamplesOld/Program.cs
+++ b/Examples/CqlSdkExamplesOld/Program.cs
@@ -390,7 +390,7 @@ internal static class Program
         // Execute CQL
         var threePlusTwo = librarySetInvoker.InvokeLibraryDefinition(
             FhirCqlContext.ForBundle(),
-            CqlVersionedLibraryIdentifier.ParseFromNameAndVersion("Add3and2", "1.0.0"),
+            CqlVersionedLibraryIdentifier.ParseFromIdentifierAndVersion("Add3and2", "1.0.0"),
             "ThreePlusTwo");
 
         Trace.Assert(threePlusTwo is 5);


### PR DESCRIPTION
Also review submodules:
- [Integration Runner](https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/pull/45)
- [Ncqa.DQIC](https://github.com/FirelyTeam/Ncqa.DQIC/pull/25)

Notes:
* Parsing cql into the `CqlLibraryString`, uses ANTLR to parse the library definition to extract the `CqlVersionedLibaryIdentifier`
* The cql library definition starts with a qualified identifier, which composes of zero or more qualifiers, followed by an identifier. The qualifiers are "." joined into the system part of a `VersionedIdentifier`, but for a `CqlVersionedLibraryIdentifier`, the qualifiers and the identifier are all "." joined into the `CqlLibraryIdentifier`. (e.g. "org.firely.FHIRHelpers" is a valid example composed of the qualifiers ["org", "firely"] and the identifier "FHIRHelpers".
* The logic for parsing libraryDefinition is more or less duplicated between `CqlParserExtensions.TryParseLibraryDefinition` and `TerminalParsers.Parse(cqlParser.LibraryDefinitionContext)`

![image](https://github.com/user-attachments/assets/3b390c13-89d3-4938-9f57-b029ee9b8178)

