### PR TITLE
Feature971/991 enable integration tests in build pipeline again

### DIFF
--- a/Cql-Sdk-All.sln
+++ b/Cql-Sdk-All.sln
@@ -340,6 +340,6 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {366252DE-C2FB-4EAC-96EE-22210BD43DE2}
-		FileExplorer = |build\|docs\|LibrarySets\|submodules\Firely.Cql.Sdk.Integration.Runner\NodeJsUtils\
+		FileExplorer = build\|docs\|LibrarySets\|submodules\Firely.Cql.Sdk.Integration.Runner\NodeJsUtils\
 	EndGlobalSection
 EndGlobal

--- a/Demo/Measures.ecqm-content-qicore-2024/Measures.ecqm-content-qicore-2024.csproj
+++ b/Demo/Measures.ecqm-content-qicore-2024/Measures.ecqm-content-qicore-2024.csproj
@@ -23,6 +23,7 @@
 		<!-- Copy dll's to IntegrationRunner -->
 		<!-- <DllDirectory>$(CqlSolutionDir)/submodules/Firely.Cql.Sdk.Integration.Runner/IntegrationRunner/CMS Assemblies</DllDirectory> -->
 		<ResourcesDirectory>$(CqlSolutionDir)/submodules/Firely.Cql.Sdk.Integration.Runner/IntegrationRunner/CMS Resources</ResourcesDirectory>
+		<CqlToElmEnabled>true</CqlToElmEnabled>
 		<!-- <ResourcesDirectory>$(LibrarySetRoot)/Resources</ResourcesDirectory> -->
 		<!-- <CqlToElmEnabled>true</CqlToElmEnabled> -->
 		<!-- <ElmToCSharpEnabled>true</ElmToCSharpEnabled> -->

--- a/Demo/Measures.ecqm-content-qicore-2025/Measures.ecqm-content-qicore-2025.csproj
+++ b/Demo/Measures.ecqm-content-qicore-2025/Measures.ecqm-content-qicore-2025.csproj
@@ -21,6 +21,8 @@
 		<CqlDirectory>$(LibrarySetRoot)/Cql</CqlDirectory>
 		<ElmDirectory>$(LibrarySetRoot)/Elm</ElmDirectory>
 		<ResourcesDirectory>$(LibrarySetRoot)/Resources</ResourcesDirectory>
+		<!-- <ResourcesDirectory>$(CqlSolutionDir)/submodules/Firely.Cql.Sdk.Integration.Runner/IntegrationRunner/CMS Resources</ResourcesDirectory> -->
+		<!-- <CqlToElmEnabled>true</CqlToElmEnabled> -->
 	</PropertyGroup>
 
 	<Import Project="../Cql/Build/CqlToElm.Targets.xml" />

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/AHAOverall.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/AHAOverall.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/AdultOutpatientEncounters.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/AdultOutpatientEncounters.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/AdvancedIllnessandFrailty.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/AdvancedIllnessandFrailty.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/AlaraCommonFunctions.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/AlaraCommonFunctions.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/Antibiotic.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/Antibiotic.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS0334FHIRPCCesareanBirth.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS0334FHIRPCCesareanBirth.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1017FHIRHHFI.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1017FHIRHHFI.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1028FHIRPCSevereOBComps.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1028FHIRPCSevereOBComps.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS104FHIRSTKDCAntithrombotic.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS104FHIRSTKDCAntithrombotic.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1074FHIRCTIQR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1074FHIRCTIQR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS108FHIRVTEProphylaxis.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS108FHIRVTEProphylaxis.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS117FHIRChildhoodImmunizationStatus.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS117FHIRChildhoodImmunizationStatus.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1206FHIRCTOQR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1206FHIRCTOQR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS122FHIRDiabetesAssessGreaterThan9Percent.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS122FHIRDiabetesAssessGreaterThan9Percent.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1244FHIRECATHOQR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1244FHIRECATHOQR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS124FHIRCervicalCancerScreening.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS124FHIRCervicalCancerScreening.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS125FHIRBreastCancerScreening.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS125FHIRBreastCancerScreening.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1264FHIRECATREHQR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS1264FHIRECATREHQR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS128FHIRAntidepressantMedManagement.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS128FHIRAntidepressantMedManagement.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS130FHIRColorectalCancerScreening.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS130FHIRColorectalCancerScreening.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS133FHIRCataracts2040BCVAwithin90Days.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS133FHIRCataracts2040BCVAwithin90Days.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS135FHIRHFACEIorARBorARNIforLVSD.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS135FHIRHFACEIorARBorARNIforLVSD.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS143FHIRPOAGOpticNerveEvaluation.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS143FHIRPOAGOpticNerveEvaluation.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS144FHIRHFBetaBlockerTherapyforLVSD.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS144FHIRHFBetaBlockerTherapyforLVSD.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS146FHIRAppropriateTestingforPharyngitis.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS146FHIRAppropriateTestingforPharyngitis.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS149FHIRDementiaCognitiveAssessment.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS149FHIRDementiaCognitiveAssessment.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS155FHIRWeightAssessandCounselforKids.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS155FHIRWeightAssessandCounselforKids.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS159FHIRDepressionRemissionatTwelveMonths.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS159FHIRDepressionRemissionatTwelveMonths.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS165FHIRControllingHighBloodPressure.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS165FHIRControllingHighBloodPressure.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS190VTEProphylaxisICUFHIR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS190VTEProphylaxisICUFHIR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS22FHIRPCSBPScreeningFollowUp.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS22FHIRPCSBPScreeningFollowUp.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS2FHIRPCSDepressionScreenAndFollowUp.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS2FHIRPCSDepressionScreenAndFollowUp.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS349FHIRHIVScreening.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS349FHIRHIVScreening.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS506FHIRSafeUseofOpioids.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS506FHIRSafeUseofOpioids.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS50FHIRCRLReceiptofSpecialistReport.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS50FHIRCRLReceiptofSpecialistReport.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS68FHIRDocumentationofCurrentMedications.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS68FHIRDocumentationofCurrentMedications.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS69FHIRPCSBMIScreenAndFollowUp.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS69FHIRPCSBMIScreenAndFollowUp.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS71FHIRSTKAnticoagAFFlutter.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS71FHIRSTKAnticoagAFFlutter.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS72FHIRSTKAntithromboticDay2.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS72FHIRSTKAntithromboticDay2.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS74FHIRPrimaryCariesPreventionasOfferedbyDentists.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS74FHIRPrimaryCariesPreventionasOfferedbyDentists.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS75FHIRChildrenWhoHaveDentalDecayOrCavities.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS75FHIRChildrenWhoHaveDentalDecayOrCavities.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS816FHIRHHHypo.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS816FHIRHHHypo.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS819FHIRHHORAE.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS819FHIRHHORAE.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS826FHIRHHPI.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS826FHIRHHPI.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS832HHAKIFHIR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS832HHAKIFHIR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS871HHHyperFHIR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS871HHHyperFHIR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS986FHIRMalnutritionScore.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS986FHIRMalnutritionScore.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMS996FHIRAptTxforSTEMI.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMS996FHIRAptTxforSTEMI.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CMSFHIR844HybridHospitalWideMortality.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CMSFHIR844HybridHospitalWideMortality.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CQMCommon.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CQMCommon.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/CumulativeMedicationDuration.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/CumulativeMedicationDuration.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/FHIRHelpers.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/FHIRHelpers.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/Hospice.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/Hospice.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/HospitalHarm.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/HospitalHarm.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/OncologyPainIntensityQuantifiedFHIR.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/OncologyPainIntensityQuantifiedFHIR.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/PCMaternal.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/PCMaternal.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/PalliativeCare.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/PalliativeCare.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/QICoreCommon.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/QICoreCommon.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/Status.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/Status.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/SupplementalDataElements.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/SupplementalDataElements.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/TJCOverall.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/TJCOverall.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/LibrarySets/ecqm-content-qicore-2025/Elm/VTE.json
+++ b/LibrarySets/ecqm-content-qicore-2025/Elm/VTE.json
@@ -1,7 +1,7 @@
 {
    "library" : {
       "annotation" : [ {
-         "translatorVersion" : "3.27.0",
+         "translatorVersion" : "3.28.0",
          "translatorOptions" : "EnableLocators,EnableResultTypes",
          "signatureLevel" : "All",
          "type" : "CqlToElmInfo"

--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -96,8 +96,7 @@ stages:
         **/*Tests/*Tests.csproj
         **/**/Test.Measures.Demo.csproj
         !**/Ncqa.HT.DeckTests.csproj
-        # TODO: Reintroduce integration test back in issue: https://github.com/FirelyTeam/firely-cql-sdk/issues/971
-        # submodules\Firely.Cql.Sdk.Integration.Runner\IntegrationRunner\IntegrationRunner.csproj
+        submodules\Firely.Cql.Sdk.Integration.Runner\IntegrationRunner\IntegrationRunner.csproj
       packageArtifacts: true
       restoreDependencies: true
       nuGetServiceConnections: GitHubPackageGetFeed


### PR DESCRIPTION
This PR re-enables integration tests in the build pipeline by updating the submodule reference and modifying the Azure pipeline configuration.

Fixes: #991