### PR TITLE
Add PackagerCLI project reference to multiple .csproj files

### DIFF
--- a/Demo/Measures.Authoring/Measures.Authoring.csproj
+++ b/Demo/Measures.Authoring/Measures.Authoring.csproj
@@ -11,6 +11,8 @@
 		<ProjectReference Include="..\..\Cql\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+		<!-- Ensure the PackagerCLI is build first, so that the ElmToCSharp targets file succeeds -->
+		<ProjectReference Include="..\..\Cql\PackagerCLI\PackagerCLI.csproj" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Demo/Measures.Demo/Measures.Demo.csproj
+++ b/Demo/Measures.Demo/Measures.Demo.csproj
@@ -10,6 +10,8 @@
 		<ProjectReference Include="..\..\Cql\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+		<!-- Ensure the PackagerCLI is build first, so that the ElmToCSharp targets file succeeds -->
+		<ProjectReference Include="..\..\Cql\PackagerCLI\PackagerCLI.csproj" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Demo/Measures.ecqm-content-cms-2025/Measures.ecqm-content-cms-2025.csproj
+++ b/Demo/Measures.ecqm-content-cms-2025/Measures.ecqm-content-cms-2025.csproj
@@ -11,6 +11,8 @@
 		<ProjectReference Include="..\..\Cql\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+		<!-- Ensure the PackagerCLI is build first, so that the ElmToCSharp targets file succeeds -->
+		<ProjectReference Include="..\..\Cql\PackagerCLI\PackagerCLI.csproj" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Demo/Measures.ecqm-content-qicore-2024/Measures.ecqm-content-qicore-2024.csproj
+++ b/Demo/Measures.ecqm-content-qicore-2024/Measures.ecqm-content-qicore-2024.csproj
@@ -11,6 +11,8 @@
 		<ProjectReference Include="..\..\Cql\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+		<!-- Ensure the PackagerCLI is build first, so that the ElmToCSharp targets file succeeds -->
+		<ProjectReference Include="..\..\Cql\PackagerCLI\PackagerCLI.csproj" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/Demo/Measures.ecqm-content-qicore-2025/Measures.ecqm-content-qicore-2025.csproj
+++ b/Demo/Measures.ecqm-content-qicore-2025/Measures.ecqm-content-qicore-2025.csproj
@@ -11,6 +11,8 @@
 		<ProjectReference Include="..\..\Cql\Cql.Runtime\Cql.Runtime.csproj" />
 		<ProjectReference Include="..\CLI\CLI.csproj" />
 		<PackageReference Include="Hl7.Fhir.R4" Version="$(FirelySdkVersion)" />
+		<!-- Ensure the PackagerCLI is build first, so that the ElmToCSharp targets file succeeds -->
+		<ProjectReference Include="..\..\Cql\PackagerCLI\PackagerCLI.csproj" />
 	</ItemGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
This commit adds a new project reference to the `PackagerCLI` project in the following `.csproj` files:
- `Measures.Authoring.csproj`
- `Measures.Demo.csproj`
- `Measures.ecqm-content-cms-2025.csproj`
- `Measures.ecqm-content-qicore-2024.csproj`
- `Measures.ecqm-content-qicore-2025.csproj`

This change ensures that the `PackagerCLI` is built first, which is necessary for the `ElmToCSharp` targets file to succeed. Comments have been added for clarity.