### PR TITLE
Update azure-pipelines.yml to include triggering on support branch 

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -8,7 +8,7 @@ resources:
       name: FirelyTeam/azure-pipeline-templates
       endpoint: FirelyTeam
       ref: refs/tags/v1
-      
+
 variables:
   - group: CodeSigning
   - group: APIKeys
@@ -22,6 +22,7 @@ trigger:
     include:
     - develop*
     - develop-2.0*
+    - support/*
     - release*
     - refs/tags/v*
     - spike*
@@ -32,11 +33,11 @@ stages:
   jobs:
     - job: CheckDocChangesJob
       displayName: 'Check for changes in docs folder'
-      pool: 
+      pool:
         vmImage: ubuntu-latest
       steps:
         - checkout: self
-          fetchDepth: 0 
+          fetchDepth: 0
         - script: |
             echo "##vso[task.setvariable variable=SOURCE_BRANCH]$(Build.SourceBranch)"
             echo "##vso[task.setvariable variable=TARGET_BRANCH]$(System.PullRequest.TargetBranch)"
@@ -65,20 +66,20 @@ stages:
                     break
                 }
                 echo "File $file is in /docs/ folder"
-            }  
+            }
 
-          
+
             if ( $skipBuildStage -eq 'true') {
               Write-Host "Only /docs/ files changed, skipping build."
-            } 
+            }
             else {
               Write-Host "Changes outside /docs/ detected, proceeding with build."
             }
-            echo "##vso[task.setvariable variable=skipBuild;isOutput=true]$skipBuildStage" 
+            echo "##vso[task.setvariable variable=skipBuild;isOutput=true]$skipBuildStage"
 
           displayName: 'Check for changes outside docs folder'
-          name: checkForDocChanges            
-- stage: build  
+          name: checkForDocChanges
+- stage: build
   dependsOn: checkForDocChangesStage
   condition: and(succeeded(), not(eq(dependencies.checkForDocChangesStage.outputs['CheckDocChangesJob.checkForDocChanges.skipBuild'], 'true')))
   jobs:
@@ -96,7 +97,7 @@ stages:
         **/*Tests/*Tests.csproj
         **/**/Test.Measures.Demo.csproj
         !**/Ncqa.HT.DeckTests.csproj
-        submodules\Firely.Cql.Sdk.Integration.Runner\IntegrationRunner\IntegrationRunner.csproj
+        submodules/Firely.Cql.Sdk.Integration.Runner/IntegrationRunner/IntegrationRunner.csproj
       packageArtifacts: true
       restoreDependencies: true
       nuGetServiceConnections: GitHubPackageGetFeed
@@ -105,10 +106,10 @@ stages:
       codeSignerPassword: $(CodeSigningPassword)
       signingKeyFileName: 'cql-sdk.snk'
       filesForSigning: >-
-        $(Build.SourcesDirectory)\Cql\*\bin\Release\*\Hl7.Cql*.dll,
-        $(Build.SourcesDirectory)\Cql\*\bin\Release\*\Ncqa.Cql*.dll,
-        $(Build.SourcesDirectory)*\bin\Release\*\Cql.*.dll,
-        $(Build.SourcesDirectory)*\bin\Release\*\PackagerCLI.dll
+        $(Build.SourcesDirectory)/Cql/*/bin/Release/*/Hl7.Cql*.dll,
+        $(Build.SourcesDirectory)/Cql/*/bin/Release/*/Ncqa.Cql*.dll,
+        $(Build.SourcesDirectory)*/bin/Release/*/Cql.*.dll,
+        $(Build.SourcesDirectory)*/bin/Release/*/PackagerCLI.dll
       filesToExcludeForSigning: >-
         *CodeGeneration*,
         *CoreTests*


### PR DESCRIPTION
- Modified trigger to include branches `support/*`.
- Change backslashes '\' to forwardslashes  '/' in paths