### PR TITLE
Update FirelySdkVersion to 5.12.0

### DIFF
--- a/Demo/Cql/Cql.csproj
+++ b/Demo/Cql/Cql.csproj
@@ -1,6 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<Import Project="..\cql-demo.props" />
+
+	<PropertyGroup>
+		<CqlToElmEnabled>true</CqlToElmEnabled>
+	</PropertyGroup>
+	
 	<Import Project="Build\Mvn.Targets.xml" />      
 
 	<ItemGroup>

--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -16,7 +16,7 @@
 			## Keep FirelySdkVersion in sync between cql-base.props and cql-demo.props
 			The version must be the same as FhirNetApiVersion in https://github.com/FirelyTeam/Vonk/blob/develop/src/Vonk.props
 			-->
-		<FirelySdkVersion>5.11.4</FirelySdkVersion>
+		<FirelySdkVersion>5.12.0</FirelySdkVersion>
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>
 		<Copyright>Copyright 2013-2024 NCQA, Firely. Contains materials (C) HL7 International</Copyright>
 		<PackageProjectUrl>https://github.com/FirelyTeam/firely-cql-sdk</PackageProjectUrl>

--- a/cql-base.props
+++ b/cql-base.props
@@ -11,7 +11,7 @@
 			Keep FirelySdkVersion in sync between cql-base.props and cql-demo.props
 			The version must be the same as FhirNetApiVersion in https://github.com/FirelyTeam/Vonk/blob/develop/src/Vonk.props
 			-->
-		<FirelySdkVersion>5.11.4</FirelySdkVersion>
+		<FirelySdkVersion>5.12.0</FirelySdkVersion>
 
 		<!-- https://hl7.org/fhir/R4/ -->
 		<FhirRelease>R4</FhirRelease>


### PR DESCRIPTION
Preparing for the first beta release by getting the version of the Firely .NET SDK in sync with the one used in Vonk