### PR TITLE
Enabled interval promotion for some tests

### DIFF
--- a/Cql/Cql.CqlToElm/Visitors/TimingExpressionVisitor.cs
+++ b/Cql/Cql.CqlToElm/Visitors/TimingExpressionVisitor.cs
@@ -209,7 +209,6 @@ namespace Hl7.Cql.CqlToElm.Visitors
                 ? [left, right, Precision(precision)]
                 : [left, right];
 
-
         // ('starts' | 'ends' | 'occurs')? quantityOffset? temporalRelationship dateTimePrecisionSpecifier? ('start' | 'end')?
         private Expression HandleBeforeOrAfter(cqlParser.BeforeOrAfterIntervalOperatorPhraseContext context,
             Expression lhs,
@@ -270,14 +269,6 @@ namespace Hl7.Cql.CqlToElm.Visitors
             // No quantity offset, so a simple "a is before/after (or on) b"
             if (context.quantityOffset() == null)
             {
-                // Make sure both left and right are intervals by turning points into Point Intervals.
-                (left,right) = (left.resultTypeSpecifier, right.resultTypeSpecifier) switch
-                {
-                    (IntervalTypeSpecifier, not IntervalTypeSpecifier) => (left, PointInterval(right)),
-                    (not IntervalTypeSpecifier, IntervalTypeSpecifier) => (PointInterval(left), right),
-                    _                                                  => (left, right)
-                };
-
                 var lrArgs = CreateArgArray(left, right, dateTimePrecision);
                 var result = (isInclusive, isBefore) switch
                 {

--- a/Cql/CqlToElmTests/(tests)/TimingExpressionTest.cs
+++ b/Cql/CqlToElmTests/(tests)/TimingExpressionTest.cs
@@ -9,7 +9,7 @@ namespace Hl7.Cql.CqlToElm.Test
         public void OnOrAfterMonthOf()
         {
             // https://cql.hl7.org/09-b-cqlreference.html#same-or-after-2
-            var library = CreateCqlToolkit().MakeLibraryFromExpression("Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15");
+            var library = CreateCqlToolkit(EnableIntervalPromotion: true).MakeLibraryFromExpression("Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15");
             var sameOrAfter = library.Should().BeACorrectlyInitializedLibraryWithStatementOfType<SameOrAfter>();
             sameOrAfter.Should().HaveType(SystemTypes.BooleanType);
             sameOrAfter.operand.Should().NotBeNull();
@@ -156,7 +156,7 @@ namespace Hl7.Cql.CqlToElm.Test
         [TestMethod]
         public void TestOnOrAfterDateTrue()
         {
-            var library = CreateCqlToolkit().MakeLibraryFromExpression("Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15");
+            var library = CreateCqlToolkit(EnableIntervalPromotion: true).MakeLibraryFromExpression("Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15");
             var sameOrAfter = library.Should().BeACorrectlyInitializedLibraryWithStatementOfType<SameOrAfter>();
             var result = Run<bool?>(sameOrAfter, library);
             result.Should().BeTrue();
@@ -165,7 +165,7 @@ namespace Hl7.Cql.CqlToElm.Test
         [TestMethod]
         public void TestOnOrBeforeDateTrue()
         {
-            var library = CreateCqlToolkit().MakeLibraryFromExpression("Interval[@2012-10-01, @2012-11-01] on or before month of @2012-11-15");
+            var library = CreateCqlToolkit(EnableIntervalPromotion: true).MakeLibraryFromExpression("Interval[@2012-10-01, @2012-11-01] on or before month of @2012-11-15");
             var sameOrBefore = library.Should().BeACorrectlyInitializedLibraryWithStatementOfType<SameOrBefore>();
             var result = Run<bool?>(sameOrBefore, library);
             result.Should().BeTrue();

--- a/Cql/CqlToElmTests/(tests)/XmlTest.cs
+++ b/Cql/CqlToElmTests/(tests)/XmlTest.cs
@@ -39,7 +39,7 @@ namespace Hl7.Cql.CqlToElm.Test
             if (SkippedTests.DoesNotCompile.TryGetValue(testCase.TestName, out var reason))
                 Assert.Inconclusive($"Case {testFullName} skipped: {reason}");
 
-            var cqlToolkit = CreateCqlToolkit(AllowNullIntervals:true);
+            var cqlToolkit = CreateCqlToolkit(AllowNullIntervals:true, EnableIntervalPromotion: true);
             var expression = cqlToolkit.Expression(testCase.Expression);
             var expressionErrors = expression.GetErrors();
             if (expressionErrors.Any())


### PR DESCRIPTION
Adding code in PR #898 to do interval promotion did not sit well with me. Discovered that we didn't need this additional code (as compared to the java version), since we do support interval promotions, but it is disabled by default. Re-enabled this in the settings for appliable tests and now removed the "ad hoc" interval promotion code.  Also see #899, since that is what mainly caused the confusion.

