### PR TITLE
857 packagercli help   fix tool name to be cql package

### DIFF
--- a/Cql/PackagerCLI/DependencyInjection/PackagerCliServiceCollectionExtensions.cs
+++ b/Cql/PackagerCLI/DependencyInjection/PackagerCliServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ internal static class PackagerCliServiceCollectionExtensions
         var asmDirName = asmFileInfo.DirectoryName!;
         var asmFileNameNoExt = asmFileInfo.Name[..^4]; // Trim ".dll"
 
-        config.AddEnvironmentVariables("CQLPACKAGER");
+        config.AddEnvironmentVariables("CQLPACKAGE");
 
         IEnumerable<string> files =
         [

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -22,6 +22,9 @@ public class Program
     {
         var rootCommand =
             new RootCommand(Description)
+                {
+                    Name = Process.GetCurrentProcess().ProcessName, // Use the name of the executable as the command name
+            }
                 //.AddOptions(ElmToFhirCommand.Options)
                 .AddGlobalOptions(LoggingCommand.Options)
                 //.SetHandler(typeof(ElmToFhirProgram), nameof(ElmToFhirProgram.CommandHandler))


### PR DESCRIPTION
Merge previous PR first:
* #865


Fixes the help usage by displaying the correct command name = exe name
![image](https://github.com/user-attachments/assets/cfc0e161-440f-41e0-8cfb-6674f79b2521)
