### PR TITLE
Change CQL Long mapping to return String for R4

### DIFF
--- a/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
+++ b/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
@@ -97,4 +97,20 @@ public class CqlTypeToFhirTypeMapperTests
         Assert.AreEqual(FHIRAllTypes.Basic, result.FhirType);
         Assert.AreEqual(CqlPrimitiveType.Tuple, result.CqlType);
     }
+
+    [TestMethod]
+    public void TypeEntryFor_CqlLongTypeTuple_ReturnsFhirString()
+    {
+        // Arrange
+        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
+        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
+
+        // Act
+        var result = mapper.TypeEntryFor(CqlPrimitiveType.Long);
+
+        // Assert
+        Assert.IsNotNull(result);
+        Assert.AreEqual(FHIRAllTypes.String, result.FhirType);
+        Assert.AreEqual(CqlPrimitiveType.Long, result.CqlType);
+    }
 }

--- a/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
+++ b/Cql/CoreTests/Packaging/CqlTypeToFhirTypeMapperTests.cs
@@ -45,18 +45,6 @@ public class CqlTypeToFhirTypeMapperTests
     }
 
     [TestMethod]
-    [ExpectedException(typeof(NotSupportedException))]
-    public void TypeEntryFor_CqlPrimitiveTypeLong_ThrowsNotSupportedException()
-    {
-        // Arrange
-        var typeResolver = new FhirTypeResolver(ModelInfo.ModelInspector);
-        var mapper = new CqlTypeToFhirTypeMapper(typeResolver);
-
-        // Act
-        mapper.TypeEntryFor(CqlPrimitiveType.Long);
-    }
-
-    [TestMethod]
     public void TypeEntryFor_CqlPrimitiveTypeListWithElementType_ReturnsFhirList()
     {
         // Arrange

--- a/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
+++ b/Cql/Cql.Packaging/CqlTypeToFhirTypeMapper.cs
@@ -131,8 +131,7 @@ namespace Hl7.Cql.Packaging
                     return new CqlTypeToFhirMapping(FHIRAllTypes.DateTime, cqlType);
                 case CqlPrimitiveType.Long:
 #if FhirReleaseR4
-                    // integer64 only supported in R5. Compare https://hl7.org/fhir/R4/datatypes.html vs https://hl7.org/fhir/R5/datatypes.html
-                    throw new NotSupportedException("No mapping from CQL Long to FHIR in release 4 (see https://hl7.org/fhir/R4/datatypes.html)");
+                      return new CqlTypeToFhirMapping(FHIRAllTypes.String, cqlType);
 //#else FhirReleaseR5
 //                    return new CqlTypeToFhirMapping(FHIRAllTypes.Integer64, cqlType);
 #endif


### PR DESCRIPTION
Updated mapping for CQL Long type to return String in R4 instead of throwing an exception.

See latest version of https://build.fhir.org/ig/HL7/cql-ig/conformance.html#fhir-type-mapping