### PR TITLE
887 Add disclaimers

### DIFF
--- a/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
@@ -30,10 +30,9 @@ public record CqlToFhirCommand
         "cql";
 
     public const string Description =
-        "Start from ELM and convert to one or more of the following outputs: C#, DLL, PDB, FHIR Resources. " +
-        "When outputing to FHIR Resources, the CQL matchinging against the ELM based on their versioned " +
-        "identifier must be supplied as well.";
-
+        "Start from CQL and convert to one or more of the following outputs: ELM, C#, DLL, PDB, FHIR Resources. " +
+        "Take note of the disclaimer above.";
+    
     public static Command CreateCommand() =>
         new Command(Name, Description)
             .AddOptions(Options)

--- a/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirCommand.cs
@@ -29,9 +29,10 @@ public record CqlToFhirCommand
     public const string Name =
         "cql";
 
-    public const string Description =
+    public static readonly string Description =
         "Start from CQL and convert to one or more of the following outputs: ELM, C#, DLL, PDB, FHIR Resources. " +
-        "Take note of the disclaimer above.";
+        "Take note of the disclaimer above." +
+        Program.Disclaimer;
     
     public static Command CreateCommand() =>
         new Command(Name, Description)

--- a/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
@@ -30,7 +30,10 @@ internal record ElmToFhirCommand
         "elm";
 
     public const string Description =
-        "Start from CQL and convert to one or more of the following outputs: ELM, C#, DLL, PDB, FHIR Resources";
+        "Start from ELM and convert to one or more of the following outputs: C#, DLL, PDB, FHIR Resources. " +
+        "When outputing to FHIR Resources, the CQL matchinging against the ELM based on their versioned " +
+        "identifier must be supplied as well. " +
+        "Take note of the disclaimer above."; 
 
     public static readonly Option[] Options =
     [

--- a/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
+++ b/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirCommand.cs
@@ -29,11 +29,11 @@ internal record ElmToFhirCommand
     public const string Name =
         "elm";
 
-    public const string Description =
+    public static readonly string Description =
         "Start from ELM and convert to one or more of the following outputs: C#, DLL, PDB, FHIR Resources. " +
         "When outputing to FHIR Resources, the CQL matchinging against the ELM based on their versioned " +
-        "identifier must be supplied as well. " +
-        "Take note of the disclaimer above."; 
+        "identifier must be supplied as well." +
+        Program.Disclaimer;
 
     public static readonly Option[] Options =
     [

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -14,9 +14,19 @@ namespace Hl7.Cql.Packager;
 
 public class Program
 {
-    private const string Description =
+    private static string Description =
         "Utilities for converting CQL or ELM into other artefacts, such as C#, .NET assemblies or FHIR Resources. " +
-        "Pick from a command listed below, or type [command] --help for more information on it.";
+        "Pick from a command listed below, or type [command] --help for more information on it." +
+        Environment.NewLine +
+        Environment.NewLine +
+        "DISCLAIMER:" +
+        Environment.NewLine +
+        "The cql command is a very early addition and only supports basic cql translation. " +
+        "It is not yet production ready. " +
+        "If you find issues, please start from the ELM produced by the Java v3.1.0 tooling instead " +
+        "as input for the elm command.";
+
+
 
     public static int Main(string[] args)
     {

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -14,6 +14,8 @@ namespace Hl7.Cql.Packager;
 
 public class Program
 {
+    private const string JavaToolVersion = "3.1.0";
+
     private static string Description =
         "Utilities for converting CQL or ELM into other artefacts, such as C#, .NET assemblies or FHIR Resources. " +
         "Pick from a command listed below, or type [command] --help for more information on it." +
@@ -23,7 +25,7 @@ public class Program
         Environment.NewLine +
         "The cql command is a very early addition and only supports basic cql translation. " +
         "It is not yet production ready. " +
-        "If you find issues, please start from the ELM produced by the Java v3.1.0 tooling instead " +
+        $"If you find issues, please start from the ELM produced by the Java v{JavaToolVersion} tooling instead " +
         "as input for the elm command.";
 
 

--- a/Cql/PackagerCLI/Program.cs
+++ b/Cql/PackagerCLI/Program.cs
@@ -16,9 +16,7 @@ public class Program
 {
     private const string JavaToolVersion = "3.1.0";
 
-    private static string Description =
-        "Utilities for converting CQL or ELM into other artefacts, such as C#, .NET assemblies or FHIR Resources. " +
-        "Pick from a command listed below, or type [command] --help for more information on it." +
+    internal static readonly string Disclaimer =
         Environment.NewLine +
         Environment.NewLine +
         "DISCLAIMER:" +
@@ -28,6 +26,10 @@ public class Program
         $"If you find issues, please start from the ELM produced by the Java v{JavaToolVersion} tooling instead " +
         "as input for the elm command.";
 
+    private static readonly string Description =
+        "Utilities for converting CQL or ELM into other artefacts, such as C#, .NET assemblies or FHIR Resources. " +
+        "Pick from a command listed below, or type [command] --help for more information on it." +
+        Disclaimer;
 
 
     public static int Main(string[] args)

--- a/Demo/Cql/Build/Mvn.Targets.xml
+++ b/Demo/Cql/Build/Mvn.Targets.xml
@@ -5,7 +5,11 @@
 	<!-- Download MVN Dependencies -->
 	<PropertyGroup>
 		<!--
-		If you change the version here, you also need to update it in the pom.xml and Mvn.Targets.xml files
+		If you change the version here, you also need to update it in these places too:
+		* pom.xml
+		* Mvn.Targets.xml
+		* The Hl7.Cql.Packager.Program.JavaToolVersion for the Packager CLI
+		
 		The latest version number can be found under the releases tab of the CQL to ELM CLI repository
 		see: https://github.com/cqframework/clinical_quality_language/releases
 

--- a/Demo/Cql/Build/pom.xml
+++ b/Demo/Cql/Build/pom.xml
@@ -10,7 +10,11 @@
 	<version>1.0</version>
 	<properties>
 		<!--
-		If you change the version here, you also need to update it in the pom.xml and Mvn.Targets.xml files
+		If you change the version here, you also need to update it in these places too:
+    * pom.xml
+    * Mvn.Targets.xml
+    * The Hl7.Cql.Packager.Program.JavaToolVersion for the Packager CLI
+		
 		The latest version number can be found under the releases tab of the CQL to ELM CLI repository
 		see: https://github.com/cqframework/clinical_quality_language/releases
 


### PR DESCRIPTION
Merge #891 first

Note the disclaimers are added on the root command, and the `cql` and `elm` commands. This allows the disclaimer to be visible when displaying help against the sub commands, but unfortunately this also means it is repeated multiple times on the root command

![image](https://github.com/user-attachments/assets/1cb2f386-6a7f-4ba6-8c3c-d9f0a303233d)
