### PR TITLE
987 generated code compiler error there is no target type for the collection expression

### DIFF
--- a/Cql/Cql.Compiler/ExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/ExpressionBuilderContext.cs
@@ -127,6 +127,20 @@ partial class ExpressionBuilderContext
         {
             using (PushElement(element))
             {
+                /*
+                This code is useful for setting breakpoints to inspect the expression tree at a specific element.
+                The ELM json must be modified to add an annotation tags with a debug counter first.
+
+                var debugCounter = element.annotation
+                                          ?.OfType<Annotation>()
+                                          .FirstOrDefault()?.t.FirstOrDefault(t => t.name == "debug")
+                                          ?.value;
+                if (debugCounter == "42") // Identify the correct debug counter from the ELM file
+                {
+                    ; // Set a breakpoint here
+                }
+                */
+
                 Expression? expression = element switch
                 {
                     //@formatter:off
@@ -442,8 +456,7 @@ partial class ExpressionBuilderContext
                 array = Expression.NewArrayBounds(elementType, Expression.Constant(0));
             }
 
-            var asEnumerable = array.NewTypeAsExpression(typeof(IEnumerable<>).MakeGenericType(elementType));
-            return asEnumerable;
+            return array;
         }
 
         throw this.NewExpressionBuildingException($"List is the wrong type");

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -84,7 +84,7 @@ public partial class MultipleResourcesExample_0_0_1 : ILibrary, ISingleton<Multi
                 "final",
                 "amended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
 
             return i_;
         };

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -2033,7 +2033,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);
@@ -2058,7 +2058,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -97,7 +97,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -140,7 +140,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -220,7 +220,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = D?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -248,7 +248,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = D?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -276,7 +276,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -304,7 +304,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -332,7 +332,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -360,7 +360,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -389,7 +389,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -413,7 +413,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -439,7 +439,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "in-progress",
                 "onleave",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -465,7 +465,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "in-progress",
                 "onleave",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -579,7 +579,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -622,7 +622,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -711,7 +711,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "in-progress",
                 "on-hold",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -735,7 +735,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "in-progress",
                 "on-hold",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -757,7 +757,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
             MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
@@ -784,7 +784,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "active",
                 "completed",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
             MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
@@ -813,7 +813,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -856,7 +856,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -898,7 +898,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -921,7 +921,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -944,7 +944,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -967,7 +967,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -990,7 +990,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -1013,7 +1013,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -1036,7 +1036,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -1059,7 +1059,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -1084,7 +1084,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -1109,7 +1109,7 @@ public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -149,7 +149,7 @@ public partial class SupplementalDataElements_3_4_000 : ILibrary, ISingleton<Sup
                 return aw_;
             };
             IEnumerable<CqlCode> ad_ = context.Operators.Select<object, CqlCode>(ab_, ac_);
-            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>(x_ as IEnumerable<CqlCode>, ad_);
+            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((IEnumerable<CqlCode>)x_, ad_);
             bool? af_(Extension @this)
             {
                 string ax_ = @this?.Url;

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -449,7 +449,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 "on-hold",
                 "completed",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             Code<RequestIntent> ak_ = FrailtyDeviceOrder?.IntentElement;
             string al_ = FHIRHelpers_4_0_001.Instance.ToString(context, ak_);
             bool? am_ = context.Operators.Equal(al_, "order");
@@ -474,7 +474,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 "amended",
                 "corrected",
             ];
-            bool? aw_ = context.Operators.In<string>(au_, av_ as IEnumerable<string>);
+            bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
             DataType ax_ = FrailtyDeviceApplied?.Effective;
             CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ax_);
             CqlInterval<CqlDateTime> az_ = this.Measurement_Period(context);
@@ -529,7 +529,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 "amended",
                 "corrected",
             ];
-            bool? bq_ = context.Operators.In<string>(bo_, bp_ as IEnumerable<string>);
+            bool? bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
             DataType br_ = FrailtySymptom?.Effective;
             CqlInterval<CqlDateTime> bs_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, br_);
             CqlInterval<CqlDateTime> bt_ = this.Measurement_Period(context);

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -460,7 +460,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             DataType j_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);
             CqlDateTime l_ = context.Operators.End(k_);
@@ -500,7 +500,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             DataType j_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);
             CqlDateTime l_ = context.Operators.End(k_);
@@ -567,7 +567,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             bool? j_ = context.Operators.Not(i_);
             DataType k_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, k_);
@@ -608,7 +608,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             bool? j_ = context.Operators.Not(i_);
             DataType k_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, k_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -295,7 +295,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = CervicalCytology?.Category;
             bool? j_(CodeableConcept CervicalCytologyCategory)
             {
@@ -348,7 +348,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = HPVTest?.Category;
             bool? j_(CodeableConcept HPVTestCategory)
             {
@@ -420,7 +420,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
             "amended",
             "corrected",
         ];
-        bool? d_ = context.Operators.In<string>(b_, c_ as IEnumerable<string>);
+        bool? d_ = context.Operators.In<string>(b_, (IEnumerable<string>)c_);
 
         return d_;
     }

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -529,7 +529,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FecalOccult?.Category;
             bool? j_(CodeableConcept FecalOccultCategory)
             {
@@ -567,7 +567,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] ae_ = [
                     "laboratory",
                 ];
-                bool? af_ = context.Operators.Equivalent<string>(ad_, ae_ as IEnumerable<string>);
+                bool? af_ = context.Operators.Equivalent<string>(ad_, (IEnumerable<string>)ae_);
 
                 return af_;
             };
@@ -605,7 +605,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FecalOccult?.Category;
             bool? j_(CodeableConcept FecalOccultCategory)
             {
@@ -643,7 +643,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] ae_ = [
                     "laboratory",
                 ];
-                bool? af_ = context.Operators.Equivalent<string>(ad_, ae_ as IEnumerable<string>);
+                bool? af_ = context.Operators.Equivalent<string>(ad_, (IEnumerable<string>)ae_);
 
                 return af_;
             };
@@ -711,7 +711,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] z_ = [
                     "laboratory",
                 ];
-                bool? aa_ = context.Operators.Equivalent<string>(y_, z_ as IEnumerable<string>);
+                bool? aa_ = context.Operators.Equivalent<string>(y_, (IEnumerable<string>)z_);
                 bool? ab_ = context.Operators.Not(aa_);
 
                 return ab_;
@@ -749,7 +749,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = FecalOccult?.Value;
             bool? k_ = context.Operators.Not((bool?)(j_ is null));
@@ -885,7 +885,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FitDNA?.Category;
             bool? j_(CodeableConcept FitDNACategory)
             {
@@ -923,7 +923,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] ao_ = [
                     "laboratory",
                 ];
-                bool? ap_ = context.Operators.Equivalent<string>(an_, ao_ as IEnumerable<string>);
+                bool? ap_ = context.Operators.Equivalent<string>(an_, (IEnumerable<string>)ao_);
 
                 return ap_;
             };
@@ -969,7 +969,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FitDNA?.Category;
             bool? j_(CodeableConcept FitDNACategory)
             {
@@ -1007,7 +1007,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] ao_ = [
                     "laboratory",
                 ];
-                bool? ap_ = context.Operators.Equivalent<string>(an_, ao_ as IEnumerable<string>);
+                bool? ap_ = context.Operators.Equivalent<string>(an_, (IEnumerable<string>)ao_);
 
                 return ap_;
             };
@@ -1083,7 +1083,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 string[] aj_ = [
                     "laboratory",
                 ];
-                bool? ak_ = context.Operators.Equivalent<string>(ai_, aj_ as IEnumerable<string>);
+                bool? ak_ = context.Operators.Equivalent<string>(ai_, (IEnumerable<string>)aj_);
                 bool? al_ = context.Operators.Not(ak_);
 
                 return al_;
@@ -1129,7 +1129,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = FitDNA?.Value;
             bool? k_ = context.Operators.Not((bool?)(j_ is null));
@@ -1209,7 +1209,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "corrected",
                 "appended",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             DataType i_ = Colonography?.Effective;
             CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, i_);
             CqlDateTime k_ = context.Operators.End(j_);
@@ -1248,7 +1248,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 "corrected",
                 "appended",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = Colonography?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -963,14 +963,14 @@ public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISing
                     m_,
                     n_,
                 ];
-                CqlDateTime p_ = context.Operators.Max<CqlDateTime>(o_ as IEnumerable<CqlDateTime>);
+                CqlDateTime p_ = context.Operators.Max<CqlDateTime>((IEnumerable<CqlDateTime>)o_);
                 CqlDateTime r_ = context.Operators.End(j_);
                 CqlDateTime t_ = context.Operators.Add(r_, l_);
                 CqlDateTime[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDateTime w_ = context.Operators.Max<CqlDateTime>(v_ as IEnumerable<CqlDateTime>);
+                CqlDateTime w_ = context.Operators.Max<CqlDateTime>((IEnumerable<CqlDateTime>)v_);
                 CqlDateTime y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -985,7 +985,7 @@ public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISing
             CqlInterval<CqlDateTime>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Union<CqlInterval<CqlDateTime>>(R, h_ as IEnumerable<CqlInterval<CqlDateTime>>);
+            IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Union<CqlInterval<CqlDateTime>>(R, (IEnumerable<CqlInterval<CqlDateTime>>)h_);
 
             return i_;
         };

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -643,7 +643,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                 "amended",
                 "corrected",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             DataType u_ = MacularExam?.Value;
             bool? v_ = context.Operators.Not((bool?)(u_ is null));
             bool? w_ = context.Operators.And(t_, v_);

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -242,7 +242,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
                 "amended",
                 "corrected",
             ];
-            bool? k_ = context.Operators.In<string>(i_, j_ as IEnumerable<string>);
+            bool? k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
             DataType l_ = RecentHbA1c?.Effective;
             CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, l_);
             CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
@@ -306,7 +306,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
                 "amended",
                 "corrected",
             ];
-            bool? j_ = context.Operators.In<string>(h_, i_ as IEnumerable<string>);
+            bool? j_ = context.Operators.In<string>(h_, (IEnumerable<string>)i_);
             DataType k_ = NoHbA1c?.Effective;
             CqlDateTime l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, k_);
             CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -176,7 +176,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                 "completed",
                 "cancelled",
             ];
-            bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+            bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
             bool? ac_ = context.Operators.And(x_, ab_);
             Code<MedicationRequest.MedicationRequestIntent> ad_ = NoAntithromboticDischarge?.IntentElement;
             string ae_ = FHIRHelpers_4_0_001.Instance.ToString(context, ad_);
@@ -255,7 +255,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                 "active",
                 "completed",
             ];
-            bool? q_ = context.Operators.In<string>(o_, p_ as IEnumerable<string>);
+            bool? q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
             bool? r_ = context.Operators.And(m_, q_);
             Code<MedicationRequest.MedicationRequestIntent> s_ = Pharmacological?.IntentElement;
             string t_ = FHIRHelpers_4_0_001.Instance.ToString(context, s_);
@@ -365,7 +365,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                 "active",
                 "completed",
             ];
-            bool? q_ = context.Operators.In<string>(o_, p_ as IEnumerable<string>);
+            bool? q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
             bool? r_ = context.Operators.And(m_, q_);
             Code<MedicationRequest.MedicationRequestIntent> s_ = Antithrombotic?.IntentElement;
             string t_ = FHIRHelpers_4_0_001.Instance.ToString(context, s_);

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -460,7 +460,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             DataType j_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);
             CqlDateTime l_ = context.Operators.End(k_);
@@ -500,7 +500,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             DataType j_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);
             CqlDateTime l_ = context.Operators.End(k_);
@@ -567,7 +567,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             bool? j_ = context.Operators.Not(i_);
             DataType k_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, k_);
@@ -608,7 +608,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? i_ = context.Operators.In<string>(g_, h_ as IEnumerable<string>);
+            bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
             bool? j_ = context.Operators.Not(i_);
             DataType k_ = Mammogram?.Effective;
             CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, k_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -529,7 +529,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FecalOccult?.Category;
             bool? j_(CodeableConcept FecalOccultCategory)
             {
@@ -567,7 +567,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] ae_ = [
                     "laboratory",
                 ];
-                bool? af_ = context.Operators.Equivalent<string>(ad_, ae_ as IEnumerable<string>);
+                bool? af_ = context.Operators.Equivalent<string>(ad_, (IEnumerable<string>)ae_);
 
                 return af_;
             };
@@ -605,7 +605,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FecalOccult?.Category;
             bool? j_(CodeableConcept FecalOccultCategory)
             {
@@ -643,7 +643,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] ae_ = [
                     "laboratory",
                 ];
-                bool? af_ = context.Operators.Equivalent<string>(ad_, ae_ as IEnumerable<string>);
+                bool? af_ = context.Operators.Equivalent<string>(ad_, (IEnumerable<string>)ae_);
 
                 return af_;
             };
@@ -711,7 +711,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] z_ = [
                     "laboratory",
                 ];
-                bool? aa_ = context.Operators.Equivalent<string>(y_, z_ as IEnumerable<string>);
+                bool? aa_ = context.Operators.Equivalent<string>(y_, (IEnumerable<string>)z_);
                 bool? ab_ = context.Operators.Not(aa_);
 
                 return ab_;
@@ -749,7 +749,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = FecalOccult?.Value;
             bool? k_ = context.Operators.Not((bool?)(j_ is null));
@@ -885,7 +885,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FitDNA?.Category;
             bool? j_(CodeableConcept FitDNACategory)
             {
@@ -923,7 +923,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] ao_ = [
                     "laboratory",
                 ];
-                bool? ap_ = context.Operators.Equivalent<string>(an_, ao_ as IEnumerable<string>);
+                bool? ap_ = context.Operators.Equivalent<string>(an_, (IEnumerable<string>)ao_);
 
                 return ap_;
             };
@@ -969,7 +969,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = FitDNA?.Category;
             bool? j_(CodeableConcept FitDNACategory)
             {
@@ -1007,7 +1007,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] ao_ = [
                     "laboratory",
                 ];
-                bool? ap_ = context.Operators.Equivalent<string>(an_, ao_ as IEnumerable<string>);
+                bool? ap_ = context.Operators.Equivalent<string>(an_, (IEnumerable<string>)ao_);
 
                 return ap_;
             };
@@ -1083,7 +1083,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 string[] aj_ = [
                     "laboratory",
                 ];
-                bool? ak_ = context.Operators.Equivalent<string>(ai_, aj_ as IEnumerable<string>);
+                bool? ak_ = context.Operators.Equivalent<string>(ai_, (IEnumerable<string>)aj_);
                 bool? al_ = context.Operators.Not(ak_);
 
                 return al_;
@@ -1129,7 +1129,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = FitDNA?.Value;
             bool? k_ = context.Operators.Not((bool?)(j_ is null));
@@ -1209,7 +1209,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             DataType i_ = Colonography?.Effective;
             CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, i_);
             CqlDateTime k_ = context.Operators.End(j_);
@@ -1248,7 +1248,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 "corrected",
                 "appended",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             bool? i_ = context.Operators.Not(h_);
             DataType j_ = Colonography?.Effective;
             CqlInterval<CqlDateTime> k_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, j_);

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -385,7 +385,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 "corrected",
                 "appended",
             ];
-            bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
             bool? t_ = context.Operators.And(o_, s_);
 
             return t_;
@@ -609,7 +609,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 "on-hold",
                 "completed",
             ];
-            bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+            bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
             bool? ah_ = context.Operators.And(ac_, ag_);
             Code<RequestIntent> ai_ = PalliativeOrHospiceCareOrder?.IntentElement;
             string aj_ = FHIRHelpers_4_0_001.Instance.ToString(context, ai_);
@@ -912,7 +912,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 "active",
                 "completed",
             ];
-            bool? cc_ = context.Operators.In<string>(ca_, cb_ as IEnumerable<string>);
+            bool? cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
             bool? cd_ = context.Operators.And(by_, cc_);
             Code<MedicationRequest.MedicationRequestIntent> ce_ = StatinOrdered?.IntentElement;
             string cf_ = FHIRHelpers_4_0_001.Instance.ToString(context, ce_);
@@ -1097,7 +1097,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 "active",
                 "completed",
             ];
-            bool? cg_ = context.Operators.In<string>(ce_, cf_ as IEnumerable<string>);
+            bool? cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
             bool? ch_ = context.Operators.And(cc_, cg_);
 
             return ch_;

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -132,7 +132,7 @@ public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_
                 "active",
                 "completed",
             ];
-            bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+            bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
             Code<RequestIntent> as_ = HospiceOrder?.IntentElement;
             string at_ = FHIRHelpers_4_0_001.Instance.ToString(context, as_);
             bool? au_ = context.Operators.Equal(at_, "order");

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -378,7 +378,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
             b_,
             e_,
         ];
-        CqlDateTime g_ = context.Operators.Min<CqlDateTime>(f_ as IEnumerable<CqlDateTime>);
+        CqlDateTime g_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)f_);
         CqlInterval<CqlDateTime> h_ = context.Operators.Interval(a_, g_, true, true);
 
         return h_;
@@ -457,7 +457,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayExpand)
         {
             int? j_ = context.Operators.End(DayExpand);

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -302,7 +302,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     "amended",
                     "preliminary",
                 ];
-                bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+                bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
                 bool? bc_ = context.Operators.And(ax_, bb_);
                 DataType bd_ = Exam?.Value;
                 bool? be_ = context.Operators.Not((bool?)(bd_ is null));
@@ -353,7 +353,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     "amended",
                     "preliminary",
                 ];
-                bool? cg_ = context.Operators.In<string>(ce_, cf_ as IEnumerable<string>);
+                bool? cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
                 bool? ch_ = context.Operators.And(cc_, cg_);
                 DataType ci_ = Exam?.Value;
                 bool? cj_ = context.Operators.Not((bool?)(ci_ is null));
@@ -422,7 +422,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     "amended",
                     "preliminary",
                 ];
-                bool? ax_ = context.Operators.In<string>(av_, aw_ as IEnumerable<string>);
+                bool? ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
                 bool? ay_ = context.Operators.And(at_, ax_);
                 DataType az_ = Lab?.Value;
                 bool? ba_ = context.Operators.Not((bool?)(az_ is null));
@@ -467,7 +467,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     "amended",
                     "preliminary",
                 ];
-                bool? bx_ = context.Operators.In<string>(bv_, bw_ as IEnumerable<string>);
+                bool? bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
                 bool? by_ = context.Operators.And(bt_, bx_);
                 DataType bz_ = Lab?.Value;
                 bool? ca_ = context.Operators.Not((bool?)(bz_ is null));
@@ -546,7 +546,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
             ad_,
             ag_,
         ];
-        IEnumerable<string> ai_ = context.Operators.Flatten<string>(ah_ as IEnumerable<IEnumerable<string>>);
+        IEnumerable<string> ai_ = context.Operators.Flatten<string>((IEnumerable<IEnumerable<string>>)ah_);
 
         return ai_;
     }

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -522,7 +522,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+                bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
                 bool? bc_ = context.Operators.And(ax_, bb_);
                 DataType bd_ = Exam?.Value;
                 bool? be_ = context.Operators.Not((bool?)(bd_ is null));
@@ -573,7 +573,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? cg_ = context.Operators.In<string>(ce_, cf_ as IEnumerable<string>);
+                bool? cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
                 bool? ch_ = context.Operators.And(cc_, cg_);
                 DataType ci_ = Exam?.Value;
                 bool? cj_ = context.Operators.Not((bool?)(ci_ is null));
@@ -645,7 +645,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+                bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
                 bool? bc_ = context.Operators.And(ax_, bb_);
                 DataType bd_ = Exam?.Value;
                 bool? be_ = context.Operators.Not((bool?)(bd_ is null));
@@ -695,7 +695,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? cg_ = context.Operators.In<string>(ce_, cf_ as IEnumerable<string>);
+                bool? cg_ = context.Operators.In<string>(ce_, (IEnumerable<string>)cf_);
                 bool? ch_ = context.Operators.And(cc_, cg_);
                 DataType ci_ = Exam?.Value;
                 bool? cj_ = context.Operators.Not((bool?)(ci_ is null));
@@ -764,7 +764,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? ax_ = context.Operators.In<string>(av_, aw_ as IEnumerable<string>);
+                bool? ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
                 bool? ay_ = context.Operators.And(at_, ax_);
                 DataType az_ = Lab?.Value;
                 bool? ba_ = context.Operators.Not((bool?)(az_ is null));
@@ -809,7 +809,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     "amended",
                     "preliminary",
                 ];
-                bool? bx_ = context.Operators.In<string>(bv_, bw_ as IEnumerable<string>);
+                bool? bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
                 bool? by_ = context.Operators.And(bt_, bx_);
                 DataType bz_ = Lab?.Value;
                 bool? ca_ = context.Operators.Not((bool?)(bz_ is null));
@@ -901,7 +901,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
             an_,
             aq_,
         ];
-        IEnumerable<string> as_ = context.Operators.Flatten<string>(ar_ as IEnumerable<IEnumerable<string>>);
+        IEnumerable<string> as_ = context.Operators.Flatten<string>((IEnumerable<IEnumerable<string>>)ar_);
 
         return as_;
     }

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -407,7 +407,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -350,7 +350,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         baseInterval,
                     ];
 
-                    return t_ as IEnumerable<CqlInterval<CqlDate>>;
+                    return (IEnumerable<CqlInterval<CqlDate>>)t_;
                 }
                 else
                 {
@@ -435,7 +435,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         bk_,
                     ];
 
-                    return bl_ as IEnumerable<CqlInterval<CqlDate>>;
+                    return (IEnumerable<CqlInterval<CqlDate>>)bl_;
                 }
             };
             (CqlTupleMetadata, IEnumerable<CqlInterval<CqlDate>> frontgaps, IEnumerable<CqlInterval<CqlDate>> endgap)? j_ = (CqlTupleMetadata_FKcLSALRMRfDigEFaJgDOPFRK, h_(), i_());
@@ -491,7 +491,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         baseInterval,
                     ];
 
-                    return t_ as IEnumerable<CqlInterval<CqlDateTime>>;
+                    return (IEnumerable<CqlInterval<CqlDateTime>>)t_;
                 }
                 else
                 {
@@ -576,7 +576,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         bk_,
                     ];
 
-                    return bl_ as IEnumerable<CqlInterval<CqlDateTime>>;
+                    return (IEnumerable<CqlInterval<CqlDateTime>>)bl_;
                 }
             };
             (CqlTupleMetadata, IEnumerable<CqlInterval<CqlDateTime>> frontgaps, IEnumerable<CqlInterval<CqlDateTime>> endgap)? j_ = (CqlTupleMetadata_BBLSSiNBQBGUDJaVjMDZMSAXg, h_(), i_());
@@ -635,7 +635,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         p_,
                         0,
                     ];
-                    int? r_ = context.Operators.Max<int?>(q_ as IEnumerable<int?>);
+                    int? r_ = context.Operators.Max<int?>((IEnumerable<int?>)q_);
 
                     return r_;
                 };
@@ -671,7 +671,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         af_,
                         0,
                     ];
-                    int? ah_ = context.Operators.Max<int?>(ag_ as IEnumerable<int?>);
+                    int? ah_ = context.Operators.Max<int?>((IEnumerable<int?>)ag_);
                     (CqlTupleMetadata, CqlInterval<CqlDate> interval, int? days)? ai_ = (CqlTupleMetadata_HEjPGjPEhLgQPGjROeWMgiGfC, I, ah_);
 
                     return ai_;
@@ -716,7 +716,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         bk_,
                         0,
                     ];
-                    int? bm_ = context.Operators.Max<int?>(bl_ as IEnumerable<int?>);
+                    int? bm_ = context.Operators.Max<int?>((IEnumerable<int?>)bl_);
                     (CqlTupleMetadata, CqlInterval<CqlDate> interval, int? days)? bn_ = (CqlTupleMetadata_HEjPGjPEhLgQPGjROeWMgiGfC, I, bm_);
 
                     return bn_;
@@ -743,7 +743,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         bs_,
                         0,
                     ];
-                    int? bu_ = context.Operators.Max<int?>(bt_ as IEnumerable<int?>);
+                    int? bu_ = context.Operators.Max<int?>((IEnumerable<int?>)bt_);
                     (CqlTupleMetadata, CqlInterval<CqlDate> interval, int? days)? bv_ = (CqlTupleMetadata_HEjPGjPEhLgQPGjROeWMgiGfC, I, bu_);
 
                     return bv_;
@@ -766,7 +766,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                     be_,
                     0,
                 ];
-                int? bg_ = context.Operators.Max<int?>(bf_ as IEnumerable<int?>);
+                int? bg_ = context.Operators.Max<int?>((IEnumerable<int?>)bf_);
 
                 return bg_;
             }
@@ -1146,7 +1146,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         r_,
                         0,
                     ];
-                    int? t_ = context.Operators.Max<int?>(s_ as IEnumerable<int?>);
+                    int? t_ = context.Operators.Max<int?>((IEnumerable<int?>)s_);
 
                     return t_;
                 };
@@ -1183,7 +1183,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         aj_,
                         0,
                     ];
-                    int? al_ = context.Operators.Max<int?>(ak_ as IEnumerable<int?>);
+                    int? al_ = context.Operators.Max<int?>((IEnumerable<int?>)ak_);
                     (CqlTupleMetadata, CqlInterval<CqlDateTime> interval, int? days)? am_ = (CqlTupleMetadata_CGHEUIgjaCjJVKEADTSZEbdCL, I, al_);
 
                     return am_;
@@ -1229,7 +1229,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         bs_,
                         0,
                     ];
-                    int? bu_ = context.Operators.Max<int?>(bt_ as IEnumerable<int?>);
+                    int? bu_ = context.Operators.Max<int?>((IEnumerable<int?>)bt_);
                     (CqlTupleMetadata, CqlInterval<CqlDateTime> interval, int? days)? bv_ = (CqlTupleMetadata_CGHEUIgjaCjJVKEADTSZEbdCL, I, bu_);
 
                     return bv_;
@@ -1258,7 +1258,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                         cc_,
                         0,
                     ];
-                    int? ce_ = context.Operators.Max<int?>(cd_ as IEnumerable<int?>);
+                    int? ce_ = context.Operators.Max<int?>((IEnumerable<int?>)cd_);
                     (CqlTupleMetadata, CqlInterval<CqlDateTime> interval, int? days)? cf_ = (CqlTupleMetadata_CGHEUIgjaCjJVKEADTSZEbdCL, I, ce_);
 
                     return cf_;
@@ -1282,7 +1282,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                     bk_,
                     0,
                 ];
-                int? bm_ = context.Operators.Max<int?>(bl_ as IEnumerable<int?>);
+                int? bm_ = context.Operators.Max<int?>((IEnumerable<int?>)bl_);
 
                 return bm_;
             }

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -1860,7 +1860,7 @@ public partial class NCQAClaims_1_0_0 : ILibrary, ISingleton<NCQAClaims_1_0_0>
                 "complete",
                 "partial",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
 
             return l_;
         };

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -139,7 +139,7 @@ public partial class NCQAStatus_1_0_0 : ILibrary, ISingleton<NCQAStatus_1_0_0>
             string[] e_ = [
                 "completed",
             ];
-            bool? f_ = context.Operators.In<string>(d_, e_ as IEnumerable<string>);
+            bool? f_ = context.Operators.In<string>(d_, (IEnumerable<string>)e_);
 
             return f_;
         };
@@ -177,7 +177,7 @@ public partial class NCQAStatus_1_0_0 : ILibrary, ISingleton<NCQAStatus_1_0_0>
                 "completed",
                 "in-progress",
             ];
-            bool? f_ = context.Operators.In<string>(d_, e_ as IEnumerable<string>);
+            bool? f_ = context.Operators.In<string>(d_, (IEnumerable<string>)e_);
 
             return f_;
         };

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -108,7 +108,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             List<CodeableConcept> w_ = PalliativeAssessment?.Category;
             bool? x_(CodeableConcept PalliativeAssessmentCategory)
             {
@@ -160,7 +160,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
                 "completed",
                 "in-progress",
             ];
-            bool? av_ = context.Operators.In<string>(at_, au_ as IEnumerable<string>);
+            bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
             DataType aw_ = PalliativeIntervention?.Performed;
             CqlInterval<CqlDateTime> ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, aw_);
             CqlInterval<CqlDateTime> ay_ = this.Measurement_Period(context);

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -297,7 +297,7 @@ public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHI
                 "completed",
                 "in-progress",
             ];
-            bool? p_ = context.Operators.In<string>(n_, o_ as IEnumerable<string>);
+            bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
 
             return p_;
         };

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS1017FHIRHHFI-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS1017FHIRHHFI-0.3.000.g.cs
@@ -749,7 +749,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+                bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
                 bool? aa_ = context.Operators.And(u_, z_);
 
                 return aa_;
@@ -1018,7 +1018,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = Anticoagulants?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1136,7 +1136,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "in-progress",
                     "completed",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, al_ as IEnumerable<string>);
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
                 bool? an_ = context.Operators.And(ah_, am_);
 
                 return an_;
@@ -1199,7 +1199,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = AntidepressantMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1311,7 +1311,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = BPMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1423,7 +1423,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = CNSMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1535,7 +1535,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = DiureticMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1647,7 +1647,7 @@ public partial class CMS1017FHIRHHFI_0_3_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = OpioidMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS1218FHIRHHRF-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS1218FHIRHHRF-0.2.000.g.cs
@@ -1044,7 +1044,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? p_ = context.Operators.In<string>(n_, o_ as IEnumerable<string>);
+                bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
                 DataType q_ = CarbonDioxide?.Effective;
                 object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
@@ -1317,7 +1317,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? er_ = context.Operators.In<string>(ep_, eq_ as IEnumerable<string>);
+                bool? er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
                 DataType es_ = BloodpH?.Effective;
                 object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
                 CqlInterval<CqlDateTime> eu_ = QICoreCommon_4_0_000.Instance.toInterval(context, et_);
@@ -1599,7 +1599,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
                 DataType o_ = Oxygen?.Effective;
                 object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
@@ -5822,7 +5822,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+                bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
                 bool? s_ = this.startsDuringHospitalization(context, ASAclass as object, QualifyingEncounter);
                 bool? t_ = context.Operators.And(r_, s_);
                 DataType u_ = ASAclass?.Value;
@@ -5884,7 +5884,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(w_, ab_);
 
                 return ac_;
@@ -6128,7 +6128,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstAlbuminTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6347,7 +6347,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstArterialpHTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6456,7 +6456,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstASTTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6565,7 +6565,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBicarbonateTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6674,7 +6674,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBilirubinTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6783,7 +6783,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBUN as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6893,7 +6893,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstBodyMass?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
@@ -6962,7 +6962,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstTemperature?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7029,7 +7029,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstCarbonDioxideTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7138,7 +7138,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstCreatinineTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7248,7 +7248,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstHeartBeats?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7315,7 +7315,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstHematocritTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7424,7 +7424,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstHemoglobinTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7533,7 +7533,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstLeukocyteCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7642,7 +7642,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstOxygenTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7751,7 +7751,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstPlateletCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7861,7 +7861,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstRespiration?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7928,7 +7928,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstSodiumTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -8036,7 +8036,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             DataType m_ = SBPReading?.Effective;
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
@@ -8137,7 +8137,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstWBCCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS165FHIRControllingHighBloodPressure-0.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS165FHIRControllingHighBloodPressure-0.5.000.g.cs
@@ -431,7 +431,7 @@ public partial class CMS165FHIRControllingHighBloodPressure_0_5_000 : ILibrary, 
                 "PRENC",
                 "SS",
             ];
-            bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
             bool? aj_ = context.Operators.Not(ai_);
             DataType ak_ = BloodPressure?.Effective;
             object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -499,7 +499,7 @@ public partial class CMS165FHIRControllingHighBloodPressure_0_5_000 : ILibrary, 
                 "PRENC",
                 "SS",
             ];
-            bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
             bool? aj_ = context.Operators.Not(ai_);
             DataType ak_ = BloodPressure?.Effective;
             object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS506FHIRSafeUseofOpioids-0.3.007.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS506FHIRSafeUseofOpioids-0.3.007.g.cs
@@ -178,7 +178,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = OpioidMedications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -190,7 +190,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -246,7 +246,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = BenzoMedications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -258,7 +258,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -474,7 +474,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = DischargeMedication?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -486,7 +486,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -589,7 +589,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                     "completed",
                     "in-progress",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(w_, ab_);
 
                 return ac_;
@@ -664,7 +664,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "completed",
                 "on-hold",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
 
             return o_;
         };
@@ -679,7 +679,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "completed",
                 "in-progress",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
 
             return t_;
         };

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS816FHIRHHHypo-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS816FHIRHHHypo-0.3.000.g.cs
@@ -285,7 +285,7 @@ public partial class CMS816FHIRHHHypo_0_3_000 : ILibrary, ISingleton<CMS816FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(q_, v_);
             DataType x_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Value;
             object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
@@ -836,7 +836,7 @@ public partial class CMS816FHIRHHHypo_0_3_000 : ILibrary, ISingleton<CMS816FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? aw_ = context.Operators.In<string>(au_, av_ as IEnumerable<string>);
+            bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
             bool? ax_ = context.Operators.And(ar_, aw_);
             DataType ay_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Value;
             object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CQMCommon-4.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CQMCommon-4.1.000.g.cs
@@ -481,7 +481,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }
@@ -523,7 +523,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
@@ -2453,14 +2453,14 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2476,7 +2476,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };
@@ -2505,14 +2505,14 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2528,7 +2528,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/QICoreCommon-4.0.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/QICoreCommon-4.0.000.g.cs
@@ -2176,7 +2176,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);
@@ -2201,7 +2201,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/Status-1.15.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/Status-1.15.000.g.cs
@@ -138,7 +138,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -161,7 +161,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = D?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -173,7 +173,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -197,7 +197,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -209,7 +209,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -233,7 +233,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -245,7 +245,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -269,7 +269,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -281,7 +281,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -305,7 +305,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             List<CodeableConcept> h_ = O?.Category;
             CqlConcept i_(CodeableConcept @this)
             {
@@ -419,7 +419,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -448,7 +448,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? k_ = context.Operators.In<string>(i_, j_ as IEnumerable<string>);
+            bool? k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
             bool? l_ = context.Operators.And(f_, k_);
 
             return l_;
@@ -472,7 +472,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "in-progress",
                 "on-hold",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -494,7 +494,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
             MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
@@ -505,7 +505,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
 
             return m_;
@@ -529,7 +529,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             List<CodeableConcept> h_ = O?.Category;
             CqlConcept i_(CodeableConcept @this)
             {
@@ -571,7 +571,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -594,7 +594,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -617,7 +617,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -640,7 +640,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -663,7 +663,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -705,7 +705,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
@@ -172,7 +172,7 @@ public partial class SupplementalDataElements_5_1_000 : ILibrary, ISingleton<Sup
                 return aw_;
             };
             IEnumerable<CqlCode> ad_ = context.Operators.Select<object, CqlCode>(ab_, ac_);
-            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>(x_ as IEnumerable<CqlCode>, ad_);
+            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((IEnumerable<CqlCode>)x_, ad_);
             bool? af_(Extension @this)
             {
                 string ax_ = @this?.Url;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/AHAOverall-2.8.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/AHAOverall-2.8.000.g.cs
@@ -239,7 +239,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(s_, y_);
 
             return z_;
@@ -590,7 +590,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "active",
                 "completed",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(i_, n_);
             Code<MedicationRequest.MedicationRequestIntent> p_ = MedicationRequest?.IntentElement;
             MedicationRequest.MedicationRequestIntent? q_ = p_?.Value;
@@ -602,7 +602,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "filler-order",
                 "instance-order",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             bool? u_ = context.Operators.And(o_, t_);
 
             return u_;
@@ -813,7 +813,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "active",
                 "completed",
             ];
-            bool? af_ = context.Operators.In<string>(ad_, ae_ as IEnumerable<string>);
+            bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
             bool? ag_ = context.Operators.And(aa_, af_);
             Code<MedicationRequest.MedicationRequestIntent> ah_ = MedicationRequest?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
@@ -825,7 +825,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "filler-order",
                 "instance-order",
             ];
-            bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+            bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
             bool? am_ = context.Operators.And(ag_, al_);
 
             return am_;
@@ -859,7 +859,7 @@ public partial class AHAOverall_2_8_000 : ILibrary, ISingleton<AHAOverall_2_8_00
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             bool? p_ = context.Operators.And(j_, o_);
 
             return p_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/AnticoagulationTherapyforAtrialFibrillationFlutterFHIR-0.3.000.g.cs
@@ -195,7 +195,7 @@ public partial class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 object bn_()
                 {
                     bool bu_()
@@ -472,7 +472,7 @@ public partial class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_
                     "active",
                     "completed",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 Code<MedicationRequest.MedicationRequestIntent> al_ = DischargeAnticoagulant?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? am_ = al_?.Value;
@@ -484,7 +484,7 @@ public partial class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_
                     "filler-order",
                     "instance-order",
                 ];
-                bool? ap_ = context.Operators.In<string>(an_, ao_ as IEnumerable<string>);
+                bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
                 bool? aq_ = context.Operators.And(ak_, ap_);
                 FhirDateTime ar_ = DischargeAnticoagulant?.AuthoredOnElement;
                 CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
@@ -549,7 +549,7 @@ public partial class AnticoagulationTherapyforAtrialFibrillationFlutterFHIR_0_3_
                 "filler-order",
                 "instance-order",
             ];
-            bool? x_ = context.Operators.In<string>(v_, w_ as IEnumerable<string>);
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
             bool? y_ = context.Operators.And(s_, x_);
 
             return y_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR-1.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR-1.4.000.g.cs
@@ -191,7 +191,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             Code<MedicationRequest.MedicationRequestIntent> af_ = ADTActive?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
             string ah_ = context.Operators.Convert<string>(ag_);
@@ -202,7 +202,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ae_, aj_);
 
             return ak_;
@@ -370,7 +370,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             Code<MedicationRequest.MedicationRequestIntent> af_ = ADTOrder?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
             string ah_ = context.Operators.Convert<string>(ag_);
@@ -381,7 +381,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ae_, aj_);
 
             return ak_;
@@ -576,7 +576,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 bool? ah_ = context.Operators.And(aa_, ag_);
                 Code<RequestIntent> ai_ = OrderTwelveMonthADT?.IntentElement;
                 RequestIntent? aj_ = ai_?.Value;
@@ -679,7 +679,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "active",
                 "completed",
             ];
-            bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+            bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
             Code<RequestIntent> bc_ = DEXAOrdered?.IntentElement;
             RequestIntent? bd_ = bc_?.Value;
             Code<RequestIntent> be_ = context.Operators.Convert<Code<RequestIntent>>(bd_);
@@ -749,7 +749,7 @@ public partial class BoneDensityProstateCancerAndrogenDeprivationTherapyFHIR_1_4
                 "amended",
                 "corrected",
             ];
-            bool? dd_ = context.Operators.In<string>(db_, dc_ as IEnumerable<string>);
+            bool? dd_ = context.Operators.In<string>(db_, (IEnumerable<string>)dc_);
 
             return dd_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1017HHFIFHIR-0.0.026.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1017HHFIFHIR-0.0.026.g.cs
@@ -647,7 +647,7 @@ public partial class CMS1017HHFIFHIR_0_0_026 : ILibrary, ISingleton<CMS1017HHFIF
                     "amended",
                     "corrected",
                 ];
-                bool? ac_ = context.Operators.In<string>(aa_, ab_ as IEnumerable<string>);
+                bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
                 bool? ad_ = context.Operators.And(w_, ac_);
 
                 return ad_;
@@ -894,7 +894,7 @@ public partial class CMS1017HHFIFHIR_0_0_026 : ILibrary, ISingleton<CMS1017HHFIF
                     "in-progress",
                     "completed",
                 ];
-                bool? an_ = context.Operators.In<string>(al_, am_ as IEnumerable<string>);
+                bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
                 bool? ao_ = context.Operators.And(ah_, an_);
 
                 return ao_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1028FHIRPCSevereOBComps-0.1.002.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1028FHIRPCSevereOBComps-0.1.002.g.cs
@@ -1625,7 +1625,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
     m_ ?? default(int),
             ];
 
-            return n_ as IEnumerable<object>;
+            return (IEnumerable<object>)n_;
         };
         IEnumerable<IEnumerable<object>> c_ = context.Operators.Select<Encounter, IEnumerable<object>>(a_, b_);
         IEnumerable<IEnumerable<object>> d_ = context.Operators.Distinct<IEnumerable<object>>(c_);
@@ -1977,7 +1977,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
                 bool? ap_ = context.Operators.And(aj_, ao_);
                 DataType aq_ = Hematocrit?.Value;
                 object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
@@ -2021,7 +2021,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 bool? bn_ = context.Operators.And(bh_, bm_);
                 DataType bo_ = Hematocrit?.Value;
                 object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
@@ -2086,7 +2086,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
                 bool? ap_ = context.Operators.And(aj_, ao_);
                 DataType aq_ = WBC?.Value;
                 object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
@@ -2130,7 +2130,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 bool? bn_ = context.Operators.And(bh_, bm_);
                 DataType bo_ = WBC?.Value;
                 object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
@@ -2194,7 +2194,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, al_ as IEnumerable<string>);
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
                 bool? an_ = context.Operators.And(ah_, am_);
 
                 return an_;
@@ -2232,7 +2232,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bf_ = context.Operators.In<string>(bd_, be_ as IEnumerable<string>);
+                bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
                 bool? bg_ = context.Operators.And(ba_, bf_);
 
                 return bg_;
@@ -2291,7 +2291,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? aq_ = context.Operators.In<string>(ao_, ap_ as IEnumerable<string>);
+                bool? aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
                 bool? ar_ = context.Operators.And(al_, aq_);
                 List<Observation.ComponentComponent> as_ = BP?.Component;
                 bool? at_(Observation.ComponentComponent @this)
@@ -2368,7 +2368,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_1_002 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? cc_ = context.Operators.In<string>(ca_, cb_ as IEnumerable<string>);
+                bool? cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
                 bool? cd_ = context.Operators.And(bx_, cc_);
                 List<Observation.ComponentComponent> ce_ = BP?.Component;
                 bool? cf_(Observation.ComponentComponent @this)

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS104FHIRSTKDCAntithrombotic-0.9.002.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS104FHIRSTKDCAntithrombotic-0.9.002.g.cs
@@ -186,7 +186,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_002 : ILibrary, ISingleto
                 "active",
                 "completed",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
             Code<MedicationRequest.MedicationRequestIntent> n_ = Antithrombotic?.IntentElement;
             MedicationRequest.MedicationRequestIntent? o_ = n_?.Value;
@@ -198,7 +198,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_002 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
 
             return s_;
@@ -298,7 +298,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_002 : ILibrary, ISingleto
                 "active",
                 "completed",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
             Code<MedicationRequest.MedicationRequestIntent> n_ = PharmacologicalContraindications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? o_ = n_?.Value;
@@ -310,7 +310,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_002 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
 
             return s_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1244ECCQHOQRFHIR-0.2.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS1244ECCQHOQRFHIR-0.2.001.g.cs
@@ -359,7 +359,7 @@ public partial class CMS1244ECCQHOQRFHIR_0_2_001 : ILibrary, ISingleton<CMS1244E
                 "active",
                 "completed",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(s_, y_);
 
             return z_;
@@ -549,7 +549,7 @@ public partial class CMS1244ECCQHOQRFHIR_0_2_001 : ILibrary, ISingleton<CMS1244E
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
 
             return ab_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS334FHIRPCCesareanBirth-0.3.002.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS334FHIRPCCesareanBirth-0.3.002.g.cs
@@ -258,7 +258,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                 "amended",
                 "corrected",
             ];
-            bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
             bool? t_ = context.Operators.And(m_, s_);
             object u_()
             {
@@ -469,7 +469,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = Parity?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -623,7 +623,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = PretermBirth?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -777,7 +777,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = TermBirth?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -960,7 +960,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                        bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                         bool? ak_ = context.Operators.And(ad_, aj_);
 
                         return ak_;
@@ -1102,7 +1102,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? cq_ = context.Operators.In<string>(co_, cp_ as IEnumerable<string>);
+                        bool? cq_ = context.Operators.In<string>(co_, (IEnumerable<string>)cp_);
                         bool? cr_ = context.Operators.And(ck_, cq_);
 
                         return cr_;
@@ -1244,7 +1244,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? ex_ = context.Operators.In<string>(ev_, ew_ as IEnumerable<string>);
+                        bool? ex_ = context.Operators.In<string>(ev_, (IEnumerable<string>)ew_);
                         bool? ey_ = context.Operators.And(er_, ex_);
 
                         return ey_;
@@ -1386,7 +1386,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? hd_ = context.Operators.In<string>(hb_, hc_ as IEnumerable<string>);
+                        bool? hd_ = context.Operators.In<string>(hb_, (IEnumerable<string>)hc_);
                         bool? he_ = context.Operators.And(gx_, hd_);
 
                         return he_;
@@ -1527,7 +1527,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? jj_ = context.Operators.In<string>(jh_, ji_ as IEnumerable<string>);
+                        bool? jj_ = context.Operators.In<string>(jh_, (IEnumerable<string>)ji_);
                         bool? jk_ = context.Operators.And(jd_, jj_);
 
                         return jk_;
@@ -1668,7 +1668,7 @@ public partial class CMS334FHIRPCCesareanBirth_0_3_002 : ILibrary, ISingleton<CM
                             "amended",
                             "corrected",
                         ];
-                        bool? lp_ = context.Operators.In<string>(ln_, lo_ as IEnumerable<string>);
+                        bool? lp_ = context.Operators.In<string>(ln_, (IEnumerable<string>)lo_);
                         bool? lq_ = context.Operators.And(lj_, lp_);
 
                         return lq_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS71FHIRSTKAnticoagAFFlutter-0.3.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS71FHIRSTKAnticoagAFFlutter-0.3.001.g.cs
@@ -195,7 +195,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_001 : ILibrary, ISingleto
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 object bn_()
                 {
                     bool bu_()
@@ -444,7 +444,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_001 : ILibrary, ISingleto
                     "active",
                     "completed",
                 ];
-                bool? q_ = context.Operators.In<string>(o_, p_ as IEnumerable<string>);
+                bool? q_ = context.Operators.In<string>(o_, (IEnumerable<string>)p_);
                 bool? r_ = context.Operators.And(l_, q_);
                 Code<MedicationRequest.MedicationRequestIntent> s_ = DischargeAnticoagulant?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? t_ = s_?.Value;
@@ -456,7 +456,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_001 : ILibrary, ISingleto
                     "filler-order",
                     "instance-order",
                 ];
-                bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+                bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
                 bool? x_ = context.Operators.And(r_, w_);
                 FhirDateTime y_ = DischargeAnticoagulant?.AuthoredOnElement;
                 CqlDateTime z_ = context.Operators.Convert<CqlDateTime>(y_);
@@ -521,7 +521,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_001 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? x_ = context.Operators.In<string>(v_, w_ as IEnumerable<string>);
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)w_);
             bool? y_ = context.Operators.And(s_, x_);
 
             return y_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS816HHHypoFHIR-0.1.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS816HHHypoFHIR-0.1.001.g.cs
@@ -303,7 +303,7 @@ public partial class CMS816HHHypoFHIR_0_1_001 : ILibrary, ISingleton<CMS816HHHyp
                 "amended",
                 "corrected",
             ];
-            bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
             bool? x_ = context.Operators.And(q_, w_);
             DataType y_ = tuple_btymmdgachdragrhofgxbxgho?.GlucoseTest?.Value;
             object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
@@ -855,7 +855,7 @@ public partial class CMS816HHHypoFHIR_0_1_001 : ILibrary, ISingleton<CMS816HHHyp
                 "amended",
                 "corrected",
             ];
-            bool? ax_ = context.Operators.In<string>(av_, aw_ as IEnumerable<string>);
+            bool? ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
             bool? ay_ = context.Operators.And(ar_, ax_);
             DataType az_ = tuple_clljqcgdejtdiiewkzyjpwapd?.FollowupGlucoseTest?.Value;
             object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS826HHPIFHIR-0.1.002.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS826HHPIFHIR-0.1.002.g.cs
@@ -252,7 +252,7 @@ public partial class CMS826HHPIFHIR_0_1_002 : ILibrary, ISingleton<CMS826HHPIFHI
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 CodeableConcept ad_ = SkinExam?.Code;
                 CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
@@ -370,7 +370,7 @@ public partial class CMS826HHPIFHIR_0_1_002 : ILibrary, ISingleton<CMS826HHPIFHI
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 CodeableConcept ad_ = SkinExam?.Code;
                 CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
@@ -499,7 +499,7 @@ public partial class CMS826HHPIFHIR_0_1_002 : ILibrary, ISingleton<CMS826HHPIFHI
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = SkinExam?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
@@ -637,7 +637,7 @@ public partial class CMS826HHPIFHIR_0_1_002 : ILibrary, ISingleton<CMS826HHPIFHI
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = SkinExam?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS871HHHyperFHIR-0.1.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMS871HHHyperFHIR-0.1.001.g.cs
@@ -341,7 +341,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
                     "amended",
                     "corrected",
                 ];
-                bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+                bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
                 bool? w_ = context.Operators.And(p_, v_);
                 ObservationStatus? y_ = q_?.Value;
                 Code<ObservationStatus> z_ = context.Operators.Convert<Code<ObservationStatus>>(y_);
@@ -419,7 +419,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
             b_,
             e_,
         ];
-        CqlDateTime g_ = context.Operators.Min<CqlDateTime>(f_ as IEnumerable<CqlDateTime>);
+        CqlDateTime g_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)f_);
         CqlInterval<CqlDateTime> h_ = context.Operators.Interval(a_, g_, true, true);
 
         return h_;
@@ -498,7 +498,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayExpand)
         {
             int? j_ = context.Operators.End(DayExpand);
@@ -559,7 +559,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                    bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                     ObservationStatus? al_ = ae_?.Value;
                     Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
                     bool? an_ = context.Operators.Equal(am_, "cancelled");
@@ -643,7 +643,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? bx_ = context.Operators.In<string>(bv_, bw_ as IEnumerable<string>);
+                    bool? bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
                     ObservationStatus? bz_ = bs_?.Value;
                     Code<ObservationStatus> ca_ = context.Operators.Convert<Code<ObservationStatus>>(bz_);
                     bool? cb_ = context.Operators.Equal(ca_, "cancelled");
@@ -727,7 +727,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? dl_ = context.Operators.In<string>(dj_, dk_ as IEnumerable<string>);
+                    bool? dl_ = context.Operators.In<string>(dj_, (IEnumerable<string>)dk_);
                     ObservationStatus? dn_ = dg_?.Value;
                     Code<ObservationStatus> do_ = context.Operators.Convert<Code<ObservationStatus>>(dn_);
                     bool? dp_ = context.Operators.Equal(do_, "cancelled");
@@ -891,7 +891,7 @@ public partial class CMS871HHHyperFHIR_0_1_001 : ILibrary, ISingleton<CMS871HHHy
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             object x_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMSFHIR529HybridHospitalWideReadmission-0.1.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMSFHIR529HybridHospitalWideReadmission-0.1.001.g.cs
@@ -229,7 +229,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = temperature?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -266,7 +266,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = temperature?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -324,7 +324,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = HeartRate?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -361,7 +361,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = HeartRate?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -471,7 +471,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = O2Saturation?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
@@ -615,7 +615,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? cp_ = context.Operators.In<string>(cn_, co_ as IEnumerable<string>);
+                        bool? cp_ = context.Operators.In<string>(cn_, (IEnumerable<string>)co_);
                         bool? cq_ = context.Operators.And(cj_, cp_);
                         DataType cr_ = O2Saturation?.Value;
                         object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
@@ -761,7 +761,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? fa_ = context.Operators.In<string>(ey_, ez_ as IEnumerable<string>);
+                        bool? fa_ = context.Operators.In<string>(ey_, (IEnumerable<string>)ez_);
                         bool? fb_ = context.Operators.And(eu_, fa_);
                         DataType fc_ = O2Saturation?.Value;
                         object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
@@ -907,7 +907,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? hl_ = context.Operators.In<string>(hj_, hk_ as IEnumerable<string>);
+                        bool? hl_ = context.Operators.In<string>(hj_, (IEnumerable<string>)hk_);
                         bool? hm_ = context.Operators.And(hf_, hl_);
                         DataType hn_ = O2Saturation?.Value;
                         object ho_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hn_);
@@ -1053,7 +1053,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? jv_ = context.Operators.In<string>(jt_, ju_ as IEnumerable<string>);
+                        bool? jv_ = context.Operators.In<string>(jt_, (IEnumerable<string>)ju_);
                         bool? jw_ = context.Operators.And(jp_, jv_);
                         DataType jx_ = O2Saturation?.Value;
                         object jy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jx_);
@@ -1198,7 +1198,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? mf_ = context.Operators.In<string>(md_, me_ as IEnumerable<string>);
+                        bool? mf_ = context.Operators.In<string>(md_, (IEnumerable<string>)me_);
                         bool? mg_ = context.Operators.And(lz_, mf_);
                         DataType mh_ = O2Saturation?.Value;
                         object mi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mh_);
@@ -1343,7 +1343,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                             "amended",
                             "corrected",
                         ];
-                        bool? op_ = context.Operators.In<string>(on_, oo_ as IEnumerable<string>);
+                        bool? op_ = context.Operators.In<string>(on_, (IEnumerable<string>)oo_);
                         bool? oq_ = context.Operators.And(oj_, op_);
                         DataType or_ = O2Saturation?.Value;
                         object os_ = FHIRHelpers_4_4_000.Instance.ToValue(context, or_);
@@ -1459,7 +1459,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = RespRate?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -1496,7 +1496,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = RespRate?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -1544,7 +1544,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -1597,7 +1597,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = bicarbonatelab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1636,7 +1636,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = bicarbonatelab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1696,7 +1696,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = CreatinineLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1735,7 +1735,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = CreatinineLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1795,7 +1795,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = GlucoseLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1834,7 +1834,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = GlucoseLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1894,7 +1894,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = HematocritLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1933,7 +1933,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = HematocritLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1993,7 +1993,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = PotassiumLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -2032,7 +2032,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = PotassiumLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -2092,7 +2092,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = SodiumLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -2131,7 +2131,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = SodiumLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -2191,7 +2191,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = WhiteBloodCellLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -2230,7 +2230,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = WhiteBloodCellLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -2289,7 +2289,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = WeightExam?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -2326,7 +2326,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_1_001 : ILibrary,
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = WeightExam?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMSFHIR844HybridHospitalWideMortality-0.1.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CMSFHIR844HybridHospitalWideMortality-0.1.001.g.cs
@@ -221,7 +221,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = temperature?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -258,7 +258,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = temperature?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -316,7 +316,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = HeartRate?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -353,7 +353,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = HeartRate?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -463,7 +463,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = O2Saturation?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
@@ -607,7 +607,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? cp_ = context.Operators.In<string>(cn_, co_ as IEnumerable<string>);
+                        bool? cp_ = context.Operators.In<string>(cn_, (IEnumerable<string>)co_);
                         bool? cq_ = context.Operators.And(cj_, cp_);
                         DataType cr_ = O2Saturation?.Value;
                         object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
@@ -753,7 +753,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? fa_ = context.Operators.In<string>(ey_, ez_ as IEnumerable<string>);
+                        bool? fa_ = context.Operators.In<string>(ey_, (IEnumerable<string>)ez_);
                         bool? fb_ = context.Operators.And(eu_, fa_);
                         DataType fc_ = O2Saturation?.Value;
                         object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
@@ -899,7 +899,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? hl_ = context.Operators.In<string>(hj_, hk_ as IEnumerable<string>);
+                        bool? hl_ = context.Operators.In<string>(hj_, (IEnumerable<string>)hk_);
                         bool? hm_ = context.Operators.And(hf_, hl_);
                         DataType hn_ = O2Saturation?.Value;
                         object ho_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hn_);
@@ -1045,7 +1045,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? jv_ = context.Operators.In<string>(jt_, ju_ as IEnumerable<string>);
+                        bool? jv_ = context.Operators.In<string>(jt_, (IEnumerable<string>)ju_);
                         bool? jw_ = context.Operators.And(jp_, jv_);
                         DataType jx_ = O2Saturation?.Value;
                         object jy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jx_);
@@ -1190,7 +1190,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? mf_ = context.Operators.In<string>(md_, me_ as IEnumerable<string>);
+                        bool? mf_ = context.Operators.In<string>(md_, (IEnumerable<string>)me_);
                         bool? mg_ = context.Operators.And(lz_, mf_);
                         DataType mh_ = O2Saturation?.Value;
                         object mi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, mh_);
@@ -1335,7 +1335,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                             "amended",
                             "corrected",
                         ];
-                        bool? op_ = context.Operators.In<string>(on_, oo_ as IEnumerable<string>);
+                        bool? op_ = context.Operators.In<string>(on_, (IEnumerable<string>)oo_);
                         bool? oq_ = context.Operators.And(oj_, op_);
                         DataType or_ = O2Saturation?.Value;
                         object os_ = FHIRHelpers_4_4_000.Instance.ToValue(context, or_);
@@ -1451,7 +1451,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
                 bool? am_ = context.Operators.And(ag_, al_);
                 List<Observation.ComponentComponent> an_ = BP?.Component;
                 bool? ao_(Observation.ComponentComponent @this)
@@ -1523,7 +1523,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 List<Observation.ComponentComponent> bu_ = BP?.Component;
                 bool? bv_(Observation.ComponentComponent @this)
@@ -1598,7 +1598,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = BicarbonateLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1637,7 +1637,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = BicarbonateLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1697,7 +1697,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = CreatinineLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1736,7 +1736,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = CreatinineLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1796,7 +1796,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = HematocritLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1835,7 +1835,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = HematocritLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1895,7 +1895,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = PlateletLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -1934,7 +1934,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = PlateletLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -1994,7 +1994,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = SodiumLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -2033,7 +2033,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = SodiumLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
@@ -2093,7 +2093,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = WhiteBloodCellLab?.Value;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -2132,7 +2132,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_1_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bc_ = context.Operators.In<string>(ba_, bb_ as IEnumerable<string>);
+                bool? bc_ = context.Operators.In<string>(ba_, (IEnumerable<string>)bb_);
                 bool? bd_ = context.Operators.And(ax_, bc_);
                 DataType be_ = WhiteBloodCellLab?.Value;
                 object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CQMCommon-2.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CQMCommon-2.2.000.g.cs
@@ -379,7 +379,7 @@ public partial class CQMCommon_2_2_000 : ILibrary, ISingleton<CQMCommon_2_2_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }
@@ -421,7 +421,7 @@ public partial class CQMCommon_2_2_000 : ILibrary, ISingleton<CQMCommon_2_2_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CRLReceiptofSpecialistReportFHIR-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CRLReceiptofSpecialistReportFHIR-0.3.000.g.cs
@@ -332,7 +332,7 @@ public partial class CRLReceiptofSpecialistReportFHIR_0_3_000 : ILibrary, ISingl
                 "active",
                 "completed",
             ];
-            bool? p_ = context.Operators.In<string>(n_, o_ as IEnumerable<string>);
+            bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
             Code<RequestIntent> q_ = ReferralOrder?.IntentElement;
             RequestIntent? r_ = q_?.Value;
             Code<RequestIntent> s_ = context.Operators.Convert<Code<RequestIntent>>(r_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/Cataracts2040BCVAwithin90DaysFHIR-0.1.000.g.cs
@@ -616,7 +616,7 @@ public partial class Cataracts2040BCVAwithin90DaysFHIR_0_1_000 : ILibrary, ISing
                     "corrected",
                     "preliminary",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
                 bool? ap_ = context.Operators.And(ai_, ao_);
                 DataType aq_ = VisualAcuityExamPerformed?.Value;
                 object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CesareanBirthFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CesareanBirthFHIR-0.2.000.g.cs
@@ -258,7 +258,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                 "amended",
                 "corrected",
             ];
-            bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
             bool? t_ = context.Operators.And(m_, s_);
             object u_()
             {
@@ -469,7 +469,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = Parity?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -623,7 +623,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = PretermBirth?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -777,7 +777,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                 "amended",
                 "corrected",
             ];
-            bool? aa_ = context.Operators.In<string>(y_, z_ as IEnumerable<string>);
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
             bool? ab_ = context.Operators.And(u_, aa_);
             DataType ac_ = TermBirth?.Value;
             object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
@@ -960,7 +960,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                        bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                         bool? ak_ = context.Operators.And(ad_, aj_);
 
                         return ak_;
@@ -1102,7 +1102,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? cq_ = context.Operators.In<string>(co_, cp_ as IEnumerable<string>);
+                        bool? cq_ = context.Operators.In<string>(co_, (IEnumerable<string>)cp_);
                         bool? cr_ = context.Operators.And(ck_, cq_);
 
                         return cr_;
@@ -1244,7 +1244,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? ex_ = context.Operators.In<string>(ev_, ew_ as IEnumerable<string>);
+                        bool? ex_ = context.Operators.In<string>(ev_, (IEnumerable<string>)ew_);
                         bool? ey_ = context.Operators.And(er_, ex_);
 
                         return ey_;
@@ -1386,7 +1386,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? hd_ = context.Operators.In<string>(hb_, hc_ as IEnumerable<string>);
+                        bool? hd_ = context.Operators.In<string>(hb_, (IEnumerable<string>)hc_);
                         bool? he_ = context.Operators.And(gx_, hd_);
 
                         return he_;
@@ -1527,7 +1527,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? jj_ = context.Operators.In<string>(jh_, ji_ as IEnumerable<string>);
+                        bool? jj_ = context.Operators.In<string>(jh_, (IEnumerable<string>)ji_);
                         bool? jk_ = context.Operators.And(jd_, jj_);
 
                         return jk_;
@@ -1668,7 +1668,7 @@ public partial class CesareanBirthFHIR_0_2_000 : ILibrary, ISingleton<CesareanBi
                             "amended",
                             "corrected",
                         ];
-                        bool? lp_ = context.Operators.In<string>(ln_, lo_ as IEnumerable<string>);
+                        bool? lp_ = context.Operators.In<string>(ln_, (IEnumerable<string>)lo_);
                         bool? lq_ = context.Operators.And(lj_, lp_);
 
                         return lq_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/ControllingHighBloodPressureFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/ControllingHighBloodPressureFHIR-0.1.000.g.cs
@@ -325,7 +325,7 @@ public partial class ControllingHighBloodPressureFHIR_0_1_000 : ILibrary, ISingl
                 "PRENC",
                 "SS",
             ];
-            bool? k_ = context.Operators.In<string>(i_, j_ as IEnumerable<string>);
+            bool? k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
             bool? l_ = context.Operators.Not(k_);
             DataType m_ = BloodPressure?.Effective;
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
@@ -362,7 +362,7 @@ public partial class ControllingHighBloodPressureFHIR_0_1_000 : ILibrary, ISingl
                 "PRENC",
                 "SS",
             ];
-            bool? k_ = context.Operators.In<string>(i_, j_ as IEnumerable<string>);
+            bool? k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
             bool? l_ = context.Operators.Not(k_);
             DataType m_ = BloodPressure?.Effective;
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CumulativeMedicationDuration-4.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CumulativeMedicationDuration-4.1.000.g.cs
@@ -2453,14 +2453,14 @@ public partial class CumulativeMedicationDuration_4_1_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2476,7 +2476,7 @@ public partial class CumulativeMedicationDuration_4_1_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };
@@ -2505,14 +2505,14 @@ public partial class CumulativeMedicationDuration_4_1_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2528,7 +2528,7 @@ public partial class CumulativeMedicationDuration_4_1_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.1.000.g.cs
@@ -351,7 +351,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_1_000 : 
                 "corrected",
                 "preliminary",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(t_, z_);
 
             return aa_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/DementiaCognitiveAssessmentFHIR-0.1.000.g.cs
@@ -322,7 +322,7 @@ public partial class DementiaCognitiveAssessmentFHIR_0_1_000 : ILibrary, ISingle
                 "corrected",
                 "preliminary",
             ];
-            bool? ap_ = context.Operators.In<string>(an_, ao_ as IEnumerable<string>);
+            bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
             bool? aq_ = context.Operators.And(aj_, ap_);
 
             return aq_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/DepressionRemissionatTwelveMonthsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/DepressionRemissionatTwelveMonthsFHIR-0.2.000.g.cs
@@ -191,7 +191,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "amended",
                 "corrected",
             ];
-            bool? m_ = context.Operators.In<string>(k_, l_ as IEnumerable<string>);
+            bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
             bool? n_ = context.Operators.And(g_, m_);
 
             return n_;
@@ -469,7 +469,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "entered-in-error",
                 "unknown",
             ];
-            bool? cb_ = context.Operators.In<string>(bz_, ca_ as IEnumerable<string>);
+            bool? cb_ = context.Operators.In<string>(bz_, (IEnumerable<string>)ca_);
             bool? cc_ = context.Operators.Not(cb_);
             bool? cd_ = context.Operators.And(bv_, cc_);
 
@@ -508,7 +508,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "amended",
                 "corrected",
             ];
-            bool? cz_ = context.Operators.In<string>(cx_, cy_ as IEnumerable<string>);
+            bool? cz_ = context.Operators.In<string>(cx_, (IEnumerable<string>)cy_);
             bool? da_ = context.Operators.And(ct_, cz_);
 
             return da_;
@@ -537,7 +537,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "active",
                 "completed",
             ];
-            bool? dp_ = context.Operators.In<string>(dn_, do_ as IEnumerable<string>);
+            bool? dp_ = context.Operators.In<string>(dn_, (IEnumerable<string>)do_);
             bool? dq_ = context.Operators.And(dj_, dp_);
             Code<RequestIntent> dr_ = HospiceOrder?.IntentElement;
             RequestIntent? ds_ = dr_?.Value;
@@ -550,7 +550,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "filler-order",
                 "instance-order",
             ];
-            bool? dw_ = context.Operators.In<string>(du_, dv_ as IEnumerable<string>);
+            bool? dw_ = context.Operators.In<string>(du_, (IEnumerable<string>)dv_);
             bool? dx_ = context.Operators.And(dq_, dw_);
             FhirBoolean dy_ = HospiceOrder?.DoNotPerformElement;
             bool? dz_ = dy_?.Value;
@@ -584,7 +584,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "entered-in-error",
                 "unknown",
             ];
-            bool? er_ = context.Operators.In<string>(ep_, eq_ as IEnumerable<string>);
+            bool? er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
             bool? es_ = context.Operators.Not(er_);
             bool? et_ = context.Operators.And(em_, es_);
 
@@ -645,7 +645,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "amended",
                 "corrected",
             ];
-            bool? an_ = context.Operators.In<string>(al_, am_ as IEnumerable<string>);
+            bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
             bool? ao_ = context.Operators.And(ah_, an_);
 
             return ao_;
@@ -718,7 +718,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "entered-in-error",
                 "unknown",
             ];
-            bool? cb_ = context.Operators.In<string>(bz_, ca_ as IEnumerable<string>);
+            bool? cb_ = context.Operators.In<string>(bz_, (IEnumerable<string>)ca_);
             bool? cc_ = context.Operators.Not(cb_);
             bool? cd_ = context.Operators.And(bw_, cc_);
 
@@ -819,7 +819,7 @@ public partial class DepressionRemissionatTwelveMonthsFHIR_0_2_000 : ILibrary, I
                 "amended",
                 "corrected",
             ];
-            bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
             bool? x_ = context.Operators.And(q_, w_);
 
             return x_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/FallsWithInjuryFHIR-0.0.024.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/FallsWithInjuryFHIR-0.0.024.g.cs
@@ -588,7 +588,7 @@ public partial class FallsWithInjuryFHIR_0_0_024 : ILibrary, ISingleton<FallsWit
                     "amended",
                     "corrected",
                 ];
-                bool? ac_ = context.Operators.In<string>(aa_, ab_ as IEnumerable<string>);
+                bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
                 bool? ad_ = context.Operators.And(w_, ac_);
 
                 return ad_;
@@ -829,7 +829,7 @@ public partial class FallsWithInjuryFHIR_0_0_024 : ILibrary, ISingleton<FallsWit
                     "in-progress",
                     "completed",
                 ];
-                bool? an_ = context.Operators.In<string>(al_, am_ as IEnumerable<string>);
+                bool? an_ = context.Operators.In<string>(al_, (IEnumerable<string>)am_);
                 bool? ao_ = context.Operators.And(ah_, an_);
 
                 return ao_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/FunctionalStatusAssessmentforTotalHipReplacementFHIR-0.0.008.g.cs
@@ -857,7 +857,7 @@ public partial class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_00
                 dl_,
                 dq_,
             ];
-            CqlDate ds_ = context.Operators.Max<CqlDate>(dr_ as IEnumerable<CqlDate>);
+            CqlDate ds_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)dr_);
 
             return ds_;
         };
@@ -1127,7 +1127,7 @@ public partial class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_00
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };
@@ -1281,7 +1281,7 @@ public partial class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_00
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };
@@ -1435,7 +1435,7 @@ public partial class FunctionalStatusAssessmentforTotalHipReplacementFHIR_0_0_00
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/GlobalMalnutritionCompositeFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/GlobalMalnutritionCompositeFHIR-0.2.000.g.cs
@@ -271,7 +271,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "completed",
                 "in-progress",
             ];
-            bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
             bool? v_ = context.Operators.And(p_, u_);
             DataType w_ = tuple_blodcpfeecjfnodfofhfzlqfa?.HospitalDietitianReferral?.Performed;
             object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
@@ -321,7 +321,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_bejjtwegpxjsnajsodybefddb?.QualifyingEncounter);
             DataType y_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
@@ -404,7 +404,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_bejjtwegpxjsnajsodybefddb?.QualifyingEncounter);
             DataType y_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
@@ -484,7 +484,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_bejjtwegpxjsnajsodybefddb?.QualifyingEncounter);
             DataType y_ = tuple_bejjtwegpxjsnajsodybefddb?.MalnutritionRiskScreening?.Effective;
@@ -563,7 +563,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_hhhypfjvjujitmizocefugcne?.QualifyingEncounter);
             DataType y_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
@@ -626,7 +626,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_hhhypfjvjujitmizocefugcne?.QualifyingEncounter);
             DataType y_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
@@ -685,7 +685,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             CqlInterval<CqlDateTime> x_ = CQMCommon_2_2_000.Instance.hospitalizationWithObservation(context, tuple_hhhypfjvjujitmizocefugcne?.QualifyingEncounter);
             DataType y_ = tuple_hhhypfjvjujitmizocefugcne?.NutritionAssessment?.Effective;
@@ -775,7 +775,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
                 "completed",
                 "in-progress",
             ];
-            bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
             bool? v_ = context.Operators.And(p_, u_);
             DataType w_ = tuple_igutmwhaufjcwzmijcgjeysm?.NutritionCarePlan?.Performed;
             object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
@@ -1027,7 +1027,7 @@ public partial class GlobalMalnutritionCompositeFHIR_0_2_000 : ILibrary, ISingle
             c_,
             d_,
         ];
-        int? f_ = context.Operators.Sum(e_ as IEnumerable<int?>);
+        int? f_ = context.Operators.Sum((IEnumerable<int?>)e_);
 
         return f_;
     }

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HFACEIorARBorARNIforLVSDFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HFACEIorARBorARNIforLVSDFHIR-0.2.000.g.cs
@@ -419,7 +419,7 @@ public partial class HFACEIorARBorARNIforLVSDFHIR_0_2_000 : ILibrary, ISingleton
                 "filler-order",
                 "instance-order",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(u_, z_);
             List<CodeableConcept> ab_ = NoACEIOrARBOrARNIOrdered?.ReasonCode;
             CqlConcept ac_(CodeableConcept @this)

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HFBetaBlockerTherapyforLVSDFHIR-1.4.000.g.cs
@@ -298,7 +298,7 @@ public partial class HFBetaBlockerTherapyforLVSDFHIR_1_4_000 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
             bool? x_ = context.Operators.And(r_, w_);
             DataType y_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Value;
             CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HIVRetentionFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HIVRetentionFHIR-0.1.000.g.cs
@@ -219,7 +219,7 @@ public partial class HIVRetentionFHIR_0_1_000 : ILibrary, ISingleton<HIVRetentio
                 return aw_;
             };
             IEnumerable<CqlCode> ad_ = context.Operators.Select<object, CqlCode>(ab_, ac_);
-            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>(x_ as IEnumerable<CqlCode>, ad_);
+            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((IEnumerable<CqlCode>)x_, ad_);
             bool? af_(Extension @this)
             {
                 string ax_ = @this?.Url;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HIVSTITestingFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HIVSTITestingFHIR-0.2.000.g.cs
@@ -287,7 +287,7 @@ public partial class HIVSTITestingFHIR_0_2_000 : ILibrary, ISingleton<HIVSTITest
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
             object p_()
             {
@@ -374,7 +374,7 @@ public partial class HIVSTITestingFHIR_0_2_000 : ILibrary, ISingleton<HIVSTITest
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
             object p_()
             {
@@ -461,7 +461,7 @@ public partial class HIVSTITestingFHIR_0_2_000 : ILibrary, ISingleton<HIVSTITest
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
             object p_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.1.000.g.cs
@@ -341,7 +341,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
                     "amended",
                     "corrected",
                 ];
-                bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+                bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
                 bool? w_ = context.Operators.And(p_, v_);
                 ObservationStatus? y_ = q_?.Value;
                 Code<ObservationStatus> z_ = context.Operators.Convert<Code<ObservationStatus>>(y_);
@@ -419,7 +419,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
             b_,
             e_,
         ];
-        CqlDateTime g_ = context.Operators.Min<CqlDateTime>(f_ as IEnumerable<CqlDateTime>);
+        CqlDateTime g_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)f_);
         CqlInterval<CqlDateTime> h_ = context.Operators.Interval(a_, g_, true, true);
 
         return h_;
@@ -498,7 +498,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayExpand)
         {
             int? j_ = context.Operators.End(DayExpand);
@@ -559,7 +559,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
                         "amended",
                         "corrected",
                     ];
-                    bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                    bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                     ObservationStatus? al_ = ae_?.Value;
                     Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
                     bool? an_ = context.Operators.Equal(am_, "cancelled");
@@ -643,7 +643,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
                         "amended",
                         "corrected",
                     ];
-                    bool? bx_ = context.Operators.In<string>(bv_, bw_ as IEnumerable<string>);
+                    bool? bx_ = context.Operators.In<string>(bv_, (IEnumerable<string>)bw_);
                     ObservationStatus? bz_ = bs_?.Value;
                     Code<ObservationStatus> ca_ = context.Operators.Convert<Code<ObservationStatus>>(bz_);
                     bool? cb_ = context.Operators.Equal(ca_, "cancelled");
@@ -727,7 +727,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
                         "amended",
                         "corrected",
                     ];
-                    bool? dl_ = context.Operators.In<string>(dj_, dk_ as IEnumerable<string>);
+                    bool? dl_ = context.Operators.In<string>(dj_, (IEnumerable<string>)dk_);
                     ObservationStatus? dn_ = dg_?.Value;
                     Code<ObservationStatus> do_ = context.Operators.Convert<Code<ObservationStatus>>(dn_);
                     bool? dp_ = context.Operators.Equal(do_, "cancelled");
@@ -891,7 +891,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_1_000
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
             object x_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmPressureInjuryFHIR-0.1.000.g.cs
@@ -256,7 +256,7 @@ public partial class HospitalHarmPressureInjuryFHIR_0_1_000 : ILibrary, ISinglet
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 CodeableConcept ad_ = SkinExam?.Code;
                 CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
@@ -374,7 +374,7 @@ public partial class HospitalHarmPressureInjuryFHIR_0_1_000 : ILibrary, ISinglet
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 CodeableConcept ad_ = SkinExam?.Code;
                 CqlConcept ae_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ad_);
@@ -532,7 +532,7 @@ public partial class HospitalHarmPressureInjuryFHIR_0_1_000 : ILibrary, ISinglet
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = SkinExam?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
@@ -670,7 +670,7 @@ public partial class HospitalHarmPressureInjuryFHIR_0_1_000 : ILibrary, ISinglet
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(v_, ab_);
                 DataType ad_ = SkinExam?.Value;
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.1.000.g.cs
@@ -303,7 +303,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_1_000 : ILibrary, ISin
                 "amended",
                 "corrected",
             ];
-            bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
             bool? x_ = context.Operators.And(q_, w_);
             DataType y_ = tuple_btymmdgachdragrhofgxbxgho?.GlucoseTest?.Value;
             object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
@@ -855,7 +855,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_1_000 : ILibrary, ISin
                 "amended",
                 "corrected",
             ];
-            bool? ax_ = context.Operators.In<string>(av_, aw_ as IEnumerable<string>);
+            bool? ax_ = context.Operators.In<string>(av_, (IEnumerable<string>)aw_);
             bool? ay_ = context.Operators.And(ar_, ax_);
             DataType az_ = tuple_clljqcgdejtdiiewkzyjpwapd?.FollowupGlucoseTest?.Value;
             object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HybridHospitalWideMortalityFHIR-0.0.001.g.cs
@@ -235,7 +235,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+                bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
                 bool? as_ = context.Operators.And(am_, ar_);
                 DataType at_ = temperature?.Value;
                 CqlQuantity au_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, at_ as Quantity);
@@ -281,7 +281,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+                bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
                 bool? bu_ = context.Operators.And(bo_, bt_);
                 DataType bv_ = temperature?.Value;
                 CqlQuantity bw_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bv_ as Quantity);
@@ -348,7 +348,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+                bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
                 bool? as_ = context.Operators.And(am_, ar_);
                 DataType at_ = HeartRate?.Value;
                 CqlQuantity au_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, at_ as Quantity);
@@ -394,7 +394,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+                bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
                 bool? bu_ = context.Operators.And(bo_, bt_);
                 DataType bv_ = HeartRate?.Value;
                 CqlQuantity bw_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bv_ as Quantity);
@@ -513,7 +513,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
                 bool? am_ = context.Operators.And(af_, al_);
                 DataType an_ = O2Saturation?.Value;
                 object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
@@ -666,7 +666,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? dj_ = context.Operators.In<string>(dh_, di_ as IEnumerable<string>);
+                        bool? dj_ = context.Operators.In<string>(dh_, (IEnumerable<string>)di_);
                         bool? dk_ = context.Operators.And(dd_, dj_);
                         DataType dl_ = O2Saturation?.Value;
                         object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
@@ -821,7 +821,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? ge_ = context.Operators.In<string>(gc_, gd_ as IEnumerable<string>);
+                        bool? ge_ = context.Operators.In<string>(gc_, (IEnumerable<string>)gd_);
                         bool? gf_ = context.Operators.And(fy_, ge_);
                         DataType gg_ = O2Saturation?.Value;
                         object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
@@ -976,7 +976,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? iz_ = context.Operators.In<string>(ix_, iy_ as IEnumerable<string>);
+                        bool? iz_ = context.Operators.In<string>(ix_, (IEnumerable<string>)iy_);
                         bool? ja_ = context.Operators.And(it_, iz_);
                         DataType jb_ = O2Saturation?.Value;
                         object jc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jb_);
@@ -1131,7 +1131,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? lt_ = context.Operators.In<string>(lr_, ls_ as IEnumerable<string>);
+                        bool? lt_ = context.Operators.In<string>(lr_, (IEnumerable<string>)ls_);
                         bool? lu_ = context.Operators.And(ln_, lt_);
                         DataType lv_ = O2Saturation?.Value;
                         object lw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, lv_);
@@ -1285,7 +1285,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? on_ = context.Operators.In<string>(ol_, om_ as IEnumerable<string>);
+                        bool? on_ = context.Operators.In<string>(ol_, (IEnumerable<string>)om_);
                         bool? oo_ = context.Operators.And(oh_, on_);
                         DataType op_ = O2Saturation?.Value;
                         object oq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, op_);
@@ -1439,7 +1439,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                             "amended",
                             "corrected",
                         ];
-                        bool? rh_ = context.Operators.In<string>(rf_, rg_ as IEnumerable<string>);
+                        bool? rh_ = context.Operators.In<string>(rf_, (IEnumerable<string>)rg_);
                         bool? ri_ = context.Operators.And(rb_, rh_);
                         DataType rj_ = O2Saturation?.Value;
                         object rk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, rj_);
@@ -1565,7 +1565,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = BicarbonateLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1613,7 +1613,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = BicarbonateLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -1682,7 +1682,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = CreatinineLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1730,7 +1730,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = CreatinineLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -1799,7 +1799,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = HematocritLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1847,7 +1847,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = HematocritLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -1916,7 +1916,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = PlateletLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1964,7 +1964,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = PlateletLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2033,7 +2033,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = SodiumLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2081,7 +2081,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = SodiumLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2135,7 +2135,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                 "amended",
                 "corrected",
             ];
-            bool? m_ = context.Operators.In<string>(k_, l_ as IEnumerable<string>);
+            bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
             bool? n_ = context.Operators.And(h_, m_);
 
             return n_;
@@ -2250,7 +2250,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = WhiteBloodCellLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2298,7 +2298,7 @@ public partial class HybridHospitalWideMortalityFHIR_0_0_001 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = WhiteBloodCellLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/HybridHospitalWideReadmissionFHIR-0.0.001.g.cs
@@ -238,7 +238,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+                bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
                 bool? as_ = context.Operators.And(am_, ar_);
                 DataType at_ = temperature?.Value;
                 CqlQuantity au_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, at_ as Quantity);
@@ -284,7 +284,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+                bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
                 bool? bu_ = context.Operators.And(bo_, bt_);
                 DataType bv_ = temperature?.Value;
                 CqlQuantity bw_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bv_ as Quantity);
@@ -351,7 +351,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+                bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
                 bool? as_ = context.Operators.And(am_, ar_);
                 DataType at_ = HeartRate?.Value;
                 CqlQuantity au_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, at_ as Quantity);
@@ -397,7 +397,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+                bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
                 bool? bu_ = context.Operators.And(bo_, bt_);
                 DataType bv_ = HeartRate?.Value;
                 CqlQuantity bw_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bv_ as Quantity);
@@ -516,7 +516,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
                 bool? am_ = context.Operators.And(af_, al_);
                 DataType an_ = O2Saturation?.Value;
                 object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
@@ -669,7 +669,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? dj_ = context.Operators.In<string>(dh_, di_ as IEnumerable<string>);
+                        bool? dj_ = context.Operators.In<string>(dh_, (IEnumerable<string>)di_);
                         bool? dk_ = context.Operators.And(dd_, dj_);
                         DataType dl_ = O2Saturation?.Value;
                         object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
@@ -824,7 +824,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? ge_ = context.Operators.In<string>(gc_, gd_ as IEnumerable<string>);
+                        bool? ge_ = context.Operators.In<string>(gc_, (IEnumerable<string>)gd_);
                         bool? gf_ = context.Operators.And(fy_, ge_);
                         DataType gg_ = O2Saturation?.Value;
                         object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
@@ -979,7 +979,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? iz_ = context.Operators.In<string>(ix_, iy_ as IEnumerable<string>);
+                        bool? iz_ = context.Operators.In<string>(ix_, (IEnumerable<string>)iy_);
                         bool? ja_ = context.Operators.And(it_, iz_);
                         DataType jb_ = O2Saturation?.Value;
                         object jc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, jb_);
@@ -1134,7 +1134,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? lt_ = context.Operators.In<string>(lr_, ls_ as IEnumerable<string>);
+                        bool? lt_ = context.Operators.In<string>(lr_, (IEnumerable<string>)ls_);
                         bool? lu_ = context.Operators.And(ln_, lt_);
                         DataType lv_ = O2Saturation?.Value;
                         object lw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, lv_);
@@ -1288,7 +1288,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? on_ = context.Operators.In<string>(ol_, om_ as IEnumerable<string>);
+                        bool? on_ = context.Operators.In<string>(ol_, (IEnumerable<string>)om_);
                         bool? oo_ = context.Operators.And(oh_, on_);
                         DataType op_ = O2Saturation?.Value;
                         object oq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, op_);
@@ -1442,7 +1442,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                             "amended",
                             "corrected",
                         ];
-                        bool? rh_ = context.Operators.In<string>(rf_, rg_ as IEnumerable<string>);
+                        bool? rh_ = context.Operators.In<string>(rf_, (IEnumerable<string>)rg_);
                         bool? ri_ = context.Operators.And(rb_, rh_);
                         DataType rj_ = O2Saturation?.Value;
                         object rk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, rj_);
@@ -1567,7 +1567,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? ar_ = context.Operators.In<string>(ap_, aq_ as IEnumerable<string>);
+                bool? ar_ = context.Operators.In<string>(ap_, (IEnumerable<string>)aq_);
                 bool? as_ = context.Operators.And(am_, ar_);
                 DataType at_ = RespRate?.Value;
                 CqlQuantity au_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, at_ as Quantity);
@@ -1613,7 +1613,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+                bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
                 bool? bu_ = context.Operators.And(bo_, bt_);
                 DataType bv_ = RespRate?.Value;
                 CqlQuantity bw_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bv_ as Quantity);
@@ -1661,7 +1661,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -1723,7 +1723,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = bicarbonatelab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1771,7 +1771,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = bicarbonatelab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -1840,7 +1840,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = CreatinineLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -1888,7 +1888,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = CreatinineLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -1957,7 +1957,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = GlucoseLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2005,7 +2005,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = GlucoseLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2074,7 +2074,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = HematocritLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2122,7 +2122,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = HematocritLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2191,7 +2191,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = PotassiumLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2239,7 +2239,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = PotassiumLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2308,7 +2308,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = SodiumLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2356,7 +2356,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = SodiumLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2425,7 +2425,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? au_ = context.Operators.In<string>(as_, at_ as IEnumerable<string>);
+                bool? au_ = context.Operators.In<string>(as_, (IEnumerable<string>)at_);
                 bool? av_ = context.Operators.And(ap_, au_);
                 DataType aw_ = WhiteBloodCellLab?.Value;
                 object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
@@ -2473,7 +2473,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
                 DataType ca_ = WhiteBloodCellLab?.Value;
                 object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
@@ -2532,7 +2532,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = WeightExam?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -2569,7 +2569,7 @@ public partial class HybridHospitalWideReadmissionFHIR_0_0_001 : ILibrary, ISing
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = WeightExam?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR-1.4.000.g.cs
@@ -379,7 +379,7 @@ public partial class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_
                 "amended",
                 "corrected",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ad_, aj_);
 
             return ak_;
@@ -658,7 +658,7 @@ public partial class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_
                 "active",
                 "completed",
             ];
-            bool? ct_ = context.Operators.In<string>(cr_, cs_ as IEnumerable<string>);
+            bool? ct_ = context.Operators.In<string>(cr_, (IEnumerable<string>)cs_);
             Code<MedicationRequest.MedicationRequestIntent> cu_ = ImmunosuppressiveDrugs?.IntentElement;
             MedicationRequest.MedicationRequestIntent? cv_ = cu_?.Value;
             string cw_ = context.Operators.Convert<string>(cv_);
@@ -925,7 +925,7 @@ public partial class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_
                 "active",
                 "completed",
             ];
-            bool? cs_ = context.Operators.In<string>(cq_, cr_ as IEnumerable<string>);
+            bool? cs_ = context.Operators.In<string>(cq_, (IEnumerable<string>)cr_);
             Code<MedicationRequest.MedicationRequestIntent> ct_ = ExclusionMed?.IntentElement;
             MedicationRequest.MedicationRequestIntent? cu_ = ct_?.Value;
             string cv_ = context.Operators.Convert<string>(cu_);
@@ -1109,7 +1109,7 @@ public partial class IntravesicalBacillusCalmetteGuerinForBladderCancerFHIR_1_4_
                 "in-progress",
                 "completed",
             ];
-            bool? bq_ = context.Operators.In<string>(bo_, bp_ as IEnumerable<string>);
+            bool? bq_ = context.Operators.In<string>(bo_, (IEnumerable<string>)bp_);
 
             return bq_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/KidneyHealthEvaluationFHIR-0.1.000.g.cs
@@ -335,7 +335,7 @@ public partial class KidneyHealthEvaluationFHIR_0_1_000 : ILibrary, ISingleton<K
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(t_, z_);
 
             return aa_;
@@ -364,7 +364,7 @@ public partial class KidneyHealthEvaluationFHIR_0_1_000 : ILibrary, ISingleton<K
                 "amended",
                 "corrected",
             ];
-            bool? ap_ = context.Operators.In<string>(an_, ao_ as IEnumerable<string>);
+            bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
             bool? aq_ = context.Operators.And(aj_, ap_);
 
             return aq_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCMaternal-5.19.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCMaternal-5.19.000.g.cs
@@ -429,7 +429,7 @@ public partial class PCMaternal_5_19_000 : ILibrary, ISingleton<PCMaternal_5_19_
                 "amended",
                 "corrected",
             ];
-            bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
             bool? t_ = context.Operators.And(m_, s_);
             object u_()
             {
@@ -581,7 +581,7 @@ public partial class PCMaternal_5_19_000 : ILibrary, ISingleton<PCMaternal_5_19_
                 "amended",
                 "corrected",
             ];
-            bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
             bool? t_ = context.Operators.And(m_, s_);
             object u_()
             {
@@ -815,7 +815,7 @@ public partial class PCMaternal_5_19_000 : ILibrary, ISingleton<PCMaternal_5_19_
                 "amended",
                 "corrected",
             ];
-            bool? ad_ = context.Operators.In<string>(ab_, ac_ as IEnumerable<string>);
+            bool? ad_ = context.Operators.In<string>(ab_, (IEnumerable<string>)ac_);
             bool? ae_ = context.Operators.And(x_, ad_);
             object af_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCSBPScreeningFollowUpFHIR-0.2.000.g.cs
@@ -311,7 +311,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? av_ = context.Operators.In<string>(at_, au_ as IEnumerable<string>);
+                bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
                 bool? aw_ = context.Operators.And(aq_, av_);
 
                 return aw_;
@@ -371,7 +371,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? bz_ = context.Operators.In<string>(bx_, by_ as IEnumerable<string>);
+                bool? bz_ = context.Operators.In<string>(bx_, (IEnumerable<string>)by_);
                 bool? ca_ = context.Operators.And(bu_, bz_);
 
                 return ca_;
@@ -447,7 +447,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? av_ = context.Operators.In<string>(at_, au_ as IEnumerable<string>);
+                bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
                 bool? aw_ = context.Operators.And(aq_, av_);
 
                 return aw_;
@@ -507,7 +507,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? bz_ = context.Operators.In<string>(bx_, by_ as IEnumerable<string>);
+                bool? bz_ = context.Operators.In<string>(bx_, (IEnumerable<string>)by_);
                 bool? ca_ = context.Operators.And(bu_, bz_);
 
                 return ca_;
@@ -750,7 +750,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? ch_ = context.Operators.In<string>(cf_, cg_ as IEnumerable<string>);
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
                 bool? ci_ = context.Operators.And(cc_, ch_);
 
                 return ci_;
@@ -818,7 +818,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? dx_ = context.Operators.In<string>(dv_, dw_ as IEnumerable<string>);
+                bool? dx_ = context.Operators.In<string>(dv_, (IEnumerable<string>)dw_);
                 bool? dy_ = context.Operators.And(ds_, dx_);
 
                 return dy_;
@@ -886,7 +886,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? fn_ = context.Operators.In<string>(fl_, fm_ as IEnumerable<string>);
+                bool? fn_ = context.Operators.In<string>(fl_, (IEnumerable<string>)fm_);
                 bool? fo_ = context.Operators.And(fi_, fn_);
 
                 return fo_;
@@ -954,7 +954,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? hd_ = context.Operators.In<string>(hb_, hc_ as IEnumerable<string>);
+                bool? hd_ = context.Operators.In<string>(hb_, (IEnumerable<string>)hc_);
                 bool? he_ = context.Operators.And(gy_, hd_);
 
                 return he_;
@@ -1313,7 +1313,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? cd_ = context.Operators.In<string>(cb_, cc_ as IEnumerable<string>);
+                bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
                 bool? ce_ = context.Operators.And(by_, cd_);
 
                 return ce_;
@@ -1373,7 +1373,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? dh_ = context.Operators.In<string>(df_, dg_ as IEnumerable<string>);
+                bool? dh_ = context.Operators.In<string>(df_, (IEnumerable<string>)dg_);
                 bool? di_ = context.Operators.And(dc_, dh_);
 
                 return di_;
@@ -1434,7 +1434,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? el_ = context.Operators.In<string>(ej_, ek_ as IEnumerable<string>);
+                bool? el_ = context.Operators.In<string>(ej_, (IEnumerable<string>)ek_);
                 bool? em_ = context.Operators.And(eg_, el_);
 
                 return em_;
@@ -1492,7 +1492,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? fp_ = context.Operators.In<string>(fn_, fo_ as IEnumerable<string>);
+                bool? fp_ = context.Operators.In<string>(fn_, (IEnumerable<string>)fo_);
                 bool? fq_ = context.Operators.And(fk_, fp_);
 
                 return fq_;
@@ -1705,7 +1705,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
 
                 return bz_;
@@ -1763,7 +1763,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? dc_ = context.Operators.In<string>(da_, db_ as IEnumerable<string>);
+                bool? dc_ = context.Operators.In<string>(da_, (IEnumerable<string>)db_);
                 bool? dd_ = context.Operators.And(cx_, dc_);
 
                 return dd_;
@@ -1821,7 +1821,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? eg_ = context.Operators.In<string>(ee_, ef_ as IEnumerable<string>);
+                bool? eg_ = context.Operators.In<string>(ee_, (IEnumerable<string>)ef_);
                 bool? eh_ = context.Operators.And(eb_, eg_);
 
                 return eh_;
@@ -1879,7 +1879,7 @@ public partial class PCSBPScreeningFollowUpFHIR_0_2_000 : ILibrary, ISingleton<P
                     "amended",
                     "corrected",
                 ];
-                bool? fk_ = context.Operators.In<string>(fi_, fj_ as IEnumerable<string>);
+                bool? fk_ = context.Operators.In<string>(fi_, (IEnumerable<string>)fj_);
                 bool? fl_ = context.Operators.And(ff_, fk_);
 
                 return fl_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/POAGOpticNerveEvaluationFHIR-0.1.000.g.cs
@@ -460,7 +460,7 @@ public partial class POAGOpticNerveEvaluationFHIR_0_1_000 : ILibrary, ISingleton
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(t_, z_);
 
             return aa_;
@@ -512,7 +512,7 @@ public partial class POAGOpticNerveEvaluationFHIR_0_1_000 : ILibrary, ISingleton
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(t_, z_);
 
             return aa_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/ProstateCaAvoidanceBoneScanOveruseFHIR-0.3.000.g.cs
@@ -281,7 +281,7 @@ public partial class ProstateCaAvoidanceBoneScanOveruseFHIR_0_3_000 : ILibrary, 
                     "amended",
                     "corrected",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 bool? ah_ = context.Operators.And(aa_, ag_);
 
                 return ah_;
@@ -395,7 +395,7 @@ public partial class ProstateCaAvoidanceBoneScanOveruseFHIR_0_3_000 : ILibrary, 
                     "amended",
                     "corrected",
                 ];
-                bool? ac_ = context.Operators.In<string>(aa_, ab_ as IEnumerable<string>);
+                bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
                 bool? ad_ = context.Operators.And(w_, ac_);
 
                 return ad_;
@@ -471,7 +471,7 @@ public partial class ProstateCaAvoidanceBoneScanOveruseFHIR_0_3_000 : ILibrary, 
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ab_, ah_);
 
                 return ai_;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/QICoreCommon-2.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/QICoreCommon-2.1.000.g.cs
@@ -2001,7 +2001,7 @@ public partial class QICoreCommon_2_1_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);
@@ -2026,7 +2026,7 @@ public partial class QICoreCommon_2_1_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/StatinTherapyforthePreventionandTreatmentofCardiovascularDiseaseFHIR-0.2.000.g.cs
@@ -442,7 +442,7 @@ public partial class StatinTherapyforthePreventionandTreatmentofCardiovascularDi
                 "corrected",
                 "appended",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(p_, v_);
 
             return w_;
@@ -1034,7 +1034,7 @@ public partial class StatinTherapyforthePreventionandTreatmentofCardiovascularDi
                 "active",
                 "completed",
             ];
-            bool? bt_ = context.Operators.In<string>(br_, bs_ as IEnumerable<string>);
+            bool? bt_ = context.Operators.In<string>(br_, (IEnumerable<string>)bs_);
             Code<MedicationRequest.MedicationRequestIntent> bu_ = StatinPrescribed?.IntentElement;
             MedicationRequest.MedicationRequestIntent? bv_ = bu_?.Value;
             string bw_ = context.Operators.Convert<string>(bv_);

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/Status-1.8.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/Status-1.8.000.g.cs
@@ -82,7 +82,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -124,7 +124,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = D?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -152,7 +152,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -180,7 +180,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -208,7 +208,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -237,7 +237,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -263,7 +263,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "in-progress",
                 "onleave",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -341,7 +341,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -407,7 +407,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "in-progress",
                 "on-hold",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };
@@ -429,7 +429,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "active",
                 "completed",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
             MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
@@ -458,7 +458,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             List<CodeableConcept> i_ = O?.Category;
             CqlConcept j_(CodeableConcept @this)
             {
@@ -500,7 +500,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -523,7 +523,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -546,7 +546,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -569,7 +569,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -594,7 +594,7 @@ public partial class Status_1_8_000 : ILibrary, ISingleton<Status_1_8_000>
                 "amended",
                 "corrected",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
 
             return h_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/SupplementalDataElements-3.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/SupplementalDataElements-3.5.000.g.cs
@@ -172,7 +172,7 @@ public partial class SupplementalDataElements_3_5_000 : ILibrary, ISingleton<Sup
                 return aw_;
             };
             IEnumerable<CqlCode> ad_ = context.Operators.Select<object, CqlCode>(ab_, ac_);
-            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>(x_ as IEnumerable<CqlCode>, ad_);
+            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((IEnumerable<CqlCode>)x_, ad_);
             bool? af_(Extension @this)
             {
                 string ax_ = @this?.Url;

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/TJCOverall-8.15.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/TJCOverall-8.15.000.g.cs
@@ -199,7 +199,7 @@ public partial class TJCOverall_8_15_000 : ILibrary, ISingleton<TJCOverall_8_15_
                 "completed",
                 "on-hold",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             Code<RequestIntent> p_ = SR?.IntentElement;
             RequestIntent? q_ = p_?.Value;
             Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
@@ -211,7 +211,7 @@ public partial class TJCOverall_8_15_000 : ILibrary, ISingleton<TJCOverall_8_15_
                 "filler-order",
                 "instance-order",
             ];
-            bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
             bool? v_ = context.Operators.And(o_, u_);
             FhirBoolean w_ = SR?.DoNotPerformElement;
             bool? x_ = w_?.Value;
@@ -232,7 +232,7 @@ public partial class TJCOverall_8_15_000 : ILibrary, ISingleton<TJCOverall_8_15_
                 "completed",
                 "in-progress",
             ];
-            bool? af_ = context.Operators.In<string>(ad_, ae_ as IEnumerable<string>);
+            bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
 
             return af_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHIR-1.4.000.g.cs
@@ -255,7 +255,7 @@ public partial class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHI
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             DataType o_ = IPSSAssessment?.Value;
             object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
             bool? q_ = context.Operators.Not((bool?)(p_ is null));
@@ -349,7 +349,7 @@ public partial class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHI
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             DataType o_ = AUASIAssessment?.Value;
             object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
             bool? q_ = context.Operators.Not((bool?)(p_ is null));
@@ -536,7 +536,7 @@ public partial class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHI
                     "amended",
                     "corrected",
                 ];
-                bool? bk_ = context.Operators.In<string>(bi_, bj_ as IEnumerable<string>);
+                bool? bk_ = context.Operators.In<string>(bi_, (IEnumerable<string>)bj_);
                 bool? bl_ = context.Operators.And(be_, bk_);
                 DataType bm_ = QOLAssessment?.Value;
                 object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
@@ -911,7 +911,7 @@ public partial class UrinarySymptomScoreChangeAfterBenignProstaticHyperplasiaFHI
                     "amended",
                     "corrected",
                 ];
-                bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+                bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
                 bool? w_ = context.Operators.And(q_, v_);
                 DataType x_ = BMIExam?.Effective;
                 object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/AHAOverall-3.0.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/AHAOverall-3.0.000.g.cs
@@ -240,7 +240,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "amended",
                 "corrected",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
 
             return af_;
@@ -730,7 +730,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "active",
                 "completed",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(i_, n_);
             Code<MedicationRequest.MedicationRequestIntent> p_ = MedicationRequest?.IntentElement;
             MedicationRequest.MedicationRequestIntent? q_ = p_?.Value;
@@ -742,7 +742,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "filler-order",
                 "instance-order",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             bool? u_ = context.Operators.And(o_, t_);
 
             return u_;
@@ -1018,7 +1018,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "active",
                 "completed",
             ];
-            bool? af_ = context.Operators.In<string>(ad_, ae_ as IEnumerable<string>);
+            bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
             bool? ag_ = context.Operators.And(aa_, af_);
             Code<MedicationRequest.MedicationRequestIntent> ah_ = MedicationRequest?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
@@ -1030,7 +1030,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "filler-order",
                 "instance-order",
             ];
-            bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+            bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
             bool? am_ = context.Operators.And(ag_, al_);
 
             return am_;
@@ -1064,7 +1064,7 @@ public partial class AHAOverall_3_0_000 : ILibrary, ISingleton<AHAOverall_3_0_00
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             bool? p_ = context.Operators.And(j_, o_);
 
             return p_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
@@ -269,7 +269,7 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             CodeableConcept m_ = C?.Code;
             CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
             CqlCode o_ = this.Calculated_CT_global_noise(context);
@@ -315,7 +315,7 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             CodeableConcept m_ = C?.Code;
             CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
             CqlCode o_ = this.Calculated_CT_size_adjusted_dose(context);
@@ -463,7 +463,7 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             CodeableConcept m_ = C?.Code;
             CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
             CqlCode o_ = this.Calculated_CT_global_noise(context);
@@ -509,7 +509,7 @@ public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraC
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             CodeableConcept m_ = C?.Code;
             CqlConcept n_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, m_);
             CqlCode o_ = this.Calculated_CT_size_adjusted_dose(context);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS0334FHIRPCCesareanBirth-0.6.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS0334FHIRPCCesareanBirth-0.6.000.g.cs
@@ -272,7 +272,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                 "amended",
                 "corrected",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
             object t_()
             {
@@ -482,7 +482,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(u_, z_);
             DataType ab_ = Parity?.Value;
             object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
@@ -635,7 +635,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(u_, z_);
             DataType ab_ = PretermBirth?.Value;
             object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
@@ -788,7 +788,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                 "amended",
                 "corrected",
             ];
-            bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+            bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
             bool? aa_ = context.Operators.And(u_, z_);
             DataType ab_ = TermBirth?.Value;
             object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
@@ -970,7 +970,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                        bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                         bool? ai_ = context.Operators.And(ac_, ah_);
 
                         return ai_;
@@ -1111,7 +1111,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? cn_ = context.Operators.In<string>(cl_, cm_ as IEnumerable<string>);
+                        bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
                         bool? co_ = context.Operators.And(ci_, cn_);
 
                         return co_;
@@ -1252,7 +1252,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? et_ = context.Operators.In<string>(er_, es_ as IEnumerable<string>);
+                        bool? et_ = context.Operators.In<string>(er_, (IEnumerable<string>)es_);
                         bool? eu_ = context.Operators.And(eo_, et_);
 
                         return eu_;
@@ -1393,7 +1393,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? gy_ = context.Operators.In<string>(gw_, gx_ as IEnumerable<string>);
+                        bool? gy_ = context.Operators.In<string>(gw_, (IEnumerable<string>)gx_);
                         bool? gz_ = context.Operators.And(gt_, gy_);
 
                         return gz_;
@@ -1533,7 +1533,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? jd_ = context.Operators.In<string>(jb_, jc_ as IEnumerable<string>);
+                        bool? jd_ = context.Operators.In<string>(jb_, (IEnumerable<string>)jc_);
                         bool? je_ = context.Operators.And(iy_, jd_);
 
                         return je_;
@@ -1673,7 +1673,7 @@ public partial class CMS0334FHIRPCCesareanBirth_0_6_000 : ILibrary, ISingleton<C
                             "amended",
                             "corrected",
                         ];
-                        bool? li_ = context.Operators.In<string>(lg_, lh_ as IEnumerable<string>);
+                        bool? li_ = context.Operators.In<string>(lg_, (IEnumerable<string>)lh_);
                         bool? lj_ = context.Operators.And(ld_, li_);
 
                         return lj_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1017FHIRHHFI-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1017FHIRHHFI-0.2.000.g.cs
@@ -830,7 +830,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? z_ = context.Operators.In<string>(x_, y_ as IEnumerable<string>);
+                bool? z_ = context.Operators.In<string>(x_, (IEnumerable<string>)y_);
                 bool? aa_ = context.Operators.And(u_, z_);
 
                 return aa_;
@@ -1099,7 +1099,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = Anticoagulants?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1217,7 +1217,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "in-progress",
                     "completed",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, al_ as IEnumerable<string>);
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
                 bool? an_ = context.Operators.And(ah_, am_);
 
                 return an_;
@@ -1280,7 +1280,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = AntidepressantMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1392,7 +1392,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = BPMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1504,7 +1504,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = CNSMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1616,7 +1616,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = DiureticMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);
@@ -1728,7 +1728,7 @@ public partial class CMS1017FHIRHHFI_0_2_000 : ILibrary, ISingleton<CMS1017FHIRH
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = OpioidMed?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1028FHIRPCSevereOBComps-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1028FHIRPCSevereOBComps-0.3.000.g.cs
@@ -1970,7 +1970,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
     m_ ?? default(int),
             ];
 
-            return n_ as IEnumerable<object>;
+            return (IEnumerable<object>)n_;
         };
         IEnumerable<IEnumerable<object>> c_ = context.Operators.Select<Encounter, IEnumerable<object>>(a_, b_);
         IEnumerable<IEnumerable<object>> d_ = context.Operators.Distinct<IEnumerable<object>>(c_);
@@ -2361,7 +2361,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
                 bool? ap_ = context.Operators.And(aj_, ao_);
                 DataType aq_ = Hematocrit?.Value;
                 object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
@@ -2405,7 +2405,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 bool? bn_ = context.Operators.And(bh_, bm_);
                 DataType bo_ = Hematocrit?.Value;
                 object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
@@ -2470,7 +2470,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
                 bool? ap_ = context.Operators.And(aj_, ao_);
                 DataType aq_ = WBC?.Value;
                 object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
@@ -2514,7 +2514,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bm_ = context.Operators.In<string>(bk_, bl_ as IEnumerable<string>);
+                bool? bm_ = context.Operators.In<string>(bk_, (IEnumerable<string>)bl_);
                 bool? bn_ = context.Operators.And(bh_, bm_);
                 DataType bo_ = WBC?.Value;
                 object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
@@ -2578,7 +2578,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? am_ = context.Operators.In<string>(ak_, al_ as IEnumerable<string>);
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
                 bool? an_ = context.Operators.And(ah_, am_);
 
                 return an_;
@@ -2616,7 +2616,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? bf_ = context.Operators.In<string>(bd_, be_ as IEnumerable<string>);
+                bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
                 bool? bg_ = context.Operators.And(ba_, bf_);
 
                 return bg_;
@@ -2675,7 +2675,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? aq_ = context.Operators.In<string>(ao_, ap_ as IEnumerable<string>);
+                bool? aq_ = context.Operators.In<string>(ao_, (IEnumerable<string>)ap_);
                 bool? ar_ = context.Operators.And(al_, aq_);
                 List<Observation.ComponentComponent> as_ = BP?.Component;
                 bool? at_(Observation.ComponentComponent @this)
@@ -2752,7 +2752,7 @@ public partial class CMS1028FHIRPCSevereOBComps_0_3_000 : ILibrary, ISingleton<C
                     "amended",
                     "corrected",
                 ];
-                bool? cc_ = context.Operators.In<string>(ca_, cb_ as IEnumerable<string>);
+                bool? cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
                 bool? cd_ = context.Operators.And(bx_, cc_);
                 List<Observation.ComponentComponent> ce_ = BP?.Component;
                 bool? cf_(Observation.ComponentComponent @this)

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS104FHIRSTKDCAntithrombotic-0.9.003.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS104FHIRSTKDCAntithrombotic-0.9.003.g.cs
@@ -137,7 +137,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                     "active",
                     "completed",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
                 Code<MedicationRequest.MedicationRequestIntent> o_ = DischargeAntithrombotic?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? p_ = o_?.Value;
                 string q_ = context.Operators.Convert<string>(p_);
@@ -148,7 +148,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                     "filler-order",
                     "instance-order",
                 ];
-                bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+                bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
                 bool? t_ = context.Operators.And(n_, s_);
                 bool? u_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAntithrombotic as object);
                 bool? v_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAntithrombotic as object);
@@ -234,7 +234,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                 "active",
                 "completed",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ae_, aj_);
             Code<MedicationRequest.MedicationRequestIntent> al_ = NoAntithromboticDischarge?.IntentElement;
             MedicationRequest.MedicationRequestIntent? am_ = al_?.Value;
@@ -246,7 +246,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? ap_ = context.Operators.In<string>(an_, ao_ as IEnumerable<string>);
+            bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
             bool? aq_ = context.Operators.And(ak_, ap_);
 
             return aq_;
@@ -372,7 +372,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                 "active",
                 "completed",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
             Code<MedicationRequest.MedicationRequestIntent> n_ = PharmacologicalContraindications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? o_ = n_?.Value;
@@ -384,7 +384,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_0_9_003 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
 
             return s_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1218FHIRHHRF-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1218FHIRHHRF-0.2.000.g.cs
@@ -1041,7 +1041,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? p_ = context.Operators.In<string>(n_, o_ as IEnumerable<string>);
+                bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
                 DataType q_ = CarbonDioxide?.Effective;
                 object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
                 CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
@@ -1314,7 +1314,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? er_ = context.Operators.In<string>(ep_, eq_ as IEnumerable<string>);
+                bool? er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
                 DataType es_ = BloodpH?.Effective;
                 object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
                 CqlInterval<CqlDateTime> eu_ = QICoreCommon_4_0_000.Instance.toInterval(context, et_);
@@ -1596,7 +1596,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
                 DataType o_ = Oxygen?.Effective;
                 object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
@@ -5819,7 +5819,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+                bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
                 bool? s_ = this.startsDuringHospitalization(context, ASAclass as object, QualifyingEncounter);
                 bool? t_ = context.Operators.And(r_, s_);
                 DataType u_ = ASAclass?.Value;
@@ -5881,7 +5881,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                     "amended",
                     "corrected",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(w_, ab_);
 
                 return ac_;
@@ -6125,7 +6125,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstAlbuminTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6344,7 +6344,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstArterialpHTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6453,7 +6453,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstASTTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6562,7 +6562,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBicarbonateTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6671,7 +6671,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBilirubinTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6780,7 +6780,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstBUN as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -6890,7 +6890,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstBodyMass?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
@@ -6959,7 +6959,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstTemperature?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7026,7 +7026,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstCarbonDioxideTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7135,7 +7135,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstCreatinineTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7245,7 +7245,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstHeartBeats?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7312,7 +7312,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstHematocritTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7421,7 +7421,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstHemoglobinTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7530,7 +7530,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstLeukocyteCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7639,7 +7639,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstOxygenTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7748,7 +7748,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstPlateletCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -7858,7 +7858,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             DataType p_ = FirstRespiration?.Effective;
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
@@ -7925,7 +7925,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstSodiumTest as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 
@@ -8033,7 +8033,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             DataType m_ = SBPReading?.Effective;
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
@@ -8134,7 +8134,7 @@ public partial class CMS1218FHIRHHRF_0_2_000 : ILibrary, ISingleton<CMS1218FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = this.isEarliestDuringHospitalization(context, FirstWBCCount as object, QualifyingEncounter);
             bool? p_ = context.Operators.And(n_, o_);
 

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1244FHIRECATHOQR-0.4.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1244FHIRECATHOQR-0.4.001.g.cs
@@ -171,7 +171,7 @@ public partial class CMS1244FHIRECATHOQR_0_4_001 : ILibrary, ISingleton<CMS1244F
                 "finished",
                 "triaged",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             bool? p_ = context.Operators.And(i_, o_);
 
             return p_;
@@ -545,7 +545,7 @@ public partial class CMS1244FHIRECATHOQR_0_4_001 : ILibrary, ISingleton<CMS1244F
                 "active",
                 "completed",
             ];
-            bool? j_ = context.Operators.In<string>(h_, i_ as IEnumerable<string>);
+            bool? j_ = context.Operators.In<string>(h_, (IEnumerable<string>)i_);
 
             return j_;
         };
@@ -752,7 +752,7 @@ public partial class CMS1244FHIRECATHOQR_0_4_001 : ILibrary, ISingleton<CMS1244F
                 "amended",
                 "corrected",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             bool? u_ = context.Operators.And(p_, t_);
 
             return u_;
@@ -879,7 +879,7 @@ public partial class CMS1244FHIRECATHOQR_0_4_001 : ILibrary, ISingleton<CMS1244F
                 "active",
                 "completed",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
 
             return n_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1264FHIRECATREHQR-0.5.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS1264FHIRECATREHQR-0.5.001.g.cs
@@ -154,7 +154,7 @@ public partial class CMS1264FHIRECATREHQR_0_5_001 : ILibrary, ISingleton<CMS1264
                 "finished",
                 "triaged",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             bool? p_ = context.Operators.And(i_, o_);
 
             return p_;
@@ -501,7 +501,7 @@ public partial class CMS1264FHIRECATREHQR_0_5_001 : ILibrary, ISingleton<CMS1264
                 "active",
                 "completed",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(s_, y_);
 
             return z_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS133FHIRCataracts2040BCVAwithin90Days-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS133FHIRCataracts2040BCVAwithin90Days-0.2.000.g.cs
@@ -1124,7 +1124,7 @@ public partial class CMS133FHIRCataracts2040BCVAwithin90Days_0_2_000 : ILibrary,
                     "corrected",
                     "preliminary",
                 ];
-                bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+                bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
                 bool? al_ = context.Operators.And(af_, ak_);
                 DataType am_ = VisualAcuityExamPerformed?.Value;
                 object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes-0.2.000.g.cs
@@ -349,7 +349,7 @@ public partial class CMS142FHIRDRCommunicationWithPhysicianManagingDiabetes_0_2_
                 "corrected",
                 "preliminary",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(t_, y_);
 
             return z_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS143FHIRPOAGOpticNerveEvaluation-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS143FHIRPOAGOpticNerveEvaluation-0.2.000.g.cs
@@ -456,7 +456,7 @@ public partial class CMS143FHIRPOAGOpticNerveEvaluation_0_2_000 : ILibrary, ISin
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(t_, y_);
 
             return z_;
@@ -507,7 +507,7 @@ public partial class CMS143FHIRPOAGOpticNerveEvaluation_0_2_000 : ILibrary, ISin
                 "amended",
                 "corrected",
             ];
-            bool? y_ = context.Operators.In<string>(w_, x_ as IEnumerable<string>);
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
             bool? z_ = context.Operators.And(t_, y_);
 
             return z_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS144FHIRHFBetaBlockerTherapyforLVSD-1.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS144FHIRHFBetaBlockerTherapyforLVSD-1.5.000.g.cs
@@ -181,7 +181,7 @@ public partial class CMS144FHIRHFBetaBlockerTherapyforLVSD_1_5_000 : ILibrary, I
                 "active",
                 "completed",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(i_, n_);
             Code<MedicationRequest.MedicationRequestIntent> p_ = MedicationRequest?.IntentElement;
             MedicationRequest.MedicationRequestIntent? q_ = p_?.Value;
@@ -193,7 +193,7 @@ public partial class CMS144FHIRHFBetaBlockerTherapyforLVSD_1_5_000 : ILibrary, I
                 "filler-order",
                 "instance-order",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             bool? u_ = context.Operators.And(o_, t_);
 
             return u_;
@@ -309,7 +309,7 @@ public partial class CMS144FHIRHFBetaBlockerTherapyforLVSD_1_5_000 : ILibrary, I
                 "amended",
                 "corrected",
             ];
-            bool? w_ = context.Operators.In<string>(u_, v_ as IEnumerable<string>);
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
             bool? x_ = context.Operators.And(r_, w_);
             DataType y_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Value;
             CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS149FHIRDementiaCognitiveAssessment-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS149FHIRDementiaCognitiveAssessment-0.2.000.g.cs
@@ -320,7 +320,7 @@ public partial class CMS149FHIRDementiaCognitiveAssessment_0_2_000 : ILibrary, I
                 "corrected",
                 "preliminary",
             ];
-            bool? ao_ = context.Operators.In<string>(am_, an_ as IEnumerable<string>);
+            bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
             bool? ap_ = context.Operators.And(aj_, ao_);
 
             return ap_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS159FHIRDepressionRemissionatTwelveMonths-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS159FHIRDepressionRemissionatTwelveMonths-0.3.000.g.cs
@@ -200,7 +200,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
 
             return m_;
@@ -482,7 +482,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "entered-in-error",
                 "unknown",
             ];
-            bool? ce_ = context.Operators.In<string>(cc_, cd_ as IEnumerable<string>);
+            bool? ce_ = context.Operators.In<string>(cc_, (IEnumerable<string>)cd_);
             bool? cf_ = context.Operators.Not(ce_);
             bool? cg_ = context.Operators.And(by_, cf_);
 
@@ -520,7 +520,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "amended",
                 "corrected",
             ];
-            bool? db_ = context.Operators.In<string>(cz_, da_ as IEnumerable<string>);
+            bool? db_ = context.Operators.In<string>(cz_, (IEnumerable<string>)da_);
             bool? dc_ = context.Operators.And(cw_, db_);
 
             return dc_;
@@ -549,7 +549,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "active",
                 "completed",
             ];
-            bool? dr_ = context.Operators.In<string>(dp_, dq_ as IEnumerable<string>);
+            bool? dr_ = context.Operators.In<string>(dp_, (IEnumerable<string>)dq_);
             bool? ds_ = context.Operators.And(dl_, dr_);
             Code<RequestIntent> dt_ = HospiceOrder?.IntentElement;
             RequestIntent? du_ = dt_?.Value;
@@ -562,7 +562,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "filler-order",
                 "instance-order",
             ];
-            bool? dy_ = context.Operators.In<string>(dw_, dx_ as IEnumerable<string>);
+            bool? dy_ = context.Operators.In<string>(dw_, (IEnumerable<string>)dx_);
             bool? dz_ = context.Operators.And(ds_, dy_);
             FhirBoolean ea_ = HospiceOrder?.DoNotPerformElement;
             bool? eb_ = ea_?.Value;
@@ -661,7 +661,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "entered-in-error",
                 "unknown",
             ];
-            bool? es_ = context.Operators.In<string>(eq_, er_ as IEnumerable<string>);
+            bool? es_ = context.Operators.In<string>(eq_, (IEnumerable<string>)er_);
             bool? et_ = context.Operators.Not(es_);
             bool? eu_ = context.Operators.And(en_, et_);
 
@@ -723,7 +723,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "amended",
                 "corrected",
             ];
-            bool? ap_ = context.Operators.In<string>(an_, ao_ as IEnumerable<string>);
+            bool? ap_ = context.Operators.In<string>(an_, (IEnumerable<string>)ao_);
             bool? aq_ = context.Operators.And(ak_, ap_);
 
             return aq_;
@@ -863,7 +863,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "entered-in-error",
                 "unknown",
             ];
-            bool? cc_ = context.Operators.In<string>(ca_, cb_ as IEnumerable<string>);
+            bool? cc_ = context.Operators.In<string>(ca_, (IEnumerable<string>)cb_);
             bool? cd_ = context.Operators.Not(cc_);
             bool? ce_ = context.Operators.And(bx_, cd_);
 
@@ -971,7 +971,7 @@ public partial class CMS159FHIRDepressionRemissionatTwelveMonths_0_3_000 : ILibr
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(q_, v_);
 
             return w_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS165FHIRControllingHighBloodPressure-0.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS165FHIRControllingHighBloodPressure-0.5.000.g.cs
@@ -428,7 +428,7 @@ public partial class CMS165FHIRControllingHighBloodPressure_0_5_000 : ILibrary, 
                 "PRENC",
                 "SS",
             ];
-            bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
             bool? aj_ = context.Operators.Not(ai_);
             DataType ak_ = BloodPressure?.Effective;
             object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -496,7 +496,7 @@ public partial class CMS165FHIRControllingHighBloodPressure_0_5_000 : ILibrary, 
                 "PRENC",
                 "SS",
             ];
-            bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
             bool? aj_ = context.Operators.Not(ai_);
             DataType ak_ = BloodPressure?.Effective;
             object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS22FHIRPCSBPScreeningFollowUp-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS22FHIRPCSBPScreeningFollowUp-0.3.000.g.cs
@@ -314,7 +314,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? av_ = context.Operators.In<string>(at_, au_ as IEnumerable<string>);
+                bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
                 bool? aw_ = context.Operators.And(aq_, av_);
 
                 return aw_;
@@ -367,7 +367,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? br_ = context.Operators.In<string>(bp_, bq_ as IEnumerable<string>);
+                bool? br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
                 bool? bs_ = context.Operators.And(bm_, br_);
 
                 return bs_;
@@ -436,7 +436,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? av_ = context.Operators.In<string>(at_, au_ as IEnumerable<string>);
+                bool? av_ = context.Operators.In<string>(at_, (IEnumerable<string>)au_);
                 bool? aw_ = context.Operators.And(aq_, av_);
 
                 return aw_;
@@ -489,7 +489,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? br_ = context.Operators.In<string>(bp_, bq_ as IEnumerable<string>);
+                bool? br_ = context.Operators.In<string>(bp_, (IEnumerable<string>)bq_);
                 bool? bs_ = context.Operators.And(bm_, br_);
 
                 return bs_;
@@ -725,7 +725,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? ch_ = context.Operators.In<string>(cf_, cg_ as IEnumerable<string>);
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
                 bool? ci_ = context.Operators.And(cc_, ch_);
 
                 return ci_;
@@ -786,7 +786,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? dp_ = context.Operators.In<string>(dn_, do_ as IEnumerable<string>);
+                bool? dp_ = context.Operators.In<string>(dn_, (IEnumerable<string>)do_);
                 bool? dq_ = context.Operators.And(dk_, dp_);
 
                 return dq_;
@@ -847,7 +847,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? ex_ = context.Operators.In<string>(ev_, ew_ as IEnumerable<string>);
+                bool? ex_ = context.Operators.In<string>(ev_, (IEnumerable<string>)ew_);
                 bool? ey_ = context.Operators.And(es_, ex_);
 
                 return ey_;
@@ -908,7 +908,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? gf_ = context.Operators.In<string>(gd_, ge_ as IEnumerable<string>);
+                bool? gf_ = context.Operators.In<string>(gd_, (IEnumerable<string>)ge_);
                 bool? gg_ = context.Operators.And(ga_, gf_);
 
                 return gg_;
@@ -1232,7 +1232,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? cd_ = context.Operators.In<string>(cb_, cc_ as IEnumerable<string>);
+                bool? cd_ = context.Operators.In<string>(cb_, (IEnumerable<string>)cc_);
                 bool? ce_ = context.Operators.And(by_, cd_);
 
                 return ce_;
@@ -1285,7 +1285,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? cz_ = context.Operators.In<string>(cx_, cy_ as IEnumerable<string>);
+                bool? cz_ = context.Operators.In<string>(cx_, (IEnumerable<string>)cy_);
                 bool? da_ = context.Operators.And(cu_, cz_);
 
                 return da_;
@@ -1339,7 +1339,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? dv_ = context.Operators.In<string>(dt_, du_ as IEnumerable<string>);
+                bool? dv_ = context.Operators.In<string>(dt_, (IEnumerable<string>)du_);
                 bool? dw_ = context.Operators.And(dq_, dv_);
 
                 return dw_;
@@ -1390,7 +1390,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? er_ = context.Operators.In<string>(ep_, eq_ as IEnumerable<string>);
+                bool? er_ = context.Operators.In<string>(ep_, (IEnumerable<string>)eq_);
                 bool? es_ = context.Operators.And(em_, er_);
 
                 return es_;
@@ -1596,7 +1596,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? by_ = context.Operators.In<string>(bw_, bx_ as IEnumerable<string>);
+                bool? by_ = context.Operators.In<string>(bw_, (IEnumerable<string>)bx_);
                 bool? bz_ = context.Operators.And(bt_, by_);
 
                 return bz_;
@@ -1647,7 +1647,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? cu_ = context.Operators.In<string>(cs_, ct_ as IEnumerable<string>);
+                bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
                 bool? cv_ = context.Operators.And(cp_, cu_);
 
                 return cv_;
@@ -1698,7 +1698,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? dq_ = context.Operators.In<string>(do_, dp_ as IEnumerable<string>);
+                bool? dq_ = context.Operators.In<string>(do_, (IEnumerable<string>)dp_);
                 bool? dr_ = context.Operators.And(dl_, dq_);
 
                 return dr_;
@@ -1749,7 +1749,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_0_3_000 : ILibrary, ISingle
                     "amended",
                     "corrected",
                 ];
-                bool? em_ = context.Operators.In<string>(ek_, el_ as IEnumerable<string>);
+                bool? em_ = context.Operators.In<string>(ek_, (IEnumerable<string>)el_);
                 bool? en_ = context.Operators.And(eh_, em_);
 
                 return en_;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS506FHIRSafeUseofOpioids-0.3.007.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS506FHIRSafeUseofOpioids-0.3.007.g.cs
@@ -175,7 +175,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = OpioidMedications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -187,7 +187,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -243,7 +243,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = BenzoMedications?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -255,7 +255,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -471,7 +471,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             bool? af_ = context.Operators.And(z_, ae_);
             Code<MedicationRequest.MedicationRequestIntent> ag_ = DischargeMedication?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ah_ = ag_?.Value;
@@ -483,7 +483,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "filler-order",
                 "instance-order",
             ];
-            bool? ak_ = context.Operators.In<string>(ai_, aj_ as IEnumerable<string>);
+            bool? ak_ = context.Operators.In<string>(ai_, (IEnumerable<string>)aj_);
             bool? al_ = context.Operators.And(af_, ak_);
 
             return al_;
@@ -586,7 +586,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                     "completed",
                     "in-progress",
                 ];
-                bool? ab_ = context.Operators.In<string>(z_, aa_ as IEnumerable<string>);
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
                 bool? ac_ = context.Operators.And(w_, ab_);
 
                 return ac_;
@@ -661,7 +661,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "completed",
                 "on-hold",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
 
             return o_;
         };
@@ -676,7 +676,7 @@ public partial class CMS506FHIRSafeUseofOpioids_0_3_007 : ILibrary, ISingleton<C
                 "completed",
                 "in-progress",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
 
             return t_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS50FHIRCRLReceiptofSpecialistReport-0.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS50FHIRCRLReceiptofSpecialistReport-0.4.000.g.cs
@@ -303,7 +303,7 @@ public partial class CMS50FHIRCRLReceiptofSpecialistReport_0_4_000 : ILibrary, I
                 "active",
                 "completed",
             ];
-            bool? p_ = context.Operators.In<string>(n_, o_ as IEnumerable<string>);
+            bool? p_ = context.Operators.In<string>(n_, (IEnumerable<string>)o_);
             Code<RequestIntent> q_ = ReferralOrder?.IntentElement;
             RequestIntent? r_ = q_?.Value;
             Code<RequestIntent> s_ = context.Operators.Convert<Code<RequestIntent>>(r_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement-1.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement-1.1.000.g.cs
@@ -1842,7 +1842,7 @@ public partial class CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement_1
                 dl_,
                 dq_,
             ];
-            CqlDate ds_ = context.Operators.Max<CqlDate>(dr_ as IEnumerable<CqlDate>);
+            CqlDate ds_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)dr_);
 
             return ds_;
         };
@@ -2242,7 +2242,7 @@ public partial class CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement_1
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };
@@ -2461,7 +2461,7 @@ public partial class CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement_1
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };
@@ -2680,7 +2680,7 @@ public partial class CMS56FHIRFunctionalStatusAssessmentforTotalHipReplacement_1
                 ao_,
                 at_,
             ];
-            CqlDate av_ = context.Operators.Max<CqlDate>(au_ as IEnumerable<CqlDate>);
+            CqlDate av_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)au_);
 
             return av_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy-1.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationTherapy-1.5.000.g.cs
@@ -188,7 +188,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             Code<MedicationRequest.MedicationRequestIntent> af_ = ADTActive?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
             string ah_ = context.Operators.Convert<string>(ag_);
@@ -199,7 +199,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ae_, aj_);
 
             return ak_;
@@ -367,7 +367,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "active",
                 "completed",
             ];
-            bool? ae_ = context.Operators.In<string>(ac_, ad_ as IEnumerable<string>);
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
             Code<MedicationRequest.MedicationRequestIntent> af_ = ADTOrder?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ag_ = af_?.Value;
             string ah_ = context.Operators.Convert<string>(ag_);
@@ -378,7 +378,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "filler-order",
                 "instance-order",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             bool? ak_ = context.Operators.And(ae_, aj_);
 
             return ak_;
@@ -575,7 +575,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 bool? ah_ = context.Operators.And(aa_, ag_);
                 Code<RequestIntent> ai_ = OrderTwelveMonthADT?.IntentElement;
                 RequestIntent? aj_ = ai_?.Value;
@@ -678,7 +678,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "active",
                 "completed",
             ];
-            bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+            bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
             Code<RequestIntent> bc_ = DEXAOrdered?.IntentElement;
             RequestIntent? bd_ = bc_?.Value;
             Code<RequestIntent> be_ = context.Operators.Convert<Code<RequestIntent>>(bd_);
@@ -747,7 +747,7 @@ public partial class CMS645FHIRBoneDensityProstateCancerAndrogenDeprivationThera
                 "amended",
                 "corrected",
             ];
-            bool? dc_ = context.Operators.In<string>(da_, db_ as IEnumerable<string>);
+            bool? dc_ = context.Operators.In<string>(da_, (IEnumerable<string>)db_);
 
             return dc_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer-1.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCancer-1.5.000.g.cs
@@ -572,7 +572,7 @@ public partial class CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCance
                 "amended",
                 "corrected",
             ];
-            bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+            bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
             bool? aj_ = context.Operators.And(ad_, ai_);
 
             return aj_;
@@ -983,7 +983,7 @@ public partial class CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCance
                 "active",
                 "completed",
             ];
-            bool? dq_ = context.Operators.In<string>(do_, dp_ as IEnumerable<string>);
+            bool? dq_ = context.Operators.In<string>(do_, (IEnumerable<string>)dp_);
             Code<MedicationRequest.MedicationRequestIntent> dr_ = ImmunosuppressiveDrugs?.IntentElement;
             MedicationRequest.MedicationRequestIntent? ds_ = dr_?.Value;
             string dt_ = context.Operators.Convert<string>(ds_);
@@ -1780,7 +1780,7 @@ public partial class CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCance
                 "active",
                 "completed",
             ];
-            bool? fj_ = context.Operators.In<string>(fh_, fi_ as IEnumerable<string>);
+            bool? fj_ = context.Operators.In<string>(fh_, (IEnumerable<string>)fi_);
             Code<MedicationRequest.MedicationRequestIntent> fk_ = ExclusionMed?.IntentElement;
             MedicationRequest.MedicationRequestIntent? fl_ = fk_?.Value;
             string fm_ = context.Operators.Convert<string>(fl_);
@@ -2422,7 +2422,7 @@ public partial class CMS646FHIRIntravesicalBacillusCalmetteGuerinForBladderCance
                 "in-progress",
                 "completed",
             ];
-            bool? eg_ = context.Operators.In<string>(ee_, ef_ as IEnumerable<string>);
+            bool? eg_ = context.Operators.In<string>(ee_, (IEnumerable<string>)ef_);
 
             return eg_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS69FHIRPCSBMIScreenAndFollowUp-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS69FHIRPCSBMIScreenAndFollowUp-0.3.000.g.cs
@@ -284,7 +284,7 @@ public partial class CMS69FHIRPCSBMIScreenAndFollowUp_0_3_000 : ILibrary, ISingl
                 "amended",
                 "corrected",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
             CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
             DataType o_ = BMI?.Effective;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS71FHIRSTKAnticoagAFFlutter-0.3.002.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS71FHIRSTKAnticoagAFFlutter-0.3.002.g.cs
@@ -281,7 +281,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                     "amended",
                     "corrected",
                 ];
-                bool? cu_ = context.Operators.In<string>(cs_, ct_ as IEnumerable<string>);
+                bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
                 object cv_()
                 {
                     bool dc_()
@@ -641,7 +641,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                     "active",
                     "completed",
                 ];
-                bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+                bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
                 Code<MedicationRequest.MedicationRequestIntent> o_ = DischargeAnticoagulant?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? p_ = o_?.Value;
                 string q_ = context.Operators.Convert<string>(p_);
@@ -652,7 +652,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                     "filler-order",
                     "instance-order",
                 ];
-                bool? s_ = context.Operators.In<string>(q_, r_ as IEnumerable<string>);
+                bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
                 bool? t_ = context.Operators.And(n_, s_);
                 bool? u_ = QICoreCommon_4_0_000.Instance.isCommunity(context, DischargeAnticoagulant as object);
                 bool? v_ = QICoreCommon_4_0_000.Instance.isDischarge(context, DischargeAnticoagulant as object);
@@ -736,7 +736,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                 "active",
                 "completed",
             ];
-            bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+            bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
             bool? ah_ = context.Operators.And(ab_, ag_);
             Code<MedicationRequest.MedicationRequestIntent> ai_ = NoAnticoagulant?.IntentElement;
             MedicationRequest.MedicationRequestIntent? aj_ = ai_?.Value;
@@ -748,7 +748,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                 "filler-order",
                 "instance-order",
             ];
-            bool? am_ = context.Operators.In<string>(ak_, al_ as IEnumerable<string>);
+            bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
             bool? an_ = context.Operators.And(ah_, am_);
 
             return an_;
@@ -806,7 +806,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_0_3_002 : ILibrary, ISingleto
                     "active",
                     "completed",
                 ];
-                bool? ca_ = context.Operators.In<string>(by_, bz_ as IEnumerable<string>);
+                bool? ca_ = context.Operators.In<string>(by_, (IEnumerable<string>)bz_);
                 bool? cb_ = context.Operators.And(bv_, ca_);
                 CodeableConcept cc_ = TaskReject?.Code;
                 CqlConcept cd_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, cc_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia-1.5.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplasia-1.5.000.g.cs
@@ -267,7 +267,7 @@ public partial class CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplas
                 "amended",
                 "corrected",
             ];
-            bool? m_ = context.Operators.In<string>(k_, l_ as IEnumerable<string>);
+            bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
             DataType n_ = IPSSAssessment?.Value;
             object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
             bool? p_ = context.Operators.Not((bool?)(o_ is null));
@@ -360,7 +360,7 @@ public partial class CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplas
                 "amended",
                 "corrected",
             ];
-            bool? m_ = context.Operators.In<string>(k_, l_ as IEnumerable<string>);
+            bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
             DataType n_ = AUASIAssessment?.Value;
             object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
             bool? p_ = context.Operators.Not((bool?)(o_ is null));
@@ -546,7 +546,7 @@ public partial class CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplas
                     "amended",
                     "corrected",
                 ];
-                bool? bi_ = context.Operators.In<string>(bg_, bh_ as IEnumerable<string>);
+                bool? bi_ = context.Operators.In<string>(bg_, (IEnumerable<string>)bh_);
                 bool? bj_ = context.Operators.And(bd_, bi_);
                 DataType bk_ = QOLAssessment?.Value;
                 object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
@@ -912,7 +912,7 @@ public partial class CMS771FHIRUrinarySymptomScoreChangeBenignProstaticHyperplas
                     "amended",
                     "corrected",
                 ];
-                bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+                bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
                 bool? w_ = context.Operators.And(q_, v_);
                 DataType x_ = BMIExam?.Effective;
                 object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS816FHIRHHHypo-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS816FHIRHHHypo-0.3.000.g.cs
@@ -282,7 +282,7 @@ public partial class CMS816FHIRHHHypo_0_3_000 : ILibrary, ISingleton<CMS816FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? v_ = context.Operators.In<string>(t_, u_ as IEnumerable<string>);
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
             bool? w_ = context.Operators.And(q_, v_);
             DataType x_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.Value;
             object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
@@ -833,7 +833,7 @@ public partial class CMS816FHIRHHHypo_0_3_000 : ILibrary, ISingleton<CMS816FHIRH
                 "amended",
                 "corrected",
             ];
-            bool? aw_ = context.Operators.In<string>(au_, av_ as IEnumerable<string>);
+            bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
             bool? ax_ = context.Operators.And(ar_, aw_);
             DataType ay_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.Value;
             object az_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ay_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS826FHIRHHPI-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS826FHIRHHPI-0.3.000.g.cs
@@ -185,7 +185,7 @@ public partial class CMS826FHIRHHPI_0_3_000 : ILibrary, ISingleton<CMS826FHIRHHP
             "amended",
             "corrected",
         ];
-        bool? d_ = context.Operators.In<string>(b_, c_ as IEnumerable<string>);
+        bool? d_ = context.Operators.In<string>(b_, (IEnumerable<string>)c_);
         object e_ = context.Operators.LateBoundProperty<object>(observation, "effective");
         object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
         CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS871HHHyperFHIR-0.3.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS871HHHyperFHIR-0.3.000.g.cs
@@ -263,7 +263,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                 "completed",
                 "in-progress",
             ];
-            bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+            bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
             CqlInterval<CqlDateTime> ak_ = tuple_brdbxsuhdqixbcfmgdsacwig?.Hospitalization?.hospitalizationPeriod;
             DataType al_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
             object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
@@ -360,7 +360,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                     "amended",
                     "corrected",
                 ];
-                bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+                bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
                 bool? v_ = context.Operators.And(p_, u_);
                 DataType w_ = GlucoseTest?.Value;
                 object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, w_);
@@ -433,7 +433,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
             b_,
             e_,
         ];
-        CqlDateTime g_ = context.Operators.Min<CqlDateTime>(f_ as IEnumerable<CqlDateTime>);
+        CqlDateTime g_ = context.Operators.Min<CqlDateTime>((IEnumerable<CqlDateTime>)f_);
         CqlInterval<CqlDateTime> h_ = context.Operators.Interval(a_, g_, true, true);
 
         return h_;
@@ -512,7 +512,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayExpand)
         {
             int? j_ = context.Operators.End(DayExpand);
@@ -572,7 +572,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                    bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                     DataType aj_ = GlucoseTest?.Value;
                     object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
                     CqlQuantity al_ = context.Operators.Quantity(300m, "mg/dL");
@@ -650,7 +650,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? bp_ = context.Operators.In<string>(bn_, bo_ as IEnumerable<string>);
+                    bool? bp_ = context.Operators.In<string>(bn_, (IEnumerable<string>)bo_);
                     DataType bq_ = GlucoseTest?.Value;
                     object br_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bq_);
                     CqlQuantity bs_ = context.Operators.Quantity(200m, "mg/dL");
@@ -728,7 +728,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                         "amended",
                         "corrected",
                     ];
-                    bool? cw_ = context.Operators.In<string>(cu_, cv_ as IEnumerable<string>);
+                    bool? cw_ = context.Operators.In<string>(cu_, (IEnumerable<string>)cv_);
                     object cx_()
                     {
                         bool dc_()
@@ -886,7 +886,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                 "amended",
                 "corrected",
             ];
-            bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
             bool? v_ = context.Operators.And(p_, u_);
             object w_()
             {
@@ -1240,7 +1240,7 @@ public partial class CMS871HHHyperFHIR_0_3_000 : ILibrary, ISingleton<CMS871HHHy
                 "amended",
                 "corrected",
             ];
-            bool? t_ = context.Operators.In<string>(r_, s_ as IEnumerable<string>);
+            bool? t_ = context.Operators.In<string>(r_, (IEnumerable<string>)s_);
             bool? u_ = context.Operators.And(o_, t_);
             object v_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS996FHIRAptTxforSTEMI-1.4.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS996FHIRAptTxforSTEMI-1.4.001.g.cs
@@ -643,7 +643,7 @@ public partial class CMS996FHIRAptTxforSTEMI_1_4_001 : ILibrary, ISingleton<CMS9
                     "active",
                     "completed",
                 ];
-                bool? ag_ = context.Operators.In<string>(ae_, af_ as IEnumerable<string>);
+                bool? ag_ = context.Operators.In<string>(ae_, (IEnumerable<string>)af_);
                 Code<MedicationRequest.MedicationRequestIntent> ah_ = OralAnticoagulant?.IntentElement;
                 MedicationRequest.MedicationRequestIntent? ai_ = ah_?.Value;
                 string aj_ = context.Operators.Convert<string>(ai_);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
@@ -215,7 +215,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = Temperature?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -252,7 +252,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = Temperature?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -310,7 +310,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ah_ = context.Operators.In<string>(af_, ag_ as IEnumerable<string>);
+                bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
                 bool? ai_ = context.Operators.And(ac_, ah_);
                 DataType aj_ = HeartRate?.Value;
                 CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
@@ -347,7 +347,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? az_ = context.Operators.In<string>(ax_, ay_ as IEnumerable<string>);
+                bool? az_ = context.Operators.In<string>(ax_, (IEnumerable<string>)ay_);
                 bool? ba_ = context.Operators.And(au_, az_);
                 DataType bb_ = HeartRate?.Value;
                 CqlQuantity bc_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bb_ as Quantity);
@@ -406,7 +406,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? aj_ = context.Operators.In<string>(ah_, ai_ as IEnumerable<string>);
+                bool? aj_ = context.Operators.In<string>(ah_, (IEnumerable<string>)ai_);
                 bool? ak_ = context.Operators.And(ae_, aj_);
                 DataType al_ = O2Saturation?.Value;
                 CqlQuantity am_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, al_ as Quantity);
@@ -444,7 +444,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bb_ = context.Operators.In<string>(az_, ba_ as IEnumerable<string>);
+                bool? bb_ = context.Operators.In<string>(az_, (IEnumerable<string>)ba_);
                 bool? bc_ = context.Operators.And(aw_, bb_);
                 DataType bd_ = O2Saturation?.Value;
                 CqlQuantity be_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, bd_ as Quantity);
@@ -502,7 +502,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? al_ = context.Operators.In<string>(aj_, ak_ as IEnumerable<string>);
+                bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
                 bool? am_ = context.Operators.And(ag_, al_);
                 List<Observation.ComponentComponent> an_ = BP?.Component;
                 bool? ao_(Observation.ComponentComponent @this)
@@ -574,7 +574,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 List<Observation.ComponentComponent> bu_ = BP?.Component;
                 bool? bv_(Observation.ComponentComponent @this)
@@ -699,7 +699,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = BicarbonateLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -788,7 +788,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = BicarbonateLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -898,7 +898,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = CreatinineLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -987,7 +987,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = CreatinineLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -1097,7 +1097,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = HematocritLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -1186,7 +1186,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = HematocritLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -1296,7 +1296,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = PlateletLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -1385,7 +1385,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = PlateletLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -1495,7 +1495,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = SodiumLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -1584,7 +1584,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = SodiumLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -1694,7 +1694,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? ai_ = context.Operators.In<string>(ag_, ah_ as IEnumerable<string>);
+                bool? ai_ = context.Operators.In<string>(ag_, (IEnumerable<string>)ah_);
                 bool? aj_ = context.Operators.And(ad_, ai_);
                 DataType ak_ = WhiteBloodCellLab?.Value;
                 object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
@@ -1783,7 +1783,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "amended",
                     "corrected",
                 ];
-                bool? bs_ = context.Operators.In<string>(bq_, br_ as IEnumerable<string>);
+                bool? bs_ = context.Operators.In<string>(bq_, (IEnumerable<string>)br_);
                 bool? bt_ = context.Operators.And(bn_, bs_);
                 DataType bu_ = WhiteBloodCellLab?.Value;
                 object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bu_);
@@ -1862,7 +1862,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     "active",
                     "completed",
                 ];
-                bool? bd_ = context.Operators.In<string>(bb_, bc_ as IEnumerable<string>);
+                bool? bd_ = context.Operators.In<string>(bb_, (IEnumerable<string>)bc_);
                 bool? be_ = context.Operators.And(ax_, bd_);
                 Code<RequestIntent> bf_ = OxygenTherapyOrder?.IntentElement;
                 RequestIntent? bg_ = bf_?.Value;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CQMCommon-4.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CQMCommon-4.1.000.g.cs
@@ -481,7 +481,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }
@@ -523,7 +523,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         (IEnumerable<Encounter.LocationComponent>)i_,
                         (IEnumerable<Encounter.LocationComponent>)j_,
                     ];
-                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>(k_ as IEnumerable<IEnumerable<Encounter.LocationComponent>>);
+                    IEnumerable<Encounter.LocationComponent> l_ = context.Operators.Flatten<Encounter.LocationComponent>((IEnumerable<IEnumerable<Encounter.LocationComponent>>)k_);
 
                     return l_;
                 }

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
@@ -2453,14 +2453,14 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2476,7 +2476,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };
@@ -2505,14 +2505,14 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                     m_,
                     n_,
                 ];
-                CqlDate p_ = context.Operators.Max<CqlDate>(o_ as IEnumerable<CqlDate>);
+                CqlDate p_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)o_);
                 CqlDate r_ = context.Operators.End(j_);
                 CqlDate t_ = context.Operators.Add(r_, l_);
                 CqlDate[] v_ = [
                     t_,
                     n_,
                 ];
-                CqlDate w_ = context.Operators.Max<CqlDate>(v_ as IEnumerable<CqlDate>);
+                CqlDate w_ = context.Operators.Max<CqlDate>((IEnumerable<CqlDate>)v_);
                 CqlDate y_ = context.Operators.End(X);
                 int? z_ = context.Operators.DurationBetween(n_, y_, "day");
                 decimal? aa_ = context.Operators.ConvertIntegerToDecimal(z_ ?? 0);
@@ -2528,7 +2528,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
             CqlInterval<CqlDate>[] h_ = [
                 g_,
             ];
-            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, h_ as IEnumerable<CqlInterval<CqlDate>>);
+            IEnumerable<CqlInterval<CqlDate>> i_ = context.Operators.Union<CqlInterval<CqlDate>>(R, (IEnumerable<CqlInterval<CqlDate>>)h_);
 
             return i_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
@@ -493,7 +493,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 "amended",
                 "corrected",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
             object t_()
             {
@@ -644,7 +644,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 "amended",
                 "corrected",
             ];
-            bool? r_ = context.Operators.In<string>(p_, q_ as IEnumerable<string>);
+            bool? r_ = context.Operators.In<string>(p_, (IEnumerable<string>)q_);
             bool? s_ = context.Operators.And(m_, r_);
             object t_()
             {
@@ -877,7 +877,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 "amended",
                 "corrected",
             ];
-            bool? ac_ = context.Operators.In<string>(aa_, ab_ as IEnumerable<string>);
+            bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)ab_);
             bool? ad_ = context.Operators.And(x_, ac_);
             object ae_()
             {

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/QICoreCommon-4.0.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/QICoreCommon-4.0.000.g.cs
@@ -2176,7 +2176,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);
@@ -2201,7 +2201,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand(e_ as IEnumerable<CqlInterval<int?>>, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
         int? g_(CqlInterval<int?> DayNumber)
         {
             int? j_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
@@ -138,7 +138,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -161,7 +161,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = D?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -173,7 +173,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -197,7 +197,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -209,7 +209,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -233,7 +233,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -245,7 +245,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -269,7 +269,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? h_ = context.Operators.In<string>(f_, g_ as IEnumerable<string>);
+            bool? h_ = context.Operators.In<string>(f_, (IEnumerable<string>)g_);
             Code<RequestIntent> i_ = S?.IntentElement;
             RequestIntent? j_ = i_?.Value;
             Code<RequestIntent> k_ = context.Operators.Convert<Code<RequestIntent>>(j_);
@@ -281,7 +281,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? n_ = context.Operators.In<string>(l_, m_ as IEnumerable<string>);
+            bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
             bool? o_ = context.Operators.And(h_, n_);
 
             return o_;
@@ -305,7 +305,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             List<CodeableConcept> h_ = O?.Category;
             CqlConcept i_(CodeableConcept @this)
             {
@@ -419,7 +419,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -448,7 +448,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? k_ = context.Operators.In<string>(i_, j_ as IEnumerable<string>);
+            bool? k_ = context.Operators.In<string>(i_, (IEnumerable<string>)j_);
             bool? l_ = context.Operators.And(f_, k_);
 
             return l_;
@@ -472,7 +472,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "in-progress",
                 "on-hold",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -494,7 +494,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "active",
                 "completed",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             Code<MedicationRequest.MedicationRequestIntent> h_ = M?.IntentElement;
             MedicationRequest.MedicationRequestIntent? i_ = h_?.Value;
             string j_ = context.Operators.Convert<string>(i_);
@@ -505,7 +505,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "filler-order",
                 "instance-order",
             ];
-            bool? l_ = context.Operators.In<string>(j_, k_ as IEnumerable<string>);
+            bool? l_ = context.Operators.In<string>(j_, (IEnumerable<string>)k_);
             bool? m_ = context.Operators.And(g_, l_);
 
             return m_;
@@ -529,7 +529,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
             List<CodeableConcept> h_ = O?.Category;
             CqlConcept i_(CodeableConcept @this)
             {
@@ -571,7 +571,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -594,7 +594,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -617,7 +617,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -640,7 +640,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -663,7 +663,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };
@@ -705,7 +705,7 @@ public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
                 "amended",
                 "corrected",
             ];
-            bool? g_ = context.Operators.In<string>(e_, f_ as IEnumerable<string>);
+            bool? g_ = context.Operators.In<string>(e_, (IEnumerable<string>)f_);
 
             return g_;
         };

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
@@ -172,7 +172,7 @@ public partial class SupplementalDataElements_5_1_000 : ILibrary, ISingleton<Sup
                 return aw_;
             };
             IEnumerable<CqlCode> ad_ = context.Operators.Select<object, CqlCode>(ab_, ac_);
-            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>(x_ as IEnumerable<CqlCode>, ad_);
+            IEnumerable<CqlCode> ae_ = context.Operators.Union<CqlCode>((IEnumerable<CqlCode>)x_, ad_);
             bool? af_(Extension @this)
             {
                 string ax_ = @this?.Url;

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/TJCOverall-8.24.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/TJCOverall-8.24.000.g.cs
@@ -211,7 +211,7 @@ public partial class TJCOverall_8_24_000 : ILibrary, ISingleton<TJCOverall_8_24_
                 "completed",
                 "on-hold",
             ];
-            bool? o_ = context.Operators.In<string>(m_, n_ as IEnumerable<string>);
+            bool? o_ = context.Operators.In<string>(m_, (IEnumerable<string>)n_);
             Code<RequestIntent> p_ = SR?.IntentElement;
             RequestIntent? q_ = p_?.Value;
             Code<RequestIntent> r_ = context.Operators.Convert<Code<RequestIntent>>(q_);
@@ -223,7 +223,7 @@ public partial class TJCOverall_8_24_000 : ILibrary, ISingleton<TJCOverall_8_24_
                 "filler-order",
                 "instance-order",
             ];
-            bool? u_ = context.Operators.In<string>(s_, t_ as IEnumerable<string>);
+            bool? u_ = context.Operators.In<string>(s_, (IEnumerable<string>)t_);
             bool? v_ = context.Operators.And(o_, u_);
             FhirBoolean w_ = SR?.DoNotPerformElement;
             bool? x_ = w_?.Value;
@@ -244,7 +244,7 @@ public partial class TJCOverall_8_24_000 : ILibrary, ISingleton<TJCOverall_8_24_
                 "completed",
                 "in-progress",
             ];
-            bool? af_ = context.Operators.In<string>(ad_, ae_ as IEnumerable<string>);
+            bool? af_ = context.Operators.In<string>(ad_, (IEnumerable<string>)ae_);
 
             return af_;
         };


### PR DESCRIPTION
Removed explicit safe casting after creating arrays in the [expression builder, line 459](https://github.com/FirelyTeam/firely-cql-sdk/pull/999/files#diff-87d951321fb28d7802b9c267bda6f2ada35d0429d792d916fca8c420e7bb8a38).

There is some commented code between lines 130 and 143, keep it there, because it speeds up finding bugs by setting a breakpoint at a specific location in the ELM tree at a specific counter.

The rest of the files are just regenerated C# libraries

Fixes: #987 