### PR TITLE
1012 fix qicore 2025 bugs tuple element value does not have a resulttypespecifier

### DIFF
--- a/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
+++ b/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
@@ -39,8 +39,13 @@ internal class MissingResultTypeSpecifierCorrector(ILogger<MissingResultTypeSpec
                 {
                     resultTypeSpecifier: ListTypeSpecifier { elementType: { } elementType },
                     @return: { resultTypeSpecifier: null } returnClause,
-                })
+                } query)
             {
+                logger.LogDebug(
+                    "Setting missing ReturnClause.resultTypeSpecifier to ListTypeSpecifier.elementType to '{resultType}' on Query @ {locator}.\n{expressionKey}",
+                    elementType,
+                    query.locator,
+                    self.ContextStackString);
                 returnClause.resultTypeSpecifier = elementType;
             }
         }
@@ -51,17 +56,26 @@ internal class MissingResultTypeSpecifierCorrector(ILogger<MissingResultTypeSpec
                 {
                     resultTypeSpecifier: TupleTypeSpecifier tupleTypeSpecifier,
                     expression: Tuple { resultTypeSpecifier: null } tuple,
-                })
+                } clause)
             {
+                logger.LogDebug(
+                    "Setting missing Tuple.resultTypeSpecifier to TupleTypeSpecifier to '{resultType}' on ReturnClause @ {locator}.\n{expressionKey}",
+                    tupleTypeSpecifier,
+                    clause.locator,
+                    self.ContextStackString);
                 tuple.resultTypeSpecifier = tupleTypeSpecifier;
             }
         }
 
         {
             // If a Tuple has elements with missing resultTypeSpecifier but the Tuple itself has a TupleTypeSpecifier as resultTypeSpecifier, set the missing element resultTypeSpecifiers from the TupleTypeSpecifier
-            if (node is Tuple { element: { Length: > 0 } elements, resultTypeSpecifier: TupleTypeSpecifier tupleTypeSpecifier }
+            if (node is Tuple { element: { Length: > 0 } elements, resultTypeSpecifier: TupleTypeSpecifier tupleTypeSpecifier } tuple
                 && elements.Any(e => e.value.resultTypeSpecifier is null))
             {
+                logger.LogDebug(
+                    "Setting missing Tuple.element.value.resultTypeSpecifier from TupleTypeSpecifier on Tuple @ {locator}.\n{expressionKey}",
+                    tuple.locator,
+                    self.ContextStackString);
                 foreach (var (index, tupleElement) in elements.Select((v, i) => (i, v)))
                 {
                     tupleElement.value.resultTypeSpecifier ??= tupleTypeSpecifier.element[index].elementType;

--- a/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
+++ b/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Elm;
+using Tuple = Hl7.Cql.Elm.Tuple;
 
 namespace Hl7.Cql.Compiler.Preprocessing;
 
@@ -18,9 +19,10 @@ internal class MissingResultTypeSpecifierCorrector(ILogger<MissingResultTypeSpec
 {
     private readonly ElmTreeWalker _walker = ElmTreeWalker.Create((self, node) =>
     {
-        switch (node)
         {
-            case Element { resultTypeSpecifier: null, resultTypeName: {} resultTypeName } element:
+            // If an Element has a resultTypeName but no resultTypeSpecifier, set resultTypeSpecifier to a NamedTypeSpecifier with the name from resultTypeName
+            if (node is Element { resultTypeSpecifier: null, resultTypeName: { } resultTypeName } element)
+            {
                 logger.LogDebug(
                     "Setting missing resultTypeSpecifier to resultTypeName on {elementType} to '{resultType}' @ {locator}.\n{expressionKey}",
                     element.GetType().ToString(),
@@ -28,7 +30,43 @@ internal class MissingResultTypeSpecifierCorrector(ILogger<MissingResultTypeSpec
                     element.locator,
                     self.ContextStackString);
                 element.resultTypeSpecifier = new NamedTypeSpecifier { name = resultTypeName };
-                break;
+            }
+        }
+
+        {
+            // If a Query has a ListTypeSpecifier as resultTypeSpecifier but its ReturnClause has no resultTypeSpecifier, set the ReturnClause's resultTypeSpecifier to the elementType of the ListTypeSpecifier
+            if (node is Query
+                {
+                    resultTypeSpecifier: ListTypeSpecifier { elementType: { } elementType },
+                    @return: { resultTypeSpecifier: null } returnClause,
+                })
+            {
+                returnClause.resultTypeSpecifier = elementType;
+            }
+        }
+
+        {
+            // If a ReturnClause has a TupleTypeSpecifier as resultTypeSpecifier but its Tuple has no resultTypeSpecifier, set the Tuple's resultTypeSpecifier to the ReturnClause's TupleTypeSpecifier
+            if (node is ReturnClause
+                {
+                    resultTypeSpecifier: TupleTypeSpecifier tupleTypeSpecifier,
+                    expression: Tuple { resultTypeSpecifier: null } tuple,
+                })
+            {
+                tuple.resultTypeSpecifier = tupleTypeSpecifier;
+            }
+        }
+
+        {
+            // If a Tuple has elements with missing resultTypeSpecifier but the Tuple itself has a TupleTypeSpecifier as resultTypeSpecifier, set the missing element resultTypeSpecifiers from the TupleTypeSpecifier
+            if (node is Tuple { element: { Length: > 0 } elements, resultTypeSpecifier: TupleTypeSpecifier tupleTypeSpecifier }
+                && elements.Any(e => e.value.resultTypeSpecifier is null))
+            {
+                foreach (var (index, tupleElement) in elements.Select((v, i) => (i, v)))
+                {
+                    tupleElement.value.resultTypeSpecifier ??= tupleTypeSpecifier.element[index].elementType;
+                }
+            }
         }
 
         return false; // Continue walking children

--- a/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
+++ b/Cql/Cql.Compiler/Preprocessing/MissingResultTypeSpecifierCorrector.cs
@@ -19,6 +19,11 @@ internal class MissingResultTypeSpecifierCorrector(ILogger<MissingResultTypeSpec
 {
     private readonly ElmTreeWalker _walker = ElmTreeWalker.Create((self, node) =>
     {
+        // DO NOT turn this into a switch expression.
+        // It is possible to match multiple patterns in one node, e.g.
+        // Element with resultTypeName then Query with ListTypeSpecifier
+        // The order of these blocks matters too, starting with the most general ones first.
+
         {
             // If an Element has a resultTypeName but no resultTypeSpecifier, set resultTypeSpecifier to a NamedTypeSpecifier with the name from resultTypeName
             if (node is Element { resultTypeSpecifier: null, resultTypeName: { } resultTypeName } element)

--- a/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-cms-2025.appsettings.json
+++ b/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-cms-2025.appsettings.json
@@ -1,9 +1,6 @@
 ﻿{
   "Elm": {
     "SkipFiles": [
-      // Tuple element value does not have a resultTypeSpecifier
-      "CMS2FHIRPCSDepressionScreenAndFollowUp.json",
-
       // Exception: cannot convert from 'Hl7.Fhir.Model.Id' to 'Hl7.Fhir.Model.Code<Hl7.Fhir.Model.Account.AccountStatus>'
       "NHSNHelpers.json",
 

--- a/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-qicore-2024.appsettings.json
+++ b/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-qicore-2024.appsettings.json
@@ -19,10 +19,6 @@
       "CMS506FHIRSafeUseofOpioids.json",
       "PCSBMIScreenAndFollowUpFHIR.json",
 
-      // Tuple element value does not have a resultTypeSpecifier
-      "CADBetaBlockerTherapyPriorMIorLVSDFHIR.json",
-      "PCSDepressionScreenAndFollowUpFHIR.json",
-
       // Multiple sort fields not supported yet
       "CMS986FHIRMalnutritionScore.json",
       "HospitalHarmAcuteKidneyInjuryFHIR.json",

--- a/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-qicore-2025.appsettings.json
+++ b/Cql/PackagerCLI/Hl7.Cql.Packager.ecqm-content-qicore-2025.appsettings.json
@@ -1,11 +1,6 @@
 ﻿{
   "Elm": {
     "SkipFiles": [
-      // Tuple element value does not have a resultTypeSpecifier
-      "CMS2FHIRPCSDepressionScreenAndFollowUp.json",
-      "CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD.json",
-      "CMS832HHAKIFHIR.json",
-
       // Cannot resolve type {http://hl7.org/fhir}DoNotPerformReason} for expression
       "CMS190VTEProphylaxisICUFHIR.json",
       "CMS108FHIRVTEProphylaxis.json"

--- a/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001.g.cs
+++ b/Demo/Measures.ecqm-content-cms-2025/CSharp/CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001.g.cs
@@ -1,0 +1,1609 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("CMS2FHIRPCSDepressionScreenAndFollowUp", "0.4.001")]
+public partial class CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001 : ILibrary, ISingleton<CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001>
+{
+    private CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001() {}
+
+    public static CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "CMS2FHIRPCSDepressionScreenAndFollowUp";
+    public string Version => "0.4.001";
+    public ILibrary[] Dependencies => [FHIRHelpers_4_4_000.Instance, QICoreCommon_4_0_000.Instance, CumulativeMedicationDuration_6_0_000.Instance, SupplementalDataElements_5_1_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Adolescent Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", valueSetVersion: null)]
+    public CqlValueSet Adolescent_Depression_Medications(CqlContext _) => _Adolescent_Depression_Medications;
+    private static readonly CqlValueSet _Adolescent_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", null);
+
+    [CqlValueSetDefinition("Adult Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", valueSetVersion: null)]
+    public CqlValueSet Adult_Depression_Medications(CqlContext _) => _Adult_Depression_Medications;
+    private static readonly CqlValueSet _Adult_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", null);
+
+    [CqlValueSetDefinition("Bipolar Disorder", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", valueSetVersion: null)]
+    public CqlValueSet Bipolar_Disorder(CqlContext _) => _Bipolar_Disorder;
+    private static readonly CqlValueSet _Bipolar_Disorder = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", null);
+
+    [CqlValueSetDefinition("Encounter to Screen for Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", valueSetVersion: null)]
+    public CqlValueSet Encounter_to_Screen_for_Depression(CqlContext _) => _Encounter_to_Screen_for_Depression;
+    private static readonly CqlValueSet _Encounter_to_Screen_for_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", null);
+
+    [CqlValueSetDefinition("Follow Up for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adolescent_Depression(CqlContext _) => _Follow_Up_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", null);
+
+    [CqlValueSetDefinition("Follow Up for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adult_Depression(CqlContext _) => _Follow_Up_for_Adult_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", null);
+
+    [CqlValueSetDefinition("Medical Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", valueSetVersion: null)]
+    public CqlValueSet Medical_Reason(CqlContext _) => _Medical_Reason;
+    private static readonly CqlValueSet _Medical_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlValueSetDefinition("Physical Therapy Evaluation", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", valueSetVersion: null)]
+    public CqlValueSet Physical_Therapy_Evaluation(CqlContext _) => _Physical_Therapy_Evaluation;
+    private static readonly CqlValueSet _Physical_Therapy_Evaluation = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+
+    [CqlValueSetDefinition("Referral for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adolescent_Depression(CqlContext _) => _Referral_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Referral_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", null);
+
+    [CqlValueSetDefinition("Referral for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adult_Depression(CqlContext _) => _Referral_for_Adult_Depression;
+    private static readonly CqlValueSet _Referral_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", null);
+
+    [CqlValueSetDefinition("Telephone Visits", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", valueSetVersion: null)]
+    public CqlValueSet Telephone_Visits(CqlContext _) => _Telephone_Visits;
+    private static readonly CqlValueSet _Telephone_Visits = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Adolescent depression screening assessment", codeId: "73831-0", codeSystem: "http://loinc.org")]
+    public CqlCode Adolescent_depression_screening_assessment(CqlContext _) => _Adolescent_depression_screening_assessment;
+    private static readonly CqlCode _Adolescent_depression_screening_assessment = new CqlCode("73831-0", "http://loinc.org");
+
+    [CqlCodeDefinition("Adult depression screening assessment", codeId: "73832-8", codeSystem: "http://loinc.org")]
+    public CqlCode Adult_depression_screening_assessment(CqlContext _) => _Adult_depression_screening_assessment;
+    private static readonly CqlCode _Adult_depression_screening_assessment = new CqlCode("73832-8", "http://loinc.org");
+
+    [CqlCodeDefinition("Depression screening declined (situation)", codeId: "720834000", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_declined__situation_(CqlContext _) => _Depression_screening_declined__situation_;
+    private static readonly CqlCode _Depression_screening_declined__situation_ = new CqlCode("720834000", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening negative (finding)", codeId: "428171000124102", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_negative__finding_(CqlContext _) => _Depression_screening_negative__finding_;
+    private static readonly CqlCode _Depression_screening_negative__finding_ = new CqlCode("428171000124102", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening positive (finding)", codeId: "428181000124104", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_positive__finding_(CqlContext _) => _Depression_screening_positive__finding_;
+    private static readonly CqlCode _Depression_screening_positive__finding_ = new CqlCode("428181000124104", "http://snomed.info/sct");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("LOINC", codeSystemId: "http://loinc.org", codeSystemVersion: null)]
+    public CqlCodeSystem LOINC(CqlContext _) => _LOINC;
+    private static readonly CqlCodeSystem _LOINC =
+      new CqlCodeSystem("http://loinc.org", null, [
+          _Adolescent_depression_screening_assessment,
+          _Adult_depression_screening_assessment]);
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Depression_screening_declined__situation_,
+          _Depression_screening_negative__finding_,
+          _Depression_screening_positive__finding_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        CqlDateTime a_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, 0.0m);
+        CqlDateTime b_ = context.Operators.DateTime(2026, 12, 31, 23, 59, 0, 0, 0.0m);
+        CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+        object d_ = context.ResolveParameter("CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001", "Measurement Period", c_);
+
+        return (CqlInterval<CqlDateTime>)d_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 12);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Encounter_to_Screen_for_Depression(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Physical_Therapy_Evaluation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Telephone_Visits(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
+        bool? i_(Encounter QualifyingEncounter)
+        {
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            Period l_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, "day");
+            Code<Encounter.EncounterStatus> o_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? p_ = o_?.Value;
+            Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+            bool? r_ = context.Operators.Equal(q_, "finished");
+            bool? s_ = context.Operators.And(n_, r_);
+
+            return s_;
+        };
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public bool? Initial_Population(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator")]
+    public bool? Denominator(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("History of Bipolar Diagnosis Before Qualifying Encounter")]
+    public IEnumerable<Condition> History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bipolar_Disorder(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> c_(Condition BipolarDiagnosis)
+        {
+            IEnumerable<Encounter> e_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? f_(Encounter QualifyingEncounter)
+            {
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BipolarDiagnosis as object);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                bool? o_ = context.Operators.Before(k_, n_, "day");
+
+                return o_;
+            };
+            IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+            Condition h_(Encounter QualifyingEncounter) =>
+                BipolarDiagnosis;
+            IEnumerable<Condition> i_ = context.Operators.Select<Encounter, Condition>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exclusions")]
+    public bool? Denominator_Exclusions(CqlContext context)
+    {
+        IEnumerable<Condition> a_ = this.History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(context);
+        bool? b_ = context.Operators.Exists<Condition>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 to 16 Years at Start of Measurement Period")]
+    public bool? Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        CqlInterval<int?> i_ = context.Operators.Interval(12, 16, true, true);
+        bool? j_ = context.Operators.In<int?>(h_, i_, default);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening")]
+    public Observation Most_Recent_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdolescentDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdolescentDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdolescentDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdolescentDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                bool? ap_ = context.Operators.And(aj_, ao_);
+
+                return ap_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdolescentDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType aq_ = @this?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+
+            return at_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adolescent Screening Negative")]
+    public bool? Has_Most_Recent_Adolescent_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdolescentScreen)
+        {
+            DataType g_ = AdolescentScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adolescent Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adolescent_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adolescent_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        IEnumerable<MedicationRequest> g_(MedicationRequest AdolescentMed)
+        {
+            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? ai_(Encounter QualifyingEncounter)
+            {
+                Observation am_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+                DataType an_ = am_?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                Period ar_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
+                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
+                bool? bf_ = context.Operators.And(ba_, be_);
+                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
+                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
+                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
+                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
+                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
+                bool? bv_ = context.Operators.And(bf_, bu_);
+                DataType bx_ = am_?.Value;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
+                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
+                bool? cc_ = context.Operators.And(bv_, cb_);
+                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdolescentMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
+                string cf_ = context.Operators.Convert<string>(ce_);
+                string[] cg_ = [
+                    "active",
+                    "completed",
+                ];
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdolescentMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
+                string cl_ = context.Operators.Convert<string>(ck_);
+                string[] cm_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
+                bool? co_ = context.Operators.And(ci_, cn_);
+
+                return co_;
+            };
+            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
+            MedicationRequest ak_(Encounter QualifyingEncounter) =>
+                AdolescentMed;
+            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
+
+            return al_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adolescent_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdolescentReferral)
+        {
+            Code<RequestStatus> cp_ = AdolescentReferral?.StatusElement;
+            RequestStatus? cq_ = cp_?.Value;
+            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
+            string cs_ = context.Operators.Convert<string>(cr_);
+            string[] ct_ = [
+                "active",
+                "completed",
+            ];
+            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+
+            return cu_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adolescent_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdolescentFollowUp)
+        {
+            Code<EventStatus> cv_ = AdolescentFollowUp?.StatusElement;
+            EventStatus? cw_ = cv_?.Value;
+            string cx_ = context.Operators.Convert<string>(cw_);
+            bool? cy_ = context.Operators.Equal(cx_, "completed");
+
+            return cy_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            DataType n_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_()
+            {
+                bool bt_()
+                {
+                    object bx_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                    bool bz_ = by_ is CqlDateTime;
+
+                    return bz_;
+                };
+                bool bu_()
+                {
+                    object ca_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                    bool cc_ = cb_ is CqlInterval<CqlDateTime>;
+
+                    return cc_;
+                };
+                bool bv_()
+                {
+                    object cd_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                    bool cf_ = ce_ is CqlQuantity;
+
+                    return cf_;
+                };
+                bool bw_()
+                {
+                    object cg_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                    bool ci_ = ch_ is CqlInterval<CqlQuantity>;
+
+                    return ci_;
+                };
+                if (bt_())
+                {
+                    object cj_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+
+                    return (ck_ as CqlDateTime) as object;
+                }
+                else if (bu_())
+                {
+                    object cl_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+
+                    return (cm_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bv_())
+                {
+                    object cn_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+
+                    return (co_ as CqlQuantity) as object;
+                }
+                else if (bw_())
+                {
+                    object cp_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+
+                    return (cq_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
+            CqlDateTime ao_ = context.Operators.Start(an_);
+            CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+            object as_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
+            CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime aw_ = context.Operators.End(av_);
+            CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime az_ = context.Operators.End(ay_);
+            CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bb_ = context.Operators.Add(az_, ba_);
+            CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(aw_, bb_, true, true);
+            bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, "day");
+            CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bg_ = context.Operators.End(bf_);
+            bool? bh_ = context.Operators.Not((bool?)(bg_ is null));
+            bool? bi_ = context.Operators.And(bd_, bh_);
+            bool? bj_ = context.Operators.Or(ar_, bi_);
+            bool? bk_ = context.Operators.And(al_, bj_);
+            object bl_()
+            {
+                bool cr_()
+                {
+                    object cv_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                    bool cx_ = cw_ is CqlDateTime;
+
+                    return cx_;
+                };
+                bool cs_()
+                {
+                    object cy_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                    bool da_ = cz_ is CqlInterval<CqlDateTime>;
+
+                    return da_;
+                };
+                bool ct_()
+                {
+                    object db_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                    bool dd_ = dc_ is CqlQuantity;
+
+                    return dd_;
+                };
+                bool cu_()
+                {
+                    object de_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                    bool dg_ = df_ is CqlInterval<CqlQuantity>;
+
+                    return dg_;
+                };
+                if (cr_())
+                {
+                    object dh_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+
+                    return (di_ as CqlDateTime) as object;
+                }
+                else if (cs_())
+                {
+                    object dj_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+
+                    return (dk_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ct_())
+                {
+                    object dl_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+
+                    return (dm_ as CqlQuantity) as object;
+                }
+                else if (cu_())
+                {
+                    object dn_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+
+                    return (do_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
+            CqlDateTime bn_ = context.Operators.Start(bm_);
+            CqlDateTime bp_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
+            bool? br_ = context.Operators.In<CqlDateTime>(bn_ ?? bp_, bq_, "day");
+            bool? bs_ = context.Operators.And(bk_, br_);
+
+            return bs_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? dp_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter);
+
+            return dp_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 17 Years at Start of Measurement Period")]
+    public bool? Patient_Age_17_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.Equal(h_, 17);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening")]
+    public Observation Most_Recent_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdultDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdultDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdultDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdultDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                bool? ap_ = context.Operators.And(aj_, ao_);
+
+                return ap_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdultDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType aq_ = @this?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+
+            return at_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adult Screening Negative")]
+    public bool? Has_Most_Recent_Adult_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdultScreen)
+        {
+            DataType g_ = AdultScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adult Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adult_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adult_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        IEnumerable<MedicationRequest> g_(MedicationRequest AdultMed)
+        {
+            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? ai_(Encounter QualifyingEncounter)
+            {
+                Observation am_ = this.Most_Recent_Adult_Depression_Screening(context);
+                DataType an_ = am_?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                Period ar_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
+                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
+                bool? bf_ = context.Operators.And(ba_, be_);
+                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
+                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
+                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
+                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
+                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
+                bool? bv_ = context.Operators.And(bf_, bu_);
+                DataType bx_ = am_?.Value;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
+                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
+                bool? cc_ = context.Operators.And(bv_, cb_);
+                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdultMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
+                string cf_ = context.Operators.Convert<string>(ce_);
+                string[] cg_ = [
+                    "active",
+                    "completed",
+                ];
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdultMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
+                string cl_ = context.Operators.Convert<string>(ck_);
+                string[] cm_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
+                bool? co_ = context.Operators.And(ci_, cn_);
+
+                return co_;
+            };
+            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
+            MedicationRequest ak_(Encounter QualifyingEncounter) =>
+                AdultMed;
+            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
+
+            return al_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adult_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdultReferral)
+        {
+            Code<RequestStatus> cp_ = AdultReferral?.StatusElement;
+            RequestStatus? cq_ = cp_?.Value;
+            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
+            string cs_ = context.Operators.Convert<string>(cr_);
+            string[] ct_ = [
+                "active",
+                "completed",
+            ];
+            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+
+            return cu_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adult_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdultFollowUp)
+        {
+            Code<EventStatus> cv_ = AdultFollowUp?.StatusElement;
+            EventStatus? cw_ = cv_?.Value;
+            string cx_ = context.Operators.Convert<string>(cw_);
+            bool? cy_ = context.Operators.Equal(cx_, "completed");
+
+            return cy_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            DataType n_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_()
+            {
+                bool bt_()
+                {
+                    object bx_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                    bool bz_ = by_ is CqlDateTime;
+
+                    return bz_;
+                };
+                bool bu_()
+                {
+                    object ca_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                    bool cc_ = cb_ is CqlInterval<CqlDateTime>;
+
+                    return cc_;
+                };
+                bool bv_()
+                {
+                    object cd_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                    bool cf_ = ce_ is CqlQuantity;
+
+                    return cf_;
+                };
+                bool bw_()
+                {
+                    object cg_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                    bool ci_ = ch_ is CqlInterval<CqlQuantity>;
+
+                    return ci_;
+                };
+                if (bt_())
+                {
+                    object cj_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+
+                    return (ck_ as CqlDateTime) as object;
+                }
+                else if (bu_())
+                {
+                    object cl_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+
+                    return (cm_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bv_())
+                {
+                    object cn_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+
+                    return (co_ as CqlQuantity) as object;
+                }
+                else if (bw_())
+                {
+                    object cp_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+
+                    return (cq_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
+            CqlDateTime ao_ = context.Operators.Start(an_);
+            CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+            object as_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
+            CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime aw_ = context.Operators.End(av_);
+            CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime az_ = context.Operators.End(ay_);
+            CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bb_ = context.Operators.Add(az_, ba_);
+            CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(aw_, bb_, true, true);
+            bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, "day");
+            CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bg_ = context.Operators.End(bf_);
+            bool? bh_ = context.Operators.Not((bool?)(bg_ is null));
+            bool? bi_ = context.Operators.And(bd_, bh_);
+            bool? bj_ = context.Operators.Or(ar_, bi_);
+            bool? bk_ = context.Operators.And(al_, bj_);
+            object bl_()
+            {
+                bool cr_()
+                {
+                    object cv_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                    bool cx_ = cw_ is CqlDateTime;
+
+                    return cx_;
+                };
+                bool cs_()
+                {
+                    object cy_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                    bool da_ = cz_ is CqlInterval<CqlDateTime>;
+
+                    return da_;
+                };
+                bool ct_()
+                {
+                    object db_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                    bool dd_ = dc_ is CqlQuantity;
+
+                    return dd_;
+                };
+                bool cu_()
+                {
+                    object de_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                    bool dg_ = df_ is CqlInterval<CqlQuantity>;
+
+                    return dg_;
+                };
+                if (cr_())
+                {
+                    object dh_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+
+                    return (di_ as CqlDateTime) as object;
+                }
+                else if (cs_())
+                {
+                    object dj_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+
+                    return (dk_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ct_())
+                {
+                    object dl_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+
+                    return (dm_ as CqlQuantity) as object;
+                }
+                else if (cu_())
+                {
+                    object dn_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+
+                    return (do_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
+            CqlDateTime bn_ = context.Operators.Start(bm_);
+            CqlDateTime bp_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
+            bool? br_ = context.Operators.In<CqlDateTime>(bn_ ?? bp_, bq_, "day");
+            bool? bs_ = context.Operators.And(bk_, br_);
+
+            return bs_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? dp_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter);
+
+            return dp_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 18 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator")]
+    public bool? Numerator(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(context);
+        bool? b_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> c_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? d_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? e_ = context.Operators.Or(b_, d_);
+        bool? f_ = context.Operators.And(a_, e_);
+        bool? g_ = this.Patient_Age_17_Years_at_Start_of_Measurement_Period(context);
+        bool? j_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? k_ = context.Operators.Or(b_, j_);
+        bool? l_ = this.Has_Most_Recent_Adult_Screening_Negative(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> n_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? o_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? p_ = context.Operators.Or(m_, o_);
+        bool? q_ = context.Operators.And(g_, p_);
+        bool? r_ = context.Operators.Or(f_, q_);
+        bool? s_ = this.Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(context);
+        bool? v_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? w_ = context.Operators.Or(l_, v_);
+        bool? x_ = context.Operators.And(s_, w_);
+        bool? y_ = context.Operators.Or(r_, x_);
+
+        return y_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adolescent for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
+        IEnumerable<Observation> d_(Observation NoAdolescentScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdolescentScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdolescentScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdolescentScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ak_ = @this?.Url;
+                FhirString al_ = context.Operators.Convert<FhirString>(ak_);
+                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
+                bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return an_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType ao_ = @this?.Value;
+
+                return ao_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+
+            return aj_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adolescent Depression Screening")]
+    public bool? Has_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdolescentScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdolescentScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdolescentScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdolescentScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                bool? an_ = context.Operators.And(ah_, am_);
+
+                return an_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdolescentScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adult for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
+        IEnumerable<Observation> d_(Observation NoAdultScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdultScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdultScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdultScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ak_ = @this?.Url;
+                FhirString al_ = context.Operators.Convert<FhirString>(ak_);
+                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
+                bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return an_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType ao_ = @this?.Value;
+
+                return ao_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+
+            return aj_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adult Depression Screening")]
+    public bool? Has_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdultScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdultScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdultScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdultScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                bool? an_ = context.Operators.And(ah_, am_);
+
+                return an_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdultScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions")]
+    public bool? Denominator_Exceptions(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(context);
+        bool? b_ = context.Operators.Exists<Observation>(a_);
+        bool? c_ = this.Has_Adolescent_Depression_Screening(context);
+        bool? d_ = context.Operators.Not(c_);
+        bool? e_ = context.Operators.And(b_, d_);
+        IEnumerable<Observation> f_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(context);
+        bool? g_ = context.Operators.Exists<Observation>(f_);
+        bool? h_ = this.Has_Adult_Depression_Screening(context);
+        bool? i_ = context.Operators.Not(h_);
+        bool? j_ = context.Operators.And(g_, i_);
+        bool? k_ = context.Operators.Or(e_, j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_5_1_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_5_1_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdultScreen", "FollowUpPositiveAdultScreen", "QualifyingEncounter"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdolescentScreen", "FollowUpPositiveAdolescentScreen", "QualifyingEncounter"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/CADBetaBlockerTherapyPriorMIorLVSDFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/CADBetaBlockerTherapyPriorMIorLVSDFHIR-0.2.000.g.cs
@@ -1,0 +1,1855 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("CADBetaBlockerTherapyPriorMIorLVSDFHIR", "0.2.000")]
+public partial class CADBetaBlockerTherapyPriorMIorLVSDFHIR_0_2_000 : ILibrary, ISingleton<CADBetaBlockerTherapyPriorMIorLVSDFHIR_0_2_000>
+{
+    private CADBetaBlockerTherapyPriorMIorLVSDFHIR_0_2_000() {}
+
+    public static CADBetaBlockerTherapyPriorMIorLVSDFHIR_0_2_000 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "CADBetaBlockerTherapyPriorMIorLVSDFHIR";
+    public string Version => "0.2.000";
+    public ILibrary[] Dependencies => [FHIRHelpers_4_4_000.Instance, SupplementalDataElements_3_5_000.Instance, QICoreCommon_2_1_000.Instance, AHAOverall_2_8_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Allergy to Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", valueSetVersion: null)]
+    public CqlValueSet Allergy_to_Beta_Blocker_Therapy(CqlContext _) => _Allergy_to_Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Allergy_to_Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", null);
+
+    [CqlValueSetDefinition("Arrhythmia", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", valueSetVersion: null)]
+    public CqlValueSet Arrhythmia(CqlContext _) => _Arrhythmia;
+    private static readonly CqlValueSet _Arrhythmia = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", null);
+
+    [CqlValueSetDefinition("Asthma", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", valueSetVersion: null)]
+    public CqlValueSet Asthma(CqlContext _) => _Asthma;
+    private static readonly CqlValueSet _Asthma = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", null);
+
+    [CqlValueSetDefinition("Atrioventricular Block", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", valueSetVersion: null)]
+    public CqlValueSet Atrioventricular_Block(CqlContext _) => _Atrioventricular_Block;
+    private static readonly CqlValueSet _Atrioventricular_Block = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy(CqlContext _) => _Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy for LVSD", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy_for_LVSD(CqlContext _) => _Beta_Blocker_Therapy_for_LVSD;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy_for_LVSD = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy Ingredient", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy_Ingredient(CqlContext _) => _Beta_Blocker_Therapy_Ingredient;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy_Ingredient = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", null);
+
+    [CqlValueSetDefinition("Bradycardia", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", valueSetVersion: null)]
+    public CqlValueSet Bradycardia(CqlContext _) => _Bradycardia;
+    private static readonly CqlValueSet _Bradycardia = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", null);
+
+    [CqlValueSetDefinition("Cardiac Pacer", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Pacer(CqlContext _) => _Cardiac_Pacer;
+    private static readonly CqlValueSet _Cardiac_Pacer = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", null);
+
+    [CqlValueSetDefinition("Cardiac Pacer in Situ", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Pacer_in_Situ(CqlContext _) => _Cardiac_Pacer_in_Situ;
+    private static readonly CqlValueSet _Cardiac_Pacer_in_Situ = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", null);
+
+    [CqlValueSetDefinition("Cardiac Surgery", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Surgery(CqlContext _) => _Cardiac_Surgery;
+    private static readonly CqlValueSet _Cardiac_Surgery = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371", null);
+
+    [CqlValueSetDefinition("Care Services in Long Term Residential Facility", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", valueSetVersion: null)]
+    public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext _) => _Care_Services_in_Long_Term_Residential_Facility;
+    private static readonly CqlValueSet _Care_Services_in_Long_Term_Residential_Facility = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlValueSetDefinition("Coronary Artery Disease No MI", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369", valueSetVersion: null)]
+    public CqlValueSet Coronary_Artery_Disease_No_MI(CqlContext _) => _Coronary_Artery_Disease_No_MI;
+    private static readonly CqlValueSet _Coronary_Artery_Disease_No_MI = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369", null);
+
+    [CqlValueSetDefinition("Ejection Fraction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", valueSetVersion: null)]
+    public CqlValueSet Ejection_Fraction(CqlContext _) => _Ejection_Fraction;
+    private static readonly CqlValueSet _Ejection_Fraction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", null);
+
+    [CqlValueSetDefinition("Face-to-Face Interaction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", valueSetVersion: null)]
+    public CqlValueSet Face_to_Face_Interaction(CqlContext _) => _Face_to_Face_Interaction;
+    private static readonly CqlValueSet _Face_to_Face_Interaction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlValueSetDefinition("Home Healthcare Services", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", valueSetVersion: null)]
+    public CqlValueSet Home_Healthcare_Services(CqlContext _) => _Home_Healthcare_Services;
+    private static readonly CqlValueSet _Home_Healthcare_Services = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlValueSetDefinition("Hypotension", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", valueSetVersion: null)]
+    public CqlValueSet Hypotension(CqlContext _) => _Hypotension;
+    private static readonly CqlValueSet _Hypotension = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", null);
+
+    [CqlValueSetDefinition("Intolerance to Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", valueSetVersion: null)]
+    public CqlValueSet Intolerance_to_Beta_Blocker_Therapy(CqlContext _) => _Intolerance_to_Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Intolerance_to_Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", null);
+
+    [CqlValueSetDefinition("Medical Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", valueSetVersion: null)]
+    public CqlValueSet Medical_Reason(CqlContext _) => _Medical_Reason;
+    private static readonly CqlValueSet _Medical_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlValueSetDefinition("Moderate or Severe", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", valueSetVersion: null)]
+    public CqlValueSet Moderate_or_Severe(CqlContext _) => _Moderate_or_Severe;
+    private static readonly CqlValueSet _Moderate_or_Severe = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", null);
+
+    [CqlValueSetDefinition("Moderate or Severe LVSD", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", valueSetVersion: null)]
+    public CqlValueSet Moderate_or_Severe_LVSD(CqlContext _) => _Moderate_or_Severe_LVSD;
+    private static readonly CqlValueSet _Moderate_or_Severe_LVSD = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", null);
+
+    [CqlValueSetDefinition("Myocardial Infarction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", valueSetVersion: null)]
+    public CqlValueSet Myocardial_Infarction(CqlContext _) => _Myocardial_Infarction;
+    private static readonly CqlValueSet _Myocardial_Infarction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", null);
+
+    [CqlValueSetDefinition("Nursing Facility Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", valueSetVersion: null)]
+    public CqlValueSet Nursing_Facility_Visit(CqlContext _) => _Nursing_Facility_Visit;
+    private static readonly CqlValueSet _Nursing_Facility_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlValueSetDefinition("Office Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", valueSetVersion: null)]
+    public CqlValueSet Office_Visit(CqlContext _) => _Office_Visit;
+    private static readonly CqlValueSet _Office_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlValueSetDefinition("Outpatient Consultation", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", valueSetVersion: null)]
+    public CqlValueSet Outpatient_Consultation(CqlContext _) => _Outpatient_Consultation;
+    private static readonly CqlValueSet _Outpatient_Consultation = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlValueSetDefinition("Patient Provider Interaction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", valueSetVersion: null)]
+    public CqlValueSet Patient_Provider_Interaction(CqlContext _) => _Patient_Provider_Interaction;
+    private static readonly CqlValueSet _Patient_Provider_Interaction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
+
+    [CqlValueSetDefinition("Patient Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", valueSetVersion: null)]
+    public CqlValueSet Patient_Reason(CqlContext _) => _Patient_Reason;
+    private static readonly CqlValueSet _Patient_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+
+    [CqlValueSetDefinition("System Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009", valueSetVersion: null)]
+    public CqlValueSet System_Reason(CqlContext _) => _System_Reason;
+    private static readonly CqlValueSet _System_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Substance with beta adrenergic receptor antagonist mechanism of action (substance)", codeId: "373254001", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(CqlContext _) => _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_;
+    private static readonly CqlCode _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_ = new CqlCode("373254001", "http://snomed.info/sct");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, 0.0m);
+        CqlDateTime b_ = context.Operators.DateTime(2025, 12, 31, 23, 59, 59, 999, 0.0m);
+        CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, true);
+        object d_ = context.ResolveParameter("CADBetaBlockerTherapyPriorMIorLVSDFHIR-0.2.000", "Measurement Period", c_);
+
+        return (CqlInterval<CqlDateTime>)d_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Office_Visit(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Outpatient_Consultation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Nursing_Facility_Visit(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+        IEnumerable<Encounter> i_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+        CqlValueSet l_ = this.Home_Healthcare_Services(context);
+        IEnumerable<Encounter> m_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet n_ = this.Patient_Provider_Interaction(context);
+        IEnumerable<Encounter> o_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+        IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+        bool? r_(Encounter ValidEncounter)
+        {
+            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+            Period u_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, "day");
+            Code<Encounter.EncounterStatus> x_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? y_ = x_?.Value;
+            Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
+            bool? aa_ = context.Operators.Equal(z_, "finished");
+            bool? ab_ = context.Operators.And(w_, aa_);
+
+            return ab_;
+        };
+        IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
+
+        return s_;
+    }
+
+
+    [CqlExpressionDefinition("Outpatient Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Outpatient_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Office_Visit(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Outpatient_Consultation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet h_ = this.Home_Healthcare_Services(context);
+        IEnumerable<Encounter> i_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+        CqlValueSet l_ = this.Nursing_Facility_Visit(context);
+        IEnumerable<Encounter> m_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
+        bool? o_(Encounter QualifyingEncounter)
+        {
+            CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+            Period r_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
+            Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            bool? x_ = context.Operators.Equal(w_, "finished");
+            bool? y_ = context.Operators.And(t_, x_);
+
+            return y_;
+        };
+        IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
+
+        return p_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsDayOfEncounter")]
+    public bool? overlapsDayOfEncounter(CqlContext context, Condition Diagnosis, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? g_ = QICoreCommon_2_1_000.Instance.isActive(context, Diagnosis);
+
+            return g_;
+        };
+        IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(EncounterList, a_);
+        bool? c_(Encounter Visit)
+        {
+            CqlInterval<CqlDateTime> h_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, Diagnosis);
+            Period i_ = Visit?.Period;
+            CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+            bool? k_ = context.Operators.Overlaps(h_, j_, "day");
+
+            return k_;
+        };
+        IEnumerable<bool?> d_ = context.Operators.Select<Encounter, bool?>(b_, c_);
+        IEnumerable<bool?> e_ = context.Operators.Distinct<bool?>(d_);
+        bool? f_ = context.Operators.AnyTrue(e_);
+
+        return f_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsDayOfEncounter")]
+    public bool? overlapsDayOfEncounter(CqlContext context, Condition Diagnosis, Encounter TheEncounter)
+    {
+        Encounter[] a_ = [
+            TheEncounter,
+        ];
+        bool? b_(Encounter Visit)
+        {
+            bool? h_ = AHAOverall_2_8_000.Instance.isConfirmedActiveDiagnosis(context, Diagnosis);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)a_, b_);
+        bool? d_(Encounter Visit)
+        {
+            CqlInterval<CqlDateTime> i_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, Diagnosis);
+            Period j_ = Visit?.Period;
+            CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+            bool? l_ = context.Operators.Overlaps(i_, k_, "day");
+
+            return l_;
+        };
+        IEnumerable<bool?> e_ = context.Operators.Select<Encounter, bool?>(c_, d_);
+        IEnumerable<bool?> f_ = context.Operators.Distinct<bool?>(e_);
+        bool? g_ = context.Operators.SingletonFrom<bool?>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Coronary Artery Disease Encounter")]
+    public IEnumerable<Encounter> Coronary_Artery_Disease_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+        {
+            CqlValueSet d_ = this.Coronary_Artery_Disease_No_MI(context);
+            IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+            bool? f_(Condition CoronaryArteryDisease)
+            {
+                bool? j_ = this.overlapsDayOfEncounter(context, CoronaryArteryDisease, ValidQualifyingEncounter);
+
+                return j_;
+            };
+            IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+            Encounter h_(Condition CoronaryArteryDisease) =>
+                ValidQualifyingEncounter;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("History of Cardiac Surgery Prior to Encounter")]
+    public IEnumerable<Encounter> History_of_Cardiac_Surgery_Prior_to_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+        {
+            CqlValueSet d_ = this.Cardiac_Surgery(context);
+            IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            bool? f_(Procedure CardiacSurgery)
+            {
+                DataType j_ = CardiacSurgery?.Performed;
+                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_2_1_000.Instance.toInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(l_);
+                Period n_ = ValidQualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                bool? q_ = context.Operators.Before(m_, p_, default);
+                Code<EventStatus> r_ = CardiacSurgery?.StatusElement;
+                EventStatus? s_ = r_?.Value;
+                string t_ = context.Operators.Convert<string>(s_);
+                bool? u_ = context.Operators.Equal(t_, "completed");
+                bool? v_ = context.Operators.And(q_, u_);
+
+                return v_;
+            };
+            IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
+            Encounter h_(Procedure CardiacSurgery) =>
+                ValidQualifyingEncounter;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Coronary_Artery_Disease_Encounter(context);
+        IEnumerable<Encounter> b_ = this.History_of_Cardiac_Surgery_Prior_to_Encounter(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public bool? Initial_Population(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> k_(Encounter Encounter1)
+        {
+            IEnumerable<Encounter> r_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? s_(Encounter Encounter2)
+            {
+                Id w_ = Encounter2?.IdElement;
+                string x_ = w_?.Value;
+                Id y_ = Encounter1?.IdElement;
+                string z_ = y_?.Value;
+                bool? aa_ = context.Operators.Equivalent(x_, z_);
+                bool? ab_ = context.Operators.Not(aa_);
+
+                return ab_;
+            };
+            IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
+            Encounter u_(Encounter Encounter2) =>
+                Encounter1;
+            IEnumerable<Encounter> v_ = context.Operators.Select<Encounter, Encounter>(t_, u_);
+
+            return v_;
+        };
+        IEnumerable<Encounter> l_ = context.Operators.SelectMany<Encounter, Encounter>(j_, k_);
+        bool? m_ = context.Operators.Exists<Encounter>(l_);
+        bool? n_ = context.Operators.And(i_, m_);
+        IEnumerable<Encounter> o_ = this.Qualifying_CAD_Encounter(context);
+        bool? p_ = context.Operators.Exists<Encounter>(o_);
+        bool? q_ = context.Operators.And(n_, p_);
+
+        return q_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter and Prior MI")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
+        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy)
+        {
+            CqlValueSet d_ = this.Myocardial_Infarction(context);
+            IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+            bool? f_(Condition MyocardialInfarction)
+            {
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, MyocardialInfarction);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(3m, "years");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
+                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, "day");
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                bool? z_ = context.Operators.And(u_, y_);
+                IEnumerable<object> aa_ = AHAOverall_2_8_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+                bool? ab_ = context.Operators.Exists<object>(aa_);
+                bool? ac_ = context.Operators.Not(ab_);
+                bool? ad_ = context.Operators.And(z_, ac_);
+
+                return ad_;
+            };
+            IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+            Encounter h_(Condition MyocardialInfarction) =>
+                EncounterWithCADProxy;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator 2")]
+    public bool? Denominator_2(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Atrioventricular_Block(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition AtrioventricularBlock)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AtrioventricularBlock, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Cardiac Pacer in Situ with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer_in_Situ(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition CardiacPacerDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, CardiacPacerDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Cardiac Pacer Device Implanted with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_(Encounter CADEncounterMI)
+            {
+                DataType k_ = ImplantedCardiacPacer?.Performed;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_2_1_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before(n_, q_, default);
+
+                return r_;
+            };
+            IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+            Procedure i_(Encounter CADEncounterMI) =>
+                ImplantedCardiacPacer;
+            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
+
+            return j_;
+        };
+        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        bool? e_ = context.Operators.Exists<Procedure>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and Prior MI without Cardiac Pacer")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI_without_Cardiac_Pacer(CqlContext context)
+    {
+        bool? a_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Not(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+        bool? e_ = this.Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? f_ = context.Operators.Not(e_);
+        bool? g_ = context.Operators.And(d_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Consecutive Heart Rates Less than 50 with Qualifying CAD Encounter and Prior MI")]
+    [CqlTag("code", "Heart rate - 8867-4")]
+    [CqlTag("profile", "http://hl7.org/fhir/StructureDefinition/heartrate")]
+    public bool? Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/StructureDefinition/heartrate"));
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+        IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+        (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? d_(ValueTuple<Observation, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? l_ = (CqlTupleMetadata_FKMQgfFigeQaXSijKCWWXILSb, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?>(c_, d_);
+        bool? f_((CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? tuple_fpxinvuudpgzjtucgzenxcjeq)
+        {
+            Period m_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.CADEncounterMI?.Period;
+            CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+            DataType o_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.HeartRate?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_2_1_000.Instance.toInterval(context, p_);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+            Code<ObservationStatus> s_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.HeartRate?.StatusElement;
+            ObservationStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            string[] v_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+            bool? x_ = context.Operators.And(r_, w_);
+            DataType y_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.HeartRate?.Value;
+            CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);
+            CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
+            bool? ab_ = context.Operators.Less(z_, aa_);
+            bool? ac_ = context.Operators.And(x_, ab_);
+            IEnumerable<Observation> ad_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/StructureDefinition/heartrate"));
+            bool? ae_(Observation MostRecentPriorHeartRate)
+            {
+                Period ao_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
+                DataType aq_ = MostRecentPriorHeartRate?.Effective;
+                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                CqlInterval<CqlDateTime> as_ = QICoreCommon_2_1_000.Instance.toInterval(context, ar_);
+                bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
+                Code<ObservationStatus> au_ = MostRecentPriorHeartRate?.StatusElement;
+                ObservationStatus? av_ = au_?.Value;
+                string aw_ = context.Operators.Convert<string>(av_);
+                string[] ax_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                bool? ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
+                bool? az_ = context.Operators.And(at_, ay_);
+                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                CqlInterval<CqlDateTime> bc_ = QICoreCommon_2_1_000.Instance.toInterval(context, bb_);
+                DataType bd_ = tuple_fpxinvuudpgzjtucgzenxcjeq?.HeartRate?.Effective;
+                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                CqlInterval<CqlDateTime> bf_ = QICoreCommon_2_1_000.Instance.toInterval(context, be_);
+                bool? bg_ = context.Operators.Before(bc_, bf_, default);
+                bool? bh_ = context.Operators.And(az_, bg_);
+
+                return bh_;
+            };
+            IEnumerable<Observation> af_ = context.Operators.Where<Observation>(ad_, ae_);
+            object ag_(Observation @this)
+            {
+                DataType bi_ = @this?.Effective;
+                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                CqlInterval<CqlDateTime> bk_ = QICoreCommon_2_1_000.Instance.toInterval(context, bj_);
+                CqlDateTime bl_ = context.Operators.Start(bk_);
+
+                return bl_;
+            };
+            IEnumerable<Observation> ah_ = context.Operators.SortBy<Observation>(af_, ag_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ai_ = context.Operators.Last<Observation>(ah_);
+            DataType aj_ = ai_?.Value;
+            CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
+            bool? am_ = context.Operators.Less(ak_, aa_);
+            bool? an_ = context.Operators.And(ac_, am_);
+
+            return an_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?> g_ = context.Operators.Where<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?>(e_, f_);
+        (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? h_((CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? tuple_fpxinvuudpgzjtucgzenxcjeq)
+        {
+            (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)? bm_ = (CqlTupleMetadata_FKMQgfFigeQaXSijKCWWXILSb, tuple_fpxinvuudpgzjtucgzenxcjeq?.HeartRate, tuple_fpxinvuudpgzjtucgzenxcjeq?.CADEncounterMI);
+
+            return bm_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?> i_ = context.Operators.Select<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?, (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?>(g_, h_);
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?> j_ = context.Operators.Distinct<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?>(i_);
+        bool? k_ = context.Operators.Exists<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterMI)?>(j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
+        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy)
+        {
+            IEnumerable<object> d_ = AHAOverall_2_8_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+            bool? e_(object LVSDFindings)
+            {
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, LVSDFindings as Condition);
+                object j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
+                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_2_1_000.Instance.toInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(i_ ?? l_);
+                Period n_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                bool? q_ = context.Operators.Before(m_, p_, default);
+
+                return q_;
+            };
+            IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
+            Encounter g_(object LVSDFindings) =>
+                EncounterWithCADProxy;
+            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("authoredDuringDayOfEncounter")]
+    public bool? authoredDuringDayOfEncounter(CqlContext context, object Order, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? e_()
+            {
+                if (Order is MedicationRequest)
+                {
+                    object f_ = context.Operators.LateBoundProperty<object>(Order, "authoredOn");
+                    CqlDateTime g_ = context.Operators.LateBoundProperty<CqlDateTime>(f_, "value");
+                    Period h_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                    bool? j_ = context.Operators.In<CqlDateTime>(g_, i_, "day");
+                    object k_ = context.Operators.LateBoundProperty<object>(Order, "status");
+                    string l_ = context.Operators.LateBoundProperty<string>(k_, "value");
+                    string[] m_ = [
+                        "active",
+                        "completed",
+                    ];
+                    bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+                    bool? o_ = context.Operators.And(j_, n_);
+                    object p_ = context.Operators.LateBoundProperty<object>(Order, "intent");
+                    string q_ = context.Operators.LateBoundProperty<string>(p_, "value");
+                    string[] r_ = [
+                        "order",
+                        "original-order",
+                        "reflex-order",
+                        "filler-order",
+                        "instance-order",
+                    ];
+                    bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+                    bool? t_ = context.Operators.And(o_, s_);
+                    object u_ = context.Operators.LateBoundProperty<object>(Order, "doNotPerform");
+                    bool? v_ = context.Operators.LateBoundProperty<bool?>(u_, "value");
+                    bool? w_ = context.Operators.IsTrue(v_);
+                    bool? x_ = context.Operators.Not(w_);
+                    bool? y_ = context.Operators.And(t_, x_);
+
+                    return y_;
+                }
+                else if (Order is MedicationRequest)
+                {
+                    object z_ = context.Operators.LateBoundProperty<object>(Order, "authoredOn");
+                    CqlDateTime aa_ = context.Operators.LateBoundProperty<CqlDateTime>(z_, "value");
+                    Period ab_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, "day");
+                    object ae_ = context.Operators.LateBoundProperty<object>(Order, "intent");
+                    string af_ = context.Operators.LateBoundProperty<string>(ae_, "value");
+                    string[] ag_ = [
+                        "order",
+                        "original-order",
+                        "reflex-order",
+                        "filler-order",
+                        "instance-order",
+                    ];
+                    bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                    bool? ai_ = context.Operators.And(ad_, ah_);
+
+                    return ai_;
+                }
+                else
+                {
+                    return false;
+                }
+            };
+
+            return e_();
+        };
+        IEnumerable<bool?> b_ = context.Operators.Select<Encounter, bool?>(EncounterList, a_);
+        IEnumerable<bool?> c_ = context.Operators.Distinct<bool?>(b_);
+        bool? d_ = context.Operators.AnyTrue(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Beta Blocker Therapy for LVSD Ordered")]
+    public bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? c_(MedicationRequest BetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.authoredDuringDayOfEncounter(context, BetaBlockerForLVSDOrdered as object, f_);
+
+            return g_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+        bool? e_ = context.Operators.Exists<MedicationRequest>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Is Currently Taking Beta Blocker Therapy for LVSD")]
+    public bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlockerForLVSD)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? i_(Encounter CADEncounterModerateOrSevereLVSD)
+            {
+                List<Dosage> m_ = ActiveBetaBlockerForLVSD?.DosageInstruction;
+                bool? n_(Dosage @this)
+                {
+                    Timing aj_ = @this?.Timing;
+                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+
+                    return ak_;
+                };
+                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                Timing p_(Dosage @this)
+                {
+                    Timing al_ = @this?.Timing;
+
+                    return al_;
+                };
+                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                bool? r_(Timing @this)
+                {
+                    Timing.RepeatComponent am_ = @this?.Repeat;
+                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+
+                    return an_;
+                };
+                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                Timing.RepeatComponent t_(Timing @this)
+                {
+                    Timing.RepeatComponent ao_ = @this?.Repeat;
+
+                    return ao_;
+                };
+                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                bool? v_(Timing.RepeatComponent @this)
+                {
+                    DataType ap_ = @this?.Bounds;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+
+                    return ar_;
+                };
+                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                object x_(Timing.RepeatComponent @this)
+                {
+                    DataType as_ = @this?.Bounds;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return at_;
+                };
+                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                CqlInterval<CqlDateTime> z_(object DoseTime)
+                {
+                    CqlInterval<CqlDateTime> au_ = QICoreCommon_2_1_000.Instance.toInterval(context, DoseTime);
+
+                    return au_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
+                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                object ad_(CqlInterval<CqlDateTime> @this)
+                {
+                    CqlDateTime av_ = context.Operators.Start(@this);
+
+                    return av_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
+                Period ag_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
+
+                return ai_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter CADEncounterModerateOrSevereLVSD) =>
+                ActiveBetaBlockerForLVSD;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest ActiveBetaBlockerForLVSD)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlockerForLVSD?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
+            string ay_ = context.Operators.Convert<string>(ax_);
+            string[] az_ = [
+                "active",
+                "completed",
+            ];
+            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlockerForLVSD?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
+            string bd_ = context.Operators.Convert<string>(bc_);
+            string[] be_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
+            bool? bg_ = context.Operators.And(ba_, bf_);
+
+            return bg_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator 1")]
+    public bool? Numerator_1(CqlContext context)
+    {
+        bool? a_ = this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered(context);
+        bool? b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Has Beta Blocker Therapy Ordered")]
+    public bool? Has_Beta_Blocker_Therapy_Ordered(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? c_(MedicationRequest BetaBlockerOrdered)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.authoredDuringDayOfEncounter(context, BetaBlockerOrdered as object, f_);
+
+            return g_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+        bool? e_ = context.Operators.Exists<MedicationRequest>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Is Currently Taking Beta Blocker Therapy")]
+    public bool? Is_Currently_Taking_Beta_Blocker_Therapy(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlocker)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? i_(Encounter CADEncounterMI)
+            {
+                List<Dosage> m_ = ActiveBetaBlocker?.DosageInstruction;
+                bool? n_(Dosage @this)
+                {
+                    Timing aj_ = @this?.Timing;
+                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+
+                    return ak_;
+                };
+                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                Timing p_(Dosage @this)
+                {
+                    Timing al_ = @this?.Timing;
+
+                    return al_;
+                };
+                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                bool? r_(Timing @this)
+                {
+                    Timing.RepeatComponent am_ = @this?.Repeat;
+                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+
+                    return an_;
+                };
+                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                Timing.RepeatComponent t_(Timing @this)
+                {
+                    Timing.RepeatComponent ao_ = @this?.Repeat;
+
+                    return ao_;
+                };
+                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                bool? v_(Timing.RepeatComponent @this)
+                {
+                    DataType ap_ = @this?.Bounds;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+
+                    return ar_;
+                };
+                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                object x_(Timing.RepeatComponent @this)
+                {
+                    DataType as_ = @this?.Bounds;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return at_;
+                };
+                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                CqlInterval<CqlDateTime> z_(object DoseTime)
+                {
+                    CqlInterval<CqlDateTime> au_ = QICoreCommon_2_1_000.Instance.toInterval(context, DoseTime);
+
+                    return au_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
+                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                object ad_(CqlInterval<CqlDateTime> @this)
+                {
+                    CqlDateTime av_ = context.Operators.Start(@this);
+
+                    return av_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
+                Period ag_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
+
+                return ai_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter CADEncounterMI) =>
+                ActiveBetaBlocker;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest ActiveBetaBlocker)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlocker?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
+            string ay_ = context.Operators.Convert<string>(ax_);
+            string[] az_ = [
+                "active",
+                "completed",
+            ];
+            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlocker?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
+            string bd_ = context.Operators.Convert<string>(bc_);
+            string[] be_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
+            bool? bg_ = context.Operators.And(ba_, bf_);
+
+            return bg_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator 2")]
+    public bool? Numerator_2(CqlContext context)
+    {
+        bool? a_ = this.Has_Beta_Blocker_Therapy_Ordered(context);
+        bool? b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_3_5_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_3_5_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_3_5_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_3_5_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator 1")]
+    public bool? Denominator_1(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Atrioventricular_Block(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition AtrioventricularBlock)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AtrioventricularBlock, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Cardiac Pacer in Situ with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer_in_Situ(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition CardiacPacerDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, CardiacPacerDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Cardiac Pacer Device Implanted with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_(Encounter CADEncounterModerateOrSevereLVSD)
+            {
+                DataType k_ = ImplantedCardiacPacer?.Performed;
+                object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+                CqlInterval<CqlDateTime> m_ = QICoreCommon_2_1_000.Instance.toInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                Period o_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                bool? r_ = context.Operators.Before(n_, q_, default);
+
+                return r_;
+            };
+            IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+            Procedure i_(Encounter CADEncounterModerateOrSevereLVSD) =>
+                ImplantedCardiacPacer;
+            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
+
+            return j_;
+        };
+        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        bool? e_ = context.Operators.Exists<Procedure>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and History of Moderate or Severe LVSD without Cardiac Pacer")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD_without_Cardiac_Pacer(CqlContext context)
+    {
+        bool? a_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Not(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+        bool? e_ = this.Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? f_ = context.Operators.Not(e_);
+        bool? g_ = context.Operators.And(d_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Consecutive Heart Rates Less than 50 with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    [CqlTag("code", "Heart rate - 8867-4")]
+    [CqlTag("profile", "http://hl7.org/fhir/StructureDefinition/heartrate")]
+    public bool? Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/StructureDefinition/heartrate"));
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+        (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? d_(ValueTuple<Observation, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? l_ = (CqlTupleMetadata_CQNZjLiVLBGWbEXYLeeWchXgX, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?>(c_, d_);
+        bool? f_((CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? tuple_daoxljkfqiagaudfazelhhich)
+        {
+            Period m_ = tuple_daoxljkfqiagaudfazelhhich?.CADEncounterModerateOrSevereLVSD?.Period;
+            CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+            DataType o_ = tuple_daoxljkfqiagaudfazelhhich?.HeartRate?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_2_1_000.Instance.toInterval(context, p_);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+            DataType s_ = tuple_daoxljkfqiagaudfazelhhich?.HeartRate?.Value;
+            CqlQuantity t_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, s_ as Quantity);
+            CqlQuantity u_ = context.Operators.Quantity(50m, "/min");
+            bool? v_ = context.Operators.Less(t_, u_);
+            bool? w_ = context.Operators.And(r_, v_);
+            IEnumerable<Observation> x_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/StructureDefinition/heartrate"));
+            bool? y_(Observation MostRecentPriorHeartRate)
+            {
+                Period ai_ = tuple_daoxljkfqiagaudfazelhhich?.CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
+                DataType ak_ = MostRecentPriorHeartRate?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                CqlInterval<CqlDateTime> am_ = QICoreCommon_2_1_000.Instance.toInterval(context, al_);
+                bool? an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, am_, default);
+                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_2_1_000.Instance.toInterval(context, ap_);
+                DataType ar_ = tuple_daoxljkfqiagaudfazelhhich?.HeartRate?.Effective;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_2_1_000.Instance.toInterval(context, as_);
+                bool? au_ = context.Operators.Before(aq_, at_, default);
+                bool? av_ = context.Operators.And(an_, au_);
+
+                return av_;
+            };
+            IEnumerable<Observation> z_ = context.Operators.Where<Observation>(x_, y_);
+            object aa_(Observation @this)
+            {
+                DataType aw_ = @this?.Effective;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                CqlInterval<CqlDateTime> ay_ = QICoreCommon_2_1_000.Instance.toInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+
+                return az_;
+            };
+            IEnumerable<Observation> ab_ = context.Operators.SortBy<Observation>(z_, aa_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ac_ = context.Operators.Last<Observation>(ab_);
+            DataType ad_ = ac_?.Value;
+            CqlQuantity ae_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ad_ as Quantity);
+            bool? ag_ = context.Operators.Less(ae_, u_);
+            bool? ah_ = context.Operators.And(w_, ag_);
+
+            return ah_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?> g_ = context.Operators.Where<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?>(e_, f_);
+        (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? h_((CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? tuple_daoxljkfqiagaudfazelhhich)
+        {
+            (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)? ba_ = (CqlTupleMetadata_CQNZjLiVLBGWbEXYLeeWchXgX, tuple_daoxljkfqiagaudfazelhhich?.HeartRate, tuple_daoxljkfqiagaudfazelhhich?.CADEncounterModerateOrSevereLVSD);
+
+            return ba_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?> i_ = context.Operators.Select<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?, (CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?>(g_, h_);
+        IEnumerable<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?> j_ = context.Operators.Distinct<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?>(i_);
+        bool? k_ = context.Operators.Exists<(CqlTupleMetadata, Observation HeartRate, Encounter CADEncounterModerateOrSevereLVSD)?>(j_);
+
+        return k_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsAfterDayOfEncounter")]
+    public bool? overlapsAfterDayOfEncounter(CqlContext context, object Event, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? e_()
+            {
+                if (Event is AllergyIntolerance)
+                {
+                    object f_ = context.Operators.LateBoundProperty<object>(Event, "onset");
+                    object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
+                    CqlInterval<CqlDateTime> h_ = QICoreCommon_2_1_000.Instance.toInterval(context, g_);
+                    CqlDateTime i_ = context.Operators.Start(h_);
+                    object j_ = context.Operators.LateBoundProperty<object>(Event, "lastOccurrence");
+                    CqlDateTime k_ = context.Operators.LateBoundProperty<CqlDateTime>(j_, "value");
+                    CqlInterval<CqlDateTime> l_ = context.Operators.Interval(i_, k_, true, true);
+                    Period m_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                    bool? o_ = context.Operators.OverlapsAfter(l_, n_, "day");
+                    object p_ = context.Operators.LateBoundProperty<object>(Event, "clinicalStatus");
+                    CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_ as CodeableConcept);
+                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_ as CodeableConcept);
+                    CqlCode t_ = QICoreCommon_2_1_000.Instance.allergy_active(context);
+                    CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
+                    bool? v_ = context.Operators.Equivalent(s_, u_);
+                    bool? w_ = context.Operators.Or((bool?)(q_ is null), v_);
+                    bool? x_ = context.Operators.And(o_, w_);
+
+                    return x_;
+                }
+                else if (Event is Condition)
+                {
+                    bool? y_ = AHAOverall_2_8_000.Instance.isConfirmedActiveDiagnosis(context, Event as Condition);
+                    CqlInterval<CqlDateTime> z_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, Event as Condition);
+                    Period aa_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                    bool? ac_ = context.Operators.OverlapsAfter(z_, ab_, "day");
+                    bool? ad_ = context.Operators.And(y_, ac_);
+                    object ae_ = context.Operators.LateBoundProperty<object>(Event, "verificationStatus");
+                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+                    CqlCode ag_ = QICoreCommon_2_1_000.Instance.confirmed(context);
+                    CqlConcept ah_ = context.Operators.ConvertCodeToConcept(ag_);
+                    bool? ai_ = context.Operators.Equivalent(af_, ah_);
+                    bool? aj_ = context.Operators.And(ad_, ai_);
+
+                    return aj_;
+                }
+                else
+                {
+                    return false;
+                }
+            };
+
+            return e_();
+        };
+        IEnumerable<bool?> b_ = context.Operators.Select<Encounter, bool?>(EncounterList, a_);
+        IEnumerable<bool?> c_ = context.Operators.Distinct<bool?>(b_);
+        bool? d_ = context.Operators.AnyTrue(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient(context);
+        IEnumerable<AllergyIntolerance> b_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(context);
+        IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+        IEnumerable<AllergyIntolerance> e_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
+        bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
+        {
+            IEnumerable<Encounter> j_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? k_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyIntolerance as object, j_);
+
+            return k_;
+        };
+        IEnumerable<AllergyIntolerance> h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
+        bool? i_ = context.Operators.Exists<AllergyIntolerance>(h_);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Has Arrhythmia with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Arrhythmia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition ArrhythmiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, ArrhythmiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Arrhythmia with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Arrhythmia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition ArrhythmiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, ArrhythmiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Asthma with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Asthma_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Asthma(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition AsthmaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AsthmaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Asthma with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Asthma_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Asthma(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition AsthmaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AsthmaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Bradycardia with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Bradycardia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bradycardia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition BradycardiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, BradycardiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Bradycardia with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Bradycardia_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bradycardia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition BradycardiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, BradycardiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+        bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? j_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyOrIntoleranceDiagnosis as object, i_);
+
+            return j_;
+        };
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+        bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? j_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyOrIntoleranceDiagnosis as object, i_);
+
+            return j_;
+        };
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Hypotension with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Hypotension_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hypotension(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition HypotensionDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, HypotensionDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Hypotension with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Hypotension_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hypotension(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        bool? c_(Condition HypotensionDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, HypotensionDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient(context);
+        IEnumerable<AllergyIntolerance> b_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(context);
+        IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+        IEnumerable<AllergyIntolerance> e_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
+        bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
+        {
+            IEnumerable<Encounter> j_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? k_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyIntolerance as object, j_);
+
+            return k_;
+        };
+        IEnumerable<AllergyIntolerance> h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
+        bool? i_ = context.Operators.Exists<AllergyIntolerance>(h_);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions 1")]
+    [CqlTag("commentedOut", "\"Has Medical or Patient Reason for Not Ordering Beta Blocker for LVSD\"")]
+    [CqlTag("commentedOutReason", "Negation issue noted in https://github.com/cqframework/cql-execution/issues/296, which is tied to https://oncprojectracking.healthit.gov/support/browse/BONNIEMAT-1455")]
+    public bool? Denominator_Exceptions_1(CqlContext context)
+    {
+        bool? a_ = this.Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? b_ = this.Has_Asthma_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+        bool? d_ = this.Has_Bradycardia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? e_ = context.Operators.Or(c_, d_);
+        bool? f_ = this.Has_Hypotension_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? g_ = context.Operators.Or(e_, f_);
+        bool? h_ = this.Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? i_ = context.Operators.Or(g_, h_);
+        bool? j_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? k_ = context.Operators.Or(i_, j_);
+        bool? l_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        bool? n_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD_without_Cardiac_Pacer(context);
+        bool? o_ = context.Operators.Or(m_, n_);
+
+        return o_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions 2")]
+    [CqlTag("commentedOut", "\"Has Medical or Patient Reason for Not Ordering Beta Blocker Therapy\" ")]
+    [CqlTag("commentedOutReason", "Negation issue noted in https://github.com/cqframework/cql-execution/issues/296, which is tied to https://oncprojectracking.healthit.gov/support/browse/BONNIEMAT-1455")]
+    public bool? Denominator_Exceptions_2(CqlContext context)
+    {
+        bool? a_ = this.Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? b_ = this.Has_Asthma_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+        bool? d_ = this.Has_Bradycardia_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? e_ = context.Operators.Or(c_, d_);
+        bool? f_ = this.Has_Hypotension_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? g_ = context.Operators.Or(e_, f_);
+        bool? h_ = this.Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? i_ = context.Operators.Or(g_, h_);
+        bool? j_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? k_ = context.Operators.Or(i_, j_);
+        bool? l_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        bool? n_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI_without_Cardiac_Pacer(context);
+        bool? o_ = context.Operators.Or(m_, n_);
+
+        return o_;
+    }
+
+
+    [CqlExpressionDefinition("Has Medical or Patient Reason for Not Ordering Beta Blocker for LVSD")]
+    [CqlTag("Issue", "Negation issue noted in https://github.com/cqframework/cql-execution/issues/296, which is tied to https://oncprojectracking.healthit.gov/support/browse/BONNIEMAT-1455")]
+    public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? i_(Encounter LVSDVisit)
+            {
+                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = LVSDVisit?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+
+                return q_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter LVSDVisit) =>
+                NoBetaBlockerForLVSDOrdered;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "active",
+                "completed",
+            ];
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            bool? ab_ = context.Operators.And(v_, aa_);
+            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            CqlConcept ad_(CodeableConcept @this)
+            {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ao_;
+            };
+            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
+            CqlValueSet af_ = this.Medical_Reason(context);
+            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
+            CqlConcept ai_(CodeableConcept @this)
+            {
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ap_;
+            };
+            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
+            CqlValueSet ak_ = this.Patient_Reason(context);
+            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
+            bool? am_ = context.Operators.Or(ag_, al_);
+            bool? an_ = context.Operators.And(ab_, am_);
+
+            return an_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Medical or Patient Reason for Not Ordering Beta Blocker Therapy")]
+    [CqlTag("Issue", "Negation issue noted in https://github.com/cqframework/cql-execution/issues/296, which is tied to https://oncprojectracking.healthit.gov/support/browse/BONNIEMAT-1455")]
+    public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_Therapy(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-mednotrequested"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? i_(Encounter PriorMIVisit)
+            {
+                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = PriorMIVisit?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+
+                return q_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter PriorMIVisit) =>
+                NoBetaBlockerForLVSDOrdered;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "active",
+                "completed",
+            ];
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            bool? ab_ = context.Operators.And(v_, aa_);
+            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            CqlConcept ad_(CodeableConcept @this)
+            {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ao_;
+            };
+            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
+            CqlValueSet af_ = this.Medical_Reason(context);
+            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
+            CqlConcept ai_(CodeableConcept @this)
+            {
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ap_;
+            };
+            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
+            CqlValueSet ak_ = this.Patient_Reason(context);
+            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
+            bool? am_ = context.Operators.Or(ag_, al_);
+            bool? an_ = context.Operators.And(ab_, am_);
+
+            return an_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_CQNZjLiVLBGWbEXYLeeWchXgX = new(
+      [typeof(Observation), typeof(Encounter)],
+      ["HeartRate", "CADEncounterModerateOrSevereLVSD"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_FKMQgfFigeQaXSijKCWWXILSb = new(
+      [typeof(Observation), typeof(Encounter)],
+      ["HeartRate", "CADEncounterMI"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCSDepressionScreenAndFollowUpFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2024/CSharp/PCSDepressionScreenAndFollowUpFHIR-0.2.000.g.cs
@@ -1,0 +1,1257 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("PCSDepressionScreenAndFollowUpFHIR", "0.2.000")]
+public partial class PCSDepressionScreenAndFollowUpFHIR_0_2_000 : ILibrary, ISingleton<PCSDepressionScreenAndFollowUpFHIR_0_2_000>
+{
+    private PCSDepressionScreenAndFollowUpFHIR_0_2_000() {}
+
+    public static PCSDepressionScreenAndFollowUpFHIR_0_2_000 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "PCSDepressionScreenAndFollowUpFHIR";
+    public string Version => "0.2.000";
+    public ILibrary[] Dependencies => [QICoreCommon_2_1_000.Instance, SupplementalDataElements_3_5_000.Instance, FHIRHelpers_4_4_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Adolescent Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", valueSetVersion: null)]
+    public CqlValueSet Adolescent_Depression_Medications(CqlContext _) => _Adolescent_Depression_Medications;
+    private static readonly CqlValueSet _Adolescent_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", null);
+
+    [CqlValueSetDefinition("Adult Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", valueSetVersion: null)]
+    public CqlValueSet Adult_Depression_Medications(CqlContext _) => _Adult_Depression_Medications;
+    private static readonly CqlValueSet _Adult_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", null);
+
+    [CqlValueSetDefinition("Bipolar Disorder", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", valueSetVersion: null)]
+    public CqlValueSet Bipolar_Disorder(CqlContext _) => _Bipolar_Disorder;
+    private static readonly CqlValueSet _Bipolar_Disorder = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", null);
+
+    [CqlValueSetDefinition("Encounter to Screen for Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", valueSetVersion: null)]
+    public CqlValueSet Encounter_to_Screen_for_Depression(CqlContext _) => _Encounter_to_Screen_for_Depression;
+    private static readonly CqlValueSet _Encounter_to_Screen_for_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", null);
+
+    [CqlValueSetDefinition("Follow Up for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adolescent_Depression(CqlContext _) => _Follow_Up_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", null);
+
+    [CqlValueSetDefinition("Follow Up for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adult_Depression(CqlContext _) => _Follow_Up_for_Adult_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", null);
+
+    [CqlValueSetDefinition("Medical Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", valueSetVersion: null)]
+    public CqlValueSet Medical_Reason(CqlContext _) => _Medical_Reason;
+    private static readonly CqlValueSet _Medical_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlValueSetDefinition("Physical Therapy Evaluation", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", valueSetVersion: null)]
+    public CqlValueSet Physical_Therapy_Evaluation(CqlContext _) => _Physical_Therapy_Evaluation;
+    private static readonly CqlValueSet _Physical_Therapy_Evaluation = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+
+    [CqlValueSetDefinition("Referral for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adolescent_Depression(CqlContext _) => _Referral_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Referral_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", null);
+
+    [CqlValueSetDefinition("Referral for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adult_Depression(CqlContext _) => _Referral_for_Adult_Depression;
+    private static readonly CqlValueSet _Referral_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", null);
+
+    [CqlValueSetDefinition("Telephone Visits", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", valueSetVersion: null)]
+    public CqlValueSet Telephone_Visits(CqlContext _) => _Telephone_Visits;
+    private static readonly CqlValueSet _Telephone_Visits = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Adolescent depression screening assessment", codeId: "73831-0", codeSystem: "http://loinc.org")]
+    public CqlCode Adolescent_depression_screening_assessment(CqlContext _) => _Adolescent_depression_screening_assessment;
+    private static readonly CqlCode _Adolescent_depression_screening_assessment = new CqlCode("73831-0", "http://loinc.org");
+
+    [CqlCodeDefinition("Adult depression screening assessment", codeId: "73832-8", codeSystem: "http://loinc.org")]
+    public CqlCode Adult_depression_screening_assessment(CqlContext _) => _Adult_depression_screening_assessment;
+    private static readonly CqlCode _Adult_depression_screening_assessment = new CqlCode("73832-8", "http://loinc.org");
+
+    [CqlCodeDefinition("Depression screening declined (situation)", codeId: "720834000", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_declined__situation_(CqlContext _) => _Depression_screening_declined__situation_;
+    private static readonly CqlCode _Depression_screening_declined__situation_ = new CqlCode("720834000", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening negative (finding)", codeId: "428171000124102", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_negative__finding_(CqlContext _) => _Depression_screening_negative__finding_;
+    private static readonly CqlCode _Depression_screening_negative__finding_ = new CqlCode("428171000124102", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening positive (finding)", codeId: "428181000124104", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_positive__finding_(CqlContext _) => _Depression_screening_positive__finding_;
+    private static readonly CqlCode _Depression_screening_positive__finding_ = new CqlCode("428181000124104", "http://snomed.info/sct");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("LOINC", codeSystemId: "http://loinc.org", codeSystemVersion: null)]
+    public CqlCodeSystem LOINC(CqlContext _) => _LOINC;
+    private static readonly CqlCodeSystem _LOINC =
+      new CqlCodeSystem("http://loinc.org", null, [
+          _Adolescent_depression_screening_assessment,
+          _Adult_depression_screening_assessment]);
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Depression_screening_declined__situation_,
+          _Depression_screening_negative__finding_,
+          _Depression_screening_positive__finding_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, 0.0m);
+        CqlDateTime b_ = context.Operators.DateTime(2025, 12, 31, 23, 59, 59, 999, 0.0m);
+        CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, true);
+        object d_ = context.ResolveParameter("PCSDepressionScreenAndFollowUpFHIR-0.2.000", "Measurement Period", c_);
+
+        return (CqlInterval<CqlDateTime>)d_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 12);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Encounter_to_Screen_for_Depression(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Physical_Therapy_Evaluation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Telephone_Visits(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
+        bool? i_(Encounter QualifyingEncounter)
+        {
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            Period l_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, "day");
+            Code<Encounter.EncounterStatus> o_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? p_ = o_?.Value;
+            Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+            bool? r_ = context.Operators.Equal(q_, "finished");
+            bool? s_ = context.Operators.And(n_, r_);
+
+            return s_;
+        };
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public bool? Initial_Population(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator")]
+    public bool? Denominator(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("History of Bipolar Diagnosis Before Qualifying Encounter")]
+    public IEnumerable<Condition> History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bipolar_Disorder(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition"));
+        IEnumerable<Condition> c_(Condition BipolarDiagnosis)
+        {
+            IEnumerable<Encounter> e_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? f_(Encounter QualifyingEncounter)
+            {
+                bool? j_ = QICoreCommon_2_1_000.Instance.isProblemListItem(context, BipolarDiagnosis);
+                bool? k_ = QICoreCommon_2_1_000.Instance.isHealthConcern(context, BipolarDiagnosis);
+                bool? l_ = context.Operators.Or(j_, k_);
+                CqlInterval<CqlDateTime> m_()
+                {
+                    bool r_()
+                    {
+                        CqlInterval<CqlDateTime> s_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, BipolarDiagnosis);
+                        CqlDateTime t_ = context.Operators.Start(s_);
+
+                        return t_ is null;
+                    };
+                    if (r_())
+                    {
+                        return default;
+                    }
+                    else
+                    {
+                        CqlInterval<CqlDateTime> u_ = QICoreCommon_2_1_000.Instance.prevalenceInterval(context, BipolarDiagnosis);
+                        CqlDateTime v_ = context.Operators.Start(u_);
+                        CqlDateTime x_ = context.Operators.Start(u_);
+                        CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
+
+                        return y_;
+                    }
+                };
+                Period n_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                bool? p_ = context.Operators.Before(m_(), o_, default);
+                bool? q_ = context.Operators.And(l_, p_);
+
+                return q_;
+            };
+            IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+            Condition h_(Encounter QualifyingEncounter) =>
+                BipolarDiagnosis;
+            IEnumerable<Condition> i_ = context.Operators.Select<Encounter, Condition>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exclusions")]
+    public bool? Denominator_Exclusions(CqlContext context)
+    {
+        IEnumerable<Condition> a_ = this.History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(context);
+        bool? b_ = context.Operators.Exists<Condition>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 to 16 Years at Start of Measurement Period")]
+    public bool? Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        CqlInterval<int?> i_ = context.Operators.Interval(12, 16, true, true);
+        bool? j_ = context.Operators.In<int?>(h_, i_, default);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening")]
+    public Observation Most_Recent_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation"));
+        IEnumerable<Observation> d_(Observation AdolescentDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdolescentDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_2_1_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdolescentDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdolescentDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+                bool? an_ = context.Operators.Equal(am_, "final");
+                bool? ao_ = context.Operators.And(aj_, an_);
+
+                return ao_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdolescentDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType ap_ = @this?.Effective;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_1_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.Start(ar_);
+
+            return as_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adolescent Screening Negative")]
+    public bool? Has_Most_Recent_Adolescent_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdolescentScreen)
+        {
+            DataType g_ = AdolescentScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adolescent Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adolescent_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adolescent_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        bool? g_(MedicationRequest AdolescentMed)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> ah_ = AdolescentMed?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            string[] ak_ = [
+                "active",
+                "completed",
+            ];
+            bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+            Code<MedicationRequest.MedicationRequestIntent> am_ = AdolescentMed?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? an_ = am_?.Value;
+            string ao_ = context.Operators.Convert<string>(an_);
+            bool? ap_ = context.Operators.Equal(ao_, "order");
+            bool? aq_ = context.Operators.And(al_, ap_);
+
+            return aq_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adolescent_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdolescentReferral)
+        {
+            Code<RequestStatus> ar_ = AdolescentReferral?.StatusElement;
+            RequestStatus? as_ = ar_?.Value;
+            Code<RequestStatus> at_ = context.Operators.Convert<Code<RequestStatus>>(as_);
+            string au_ = context.Operators.Convert<string>(at_);
+            string[] av_ = [
+                "active",
+                "completed",
+            ];
+            bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+
+            return aw_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adolescent_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdolescentFollowUp)
+        {
+            Code<EventStatus> ax_ = AdolescentFollowUp?.StatusElement;
+            EventStatus? ay_ = ax_?.Value;
+            string az_ = context.Operators.Convert<string>(ay_);
+            bool? ba_ = context.Operators.Equal(az_, "completed");
+
+            return ba_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            DataType n_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_2_1_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_1_000.Instance.toInterval(context, an_);
+            CqlDateTime ap_ = context.Operators.Start(ao_);
+            CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, default);
+            object at_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
+            CqlDateTime au_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
+            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ba_ = context.Operators.End(az_);
+            CqlQuantity bb_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bc_ = context.Operators.Add(ba_, bb_);
+            CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(ax_, bc_, true, true);
+            bool? be_ = context.Operators.In<CqlDateTime>(au_, bd_, "day");
+            CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bh_ = context.Operators.End(bg_);
+            bool? bi_ = context.Operators.Not((bool?)(bh_ is null));
+            bool? bj_ = context.Operators.And(be_, bi_);
+            bool? bk_ = context.Operators.Or(as_, bj_);
+            bool? bl_ = context.Operators.And(al_, bk_);
+            object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_1_000.Instance.toInterval(context, bn_);
+            CqlDateTime bp_ = context.Operators.Start(bo_);
+            CqlDateTime br_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
+            CqlInterval<CqlDateTime> bs_ = this.Measurement_Period(context);
+            bool? bt_ = context.Operators.In<CqlDateTime>(bp_ ?? br_, bs_, "day");
+            bool? bu_ = context.Operators.And(bl_, bt_);
+
+            return bu_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? bv_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter);
+
+            return bv_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 17 Years at Start of Measurement Period")]
+    public bool? Patient_Age_17_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.Equal(h_, 17);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening")]
+    public Observation Most_Recent_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation"));
+        IEnumerable<Observation> d_(Observation AdultDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdultDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_2_1_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdultDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdultDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+                bool? an_ = context.Operators.Equal(am_, "final");
+                bool? ao_ = context.Operators.And(aj_, an_);
+
+                return ao_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdultDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType ap_ = @this?.Effective;
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+            CqlInterval<CqlDateTime> ar_ = QICoreCommon_2_1_000.Instance.toInterval(context, aq_);
+            CqlDateTime as_ = context.Operators.Start(ar_);
+
+            return as_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adult Screening Negative")]
+    public bool? Has_Most_Recent_Adult_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdultScreen)
+        {
+            DataType g_ = AdultScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adult Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adult_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adult_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        bool? g_(MedicationRequest AdultMed)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> ah_ = AdultMed?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ai_ = ah_?.Value;
+            string aj_ = context.Operators.Convert<string>(ai_);
+            string[] ak_ = [
+                "active",
+                "completed",
+            ];
+            bool? al_ = context.Operators.In<string>(aj_, (IEnumerable<string>)ak_);
+            Code<MedicationRequest.MedicationRequestIntent> am_ = AdultMed?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? an_ = am_?.Value;
+            string ao_ = context.Operators.Convert<string>(an_);
+            bool? ap_ = context.Operators.Equal(ao_, "order");
+            bool? aq_ = context.Operators.And(al_, ap_);
+
+            return aq_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adult_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdultReferral)
+        {
+            Code<RequestStatus> ar_ = AdultReferral?.StatusElement;
+            RequestStatus? as_ = ar_?.Value;
+            Code<RequestStatus> at_ = context.Operators.Convert<Code<RequestStatus>>(as_);
+            string au_ = context.Operators.Convert<string>(at_);
+            string[] av_ = [
+                "active",
+                "completed",
+            ];
+            bool? aw_ = context.Operators.In<string>(au_, (IEnumerable<string>)av_);
+
+            return aw_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adult_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdultFollowUp)
+        {
+            Code<EventStatus> ax_ = AdultFollowUp?.StatusElement;
+            EventStatus? ay_ = ax_?.Value;
+            string az_ = context.Operators.Convert<string>(ay_);
+            bool? ba_ = context.Operators.Equal(az_, "completed");
+
+            return ba_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            DataType n_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_2_1_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+            object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlInterval<CqlDateTime> ao_ = QICoreCommon_2_1_000.Instance.toInterval(context, an_);
+            CqlDateTime ap_ = context.Operators.Start(ao_);
+            CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? as_ = context.Operators.In<CqlDateTime>(ap_, ar_, default);
+            object at_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
+            CqlDateTime au_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
+            CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ax_ = context.Operators.End(aw_);
+            CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ba_ = context.Operators.End(az_);
+            CqlQuantity bb_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bc_ = context.Operators.Add(ba_, bb_);
+            CqlInterval<CqlDateTime> bd_ = context.Operators.Interval(ax_, bc_, true, true);
+            bool? be_ = context.Operators.In<CqlDateTime>(au_, bd_, "day");
+            CqlInterval<CqlDateTime> bg_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bh_ = context.Operators.End(bg_);
+            bool? bi_ = context.Operators.Not((bool?)(bh_ is null));
+            bool? bj_ = context.Operators.And(be_, bi_);
+            bool? bk_ = context.Operators.Or(as_, bj_);
+            bool? bl_ = context.Operators.And(al_, bk_);
+            object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+            CqlInterval<CqlDateTime> bo_ = QICoreCommon_2_1_000.Instance.toInterval(context, bn_);
+            CqlDateTime bp_ = context.Operators.Start(bo_);
+            CqlDateTime br_ = context.Operators.LateBoundProperty<CqlDateTime>(at_, "value");
+            CqlInterval<CqlDateTime> bs_ = this.Measurement_Period(context);
+            bool? bt_ = context.Operators.In<CqlDateTime>(bp_ ?? br_, bs_, "day");
+            bool? bu_ = context.Operators.And(bl_, bt_);
+
+            return bu_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? bv_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter);
+
+            return bv_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 18 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator")]
+    public bool? Numerator(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(context);
+        bool? b_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> c_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? d_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? e_ = context.Operators.Or(b_, d_);
+        bool? f_ = context.Operators.And(a_, e_);
+        bool? g_ = this.Patient_Age_17_Years_at_Start_of_Measurement_Period(context);
+        bool? j_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? k_ = context.Operators.Or(b_, j_);
+        bool? l_ = this.Has_Most_Recent_Adult_Screening_Negative(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> n_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? o_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? p_ = context.Operators.Or(m_, o_);
+        bool? q_ = context.Operators.And(g_, p_);
+        bool? r_ = context.Operators.Or(f_, q_);
+        bool? s_ = this.Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(context);
+        bool? v_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? w_ = context.Operators.Or(l_, v_);
+        bool? x_ = context.Operators.And(s_, w_);
+        bool? y_ = context.Operators.Or(r_, x_);
+
+        return y_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adolescent for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone"));
+        IEnumerable<Observation> d_(Observation NoAdolescentScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdolescentScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, default);
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdolescentScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdolescentScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string au_ = @this?.Url;
+                FhirString av_ = context.Operators.Convert<FhirString>(au_);
+                string aw_ = FHIRHelpers_4_4_000.Instance.ToString(context, av_);
+                bool? ax_ = context.Operators.Equal(aw_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return ax_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType ay_ = @this?.Value;
+
+                return ay_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+            Code<ObservationStatus> ak_ = NoAdolescentScreen?.StatusElement;
+            ObservationStatus? al_ = ak_?.Value;
+            Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+            bool? an_ = context.Operators.Equal(am_, "cancelled");
+            bool? ao_ = context.Operators.And(aj_, an_);
+
+            return ao_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adolescent Depression Screening")]
+    public bool? Has_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation"));
+        IEnumerable<Observation> d_(Observation AdolescentScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdolescentScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_2_1_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdolescentScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdolescentScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                Code<ObservationStatus> ak_ = context.Operators.Convert<Code<ObservationStatus>>(aj_);
+                bool? al_ = context.Operators.Equal(ak_, "final");
+                bool? am_ = context.Operators.And(ah_, al_);
+
+                return am_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdolescentScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adult for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationnotdone"));
+        IEnumerable<Observation> d_(Observation NoAdultScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdultScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, default);
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdultScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdultScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string au_ = @this?.Url;
+                FhirString av_ = context.Operators.Convert<FhirString>(au_);
+                string aw_ = FHIRHelpers_4_4_000.Instance.ToString(context, av_);
+                bool? ax_ = context.Operators.Equal(aw_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return ax_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType ay_ = @this?.Value;
+
+                return ay_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+            Code<ObservationStatus> ak_ = NoAdultScreen?.StatusElement;
+            ObservationStatus? al_ = ak_?.Value;
+            Code<ObservationStatus> am_ = context.Operators.Convert<Code<ObservationStatus>>(al_);
+            bool? an_ = context.Operators.Equal(am_, "cancelled");
+            bool? ao_ = context.Operators.And(aj_, an_);
+
+            return ao_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adult Depression Screening")]
+    public bool? Has_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation"));
+        IEnumerable<Observation> d_(Observation AdultScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdultScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_2_1_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdultScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdultScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                Code<ObservationStatus> ak_ = context.Operators.Convert<Code<ObservationStatus>>(aj_);
+                bool? al_ = context.Operators.Equal(ak_, "final");
+                bool? am_ = context.Operators.And(ah_, al_);
+
+                return am_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdultScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions")]
+    public bool? Denominator_Exceptions(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(context);
+        bool? b_ = context.Operators.Exists<Observation>(a_);
+        bool? c_ = this.Has_Adolescent_Depression_Screening(context);
+        bool? d_ = context.Operators.Not(c_);
+        bool? e_ = context.Operators.And(b_, d_);
+        IEnumerable<Observation> f_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(context);
+        bool? g_ = context.Operators.Exists<Observation>(f_);
+        bool? h_ = this.Has_Adult_Depression_Screening(context);
+        bool? i_ = context.Operators.Not(h_);
+        bool? j_ = context.Operators.And(g_, i_);
+        bool? k_ = context.Operators.Or(e_, j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_3_5_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_3_5_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_3_5_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_3_5_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdultScreen", "FollowUpPositiveAdultScreen", "QualifyingEncounter"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdolescentScreen", "FollowUpPositiveAdolescentScreen", "QualifyingEncounter"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD-0.4.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD-0.4.000.g.cs
@@ -1,0 +1,2045 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD", "0.4.000")]
+public partial class CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD_0_4_000 : ILibrary, ISingleton<CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD_0_4_000>
+{
+    private CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD_0_4_000() {}
+
+    public static CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD_0_4_000 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD";
+    public string Version => "0.4.000";
+    public ILibrary[] Dependencies => [FHIRHelpers_4_4_000.Instance, SupplementalDataElements_5_1_000.Instance, QICoreCommon_4_0_000.Instance, AHAOverall_3_0_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Allergy to Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", valueSetVersion: null)]
+    public CqlValueSet Allergy_to_Beta_Blocker_Therapy(CqlContext _) => _Allergy_to_Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Allergy_to_Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1177", null);
+
+    [CqlValueSetDefinition("Arrhythmia", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", valueSetVersion: null)]
+    public CqlValueSet Arrhythmia(CqlContext _) => _Arrhythmia;
+    private static readonly CqlValueSet _Arrhythmia = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.366", null);
+
+    [CqlValueSetDefinition("Asthma", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", valueSetVersion: null)]
+    public CqlValueSet Asthma(CqlContext _) => _Asthma;
+    private static readonly CqlValueSet _Asthma = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.362", null);
+
+    [CqlValueSetDefinition("Atrioventricular Block", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", valueSetVersion: null)]
+    public CqlValueSet Atrioventricular_Block(CqlContext _) => _Atrioventricular_Block;
+    private static readonly CqlValueSet _Atrioventricular_Block = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.367", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy(CqlContext _) => _Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1174", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy for LVSD", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy_for_LVSD(CqlContext _) => _Beta_Blocker_Therapy_for_LVSD;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy_for_LVSD = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1184", null);
+
+    [CqlValueSetDefinition("Beta Blocker Therapy Ingredient", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", valueSetVersion: null)]
+    public CqlValueSet Beta_Blocker_Therapy_Ingredient(CqlContext _) => _Beta_Blocker_Therapy_Ingredient;
+    private static readonly CqlValueSet _Beta_Blocker_Therapy_Ingredient = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1493", null);
+
+    [CqlValueSetDefinition("Bradycardia", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", valueSetVersion: null)]
+    public CqlValueSet Bradycardia(CqlContext _) => _Bradycardia;
+    private static readonly CqlValueSet _Bradycardia = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.412", null);
+
+    [CqlValueSetDefinition("Cardiac Pacer", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Pacer(CqlContext _) => _Cardiac_Pacer;
+    private static readonly CqlValueSet _Cardiac_Pacer = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1178.53", null);
+
+    [CqlValueSetDefinition("Cardiac Pacer in Situ", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Pacer_in_Situ(CqlContext _) => _Cardiac_Pacer_in_Situ;
+    private static readonly CqlValueSet _Cardiac_Pacer_in_Situ = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.368", null);
+
+    [CqlValueSetDefinition("Cardiac Surgery", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371", valueSetVersion: null)]
+    public CqlValueSet Cardiac_Surgery(CqlContext _) => _Cardiac_Surgery;
+    private static readonly CqlValueSet _Cardiac_Surgery = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.371", null);
+
+    [CqlValueSetDefinition("Care Services in Long Term Residential Facility", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", valueSetVersion: null)]
+    public CqlValueSet Care_Services_in_Long_Term_Residential_Facility(CqlContext _) => _Care_Services_in_Long_Term_Residential_Facility;
+    private static readonly CqlValueSet _Care_Services_in_Long_Term_Residential_Facility = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014", null);
+
+    [CqlValueSetDefinition("Coronary Artery Disease No MI", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369", valueSetVersion: null)]
+    public CqlValueSet Coronary_Artery_Disease_No_MI(CqlContext _) => _Coronary_Artery_Disease_No_MI;
+    private static readonly CqlValueSet _Coronary_Artery_Disease_No_MI = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.369", null);
+
+    [CqlValueSetDefinition("Ejection Fraction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", valueSetVersion: null)]
+    public CqlValueSet Ejection_Fraction(CqlContext _) => _Ejection_Fraction;
+    private static readonly CqlValueSet _Ejection_Fraction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1134", null);
+
+    [CqlValueSetDefinition("Face-to-Face Interaction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", valueSetVersion: null)]
+    public CqlValueSet Face_to_Face_Interaction(CqlContext _) => _Face_to_Face_Interaction;
+    private static readonly CqlValueSet _Face_to_Face_Interaction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1048", null);
+
+    [CqlValueSetDefinition("Home Healthcare Services", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", valueSetVersion: null)]
+    public CqlValueSet Home_Healthcare_Services(CqlContext _) => _Home_Healthcare_Services;
+    private static readonly CqlValueSet _Home_Healthcare_Services = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016", null);
+
+    [CqlValueSetDefinition("Hypotension", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", valueSetVersion: null)]
+    public CqlValueSet Hypotension(CqlContext _) => _Hypotension;
+    private static readonly CqlValueSet _Hypotension = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.370", null);
+
+    [CqlValueSetDefinition("Intolerance to Beta Blocker Therapy", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", valueSetVersion: null)]
+    public CqlValueSet Intolerance_to_Beta_Blocker_Therapy(CqlContext _) => _Intolerance_to_Beta_Blocker_Therapy;
+    private static readonly CqlValueSet _Intolerance_to_Beta_Blocker_Therapy = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1178", null);
+
+    [CqlValueSetDefinition("Medical Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", valueSetVersion: null)]
+    public CqlValueSet Medical_Reason(CqlContext _) => _Medical_Reason;
+    private static readonly CqlValueSet _Medical_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlValueSetDefinition("Moderate or Severe", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", valueSetVersion: null)]
+    public CqlValueSet Moderate_or_Severe(CqlContext _) => _Moderate_or_Severe;
+    private static readonly CqlValueSet _Moderate_or_Severe = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1092", null);
+
+    [CqlValueSetDefinition("Moderate or Severe LVSD", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", valueSetVersion: null)]
+    public CqlValueSet Moderate_or_Severe_LVSD(CqlContext _) => _Moderate_or_Severe_LVSD;
+    private static readonly CqlValueSet _Moderate_or_Severe_LVSD = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1090", null);
+
+    [CqlValueSetDefinition("Myocardial Infarction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", valueSetVersion: null)]
+    public CqlValueSet Myocardial_Infarction(CqlContext _) => _Myocardial_Infarction;
+    private static readonly CqlValueSet _Myocardial_Infarction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.403", null);
+
+    [CqlValueSetDefinition("Nursing Facility Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", valueSetVersion: null)]
+    public CqlValueSet Nursing_Facility_Visit(CqlContext _) => _Nursing_Facility_Visit;
+    private static readonly CqlValueSet _Nursing_Facility_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012", null);
+
+    [CqlValueSetDefinition("Office Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", valueSetVersion: null)]
+    public CqlValueSet Office_Visit(CqlContext _) => _Office_Visit;
+    private static readonly CqlValueSet _Office_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlValueSetDefinition("Outpatient Consultation", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", valueSetVersion: null)]
+    public CqlValueSet Outpatient_Consultation(CqlContext _) => _Outpatient_Consultation;
+    private static readonly CqlValueSet _Outpatient_Consultation = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1008", null);
+
+    [CqlValueSetDefinition("Patient Provider Interaction", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", valueSetVersion: null)]
+    public CqlValueSet Patient_Provider_Interaction(CqlContext _) => _Patient_Provider_Interaction;
+    private static readonly CqlValueSet _Patient_Provider_Interaction = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1012", null);
+
+    [CqlValueSetDefinition("Patient Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", valueSetVersion: null)]
+    public CqlValueSet Patient_Reason(CqlContext _) => _Patient_Reason;
+    private static readonly CqlValueSet _Patient_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008", null);
+
+    [CqlValueSetDefinition("System Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009", valueSetVersion: null)]
+    public CqlValueSet System_Reason(CqlContext _) => _System_Reason;
+    private static readonly CqlValueSet _System_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1009", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Substance with beta adrenergic receptor antagonist mechanism of action (substance)", codeId: "373254001", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(CqlContext _) => _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_;
+    private static readonly CqlCode _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_ = new CqlCode("373254001", "http://snomed.info/sct");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        object a_ = context.ResolveParameter("CMS145FHIRCADBetaBlockerTherapyPriorMIorLVSD-0.4.000", "Measurement Period", null);
+
+        return (CqlInterval<CqlDateTime>)a_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Office_Visit(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Outpatient_Consultation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Nursing_Facility_Visit(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet h_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+        IEnumerable<Encounter> i_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+        CqlValueSet l_ = this.Home_Healthcare_Services(context);
+        IEnumerable<Encounter> m_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet n_ = this.Patient_Provider_Interaction(context);
+        IEnumerable<Encounter> o_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> p_ = context.Operators.Union<Encounter>(m_, o_);
+        IEnumerable<Encounter> q_ = context.Operators.Union<Encounter>(k_, p_);
+        bool? r_(Encounter ValidEncounter)
+        {
+            CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
+            Period u_ = ValidEncounter?.Period;
+            CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
+            bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, "day");
+            Code<Encounter.EncounterStatus> x_ = ValidEncounter?.StatusElement;
+            Encounter.EncounterStatus? y_ = x_?.Value;
+            Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
+            bool? aa_ = context.Operators.Equal(z_, "finished");
+            bool? ab_ = context.Operators.And(w_, aa_);
+
+            return ab_;
+        };
+        IEnumerable<Encounter> s_ = context.Operators.Where<Encounter>(q_, r_);
+
+        return s_;
+    }
+
+
+    [CqlExpressionDefinition("Outpatient Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Outpatient_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Office_Visit(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Outpatient_Consultation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Care_Services_in_Long_Term_Residential_Facility(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet h_ = this.Home_Healthcare_Services(context);
+        IEnumerable<Encounter> i_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, h_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(g_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(e_, j_);
+        CqlValueSet l_ = this.Nursing_Facility_Visit(context);
+        IEnumerable<Encounter> m_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, l_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> n_ = context.Operators.Union<Encounter>(k_, m_);
+        bool? o_(Encounter QualifyingEncounter)
+        {
+            CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+            Period r_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, "day");
+            Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? v_ = u_?.Value;
+            Code<Encounter.EncounterStatus> w_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(v_);
+            bool? x_ = context.Operators.Equal(w_, "finished");
+            bool? y_ = context.Operators.And(t_, x_);
+
+            return y_;
+        };
+        IEnumerable<Encounter> p_ = context.Operators.Where<Encounter>(n_, o_);
+
+        return p_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsDayOfEncounter")]
+    public bool? overlapsDayOfEncounter(CqlContext context, Condition Diagnosis, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? g_ = QICoreCommon_4_0_000.Instance.isActive(context, Diagnosis as object);
+
+            return g_;
+        };
+        IEnumerable<Encounter> b_ = context.Operators.Where<Encounter>(EncounterList, a_);
+        bool? c_(Encounter Visit)
+        {
+            CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Diagnosis as object);
+            Period i_ = Visit?.Period;
+            CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+            bool? k_ = context.Operators.Overlaps(h_, j_, "day");
+
+            return k_;
+        };
+        IEnumerable<bool?> d_ = context.Operators.Select<Encounter, bool?>(b_, c_);
+        IEnumerable<bool?> e_ = context.Operators.Distinct<bool?>(d_);
+        bool? f_ = context.Operators.AnyTrue(e_);
+
+        return f_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsDayOfEncounter")]
+    public bool? overlapsDayOfEncounter(CqlContext context, Condition Diagnosis, Encounter TheEncounter)
+    {
+        Encounter[] a_ = [
+            TheEncounter,
+        ];
+        bool? b_(Encounter Visit)
+        {
+            bool? h_ = AHAOverall_3_0_000.Instance.isConfirmedActiveDiagnosis(context, Diagnosis as object);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>((IEnumerable<Encounter>)a_, b_);
+        bool? d_(Encounter Visit)
+        {
+            CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Diagnosis as object);
+            Period j_ = Visit?.Period;
+            CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
+            bool? l_ = context.Operators.Overlaps(i_, k_, "day");
+
+            return l_;
+        };
+        IEnumerable<bool?> e_ = context.Operators.Select<Encounter, bool?>(c_, d_);
+        IEnumerable<bool?> f_ = context.Operators.Distinct<bool?>(e_);
+        bool? g_ = context.Operators.SingletonFrom<bool?>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Coronary Artery Disease Encounter")]
+    public IEnumerable<Encounter> Coronary_Artery_Disease_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+        {
+            CqlValueSet d_ = this.Coronary_Artery_Disease_No_MI(context);
+            IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            bool? f_(Condition CoronaryArteryDisease)
+            {
+                bool? j_ = this.overlapsDayOfEncounter(context, CoronaryArteryDisease, ValidQualifyingEncounter);
+
+                return j_;
+            };
+            IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+            Encounter h_(Condition CoronaryArteryDisease) =>
+                ValidQualifyingEncounter;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("History of Cardiac Surgery Prior to Encounter")]
+    public IEnumerable<Encounter> History_of_Cardiac_Surgery_Prior_to_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Outpatient_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> b_(Encounter ValidQualifyingEncounter)
+        {
+            CqlValueSet d_ = this.Cardiac_Surgery(context);
+            IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            bool? f_(Procedure CardiacSurgeryProcedure)
+            {
+                object j_()
+                {
+                    bool v_()
+                    {
+                        DataType z_ = CardiacSurgeryProcedure?.Performed;
+                        object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+                        bool ab_ = aa_ is CqlDateTime;
+
+                        return ab_;
+                    };
+                    bool w_()
+                    {
+                        DataType ac_ = CardiacSurgeryProcedure?.Performed;
+                        object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
+                        bool ae_ = ad_ is CqlInterval<CqlDateTime>;
+
+                        return ae_;
+                    };
+                    bool x_()
+                    {
+                        DataType af_ = CardiacSurgeryProcedure?.Performed;
+                        object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, af_);
+                        bool ah_ = ag_ is CqlQuantity;
+
+                        return ah_;
+                    };
+                    bool y_()
+                    {
+                        DataType ai_ = CardiacSurgeryProcedure?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+                        bool ak_ = aj_ is CqlInterval<CqlQuantity>;
+
+                        return ak_;
+                    };
+                    if (v_())
+                    {
+                        DataType al_ = CardiacSurgeryProcedure?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+
+                        return (am_ as CqlDateTime) as object;
+                    }
+                    else if (w_())
+                    {
+                        DataType an_ = CardiacSurgeryProcedure?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+
+                        return (ao_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (x_())
+                    {
+                        DataType ap_ = CardiacSurgeryProcedure?.Performed;
+                        object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+
+                        return (aq_ as CqlQuantity) as object;
+                    }
+                    else if (y_())
+                    {
+                        DataType ar_ = CardiacSurgeryProcedure?.Performed;
+                        object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+
+                        return (as_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                };
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                Period m_ = ValidQualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                bool? p_ = context.Operators.Before(l_, o_, default);
+                Code<EventStatus> q_ = CardiacSurgeryProcedure?.StatusElement;
+                EventStatus? r_ = q_?.Value;
+                string s_ = context.Operators.Convert<string>(r_);
+                bool? t_ = context.Operators.Equal(s_, "completed");
+                bool? u_ = context.Operators.And(p_, t_);
+
+                return u_;
+            };
+            IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
+            Encounter h_(Procedure CardiacSurgeryProcedure) =>
+                ValidQualifyingEncounter;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Coronary_Artery_Disease_Encounter(context);
+        IEnumerable<Encounter> b_ = this.History_of_Cardiac_Surgery_Prior_to_Encounter(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public bool? Initial_Population(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+        IEnumerable<Encounter> j_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<Encounter> k_(Encounter Encounter1)
+        {
+            IEnumerable<Encounter> r_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? s_(Encounter Encounter2)
+            {
+                Id w_ = Encounter2?.IdElement;
+                string x_ = w_?.Value;
+                Id y_ = Encounter1?.IdElement;
+                string z_ = y_?.Value;
+                bool? aa_ = context.Operators.Equivalent(x_, z_);
+                bool? ab_ = context.Operators.Not(aa_);
+
+                return ab_;
+            };
+            IEnumerable<Encounter> t_ = context.Operators.Where<Encounter>(r_, s_);
+            Encounter u_(Encounter Encounter2) =>
+                Encounter1;
+            IEnumerable<Encounter> v_ = context.Operators.Select<Encounter, Encounter>(t_, u_);
+
+            return v_;
+        };
+        IEnumerable<Encounter> l_ = context.Operators.SelectMany<Encounter, Encounter>(j_, k_);
+        bool? m_ = context.Operators.Exists<Encounter>(l_);
+        bool? n_ = context.Operators.And(i_, m_);
+        IEnumerable<Encounter> o_ = this.Qualifying_CAD_Encounter(context);
+        bool? p_ = context.Operators.Exists<Encounter>(o_);
+        bool? q_ = context.Operators.And(n_, p_);
+
+        return q_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter and Prior MI")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
+        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy)
+        {
+            CqlValueSet d_ = this.Myocardial_Infarction(context);
+            IEnumerable<Condition> e_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+            bool? f_(Condition MyocardialInfarction)
+            {
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MyocardialInfarction as object);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                CqlQuantity o_ = context.Operators.Quantity(3m, "years");
+                CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
+                bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, "day");
+                CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime x_ = context.Operators.Start(w_);
+                bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                bool? z_ = context.Operators.And(u_, y_);
+                IEnumerable<object> aa_ = AHAOverall_3_0_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+                bool? ab_ = context.Operators.Exists<object>(aa_);
+                bool? ac_ = context.Operators.Not(ab_);
+                bool? ad_ = context.Operators.And(z_, ac_);
+
+                return ad_;
+            };
+            IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+            Encounter h_(Condition MyocardialInfarction) =>
+                EncounterWithCADProxy;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Condition, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator 2")]
+    public bool? Denominator_2(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Atrioventricular_Block(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition AtrioventricularBlockDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AtrioventricularBlockDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Cardiac Pacer in Situ with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer_in_Situ(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition CardiacPacerDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, CardiacPacerDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Cardiac Pacer Device Implanted with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_(Encounter CADEncounterMI)
+            {
+                object k_()
+                {
+                    bool r_()
+                    {
+                        DataType v_ = ImplantedCardiacPacer?.Performed;
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+
+                        return x_;
+                    };
+                    bool s_()
+                    {
+                        DataType y_ = ImplantedCardiacPacer?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+
+                        return aa_;
+                    };
+                    bool t_()
+                    {
+                        DataType ab_ = ImplantedCardiacPacer?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+
+                        return ad_;
+                    };
+                    bool u_()
+                    {
+                        DataType ae_ = ImplantedCardiacPacer?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+
+                        return ag_;
+                    };
+                    if (r_())
+                    {
+                        DataType ah_ = ImplantedCardiacPacer?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType aj_ = ImplantedCardiacPacer?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType al_ = ImplantedCardiacPacer?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+
+                        return (am_ as CqlQuantity) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType an_ = ImplantedCardiacPacer?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                };
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+                CqlDateTime m_ = context.Operators.Start(l_);
+                Period n_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                bool? q_ = context.Operators.Before(m_, p_, default);
+
+                return q_;
+            };
+            IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+            Procedure i_(Encounter CADEncounterMI) =>
+                ImplantedCardiacPacer;
+            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
+
+            return j_;
+        };
+        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        bool? e_ = context.Operators.Exists<Procedure>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and Prior MI without Cardiac Pacer")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI_without_Cardiac_Pacer(CqlContext context)
+    {
+        bool? a_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Not(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+        bool? e_ = this.Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? f_ = context.Operators.Not(e_);
+        bool? g_ = context.Operators.And(d_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Consecutive Heart Rates Less than 50 with Qualifying CAD Encounter and Prior MI")]
+    [CqlTag("code", "Heart rate - 8867-4")]
+    [CqlTag("profile", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate")]
+    public bool? Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+        IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+        (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? d_(ValueTuple<Observation, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? l_ = (CqlTupleMetadata_GgEMjKUjZUgEdXjOgPVEWONDD, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(c_, d_);
+        bool? f_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? tuple_ezawxthbubhdjanfnawxfxgjj)
+        {
+            Period m_ = tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI?.Period;
+            CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+            DataType o_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+            Code<ObservationStatus> s_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.StatusElement;
+            ObservationStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            string[] v_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+            bool? x_ = context.Operators.And(r_, w_);
+            DataType y_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Value;
+            CqlQuantity z_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, y_ as Quantity);
+            CqlQuantity aa_ = context.Operators.Quantity(50m, "/min");
+            bool? ab_ = context.Operators.Less(z_, aa_);
+            bool? ac_ = context.Operators.And(x_, ab_);
+            IEnumerable<Observation> ad_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
+            bool? ae_(Observation MostRecentPriorHeartRateExam)
+            {
+                Period ao_ = tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
+                DataType aq_ = MostRecentPriorHeartRateExam?.Effective;
+                object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+                bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
+                Code<ObservationStatus> au_ = MostRecentPriorHeartRateExam?.StatusElement;
+                ObservationStatus? av_ = au_?.Value;
+                string aw_ = context.Operators.Convert<string>(av_);
+                string[] ax_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                bool? ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
+                bool? az_ = context.Operators.And(at_, ay_);
+                object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                CqlInterval<CqlDateTime> bc_ = QICoreCommon_4_0_000.Instance.toInterval(context, bb_);
+                DataType bd_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
+                object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
+                CqlInterval<CqlDateTime> bf_ = QICoreCommon_4_0_000.Instance.toInterval(context, be_);
+                bool? bg_ = context.Operators.Before(bc_, bf_, default);
+                bool? bh_ = context.Operators.And(az_, bg_);
+
+                return bh_;
+            };
+            IEnumerable<Observation> af_ = context.Operators.Where<Observation>(ad_, ae_);
+            object ag_(Observation @this)
+            {
+                DataType bi_ = @this?.Effective;
+                object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                CqlInterval<CqlDateTime> bk_ = QICoreCommon_4_0_000.Instance.toInterval(context, bj_);
+                CqlDateTime bl_ = context.Operators.Start(bk_);
+
+                return bl_;
+            };
+            IEnumerable<Observation> ah_ = context.Operators.SortBy<Observation>(af_, ag_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ai_ = context.Operators.Last<Observation>(ah_);
+            DataType aj_ = ai_?.Value;
+            CqlQuantity ak_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, aj_ as Quantity);
+            bool? am_ = context.Operators.Less(ak_, aa_);
+            bool? an_ = context.Operators.And(ac_, am_);
+
+            return an_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> g_ = context.Operators.Where<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(e_, f_);
+        (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? h_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? tuple_ezawxthbubhdjanfnawxfxgjj)
+        {
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)? bm_ = (CqlTupleMetadata_GgEMjKUjZUgEdXjOgPVEWONDD, tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam, tuple_ezawxthbubhdjanfnawxfxgjj?.CADEncounterMI);
+
+            return bm_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> i_ = context.Operators.Select<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(g_, h_);
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?> j_ = context.Operators.Distinct<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(i_);
+        bool? k_ = context.Operators.Exists<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterMI)?>(j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public IEnumerable<Encounter> Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Qualifying_CAD_Encounter(context);
+        IEnumerable<Encounter> b_(Encounter EncounterWithCADProxy)
+        {
+            IEnumerable<object> d_ = AHAOverall_3_0_000.Instance.Moderate_or_Severe_LVSD_Findings(context);
+            bool? e_(object LVSDFindings)
+            {
+                CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, LVSDFindings as object);
+                object j_ = context.Operators.LateBoundProperty<object>(LVSDFindings, "effective");
+                object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_);
+                CqlDateTime m_ = context.Operators.Start(i_ ?? l_);
+                Period n_ = EncounterWithCADProxy?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                bool? q_ = context.Operators.Before(m_, p_, default);
+
+                return q_;
+            };
+            IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
+            Encounter g_(object LVSDFindings) =>
+                EncounterWithCADProxy;
+            IEnumerable<Encounter> h_ = context.Operators.Select<object, Encounter>(f_, g_);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("authoredDuringDayOfEncounter")]
+    public bool? authoredDuringDayOfEncounter(CqlContext context, object Order, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? e_()
+            {
+                if (Order is MedicationRequest)
+                {
+                    object f_ = context.Operators.LateBoundProperty<object>(Order, "authoredOn");
+                    CqlDateTime g_ = context.Operators.LateBoundProperty<CqlDateTime>(f_, "value");
+                    Period h_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                    bool? j_ = context.Operators.In<CqlDateTime>(g_, i_, "day");
+                    object k_ = context.Operators.LateBoundProperty<object>(Order, "status");
+                    string l_ = context.Operators.LateBoundProperty<string>(k_, "value");
+                    string[] m_ = [
+                        "active",
+                        "completed",
+                    ];
+                    bool? n_ = context.Operators.In<string>(l_, (IEnumerable<string>)m_);
+                    bool? o_ = context.Operators.And(j_, n_);
+                    object p_ = context.Operators.LateBoundProperty<object>(Order, "intent");
+                    string q_ = context.Operators.LateBoundProperty<string>(p_, "value");
+                    string[] r_ = [
+                        "order",
+                        "original-order",
+                        "reflex-order",
+                        "filler-order",
+                        "instance-order",
+                    ];
+                    bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+                    bool? t_ = context.Operators.And(o_, s_);
+                    object u_ = context.Operators.LateBoundProperty<object>(Order, "doNotPerform");
+                    bool? v_ = context.Operators.LateBoundProperty<bool?>(u_, "value");
+                    bool? w_ = context.Operators.IsTrue(v_);
+                    bool? x_ = context.Operators.Not(w_);
+                    bool? y_ = context.Operators.And(t_, x_);
+
+                    return y_;
+                }
+                else if (Order is MedicationRequest)
+                {
+                    object z_ = context.Operators.LateBoundProperty<object>(Order, "authoredOn");
+                    CqlDateTime aa_ = context.Operators.LateBoundProperty<CqlDateTime>(z_, "value");
+                    Period ab_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(aa_, ac_, "day");
+                    object ae_ = context.Operators.LateBoundProperty<object>(Order, "intent");
+                    string af_ = context.Operators.LateBoundProperty<string>(ae_, "value");
+                    string[] ag_ = [
+                        "order",
+                        "original-order",
+                        "reflex-order",
+                        "filler-order",
+                        "instance-order",
+                    ];
+                    bool? ah_ = context.Operators.In<string>(af_, (IEnumerable<string>)ag_);
+                    bool? ai_ = context.Operators.And(ad_, ah_);
+
+                    return ai_;
+                }
+                else
+                {
+                    return false;
+                }
+            };
+
+            return e_();
+        };
+        IEnumerable<bool?> b_ = context.Operators.Select<Encounter, bool?>(EncounterList, a_);
+        IEnumerable<bool?> c_ = context.Operators.Distinct<bool?>(b_);
+        bool? d_ = context.Operators.AnyTrue(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Beta Blocker Therapy for LVSD Ordered")]
+    public bool? Has_Beta_Blocker_Therapy_for_LVSD_Ordered(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? c_(MedicationRequest BetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.authoredDuringDayOfEncounter(context, BetaBlockerForLVSDOrdered as object, f_);
+
+            return g_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+        bool? e_ = context.Operators.Exists<MedicationRequest>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Is Currently Taking Beta Blocker Therapy for LVSD")]
+    public bool? Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlockerForLVSD)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? i_(Encounter CADEncounterModerateOrSevereLVSD)
+            {
+                List<Dosage> m_ = ActiveBetaBlockerForLVSD?.DosageInstruction;
+                bool? n_(Dosage @this)
+                {
+                    Timing aj_ = @this?.Timing;
+                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+
+                    return ak_;
+                };
+                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                Timing p_(Dosage @this)
+                {
+                    Timing al_ = @this?.Timing;
+
+                    return al_;
+                };
+                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                bool? r_(Timing @this)
+                {
+                    Timing.RepeatComponent am_ = @this?.Repeat;
+                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+
+                    return an_;
+                };
+                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                Timing.RepeatComponent t_(Timing @this)
+                {
+                    Timing.RepeatComponent ao_ = @this?.Repeat;
+
+                    return ao_;
+                };
+                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                bool? v_(Timing.RepeatComponent @this)
+                {
+                    DataType ap_ = @this?.Bounds;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+
+                    return ar_;
+                };
+                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                object x_(Timing.RepeatComponent @this)
+                {
+                    DataType as_ = @this?.Bounds;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return at_;
+                };
+                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                CqlInterval<CqlDateTime> z_(object DoseTime)
+                {
+                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+
+                    return au_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
+                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                object ad_(CqlInterval<CqlDateTime> @this)
+                {
+                    CqlDateTime av_ = context.Operators.Start(@this);
+
+                    return av_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
+                Period ag_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
+
+                return ai_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter CADEncounterModerateOrSevereLVSD) =>
+                ActiveBetaBlockerForLVSD;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest ActiveBetaBlockerForLVSD)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlockerForLVSD?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
+            string ay_ = context.Operators.Convert<string>(ax_);
+            string[] az_ = [
+                "active",
+                "completed",
+            ];
+            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlockerForLVSD?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
+            string bd_ = context.Operators.Convert<string>(bc_);
+            string[] be_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
+            bool? bg_ = context.Operators.And(ba_, bf_);
+
+            return bg_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator 1")]
+    public bool? Numerator_1(CqlContext context)
+    {
+        bool? a_ = this.Has_Beta_Blocker_Therapy_for_LVSD_Ordered(context);
+        bool? b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy_for_LVSD(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Has Beta Blocker Therapy Ordered")]
+    public bool? Has_Beta_Blocker_Therapy_Ordered(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        bool? c_(MedicationRequest BetaBlockerOrdered)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.authoredDuringDayOfEncounter(context, BetaBlockerOrdered as object, f_);
+
+            return g_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.Where<MedicationRequest>(b_, c_);
+        bool? e_ = context.Operators.Exists<MedicationRequest>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Is Currently Taking Beta Blocker Therapy")]
+    public bool? Is_Currently_Taking_Beta_Blocker_Therapy(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest ActiveBetaBlocker)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? i_(Encounter CADEncounterMI)
+            {
+                List<Dosage> m_ = ActiveBetaBlocker?.DosageInstruction;
+                bool? n_(Dosage @this)
+                {
+                    Timing aj_ = @this?.Timing;
+                    bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
+
+                    return ak_;
+                };
+                IEnumerable<Dosage> o_ = context.Operators.Where<Dosage>((IEnumerable<Dosage>)m_, n_);
+                Timing p_(Dosage @this)
+                {
+                    Timing al_ = @this?.Timing;
+
+                    return al_;
+                };
+                IEnumerable<Timing> q_ = context.Operators.Select<Dosage, Timing>(o_, p_);
+                bool? r_(Timing @this)
+                {
+                    Timing.RepeatComponent am_ = @this?.Repeat;
+                    bool? an_ = context.Operators.Not((bool?)(am_ is null));
+
+                    return an_;
+                };
+                IEnumerable<Timing> s_ = context.Operators.Where<Timing>(q_, r_);
+                Timing.RepeatComponent t_(Timing @this)
+                {
+                    Timing.RepeatComponent ao_ = @this?.Repeat;
+
+                    return ao_;
+                };
+                IEnumerable<Timing.RepeatComponent> u_ = context.Operators.Select<Timing, Timing.RepeatComponent>(s_, t_);
+                bool? v_(Timing.RepeatComponent @this)
+                {
+                    DataType ap_ = @this?.Bounds;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool? ar_ = context.Operators.Not((bool?)(aq_ is null));
+
+                    return ar_;
+                };
+                IEnumerable<Timing.RepeatComponent> w_ = context.Operators.Where<Timing.RepeatComponent>(u_, v_);
+                object x_(Timing.RepeatComponent @this)
+                {
+                    DataType as_ = @this?.Bounds;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return at_;
+                };
+                IEnumerable<object> y_ = context.Operators.Select<Timing.RepeatComponent, object>(w_, x_);
+                CqlInterval<CqlDateTime> z_(object DoseTime)
+                {
+                    CqlInterval<CqlDateTime> au_ = QICoreCommon_4_0_000.Instance.toInterval(context, DoseTime);
+
+                    return au_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
+                IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
+                IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                object ad_(CqlInterval<CqlDateTime> @this)
+                {
+                    CqlDateTime av_ = context.Operators.Start(@this);
+
+                    return av_;
+                };
+                IEnumerable<CqlInterval<CqlDateTime>> ae_ = context.Operators.SortBy<CqlInterval<CqlDateTime>>(ac_, ad_, System.ComponentModel.ListSortDirection.Ascending);
+                CqlInterval<CqlDateTime> af_ = context.Operators.First<CqlInterval<CqlDateTime>>(ae_);
+                Period ag_ = CADEncounterMI?.Period;
+                CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
+                bool? ai_ = context.Operators.OverlapsAfter(af_, ah_, "day");
+
+                return ai_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter CADEncounterMI) =>
+                ActiveBetaBlocker;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest ActiveBetaBlocker)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> aw_ = ActiveBetaBlocker?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? ax_ = aw_?.Value;
+            string ay_ = context.Operators.Convert<string>(ax_);
+            string[] az_ = [
+                "active",
+                "completed",
+            ];
+            bool? ba_ = context.Operators.In<string>(ay_, (IEnumerable<string>)az_);
+            Code<MedicationRequest.MedicationRequestIntent> bb_ = ActiveBetaBlocker?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? bc_ = bb_?.Value;
+            string bd_ = context.Operators.Convert<string>(bc_);
+            string[] be_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? bf_ = context.Operators.In<string>(bd_, (IEnumerable<string>)be_);
+            bool? bg_ = context.Operators.And(ba_, bf_);
+
+            return bg_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator 2")]
+    public bool? Numerator_2(CqlContext context)
+    {
+        bool? a_ = this.Has_Beta_Blocker_Therapy_Ordered(context);
+        bool? b_ = this.Is_Currently_Taking_Beta_Blocker_Therapy(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_5_1_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_5_1_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator 1")]
+    public bool? Denominator_1(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Atrioventricular_Block(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition AtrioventricularBlock)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AtrioventricularBlock, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Cardiac Pacer in Situ with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer_in_Situ(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition CardiacPacerDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, CardiacPacerDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Cardiac Pacer Device Implanted with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Cardiac_Pacer(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Procedure> c_(Procedure ImplantedCardiacPacer)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_(Encounter CADEncounterModerateOrSevereLVSD)
+            {
+                object k_()
+                {
+                    bool r_()
+                    {
+                        DataType v_ = ImplantedCardiacPacer?.Performed;
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlDateTime;
+
+                        return x_;
+                    };
+                    bool s_()
+                    {
+                        DataType y_ = ImplantedCardiacPacer?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlInterval<CqlDateTime>;
+
+                        return aa_;
+                    };
+                    bool t_()
+                    {
+                        DataType ab_ = ImplantedCardiacPacer?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlQuantity;
+
+                        return ad_;
+                    };
+                    bool u_()
+                    {
+                        DataType ae_ = ImplantedCardiacPacer?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                        bool ag_ = af_ is CqlInterval<CqlQuantity>;
+
+                        return ag_;
+                    };
+                    if (r_())
+                    {
+                        DataType ah_ = ImplantedCardiacPacer?.Performed;
+                        object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+
+                        return (ai_ as CqlDateTime) as object;
+                    }
+                    else if (s_())
+                    {
+                        DataType aj_ = ImplantedCardiacPacer?.Performed;
+                        object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+
+                        return (ak_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (t_())
+                    {
+                        DataType al_ = ImplantedCardiacPacer?.Performed;
+                        object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+
+                        return (am_ as CqlQuantity) as object;
+                    }
+                    else if (u_())
+                    {
+                        DataType an_ = ImplantedCardiacPacer?.Performed;
+                        object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+
+                        return (ao_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                };
+                CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
+                CqlDateTime m_ = context.Operators.Start(l_);
+                Period n_ = CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+                CqlDateTime p_ = context.Operators.End(o_);
+                bool? q_ = context.Operators.Before(m_, p_, default);
+
+                return q_;
+            };
+            IEnumerable<Encounter> h_ = context.Operators.Where<Encounter>(f_, g_);
+            Procedure i_(Encounter CADEncounterModerateOrSevereLVSD) =>
+                ImplantedCardiacPacer;
+            IEnumerable<Procedure> j_ = context.Operators.Select<Encounter, Procedure>(h_, i_);
+
+            return j_;
+        };
+        IEnumerable<Procedure> d_ = context.Operators.SelectMany<Procedure, Procedure>(b_, c_);
+        bool? e_ = context.Operators.Exists<Procedure>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Atrioventricular Block with Qualifying CAD Encounter and History of Moderate or Severe LVSD without Cardiac Pacer")]
+    public bool? Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD_without_Cardiac_Pacer(CqlContext context)
+    {
+        bool? a_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? b_ = this.Has_Diagnosis_of_Cardiac_Pacer_in_Situ_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Not(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+        bool? e_ = this.Has_Cardiac_Pacer_Device_Implanted_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? f_ = context.Operators.Not(e_);
+        bool? g_ = context.Operators.And(d_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Consecutive Heart Rates Less than 50 with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    [CqlTag("code", "Heart rate - 8867-4")]
+    [CqlTag("profile", "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate")]
+    public bool? Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
+        IEnumerable<Encounter> b_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        IEnumerable<ValueTuple<Observation, Encounter>> c_ = context.Operators.CrossJoin<Observation, Encounter>(a_, b_);
+        (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? d_(ValueTuple<Observation, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? l_ = (CqlTupleMetadata_EWMjLSaIFCaWRZLQBiUcVjDES, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> e_ = context.Operators.Select<ValueTuple<Observation, Encounter>, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(c_, d_);
+        bool? f_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? tuple_dyeiilrxycxwhkhdhbjdnjgdc)
+        {
+            Period m_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD?.Period;
+            CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+            DataType o_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+            DataType s_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Value;
+            CqlQuantity t_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, s_ as Quantity);
+            CqlQuantity u_ = context.Operators.Quantity(50m, "/min");
+            bool? v_ = context.Operators.Less(t_, u_);
+            bool? w_ = context.Operators.And(r_, v_);
+            IEnumerable<Observation> x_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
+            bool? y_(Observation MostRecentPriorHeartRateExam)
+            {
+                Period ai_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD?.Period;
+                CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ai_);
+                DataType ak_ = MostRecentPriorHeartRateExam?.Effective;
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
+                bool? an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aj_, am_, default);
+                object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
+                DataType ar_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
+                object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                CqlInterval<CqlDateTime> at_ = QICoreCommon_4_0_000.Instance.toInterval(context, as_);
+                bool? au_ = context.Operators.Before(aq_, at_, default);
+                bool? av_ = context.Operators.And(an_, au_);
+
+                return av_;
+            };
+            IEnumerable<Observation> z_ = context.Operators.Where<Observation>(x_, y_);
+            object aa_(Observation @this)
+            {
+                DataType aw_ = @this?.Effective;
+                object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+                CqlInterval<CqlDateTime> ay_ = QICoreCommon_4_0_000.Instance.toInterval(context, ax_);
+                CqlDateTime az_ = context.Operators.Start(ay_);
+
+                return az_;
+            };
+            IEnumerable<Observation> ab_ = context.Operators.SortBy<Observation>(z_, aa_, System.ComponentModel.ListSortDirection.Ascending);
+            Observation ac_ = context.Operators.Last<Observation>(ab_);
+            DataType ad_ = ac_?.Value;
+            CqlQuantity ae_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, ad_ as Quantity);
+            bool? ag_ = context.Operators.Less(ae_, u_);
+            bool? ah_ = context.Operators.And(w_, ag_);
+
+            return ah_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> g_ = context.Operators.Where<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(e_, f_);
+        (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? h_((CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? tuple_dyeiilrxycxwhkhdhbjdnjgdc)
+        {
+            (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)? ba_ = (CqlTupleMetadata_EWMjLSaIFCaWRZLQBiUcVjDES, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam, tuple_dyeiilrxycxwhkhdhbjdnjgdc?.CADEncounterModerateOrSevereLVSD);
+
+            return ba_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> i_ = context.Operators.Select<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?, (CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(g_, h_);
+        IEnumerable<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?> j_ = context.Operators.Distinct<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(i_);
+        bool? k_ = context.Operators.Exists<(CqlTupleMetadata, Observation HeartRateExam, Encounter CADEncounterModerateOrSevereLVSD)?>(j_);
+
+        return k_;
+    }
+
+
+    [CqlFunctionDefinition("overlapsAfterDayOfEncounter")]
+    public bool? overlapsAfterDayOfEncounter(CqlContext context, object Event, IEnumerable<Encounter> EncounterList)
+    {
+        bool? a_(Encounter Visit)
+        {
+            bool? e_()
+            {
+                if (Event is AllergyIntolerance)
+                {
+                    object f_ = context.Operators.LateBoundProperty<object>(Event, "onset");
+                    object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
+                    CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
+                    CqlDateTime i_ = context.Operators.Start(h_);
+                    object j_ = context.Operators.LateBoundProperty<object>(Event, "lastOccurrence");
+                    CqlDateTime k_ = context.Operators.LateBoundProperty<CqlDateTime>(j_, "value");
+                    CqlInterval<CqlDateTime> l_ = context.Operators.Interval(i_, k_, true, true);
+                    Period m_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
+                    bool? o_ = context.Operators.OverlapsAfter(l_, n_, "day");
+                    object p_ = context.Operators.LateBoundProperty<object>(Event, "clinicalStatus");
+                    CqlConcept q_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_ as CodeableConcept);
+                    CqlConcept s_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, p_ as CodeableConcept);
+                    CqlCode t_ = QICoreCommon_4_0_000.Instance.allergy_active(context);
+                    CqlConcept u_ = context.Operators.ConvertCodeToConcept(t_);
+                    bool? v_ = context.Operators.Equivalent(s_, u_);
+                    bool? w_ = context.Operators.Or((bool?)(q_ is null), v_);
+                    bool? x_ = context.Operators.And(o_, w_);
+
+                    return x_;
+                }
+                else if (Event is Condition)
+                {
+                    bool? y_ = AHAOverall_3_0_000.Instance.isConfirmedActiveDiagnosis(context, (Event as Condition) as object);
+                    CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, (Event as Condition) as object);
+                    Period aa_ = Visit?.Period;
+                    CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
+                    bool? ac_ = context.Operators.OverlapsAfter(z_, ab_, "day");
+                    bool? ad_ = context.Operators.And(y_, ac_);
+                    object ae_ = context.Operators.LateBoundProperty<object>(Event, "verificationStatus");
+                    CqlConcept af_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ae_ as CodeableConcept);
+                    CqlCode ag_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+                    CqlConcept ah_ = context.Operators.ConvertCodeToConcept(ag_);
+                    bool? ai_ = context.Operators.Equivalent(af_, ah_);
+                    bool? aj_ = context.Operators.And(ad_, ai_);
+
+                    return aj_;
+                }
+                else
+                {
+                    return false;
+                }
+            };
+
+            return e_();
+        };
+        IEnumerable<bool?> b_ = context.Operators.Select<Encounter, bool?>(EncounterList, a_);
+        IEnumerable<bool?> c_ = context.Operators.Distinct<bool?>(b_);
+        bool? d_ = context.Operators.AnyTrue(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient(context);
+        IEnumerable<AllergyIntolerance> b_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(context);
+        IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+        IEnumerable<AllergyIntolerance> e_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
+        bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
+        {
+            IEnumerable<Encounter> j_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? k_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyIntolerance as object, j_);
+
+            return k_;
+        };
+        IEnumerable<AllergyIntolerance> h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
+        bool? i_ = context.Operators.Exists<AllergyIntolerance>(h_);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Has Arrhythmia with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Arrhythmia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition ArrhythmiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, ArrhythmiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Arrhythmia with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Arrhythmia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition ArrhythmiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, ArrhythmiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Asthma with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Asthma_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Asthma(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition AsthmaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AsthmaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Asthma with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Asthma_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Asthma(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition AsthmaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, AsthmaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Bradycardia with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Bradycardia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bradycardia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition BradycardiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, BradycardiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Bradycardia with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Bradycardia_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bradycardia(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition BradycardiaDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, BradycardiaDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+        bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? j_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyOrIntoleranceDiagnosis as object, i_);
+
+            return j_;
+        };
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Diagnosis of Allergy or Intolerance to Beta Blocker Therapy with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Allergy_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        CqlValueSet c_ = this.Intolerance_to_Beta_Blocker_Therapy(context);
+        IEnumerable<Condition> d_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> e_ = context.Operators.Union<Condition>(b_, d_);
+        bool? f_(Condition BetaBlockerAllergyOrIntoleranceDiagnosis)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? j_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyOrIntoleranceDiagnosis as object, i_);
+
+            return j_;
+        };
+        IEnumerable<Condition> g_ = context.Operators.Where<Condition>(e_, f_);
+        bool? h_ = context.Operators.Exists<Condition>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Hypotension with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Hypotension_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hypotension(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition HypotensionDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, HypotensionDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Hypotension with Qualifying CAD Encounter and Prior MI")]
+    public bool? Has_Hypotension_with_Qualifying_CAD_Encounter_and_Prior_MI(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hypotension(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        bool? c_(Condition HypotensionDiagnosis)
+        {
+            IEnumerable<Encounter> f_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? g_ = this.overlapsDayOfEncounter(context, HypotensionDiagnosis, f_);
+
+            return g_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.Where<Condition>(b_, c_);
+        bool? e_ = context.Operators.Exists<Condition>(d_);
+
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Has Allergy or Intolerance to Beta Blocker Therapy Ingredient with Qualifying CAD Encounter and History of Moderate or Severe LVSD")]
+    public bool? Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_Ingredient(context);
+        IEnumerable<AllergyIntolerance> b_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        CqlCode c_ = this.Substance_with_beta_adrenergic_receptor_antagonist_mechanism_of_action__substance_(context);
+        IEnumerable<CqlCode> d_ = context.Operators.ToList<CqlCode>(c_);
+        IEnumerable<AllergyIntolerance> e_ = context.Operators.Retrieve<AllergyIntolerance>(new RetrieveParameters(default, default, d_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-allergyintolerance"));
+        IEnumerable<AllergyIntolerance> f_ = context.Operators.Union<AllergyIntolerance>(b_, e_);
+        bool? g_(AllergyIntolerance BetaBlockerAllergyIntolerance)
+        {
+            IEnumerable<Encounter> j_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? k_ = this.overlapsAfterDayOfEncounter(context, BetaBlockerAllergyIntolerance as object, j_);
+
+            return k_;
+        };
+        IEnumerable<AllergyIntolerance> h_ = context.Operators.Where<AllergyIntolerance>(f_, g_);
+        bool? i_ = context.Operators.Exists<AllergyIntolerance>(h_);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Has Medical or Patient Reason for Not Ordering Beta Blocker for LVSD")]
+    public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+            bool? i_(Encounter LVSDVisit)
+            {
+                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = LVSDVisit?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+
+                return q_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter LVSDVisit) =>
+                NoBetaBlockerForLVSDOrdered;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "active",
+                "completed",
+            ];
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            bool? ab_ = context.Operators.And(v_, aa_);
+            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            CqlConcept ad_(CodeableConcept @this)
+            {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ao_;
+            };
+            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
+            CqlValueSet af_ = this.Medical_Reason(context);
+            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
+            CqlConcept ai_(CodeableConcept @this)
+            {
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ap_;
+            };
+            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
+            CqlValueSet ak_ = this.Patient_Reason(context);
+            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
+            bool? am_ = context.Operators.Or(ag_, al_);
+            bool? an_ = context.Operators.And(ab_, am_);
+
+            return an_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions 1")]
+    public bool? Denominator_Exceptions_1(CqlContext context)
+    {
+        bool? a_ = this.Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? b_ = this.Has_Asthma_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+        bool? d_ = this.Has_Bradycardia_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? e_ = context.Operators.Or(c_, d_);
+        bool? f_ = this.Has_Hypotension_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? g_ = context.Operators.Or(e_, f_);
+        bool? h_ = this.Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? i_ = context.Operators.Or(g_, h_);
+        bool? j_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? k_ = context.Operators.Or(i_, j_);
+        bool? l_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        bool? n_ = this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_for_LVSD(context);
+        bool? o_ = context.Operators.Or(m_, n_);
+        bool? p_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_History_of_Moderate_or_Severe_LVSD_without_Cardiac_Pacer(context);
+        bool? q_ = context.Operators.Or(o_, p_);
+
+        return q_;
+    }
+
+
+    [CqlExpressionDefinition("Has Medical or Patient Reason for Not Ordering Beta Blocker Therapy")]
+    public bool? Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_Therapy(CqlContext context)
+    {
+        CqlValueSet a_ = this.Beta_Blocker_Therapy_for_LVSD(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationnotrequested"));
+        IEnumerable<MedicationRequest> c_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_CAD_Encounter_and_Prior_MI(context);
+            bool? i_(Encounter PriorMIVisit)
+            {
+                FhirDateTime m_ = NoBetaBlockerForLVSDOrdered?.AuthoredOnElement;
+                CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
+                Period o_ = PriorMIVisit?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, "day");
+
+                return q_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            MedicationRequest k_(Encounter PriorMIVisit) =>
+                NoBetaBlockerForLVSDOrdered;
+            IEnumerable<MedicationRequest> l_ = context.Operators.Select<Encounter, MedicationRequest>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<MedicationRequest> d_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(b_, c_);
+        bool? e_(MedicationRequest NoBetaBlockerForLVSDOrdered)
+        {
+            Code<MedicationRequest.MedicationrequestStatus> r_ = NoBetaBlockerForLVSDOrdered?.StatusElement;
+            MedicationRequest.MedicationrequestStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "active",
+                "completed",
+            ];
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            Code<MedicationRequest.MedicationRequestIntent> w_ = NoBetaBlockerForLVSDOrdered?.IntentElement;
+            MedicationRequest.MedicationRequestIntent? x_ = w_?.Value;
+            string y_ = context.Operators.Convert<string>(x_);
+            string[] z_ = [
+                "order",
+                "original-order",
+                "reflex-order",
+                "filler-order",
+                "instance-order",
+            ];
+            bool? aa_ = context.Operators.In<string>(y_, (IEnumerable<string>)z_);
+            bool? ab_ = context.Operators.And(v_, aa_);
+            List<CodeableConcept> ac_ = NoBetaBlockerForLVSDOrdered?.ReasonCode;
+            CqlConcept ad_(CodeableConcept @this)
+            {
+                CqlConcept ao_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ao_;
+            };
+            IEnumerable<CqlConcept> ae_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ad_);
+            CqlValueSet af_ = this.Medical_Reason(context);
+            bool? ag_ = context.Operators.ConceptsInValueSet(ae_, af_);
+            CqlConcept ai_(CodeableConcept @this)
+            {
+                CqlConcept ap_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+
+                return ap_;
+            };
+            IEnumerable<CqlConcept> aj_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)ac_, ai_);
+            CqlValueSet ak_ = this.Patient_Reason(context);
+            bool? al_ = context.Operators.ConceptsInValueSet(aj_, ak_);
+            bool? am_ = context.Operators.Or(ag_, al_);
+            bool? an_ = context.Operators.And(ab_, am_);
+
+            return an_;
+        };
+        IEnumerable<MedicationRequest> f_ = context.Operators.Where<MedicationRequest>(d_, e_);
+        bool? g_ = context.Operators.Exists<MedicationRequest>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions 2")]
+    public bool? Denominator_Exceptions_2(CqlContext context)
+    {
+        bool? a_ = this.Has_Arrhythmia_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? b_ = this.Has_Asthma_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? c_ = context.Operators.Or(a_, b_);
+        bool? d_ = this.Has_Bradycardia_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? e_ = context.Operators.Or(c_, d_);
+        bool? f_ = this.Has_Hypotension_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? g_ = context.Operators.Or(e_, f_);
+        bool? h_ = this.Has_Consecutive_Heart_Rates_Less_than_50_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? i_ = context.Operators.Or(g_, h_);
+        bool? j_ = this.Has_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_Ingredient_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? k_ = context.Operators.Or(i_, j_);
+        bool? l_ = this.Has_Diagnosis_of_Allergy_or_Intolerance_to_Beta_Blocker_Therapy_with_Qualifying_CAD_Encounter_and_Prior_MI(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        bool? n_ = this.Has_Medical_or_Patient_Reason_for_Not_Ordering_Beta_Blocker_Therapy(context);
+        bool? o_ = context.Operators.Or(m_, n_);
+        bool? p_ = this.Has_Atrioventricular_Block_with_Qualifying_CAD_Encounter_and_Prior_MI_without_Cardiac_Pacer(context);
+        bool? q_ = context.Operators.Or(o_, p_);
+
+        return q_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_EWMjLSaIFCaWRZLQBiUcVjDES = new(
+      [typeof(Observation), typeof(Encounter)],
+      ["HeartRateExam", "CADEncounterModerateOrSevereLVSD"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_GgEMjKUjZUgEdXjOgPVEWONDD = new(
+      [typeof(Observation), typeof(Encounter)],
+      ["HeartRateExam", "CADEncounterMI"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001.g.cs
@@ -1,0 +1,1606 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("CMS2FHIRPCSDepressionScreenAndFollowUp", "0.4.001")]
+public partial class CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001 : ILibrary, ISingleton<CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001>
+{
+    private CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001() {}
+
+    public static CMS2FHIRPCSDepressionScreenAndFollowUp_0_4_001 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "CMS2FHIRPCSDepressionScreenAndFollowUp";
+    public string Version => "0.4.001";
+    public ILibrary[] Dependencies => [FHIRHelpers_4_4_000.Instance, QICoreCommon_4_0_000.Instance, CumulativeMedicationDuration_6_0_000.Instance, SupplementalDataElements_5_1_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Adolescent Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", valueSetVersion: null)]
+    public CqlValueSet Adolescent_Depression_Medications(CqlContext _) => _Adolescent_Depression_Medications;
+    private static readonly CqlValueSet _Adolescent_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1567", null);
+
+    [CqlValueSetDefinition("Adult Depression Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", valueSetVersion: null)]
+    public CqlValueSet Adult_Depression_Medications(CqlContext _) => _Adult_Depression_Medications;
+    private static readonly CqlValueSet _Adult_Depression_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1566", null);
+
+    [CqlValueSetDefinition("Bipolar Disorder", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", valueSetVersion: null)]
+    public CqlValueSet Bipolar_Disorder(CqlContext _) => _Bipolar_Disorder;
+    private static readonly CqlValueSet _Bipolar_Disorder = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.67.1.101.1.128", null);
+
+    [CqlValueSetDefinition("Encounter to Screen for Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", valueSetVersion: null)]
+    public CqlValueSet Encounter_to_Screen_for_Depression(CqlContext _) => _Encounter_to_Screen_for_Depression;
+    private static readonly CqlValueSet _Encounter_to_Screen_for_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.600.1916", null);
+
+    [CqlValueSetDefinition("Follow Up for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adolescent_Depression(CqlContext _) => _Follow_Up_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1569", null);
+
+    [CqlValueSetDefinition("Follow Up for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", valueSetVersion: null)]
+    public CqlValueSet Follow_Up_for_Adult_Depression(CqlContext _) => _Follow_Up_for_Adult_Depression;
+    private static readonly CqlValueSet _Follow_Up_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1568", null);
+
+    [CqlValueSetDefinition("Medical Reason", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", valueSetVersion: null)]
+    public CqlValueSet Medical_Reason(CqlContext _) => _Medical_Reason;
+    private static readonly CqlValueSet _Medical_Reason = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007", null);
+
+    [CqlValueSetDefinition("Physical Therapy Evaluation", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", valueSetVersion: null)]
+    public CqlValueSet Physical_Therapy_Evaluation(CqlContext _) => _Physical_Therapy_Evaluation;
+    private static readonly CqlValueSet _Physical_Therapy_Evaluation = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1022", null);
+
+    [CqlValueSetDefinition("Referral for Adolescent Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adolescent_Depression(CqlContext _) => _Referral_for_Adolescent_Depression;
+    private static readonly CqlValueSet _Referral_for_Adolescent_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1570", null);
+
+    [CqlValueSetDefinition("Referral for Adult Depression", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", valueSetVersion: null)]
+    public CqlValueSet Referral_for_Adult_Depression(CqlContext _) => _Referral_for_Adult_Depression;
+    private static readonly CqlValueSet _Referral_for_Adult_Depression = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1571", null);
+
+    [CqlValueSetDefinition("Telephone Visits", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", valueSetVersion: null)]
+    public CqlValueSet Telephone_Visits(CqlContext _) => _Telephone_Visits;
+    private static readonly CqlValueSet _Telephone_Visits = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1080", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Adolescent depression screening assessment", codeId: "73831-0", codeSystem: "http://loinc.org")]
+    public CqlCode Adolescent_depression_screening_assessment(CqlContext _) => _Adolescent_depression_screening_assessment;
+    private static readonly CqlCode _Adolescent_depression_screening_assessment = new CqlCode("73831-0", "http://loinc.org");
+
+    [CqlCodeDefinition("Adult depression screening assessment", codeId: "73832-8", codeSystem: "http://loinc.org")]
+    public CqlCode Adult_depression_screening_assessment(CqlContext _) => _Adult_depression_screening_assessment;
+    private static readonly CqlCode _Adult_depression_screening_assessment = new CqlCode("73832-8", "http://loinc.org");
+
+    [CqlCodeDefinition("Depression screening declined (situation)", codeId: "720834000", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_declined__situation_(CqlContext _) => _Depression_screening_declined__situation_;
+    private static readonly CqlCode _Depression_screening_declined__situation_ = new CqlCode("720834000", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening negative (finding)", codeId: "428171000124102", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_negative__finding_(CqlContext _) => _Depression_screening_negative__finding_;
+    private static readonly CqlCode _Depression_screening_negative__finding_ = new CqlCode("428171000124102", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Depression screening positive (finding)", codeId: "428181000124104", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Depression_screening_positive__finding_(CqlContext _) => _Depression_screening_positive__finding_;
+    private static readonly CqlCode _Depression_screening_positive__finding_ = new CqlCode("428181000124104", "http://snomed.info/sct");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("LOINC", codeSystemId: "http://loinc.org", codeSystemVersion: null)]
+    public CqlCodeSystem LOINC(CqlContext _) => _LOINC;
+    private static readonly CqlCodeSystem _LOINC =
+      new CqlCodeSystem("http://loinc.org", null, [
+          _Adolescent_depression_screening_assessment,
+          _Adult_depression_screening_assessment]);
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Depression_screening_declined__situation_,
+          _Depression_screening_negative__finding_,
+          _Depression_screening_positive__finding_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        object a_ = context.ResolveParameter("CMS2FHIRPCSDepressionScreenAndFollowUp-0.4.001", "Measurement Period", null);
+
+        return (CqlInterval<CqlDateTime>)a_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 12);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Encounter During Measurement Period")]
+    public IEnumerable<Encounter> Qualifying_Encounter_During_Measurement_Period(CqlContext context)
+    {
+        CqlValueSet a_ = this.Encounter_to_Screen_for_Depression(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        CqlValueSet c_ = this.Physical_Therapy_Evaluation(context);
+        IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+        CqlValueSet f_ = this.Telephone_Visits(context);
+        IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
+        bool? i_(Encounter QualifyingEncounter)
+        {
+            CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
+            Period l_ = QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+            bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, "day");
+            Code<Encounter.EncounterStatus> o_ = QualifyingEncounter?.StatusElement;
+            Encounter.EncounterStatus? p_ = o_?.Value;
+            Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
+            bool? r_ = context.Operators.Equal(q_, "finished");
+            bool? s_ = context.Operators.And(n_, r_);
+
+            return s_;
+        };
+        IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public bool? Initial_Population(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_Years_or_Older_at_Start_of_Measurement_Period(context);
+        IEnumerable<Encounter> b_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        bool? c_ = context.Operators.Exists<Encounter>(b_);
+        bool? d_ = context.Operators.And(a_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator")]
+    public bool? Denominator(CqlContext context)
+    {
+        bool? a_ = this.Initial_Population(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("History of Bipolar Diagnosis Before Qualifying Encounter")]
+    public IEnumerable<Condition> History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(CqlContext context)
+    {
+        CqlValueSet a_ = this.Bipolar_Disorder(context);
+        IEnumerable<Condition> b_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+        IEnumerable<Condition> c_(Condition BipolarDiagnosis)
+        {
+            IEnumerable<Encounter> e_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? f_(Encounter QualifyingEncounter)
+            {
+                CqlInterval<CqlDateTime> j_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, BipolarDiagnosis as object);
+                CqlDateTime k_ = context.Operators.Start(j_);
+                Period l_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.Start(m_);
+                bool? o_ = context.Operators.Before(k_, n_, "day");
+
+                return o_;
+            };
+            IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+            Condition h_(Encounter QualifyingEncounter) =>
+                BipolarDiagnosis;
+            IEnumerable<Condition> i_ = context.Operators.Select<Encounter, Condition>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Condition> d_ = context.Operators.SelectMany<Condition, Condition>(b_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exclusions")]
+    public bool? Denominator_Exclusions(CqlContext context)
+    {
+        IEnumerable<Condition> a_ = this.History_of_Bipolar_Diagnosis_Before_Qualifying_Encounter(context);
+        bool? b_ = context.Operators.Exists<Condition>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 12 to 16 Years at Start of Measurement Period")]
+    public bool? Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        CqlInterval<int?> i_ = context.Operators.Interval(12, 16, true, true);
+        bool? j_ = context.Operators.In<int?>(h_, i_, default);
+
+        return j_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening")]
+    public Observation Most_Recent_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdolescentDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdolescentDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdolescentDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdolescentDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                bool? ap_ = context.Operators.And(aj_, ao_);
+
+                return ap_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdolescentDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType aq_ = @this?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+
+            return at_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adolescent Screening Negative")]
+    public bool? Has_Most_Recent_Adolescent_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdolescentScreen)
+        {
+            DataType g_ = AdolescentScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adolescent Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adolescent_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adolescent_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        IEnumerable<MedicationRequest> g_(MedicationRequest AdolescentMed)
+        {
+            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? ai_(Encounter QualifyingEncounter)
+            {
+                Observation am_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+                DataType an_ = am_?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                Period ar_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
+                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
+                bool? bf_ = context.Operators.And(ba_, be_);
+                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdolescentMed);
+                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
+                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
+                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
+                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
+                bool? bv_ = context.Operators.And(bf_, bu_);
+                DataType bx_ = am_?.Value;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
+                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
+                bool? cc_ = context.Operators.And(bv_, cb_);
+                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdolescentMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
+                string cf_ = context.Operators.Convert<string>(ce_);
+                string[] cg_ = [
+                    "active",
+                    "completed",
+                ];
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdolescentMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
+                string cl_ = context.Operators.Convert<string>(ck_);
+                string[] cm_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
+                bool? co_ = context.Operators.And(ci_, cn_);
+
+                return co_;
+            };
+            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
+            MedicationRequest ak_(Encounter QualifyingEncounter) =>
+                AdolescentMed;
+            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
+
+            return al_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adolescent_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdolescentReferral)
+        {
+            Code<RequestStatus> cp_ = AdolescentReferral?.StatusElement;
+            RequestStatus? cq_ = cp_?.Value;
+            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
+            string cs_ = context.Operators.Convert<string>(cr_);
+            string[] ct_ = [
+                "active",
+                "completed",
+            ];
+            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+
+            return cu_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adolescent_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdolescentFollowUp)
+        {
+            Code<EventStatus> cv_ = AdolescentFollowUp?.StatusElement;
+            EventStatus? cw_ = cv_?.Value;
+            string cx_ = context.Operators.Convert<string>(cw_);
+            bool? cy_ = context.Operators.Equal(cx_, "completed");
+
+            return cy_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adolescent Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adolescent_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adolescent_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            DataType n_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_()
+            {
+                bool bt_()
+                {
+                    object bx_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                    bool bz_ = by_ is CqlDateTime;
+
+                    return bz_;
+                };
+                bool bu_()
+                {
+                    object ca_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                    bool cc_ = cb_ is CqlInterval<CqlDateTime>;
+
+                    return cc_;
+                };
+                bool bv_()
+                {
+                    object cd_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                    bool cf_ = ce_ is CqlQuantity;
+
+                    return cf_;
+                };
+                bool bw_()
+                {
+                    object cg_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                    bool ci_ = ch_ is CqlInterval<CqlQuantity>;
+
+                    return ci_;
+                };
+                if (bt_())
+                {
+                    object cj_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+
+                    return (ck_ as CqlDateTime) as object;
+                }
+                else if (bu_())
+                {
+                    object cl_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+
+                    return (cm_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bv_())
+                {
+                    object cn_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+
+                    return (co_ as CqlQuantity) as object;
+                }
+                else if (bw_())
+                {
+                    object cp_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+
+                    return (cq_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
+            CqlDateTime ao_ = context.Operators.Start(an_);
+            CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+            object as_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
+            CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime aw_ = context.Operators.End(av_);
+            CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime az_ = context.Operators.End(ay_);
+            CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bb_ = context.Operators.Add(az_, ba_);
+            CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(aw_, bb_, true, true);
+            bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, "day");
+            CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bg_ = context.Operators.End(bf_);
+            bool? bh_ = context.Operators.Not((bool?)(bg_ is null));
+            bool? bi_ = context.Operators.And(bd_, bh_);
+            bool? bj_ = context.Operators.Or(ar_, bi_);
+            bool? bk_ = context.Operators.And(al_, bj_);
+            object bl_()
+            {
+                bool cr_()
+                {
+                    object cv_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                    bool cx_ = cw_ is CqlDateTime;
+
+                    return cx_;
+                };
+                bool cs_()
+                {
+                    object cy_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                    bool da_ = cz_ is CqlInterval<CqlDateTime>;
+
+                    return da_;
+                };
+                bool ct_()
+                {
+                    object db_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                    bool dd_ = dc_ is CqlQuantity;
+
+                    return dd_;
+                };
+                bool cu_()
+                {
+                    object de_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                    bool dg_ = df_ is CqlInterval<CqlQuantity>;
+
+                    return dg_;
+                };
+                if (cr_())
+                {
+                    object dh_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+
+                    return (di_ as CqlDateTime) as object;
+                }
+                else if (cs_())
+                {
+                    object dj_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+
+                    return (dk_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ct_())
+                {
+                    object dl_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+
+                    return (dm_ as CqlQuantity) as object;
+                }
+                else if (cu_())
+                {
+                    object dn_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "performed");
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+
+                    return (do_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
+            CqlDateTime bn_ = context.Operators.Start(bm_);
+            CqlDateTime bp_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
+            bool? br_ = context.Operators.In<CqlDateTime>(bn_ ?? bp_, bq_, "day");
+            bool? bs_ = context.Operators.And(bk_, br_);
+
+            return bs_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? tuple_ewmohjtdtinujhphqjvbwmmhh)
+        {
+            (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)? dp_ = (CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS, tuple_ewmohjtdtinujhphqjvbwmmhh?.LastAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, tuple_ewmohjtdtinujhphqjvbwmmhh?.QualifyingEncounter);
+
+            return dp_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 17 Years at Start of Measurement Period")]
+    public bool? Patient_Age_17_Years_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.Equal(h_, 17);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening")]
+    public Observation Most_Recent_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdultDepressionScreening)
+        {
+            IEnumerable<Encounter> i_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? j_(Encounter QualifyingEncounter)
+            {
+                DataType n_ = AdultDepressionScreening?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.End(p_);
+                Period r_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime t_ = context.Operators.Start(s_);
+                CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+                CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime y_ = context.Operators.Start(x_);
+                CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+                bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+                CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                CqlDateTime ad_ = context.Operators.Start(ac_);
+                bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+                bool? af_ = context.Operators.And(aa_, ae_);
+                DataType ag_ = AdultDepressionScreening?.Value;
+                object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
+                bool? aj_ = context.Operators.And(af_, ai_);
+                Code<ObservationStatus> ak_ = AdultDepressionScreening?.StatusElement;
+                ObservationStatus? al_ = ak_?.Value;
+                string am_ = context.Operators.Convert<string>(al_);
+                string[] an_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? ao_ = context.Operators.In<string>(am_, (IEnumerable<string>)an_);
+                bool? ap_ = context.Operators.And(aj_, ao_);
+
+                return ap_;
+            };
+            IEnumerable<Encounter> k_ = context.Operators.Where<Encounter>(i_, j_);
+            Observation l_(Encounter QualifyingEncounter) =>
+                AdultDepressionScreening;
+            IEnumerable<Observation> m_ = context.Operators.Select<Encounter, Observation>(k_, l_);
+
+            return m_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType aq_ = @this?.Effective;
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+            CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
+            CqlDateTime at_ = context.Operators.Start(as_);
+
+            return at_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.Last<Observation>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Has Most Recent Adult Screening Negative")]
+    public bool? Has_Most_Recent_Adult_Screening_Negative(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        bool? c_(Observation AdultScreen)
+        {
+            DataType g_ = AdultScreen?.Value;
+            object h_ = FHIRHelpers_4_4_000.Instance.ToValue(context, g_);
+            CqlCode i_ = this.Depression_screening_negative__finding_(context);
+            CqlConcept j_ = context.Operators.ConvertCodeToConcept(i_);
+            bool? k_ = context.Operators.Equivalent(h_ as CqlConcept, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>((IEnumerable<Observation>)b_, c_);
+        Observation e_ = context.Operators.SingletonFrom<Observation>(d_);
+        bool? f_ = context.Operators.Not((bool?)(e_ is null));
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Follow Up Intervention for Positive Adult Depression Screening")]
+    public IEnumerable<object> Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlValueSet a_ = this.Adult_Depression_Medications(context);
+        IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+        IEnumerable<MedicationRequest> d_(MedicationRequest MR)
+        {
+            IEnumerable<Medication> s_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+            bool? t_(Medication M)
+            {
+                object x_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                object y_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                IEnumerable<string> z_ = context.Operators.Split((string)y_, "/");
+                string aa_ = context.Operators.Last<string>(z_);
+                bool? ab_ = context.Operators.Equal(x_, aa_);
+                CodeableConcept ac_ = M?.Code;
+                CqlConcept ad_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ac_);
+                CqlValueSet ae_ = this.Adult_Depression_Medications(context);
+                bool? af_ = context.Operators.ConceptInValueSet(ad_, ae_);
+                bool? ag_ = context.Operators.And(ab_, af_);
+
+                return ag_;
+            };
+            IEnumerable<Medication> u_ = context.Operators.Where<Medication>(s_, t_);
+            MedicationRequest v_(Medication M) =>
+                MR;
+            IEnumerable<MedicationRequest> w_ = context.Operators.Select<Medication, MedicationRequest>(u_, v_);
+
+            return w_;
+        };
+        IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+        IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+        IEnumerable<MedicationRequest> g_(MedicationRequest AdultMed)
+        {
+            IEnumerable<Encounter> ah_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? ai_(Encounter QualifyingEncounter)
+            {
+                Observation am_ = this.Most_Recent_Adult_Depression_Screening(context);
+                DataType an_ = am_?.Effective;
+                object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                CqlInterval<CqlDateTime> ap_ = QICoreCommon_4_0_000.Instance.toInterval(context, ao_);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                Period ar_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime at_ = context.Operators.Start(as_);
+                CqlQuantity au_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime av_ = context.Operators.Subtract(at_, au_);
+                CqlInterval<CqlDateTime> ax_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime ay_ = context.Operators.Start(ax_);
+                CqlInterval<CqlDateTime> az_ = context.Operators.Interval(av_, ay_, true, true);
+                bool? ba_ = context.Operators.In<CqlDateTime>(aq_, az_, "day");
+                CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                CqlDateTime bd_ = context.Operators.Start(bc_);
+                bool? be_ = context.Operators.Not((bool?)(bd_ is null));
+                bool? bf_ = context.Operators.And(ba_, be_);
+                CqlInterval<CqlDate> bg_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, AdultMed);
+                CqlDate bh_ = (bg_ as CqlInterval<CqlDate>)?.low;
+                CqlDateTime bi_ = context.Operators.ConvertDateToDateTime(bh_);
+                CqlDate bk_ = (bg_ as CqlInterval<CqlDate>)?.high;
+                CqlDateTime bl_ = context.Operators.ConvertDateToDateTime(bk_);
+                bool? bn_ = (bg_ as CqlInterval<CqlDate>)?.lowClosed;
+                bool? bp_ = (bg_ as CqlInterval<CqlDate>)?.highClosed;
+                CqlInterval<CqlDateTime> bq_ = context.Operators.Interval(bi_, bl_, bn_, bp_);
+                CqlInterval<CqlDateTime> br_ = QICoreCommon_4_0_000.Instance.toInterval(context, bq_);
+                CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ar_);
+                bool? bu_ = context.Operators.OverlapsAfter(br_, bt_, "day");
+                bool? bv_ = context.Operators.And(bf_, bu_);
+                DataType bx_ = am_?.Value;
+                object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                CqlCode bz_ = this.Depression_screening_positive__finding_(context);
+                CqlConcept ca_ = context.Operators.ConvertCodeToConcept(bz_);
+                bool? cb_ = context.Operators.Equivalent(by_ as CqlConcept, ca_);
+                bool? cc_ = context.Operators.And(bv_, cb_);
+                Code<MedicationRequest.MedicationrequestStatus> cd_ = AdultMed?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? ce_ = cd_?.Value;
+                string cf_ = context.Operators.Convert<string>(ce_);
+                string[] cg_ = [
+                    "active",
+                    "completed",
+                ];
+                bool? ch_ = context.Operators.In<string>(cf_, (IEnumerable<string>)cg_);
+                bool? ci_ = context.Operators.And(cc_, ch_);
+                Code<MedicationRequest.MedicationRequestIntent> cj_ = AdultMed?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ck_ = cj_?.Value;
+                string cl_ = context.Operators.Convert<string>(ck_);
+                string[] cm_ = [
+                    "order",
+                    "original-order",
+                    "reflex-order",
+                    "filler-order",
+                    "instance-order",
+                ];
+                bool? cn_ = context.Operators.In<string>(cl_, (IEnumerable<string>)cm_);
+                bool? co_ = context.Operators.And(ci_, cn_);
+
+                return co_;
+            };
+            IEnumerable<Encounter> aj_ = context.Operators.Where<Encounter>(ah_, ai_);
+            MedicationRequest ak_(Encounter QualifyingEncounter) =>
+                AdultMed;
+            IEnumerable<MedicationRequest> al_ = context.Operators.Select<Encounter, MedicationRequest>(aj_, ak_);
+
+            return al_;
+        };
+        IEnumerable<MedicationRequest> h_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(f_, g_);
+        CqlValueSet i_ = this.Referral_for_Adult_Depression(context);
+        IEnumerable<ServiceRequest> j_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+        bool? k_(ServiceRequest AdultReferral)
+        {
+            Code<RequestStatus> cp_ = AdultReferral?.StatusElement;
+            RequestStatus? cq_ = cp_?.Value;
+            Code<RequestStatus> cr_ = context.Operators.Convert<Code<RequestStatus>>(cq_);
+            string cs_ = context.Operators.Convert<string>(cr_);
+            string[] ct_ = [
+                "active",
+                "completed",
+            ];
+            bool? cu_ = context.Operators.In<string>(cs_, (IEnumerable<string>)ct_);
+
+            return cu_;
+        };
+        IEnumerable<ServiceRequest> l_ = context.Operators.Where<ServiceRequest>(j_, k_);
+        IEnumerable<object> m_ = context.Operators.Union<object>(h_ as IEnumerable<object>, l_ as IEnumerable<object>);
+        CqlValueSet n_ = this.Follow_Up_for_Adult_Depression(context);
+        IEnumerable<Procedure> o_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, n_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        bool? p_(Procedure AdultFollowUp)
+        {
+            Code<EventStatus> cv_ = AdultFollowUp?.StatusElement;
+            EventStatus? cw_ = cv_?.Value;
+            string cx_ = context.Operators.Convert<string>(cw_);
+            bool? cy_ = context.Operators.Equal(cx_, "completed");
+
+            return cy_;
+        };
+        IEnumerable<Procedure> q_ = context.Operators.Where<Procedure>(o_, p_);
+        IEnumerable<object> r_ = context.Operators.Union<object>(m_ as IEnumerable<object>, q_ as IEnumerable<object>);
+
+        return r_;
+    }
+
+
+    [CqlExpressionDefinition("Most Recent Adult Depression Screening Positive and Follow Up Provided")]
+    public IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(CqlContext context)
+    {
+        Observation a_ = this.Most_Recent_Adult_Depression_Screening(context);
+        Observation[] b_ = [
+            a_,
+        ];
+        IEnumerable<object> c_ = this.Follow_Up_Intervention_for_Positive_Adult_Depression_Screening(context);
+        IEnumerable<Encounter> d_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+        IEnumerable<ValueTuple<Observation, object, Encounter>> e_ = context.Operators.CrossJoin<Observation, object, Encounter>((IEnumerable<Observation>)b_, c_, d_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? f_(ValueTuple<Observation, object, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? m_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> g_ = context.Operators.Select<ValueTuple<Observation, object, Encounter>, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(e_, f_);
+        bool? h_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            DataType n_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Effective;
+            object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+            CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            Period r_ = tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter?.Period;
+            CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime t_ = context.Operators.Start(s_);
+            CqlQuantity u_ = context.Operators.Quantity(14m, "days");
+            CqlDateTime v_ = context.Operators.Subtract(t_, u_);
+            CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime y_ = context.Operators.Start(x_);
+            CqlInterval<CqlDateTime> z_ = context.Operators.Interval(v_, y_, true, true);
+            bool? aa_ = context.Operators.In<CqlDateTime>(q_, z_, "day");
+            CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime ad_ = context.Operators.Start(ac_);
+            bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
+            bool? af_ = context.Operators.And(aa_, ae_);
+            DataType ag_ = tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen?.Value;
+            object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+            CqlCode ai_ = this.Depression_screening_positive__finding_(context);
+            CqlConcept aj_ = context.Operators.ConvertCodeToConcept(ai_);
+            bool? ak_ = context.Operators.Equivalent(ah_ as CqlConcept, aj_);
+            bool? al_ = context.Operators.And(af_, ak_);
+            object am_()
+            {
+                bool bt_()
+                {
+                    object bx_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+                    bool bz_ = by_ is CqlDateTime;
+
+                    return bz_;
+                };
+                bool bu_()
+                {
+                    object ca_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ca_);
+                    bool cc_ = cb_ is CqlInterval<CqlDateTime>;
+
+                    return cc_;
+                };
+                bool bv_()
+                {
+                    object cd_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ce_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cd_);
+                    bool cf_ = ce_ is CqlQuantity;
+
+                    return cf_;
+                };
+                bool bw_()
+                {
+                    object cg_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ch_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cg_);
+                    bool ci_ = ch_ is CqlInterval<CqlQuantity>;
+
+                    return ci_;
+                };
+                if (bt_())
+                {
+                    object cj_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+
+                    return (ck_ as CqlDateTime) as object;
+                }
+                else if (bu_())
+                {
+                    object cl_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+
+                    return (cm_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bv_())
+                {
+                    object cn_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+
+                    return (co_ as CqlQuantity) as object;
+                }
+                else if (bw_())
+                {
+                    object cp_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+
+                    return (cq_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
+            CqlDateTime ao_ = context.Operators.Start(an_);
+            CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+            object as_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
+            CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime aw_ = context.Operators.End(av_);
+            CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime az_ = context.Operators.End(ay_);
+            CqlQuantity ba_ = context.Operators.Quantity(2m, "days");
+            CqlDateTime bb_ = context.Operators.Add(az_, ba_);
+            CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(aw_, bb_, true, true);
+            bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, "day");
+            CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+            CqlDateTime bg_ = context.Operators.End(bf_);
+            bool? bh_ = context.Operators.Not((bool?)(bg_ is null));
+            bool? bi_ = context.Operators.And(bd_, bh_);
+            bool? bj_ = context.Operators.Or(ar_, bi_);
+            bool? bk_ = context.Operators.And(al_, bj_);
+            object bl_()
+            {
+                bool cr_()
+                {
+                    object cv_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+                    bool cx_ = cw_ is CqlDateTime;
+
+                    return cx_;
+                };
+                bool cs_()
+                {
+                    object cy_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+                    bool da_ = cz_ is CqlInterval<CqlDateTime>;
+
+                    return da_;
+                };
+                bool ct_()
+                {
+                    object db_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                    bool dd_ = dc_ is CqlQuantity;
+
+                    return dd_;
+                };
+                bool cu_()
+                {
+                    object de_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                    bool dg_ = df_ is CqlInterval<CqlQuantity>;
+
+                    return dg_;
+                };
+                if (cr_())
+                {
+                    object dh_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+
+                    return (di_ as CqlDateTime) as object;
+                }
+                else if (cs_())
+                {
+                    object dj_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+
+                    return (dk_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ct_())
+                {
+                    object dl_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+
+                    return (dm_ as CqlQuantity) as object;
+                }
+                else if (cu_())
+                {
+                    object dn_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "performed");
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+
+                    return (do_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> bm_ = QICoreCommon_4_0_000.Instance.toInterval(context, bl_());
+            CqlDateTime bn_ = context.Operators.Start(bm_);
+            CqlDateTime bp_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
+            CqlInterval<CqlDateTime> bq_ = this.Measurement_Period(context);
+            bool? br_ = context.Operators.In<CqlDateTime>(bn_ ?? bp_, bq_, "day");
+            bool? bs_ = context.Operators.And(bk_, br_);
+
+            return bs_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> i_ = context.Operators.Where<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(g_, h_);
+        (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? j_((CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? tuple_cgtoaqsajoehgwcararimqzsa)
+        {
+            (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)? dp_ = (CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe, tuple_cgtoaqsajoehgwcararimqzsa?.LastAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, tuple_cgtoaqsajoehgwcararimqzsa?.QualifyingEncounter);
+
+            return dp_;
+        };
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> k_ = context.Operators.Select<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?, (CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(i_, j_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> l_ = context.Operators.Distinct<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(k_);
+
+        return l_;
+    }
+
+
+    [CqlExpressionDefinition("Patient Age 18 Years or Older at Start of Measurement Period")]
+    public bool? Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(CqlContext context)
+    {
+        Patient a_ = this.Patient(context);
+        Date b_ = a_?.BirthDateElement;
+        string c_ = b_?.Value;
+        CqlDate d_ = context.Operators.ConvertStringToDate(c_);
+        CqlInterval<CqlDateTime> e_ = this.Measurement_Period(context);
+        CqlDateTime f_ = context.Operators.Start(e_);
+        CqlDate g_ = context.Operators.DateFrom(f_);
+        int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
+        bool? i_ = context.Operators.GreaterOrEqual(h_, 18);
+
+        return i_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator")]
+    public bool? Numerator(CqlContext context)
+    {
+        bool? a_ = this.Patient_Age_12_to_16_Years_at_Start_of_Measurement_Period(context);
+        bool? b_ = this.Has_Most_Recent_Adolescent_Screening_Negative(context);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?> c_ = this.Most_Recent_Adolescent_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? d_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? e_ = context.Operators.Or(b_, d_);
+        bool? f_ = context.Operators.And(a_, e_);
+        bool? g_ = this.Patient_Age_17_Years_at_Start_of_Measurement_Period(context);
+        bool? j_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdolescentScreen, object FollowUpPositiveAdolescentScreen, Encounter QualifyingEncounter)?>(c_);
+        bool? k_ = context.Operators.Or(b_, j_);
+        bool? l_ = this.Has_Most_Recent_Adult_Screening_Negative(context);
+        bool? m_ = context.Operators.Or(k_, l_);
+        IEnumerable<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?> n_ = this.Most_Recent_Adult_Depression_Screening_Positive_and_Follow_Up_Provided(context);
+        bool? o_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? p_ = context.Operators.Or(m_, o_);
+        bool? q_ = context.Operators.And(g_, p_);
+        bool? r_ = context.Operators.Or(f_, q_);
+        bool? s_ = this.Patient_Age_18_Years_or_Older_at_Start_of_Measurement_Period(context);
+        bool? v_ = context.Operators.Exists<(CqlTupleMetadata, Observation LastAdultScreen, object FollowUpPositiveAdultScreen, Encounter QualifyingEncounter)?>(n_);
+        bool? w_ = context.Operators.Or(l_, v_);
+        bool? x_ = context.Operators.And(s_, w_);
+        bool? y_ = context.Operators.Or(r_, x_);
+
+        return y_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adolescent for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
+        IEnumerable<Observation> d_(Observation NoAdolescentScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdolescentScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdolescentScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdolescentScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ak_ = @this?.Url;
+                FhirString al_ = context.Operators.Convert<FhirString>(ak_);
+                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
+                bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return an_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType ao_ = @this?.Value;
+
+                return ao_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdolescentScreen is DomainResource
+                    ? (NoAdolescentScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+
+            return aj_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adolescent Depression Screening")]
+    public bool? Has_Adolescent_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adolescent_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdolescentScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdolescentScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdolescentScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdolescentScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                bool? an_ = context.Operators.And(ah_, am_);
+
+                return an_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdolescentScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Medical or Patient Reason for Not Screening Adult for Depression")]
+    public IEnumerable<Observation> Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observationcancelled"));
+        IEnumerable<Observation> d_(Observation NoAdultScreen)
+        {
+            IEnumerable<Encounter> h_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? i_(Encounter QualifyingEncounter)
+            {
+                Instant m_ = NoAdultScreen?.IssuedElement;
+                DateTimeOffset? n_ = m_?.Value;
+                CqlDateTime o_ = context.Operators.Convert<CqlDateTime>(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, "day");
+
+                return r_;
+            };
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            Observation k_(Encounter QualifyingEncounter) =>
+                NoAdultScreen;
+            IEnumerable<Observation> l_ = context.Operators.Select<Encounter, Observation>(j_, k_);
+
+            return l_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_(Observation NoAdultScreen)
+        {
+            bool? s_(Extension @this)
+            {
+                string ak_ = @this?.Url;
+                FhirString al_ = context.Operators.Convert<FhirString>(ak_);
+                string am_ = FHIRHelpers_4_4_000.Instance.ToString(context, al_);
+                bool? an_ = context.Operators.Equal(am_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return an_;
+            };
+            IEnumerable<Extension> t_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), s_);
+            object u_(Extension @this)
+            {
+                DataType ao_ = @this?.Value;
+
+                return ao_;
+            };
+            IEnumerable<object> v_ = context.Operators.Select<Extension, object>(t_, u_);
+            object w_ = context.Operators.SingletonFrom<object>(v_);
+            CqlConcept x_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, w_ as CodeableConcept);
+            CqlCode y_ = this.Depression_screening_declined__situation_(context);
+            CqlConcept z_ = context.Operators.ConvertCodeToConcept(y_);
+            bool? aa_ = context.Operators.Equivalent(x_, z_);
+            bool? ab_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-notDoneReason");
+
+                return as_;
+            };
+            IEnumerable<Extension> ac_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(NoAdultScreen is DomainResource
+                    ? (NoAdultScreen as DomainResource).Extension
+                    : default), ab_);
+            object ad_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<object> ae_ = context.Operators.Select<Extension, object>(ac_, ad_);
+            object af_ = context.Operators.SingletonFrom<object>(ae_);
+            CqlConcept ag_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, af_ as CodeableConcept);
+            CqlValueSet ah_ = this.Medical_Reason(context);
+            bool? ai_ = context.Operators.ConceptInValueSet(ag_, ah_);
+            bool? aj_ = context.Operators.Or(aa_, ai_);
+
+            return aj_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.Where<Observation>(e_, f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Has Adult Depression Screening")]
+    public bool? Has_Adult_Depression_Screening(CqlContext context)
+    {
+        CqlCode a_ = this.Adult_depression_screening_assessment(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+        IEnumerable<Observation> d_(Observation AdultScreening)
+        {
+            IEnumerable<Encounter> g_ = this.Qualifying_Encounter_During_Measurement_Period(context);
+            bool? h_(Encounter QualifyingEncounter)
+            {
+                DataType l_ = AdultScreening?.Effective;
+                object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+                CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
+                CqlDateTime o_ = context.Operators.End(n_);
+                Period p_ = QualifyingEncounter?.Period;
+                CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime r_ = context.Operators.Start(q_);
+                CqlQuantity s_ = context.Operators.Quantity(14m, "days");
+                CqlDateTime t_ = context.Operators.Subtract(r_, s_);
+                CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime w_ = context.Operators.Start(v_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, "day");
+                CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
+                CqlDateTime ab_ = context.Operators.Start(aa_);
+                bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
+                bool? ad_ = context.Operators.And(y_, ac_);
+                DataType ae_ = AdultScreening?.Value;
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                Code<ObservationStatus> ai_ = AdultScreening?.StatusElement;
+                ObservationStatus? aj_ = ai_?.Value;
+                string ak_ = context.Operators.Convert<string>(aj_);
+                string[] al_ = [
+                    "final",
+                    "corrected",
+                ];
+                bool? am_ = context.Operators.In<string>(ak_, (IEnumerable<string>)al_);
+                bool? an_ = context.Operators.And(ah_, am_);
+
+                return an_;
+            };
+            IEnumerable<Encounter> i_ = context.Operators.Where<Encounter>(g_, h_);
+            Observation j_(Encounter QualifyingEncounter) =>
+                AdultScreening;
+            IEnumerable<Observation> k_ = context.Operators.Select<Encounter, Observation>(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.SelectMany<Observation, Observation>(c_, d_);
+        bool? f_ = context.Operators.Exists<Observation>(e_);
+
+        return f_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exceptions")]
+    public bool? Denominator_Exceptions(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adolescent_for_Depression(context);
+        bool? b_ = context.Operators.Exists<Observation>(a_);
+        bool? c_ = this.Has_Adolescent_Depression_Screening(context);
+        bool? d_ = context.Operators.Not(c_);
+        bool? e_ = context.Operators.And(b_, d_);
+        IEnumerable<Observation> f_ = this.Medical_or_Patient_Reason_for_Not_Screening_Adult_for_Depression(context);
+        bool? g_ = context.Operators.Exists<Observation>(f_);
+        bool? h_ = this.Has_Adult_Depression_Screening(context);
+        bool? i_ = context.Operators.Not(h_);
+        bool? j_ = context.Operators.And(g_, i_);
+        bool? k_ = context.Operators.Or(e_, j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_5_1_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_5_1_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_ICeCVaggPeLLMJUWQdWMZROe = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdultScreen", "FollowUpPositiveAdultScreen", "QualifyingEncounter"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_ZRHehPJEDEeRJPiLbCPjUggS = new(
+      [typeof(Observation), typeof(object), typeof(Encounter)],
+      ["LastAdolescentScreen", "FollowUpPositiveAdolescentScreen", "QualifyingEncounter"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS832HHAKIFHIR-0.2.000.g.cs
+++ b/Demo/Measures.ecqm-content-qicore-2025/CSharp/CMS832HHAKIFHIR-0.2.000.g.cs
@@ -1,0 +1,4387 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "3.1.0.0")]
+[CqlLibrary("CMS832HHAKIFHIR", "0.2.000")]
+public partial class CMS832HHAKIFHIR_0_2_000 : ILibrary, ISingleton<CMS832HHAKIFHIR_0_2_000>
+{
+    private CMS832HHAKIFHIR_0_2_000() {}
+
+    public static CMS832HHAKIFHIR_0_2_000 Instance { get; } = new();
+
+    #region ILibrary Implementation
+
+    public string Name => "CMS832HHAKIFHIR";
+    public string Version => "0.2.000";
+    public ILibrary[] Dependencies => [FHIRHelpers_4_4_000.Instance, SupplementalDataElements_5_1_000.Instance, CQMCommon_4_1_000.Instance, QICoreCommon_4_0_000.Instance, CumulativeMedicationDuration_6_0_000.Instance, HospitalHarm_2_5_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region ValueSets
+
+    [CqlValueSetDefinition("Body temperature", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", valueSetVersion: null)]
+    public CqlValueSet Body_temperature(CqlContext _) => _Body_temperature;
+    private static readonly CqlValueSet _Body_temperature = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1045.152", null);
+
+    [CqlValueSetDefinition("Creatinine Mass Per Volume", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.21", valueSetVersion: null)]
+    public CqlValueSet Creatinine_Mass_Per_Volume(CqlContext _) => _Creatinine_Mass_Per_Volume;
+    private static readonly CqlValueSet _Creatinine_Mass_Per_Volume = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.21", null);
+
+    [CqlValueSetDefinition("Emergency Department Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", valueSetVersion: null)]
+    public CqlValueSet Emergency_Department_Visit(CqlContext _) => _Emergency_Department_Visit;
+    private static readonly CqlValueSet _Emergency_Department_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.117.1.7.1.292", null);
+
+    [CqlValueSetDefinition("Encounter Inpatient", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", valueSetVersion: null)]
+    public CqlValueSet Encounter_Inpatient(CqlContext _) => _Encounter_Inpatient;
+    private static readonly CqlValueSet _Encounter_Inpatient = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlValueSetDefinition("Glomerular Filtration Rate", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.17.4077.2.2038", valueSetVersion: null)]
+    public CqlValueSet Glomerular_Filtration_Rate(CqlContext _) => _Glomerular_Filtration_Rate;
+    private static readonly CqlValueSet _Glomerular_Filtration_Rate = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.17.4077.2.2038", null);
+
+    [CqlValueSetDefinition("High Risk Diagnosis for AKI", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.12", valueSetVersion: null)]
+    public CqlValueSet High_Risk_Diagnosis_for_AKI(CqlContext _) => _High_Risk_Diagnosis_for_AKI;
+    private static readonly CqlValueSet _High_Risk_Diagnosis_for_AKI = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.12", null);
+
+    [CqlValueSetDefinition("High Risk Procedures for AKI", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.19", valueSetVersion: null)]
+    public CqlValueSet High_Risk_Procedures_for_AKI(CqlContext _) => _High_Risk_Procedures_for_AKI;
+    private static readonly CqlValueSet _High_Risk_Procedures_for_AKI = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.19", null);
+
+    [CqlValueSetDefinition("Hospital Based Dialysis Services", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.199", valueSetVersion: null)]
+    public CqlValueSet Hospital_Based_Dialysis_Services(CqlContext _) => _Hospital_Based_Dialysis_Services;
+    private static readonly CqlValueSet _Hospital_Based_Dialysis_Services = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.199", null);
+
+    [CqlValueSetDefinition("Observation Services", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", valueSetVersion: null)]
+    public CqlValueSet Observation_Services(CqlContext _) => _Observation_Services;
+    private static readonly CqlValueSet _Observation_Services = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1111.143", null);
+
+    [CqlValueSetDefinition("Obstetrics and VTE Obstetrics", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.33", valueSetVersion: null)]
+    public CqlValueSet Obstetrics_and_VTE_Obstetrics(CqlContext _) => _Obstetrics_and_VTE_Obstetrics;
+    private static readonly CqlValueSet _Obstetrics_and_VTE_Obstetrics = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1248.33", null);
+
+    [CqlValueSetDefinition("Present on Admission or Clinically Undetermined", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", valueSetVersion: null)]
+    public CqlValueSet Present_on_Admission_or_Clinically_Undetermined(CqlContext _) => _Present_on_Admission_or_Clinically_Undetermined;
+    private static readonly CqlValueSet _Present_on_Admission_or_Clinically_Undetermined = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1147.197", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Female (finding)", codeId: "248152002", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Female__finding_(CqlContext _) => _Female__finding_;
+    private static readonly CqlCode _Female__finding_ = new CqlCode("248152002", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Male (finding)", codeId: "248153007", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Male__finding_(CqlContext _) => _Male__finding_;
+    private static readonly CqlCode _Male__finding_ = new CqlCode("248153007", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Heart rate", codeId: "8867-4", codeSystem: "http://loinc.org")]
+    public CqlCode Heart_rate(CqlContext _) => _Heart_rate;
+    private static readonly CqlCode _Heart_rate = new CqlCode("8867-4", "http://loinc.org");
+
+    [CqlCodeDefinition("Respiratory rate", codeId: "9279-1", codeSystem: "http://loinc.org")]
+    public CqlCode Respiratory_rate(CqlContext _) => _Respiratory_rate;
+    private static readonly CqlCode _Respiratory_rate = new CqlCode("9279-1", "http://loinc.org");
+
+    [CqlCodeDefinition("Systolic blood pressure", codeId: "8480-6", codeSystem: "http://loinc.org")]
+    public CqlCode Systolic_blood_pressure(CqlContext _) => _Systolic_blood_pressure;
+    private static readonly CqlCode _Systolic_blood_pressure = new CqlCode("8480-6", "http://loinc.org");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Female__finding_,
+          _Male__finding_]);
+
+    [CqlCodeSystemDefinition("LOINC", codeSystemId: "http://loinc.org", codeSystemVersion: null)]
+    public CqlCodeSystem LOINC(CqlContext _) => _LOINC;
+    private static readonly CqlCodeSystem _LOINC =
+      new CqlCodeSystem("http://loinc.org", null, [
+          _Heart_rate,
+          _Respiratory_rate,
+          _Systolic_blood_pressure]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context)
+    {
+        object a_ = context.ResolveParameter("CMS832HHAKIFHIR-0.2.000", "Measurement Period", null);
+
+        return (CqlInterval<CqlDateTime>)a_;
+    }
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context)
+    {
+        IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+        Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+
+        return b_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Ethnicity(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context)
+    {
+        IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_5_1_000.Instance.SDE_Payer(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context)
+    {
+        (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Race(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context)
+    {
+        CqlCode a_ = SupplementalDataElements_5_1_000.Instance.SDE_Sex(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Age 18 and Length of Stay 48 Hours or More")]
+    public IEnumerable<Encounter> Encounter_with_Age_18_and_Length_of_Stay_48_Hours_or_More(CqlContext context)
+    {
+        CqlValueSet a_ = this.Encounter_Inpatient(context);
+        IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+        bool? c_(Encounter InpatientEncounter)
+        {
+            List<Extension> e_()
+            {
+                bool al_()
+                {
+                    Patient am_ = this.Patient(context);
+                    bool an_ = am_ is DomainResource;
+
+                    return an_;
+                };
+                if (al_())
+                {
+                    Patient ao_ = this.Patient(context);
+
+                    return (ao_ as DomainResource).Extension;
+                }
+                else
+                {
+                    return default;
+                }
+            };
+            bool? f_(Extension @this)
+            {
+                string ap_ = @this?.Url;
+                FhirString aq_ = context.Operators.Convert<FhirString>(ap_);
+                string ar_ = FHIRHelpers_4_4_000.Instance.ToString(context, aq_);
+                bool? as_ = context.Operators.Equal(ar_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+
+                return as_;
+            };
+            IEnumerable<Extension> g_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(e_()), f_);
+            DataType h_(Extension @this)
+            {
+                DataType at_ = @this?.Value;
+
+                return at_;
+            };
+            IEnumerable<DataType> i_ = context.Operators.Select<Extension, DataType>(g_, h_);
+            DataType j_ = context.Operators.SingletonFrom<DataType>(i_);
+            string k_ = context.Operators.Convert<string>(j_);
+            string[] l_ = [
+                "248153007",
+                "248152002",
+            ];
+            bool? m_ = context.Operators.In<string>(k_, (IEnumerable<string>)l_);
+            Period n_ = InpatientEncounter?.Period;
+            CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+            CqlDateTime p_ = context.Operators.End(o_);
+            CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
+            bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, "day");
+            bool? s_ = context.Operators.And(m_, r_);
+            Patient t_ = this.Patient(context);
+            Date u_ = t_?.BirthDateElement;
+            string v_ = u_?.Value;
+            CqlDate w_ = context.Operators.ConvertStringToDate(v_);
+            CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
+            CqlDateTime z_ = context.Operators.Start(y_);
+            CqlDate aa_ = context.Operators.DateFrom(z_);
+            int? ab_ = context.Operators.CalculateAgeAt(w_, aa_, "year");
+            bool? ac_ = context.Operators.GreaterOrEqual(ab_, 18);
+            bool? ad_ = context.Operators.And(s_, ac_);
+            CqlInterval<CqlDateTime> ae_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
+            CqlDateTime af_ = context.Operators.Start(ae_);
+            CqlDateTime ah_ = context.Operators.End(ae_);
+            int? ai_ = context.Operators.DurationBetween(af_, ah_, "hour");
+            bool? aj_ = context.Operators.GreaterOrEqual(ai_, 48);
+            bool? ak_ = context.Operators.And(ad_, aj_);
+
+            return ak_;
+        };
+        IEnumerable<Encounter> d_ = context.Operators.Where<Encounter>(b_, c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Inpatient Encounter with Creatinine")]
+    public IEnumerable<Encounter> Inpatient_Encounter_with_Creatinine(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Age_18_and_Length_of_Stay_48_Hours_or_More(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+        (CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)? e_(ValueTuple<Encounter, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)? l_ = (CqlTupleMetadata_BSZZjZXQgCBZNijVbAJbPfNhP, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?>(d_, e_);
+        bool? g_((CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)? tuple_bbcfbwcplsbuhefbwpxpvuequ)
+        {
+            DataType m_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Value;
+            object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
+            bool? o_ = context.Operators.Not((bool?)(n_ is null));
+            object p_()
+            {
+                bool ag_()
+                {
+                    DataType aj_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                    bool al_ = ak_ is CqlDateTime;
+
+                    return al_;
+                };
+                bool ah_()
+                {
+                    DataType am_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                    bool ao_ = an_ is CqlInterval<CqlDateTime>;
+
+                    return ao_;
+                };
+                bool ai_()
+                {
+                    DataType ap_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool ar_ = aq_ is CqlDateTime;
+
+                    return ar_;
+                };
+                if (ag_())
+                {
+                    DataType as_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return (at_ as CqlDateTime) as object;
+                }
+                else if (ah_())
+                {
+                    DataType au_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+
+                    return (av_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ai_())
+                {
+                    DataType aw_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.Effective;
+                    object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+
+                    return (ax_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime q_ = QICoreCommon_4_0_000.Instance.earliest(context, p_());
+            CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bbcfbwcplsbuhefbwpxpvuequ?.Encounter48Hours);
+            CqlDateTime s_ = context.Operators.Start(r_);
+            CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlDateTime w_ = context.Operators.End(r_);
+            CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
+            bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, default);
+            bool? z_ = context.Operators.And(o_, y_);
+            Code<ObservationStatus> aa_ = tuple_bbcfbwcplsbuhefbwpxpvuequ?.CreatinineTest?.StatusElement;
+            ObservationStatus? ab_ = aa_?.Value;
+            string ac_ = context.Operators.Convert<string>(ab_);
+            string[] ad_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+            bool? af_ = context.Operators.And(z_, ae_);
+
+            return af_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?> h_ = context.Operators.Where<(CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?>(f_, g_);
+        Encounter i_((CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)? tuple_bbcfbwcplsbuhefbwpxpvuequ) =>
+            tuple_bbcfbwcplsbuhefbwpxpvuequ?.Encounter48Hours;
+        IEnumerable<Encounter> j_ = context.Operators.Select<(CqlTupleMetadata, Encounter Encounter48Hours, Observation CreatinineTest)?, Encounter>(h_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Distinct<Encounter>(j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Creatinine and without Obstetrical Conditions")]
+    public IEnumerable<Encounter> Encounter_with_Creatinine_and_without_Obstetrical_Conditions(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Inpatient_Encounter_with_Creatinine(context);
+        bool? b_(Encounter EncounterWithCreatinine)
+        {
+            IEnumerable<object> d_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, EncounterWithCreatinine);
+            bool? e_(object EncounterDiagnosis)
+            {
+                object i_ = context.Operators.LateBoundProperty<object>(EncounterDiagnosis, "code");
+                CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, i_ as CodeableConcept);
+                CqlValueSet k_ = this.Obstetrics_and_VTE_Obstetrics(context);
+                bool? l_ = context.Operators.ConceptInValueSet(j_, k_);
+
+                return l_;
+            };
+            IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
+            bool? g_ = context.Operators.Exists<object>(f_);
+            bool? h_ = context.Operators.Not(g_);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public IEnumerable<Encounter> Initial_Population(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+
+        return a_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator")]
+    public IEnumerable<Encounter> Denominator(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Initial_Population(context);
+
+        return a_;
+    }
+
+
+    [CqlFunctionDefinition("CreatinineLabTestwithResultwithinFirst48Hours")]
+    public IEnumerable<Observation> CreatinineLabTestwithResultwithinFirst48Hours(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlValueSet a_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        bool? c_(Observation CreatinineTest)
+        {
+            DataType h_ = CreatinineTest?.Value;
+            object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+            bool? j_ = context.Operators.Not((bool?)(i_ is null));
+            object k_()
+            {
+                bool ag_()
+                {
+                    DataType aj_ = CreatinineTest?.Effective;
+                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+                    bool al_ = ak_ is CqlDateTime;
+
+                    return al_;
+                };
+                bool ah_()
+                {
+                    DataType am_ = CreatinineTest?.Effective;
+                    object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, am_);
+                    bool ao_ = an_ is CqlInterval<CqlDateTime>;
+
+                    return ao_;
+                };
+                bool ai_()
+                {
+                    DataType ap_ = CreatinineTest?.Effective;
+                    object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ap_);
+                    bool ar_ = aq_ is CqlDateTime;
+
+                    return ar_;
+                };
+                if (ag_())
+                {
+                    DataType as_ = CreatinineTest?.Effective;
+                    object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
+
+                    return (at_ as CqlDateTime) as object;
+                }
+                else if (ah_())
+                {
+                    DataType au_ = CreatinineTest?.Effective;
+                    object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+
+                    return (av_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ai_())
+                {
+                    DataType aw_ = CreatinineTest?.Effective;
+                    object ax_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aw_);
+
+                    return (ax_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime l_ = QICoreCommon_4_0_000.Instance.earliest(context, k_());
+            CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime n_ = context.Operators.Start(m_);
+            CqlDateTime p_ = context.Operators.Start(m_);
+            CqlQuantity q_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime r_ = context.Operators.Add(p_, q_);
+            CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
+            bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+            bool? u_ = context.Operators.And(j_, t_);
+            object v_()
+            {
+                bool ay_()
+                {
+                    DataType bb_ = CreatinineTest?.Effective;
+                    object bc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bb_);
+                    bool bd_ = bc_ is CqlDateTime;
+
+                    return bd_;
+                };
+                bool az_()
+                {
+                    DataType be_ = CreatinineTest?.Effective;
+                    object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+                    bool bg_ = bf_ is CqlInterval<CqlDateTime>;
+
+                    return bg_;
+                };
+                bool ba_()
+                {
+                    DataType bh_ = CreatinineTest?.Effective;
+                    object bi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bh_);
+                    bool bj_ = bi_ is CqlDateTime;
+
+                    return bj_;
+                };
+                if (ay_())
+                {
+                    DataType bk_ = CreatinineTest?.Effective;
+                    object bl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bk_);
+
+                    return (bl_ as CqlDateTime) as object;
+                }
+                else if (az_())
+                {
+                    DataType bm_ = CreatinineTest?.Effective;
+                    object bn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bm_);
+
+                    return (bn_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ba_())
+                {
+                    DataType bo_ = CreatinineTest?.Effective;
+                    object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+
+                    return (bp_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_());
+            bool? y_ = context.Operators.In<CqlDateTime>(w_, m_, default);
+            bool? z_ = context.Operators.And(u_, y_);
+            Code<ObservationStatus> aa_ = CreatinineTest?.StatusElement;
+            ObservationStatus? ab_ = aa_?.Value;
+            string ac_ = context.Operators.Convert<string>(ab_);
+            string[] ad_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? ae_ = context.Operators.In<string>(ac_, (IEnumerable<string>)ad_);
+            bool? af_ = context.Operators.And(z_, ae_);
+
+            return af_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+        Observation e_(Observation CreatinineTest) =>
+            CreatinineTest;
+        IEnumerable<Observation> f_ = context.Operators.Select<Observation, Observation>(d_, e_);
+        IEnumerable<Observation> g_ = context.Operators.Distinct<Observation>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Less Than 2 Creatinine Results within 48 Hours of Arrival")]
+    public IEnumerable<Encounter> Encounter_with_Less_Than_2_Creatinine_Results_within_48_Hours_of_Arrival(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        bool? b_(Encounter QualifyingEncounter)
+        {
+            IEnumerable<Observation> d_ = this.CreatinineLabTestwithResultwithinFirst48Hours(context, QualifyingEncounter);
+            int? e_ = context.Operators.Count<Observation>(d_);
+            bool? f_ = context.Operators.Less(e_, 2);
+
+            return f_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("MaleeGFR")]
+    public decimal? MaleeGFR(CqlContext context, Encounter QualifyingEncounter)
+    {
+        decimal? a_()
+        {
+            bool b_()
+            {
+                List<Extension> c_()
+                {
+                    bool j_()
+                    {
+                        Patient k_ = this.Patient(context);
+                        bool l_ = k_ is DomainResource;
+
+                        return l_;
+                    };
+                    if (j_())
+                    {
+                        Patient m_ = this.Patient(context);
+
+                        return (m_ as DomainResource).Extension;
+                    }
+                    else
+                    {
+                        return default;
+                    }
+                };
+                bool? d_(Extension @this)
+                {
+                    string n_ = @this?.Url;
+                    FhirString o_ = context.Operators.Convert<FhirString>(n_);
+                    string p_ = FHIRHelpers_4_4_000.Instance.ToString(context, o_);
+                    bool? q_ = context.Operators.Equal(p_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+
+                    return q_;
+                };
+                IEnumerable<Extension> e_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(c_()), d_);
+                DataType f_(Extension @this)
+                {
+                    DataType r_ = @this?.Value;
+
+                    return r_;
+                };
+                IEnumerable<DataType> g_ = context.Operators.Select<Extension, DataType>(e_, f_);
+                DataType h_ = context.Operators.SingletonFrom<DataType>(g_);
+                bool? i_ = context.Operators.Equal(h_, "248153007");
+
+                return i_ ?? false;
+            };
+            if (b_())
+            {
+                decimal? s_ = context.Operators.ConvertIntegerToDecimal(142);
+                CqlQuantity t_ = this.IndexCreatinine(context, QualifyingEncounter);
+                decimal? u_ = t_?.value;
+                decimal? v_ = context.Operators.Divide(u_, 0.9m);
+                decimal? w_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal?[] x_ = [
+                    v_,
+                    w_,
+                ];
+                decimal? y_ = context.Operators.Min<decimal?>((IEnumerable<decimal?>)x_);
+                decimal? z_ = context.Operators.Negate(0.302m);
+                decimal? aa_ = context.Operators.Power(y_, z_);
+                decimal? ab_ = context.Operators.Multiply(s_, aa_);
+                decimal? ad_ = t_?.value;
+                decimal? ae_ = context.Operators.Divide(ad_, 0.9m);
+                decimal?[] ag_ = [
+                    ae_,
+                    w_,
+                ];
+                decimal? ah_ = context.Operators.Max<decimal?>((IEnumerable<decimal?>)ag_);
+                decimal? ai_ = context.Operators.Negate(1.200m);
+                decimal? aj_ = context.Operators.Power(ah_, ai_);
+                decimal? ak_ = context.Operators.Multiply(ab_, aj_);
+                Patient al_ = this.Patient(context);
+                Date am_ = al_?.BirthDateElement;
+                string an_ = am_?.Value;
+                CqlDateTime ao_ = context.Operators.ConvertStringToDateTime(an_);
+                CqlInterval<CqlDateTime> ap_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                int? ar_ = context.Operators.CalculateAgeAt(ao_, aq_, "year");
+                decimal? as_ = context.Operators.ConvertIntegerToDecimal(ar_);
+                decimal? at_ = context.Operators.Power(0.9938m, as_);
+                decimal? au_ = context.Operators.Multiply(ak_, at_);
+
+                return au_;
+            }
+            else
+            {
+                return default;
+            }
+        };
+
+        return a_();
+    }
+
+
+    [CqlFunctionDefinition("IndexCreatinine")]
+    public CqlQuantity IndexCreatinine(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlQuantity a_ = this.LowestSerumCreatinineIn24Hours(context, QualifyingEncounter);
+        IEnumerable<CqlQuantity> b_ = this.FirstSerumCreatinineIn48Hours(context, QualifyingEncounter);
+        CqlQuantity c_ = context.Operators.SingletonFrom<CqlQuantity>(b_);
+
+        return a_ ?? c_;
+    }
+
+
+    [CqlFunctionDefinition("LowestSerumCreatinineIn24Hours")]
+    public CqlQuantity LowestSerumCreatinineIn24Hours(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTestsLow)
+        {
+            string i_ = LabTestsLow?.CrEncInPtId;
+            string j_ = (QualifyingEncounter is Resource
+        ? (QualifyingEncounter as Resource).IdElement
+        : default)?.Value;
+            bool? k_ = context.Operators.Equal(i_, j_);
+            CqlDateTime l_ = LabTestsLow?.CrLabTime;
+            CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime n_ = context.Operators.Start(m_);
+            CqlDateTime p_ = context.Operators.Start(m_);
+            CqlQuantity q_ = context.Operators.Quantity(24m, "hours");
+            CqlDateTime r_ = context.Operators.Add(p_, q_);
+            CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
+            bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+            bool? u_ = context.Operators.And(k_, t_);
+
+            return u_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        bool? d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity v_ = @this?.CrLabResult;
+            bool? w_ = context.Operators.Not((bool?)(v_ is null));
+
+            return w_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> e_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(c_, d_);
+        CqlQuantity f_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity x_ = @this?.CrLabResult;
+
+            return x_;
+        };
+        IEnumerable<CqlQuantity> g_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlQuantity>(e_, f_);
+        CqlQuantity h_ = context.Operators.Min<CqlQuantity>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Creatinine Lab Result by Time")]
+    public IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> Qualifying_Creatinine_Lab_Result_by_Time(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation>> d_ = context.Operators.CrossJoin<Encounter, Observation>(a_, c_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? e_(ValueTuple<Encounter, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? n_ = (CqlTupleMetadata_GiiGRATBZEQfMLdbZgPRgTeRJ, _valueTuple.Item1, _valueTuple.Item2);
+
+            return n_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?> f_ = context.Operators.Select<ValueTuple<Encounter, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?>(d_, e_);
+        bool? g_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? tuple_ccccqpjvqogtctjhtilehkfoj)
+        {
+            object o_()
+            {
+                bool ao_()
+                {
+                    DataType ar_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object as_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ar_);
+                    bool at_ = as_ is CqlDateTime;
+
+                    return at_;
+                };
+                bool ap_()
+                {
+                    DataType au_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, au_);
+                    bool aw_ = av_ is CqlInterval<CqlDateTime>;
+
+                    return aw_;
+                };
+                bool aq_()
+                {
+                    DataType ax_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+                    bool az_ = ay_ is CqlDateTime;
+
+                    return az_;
+                };
+                if (ao_())
+                {
+                    DataType ba_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object bb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ba_);
+
+                    return (bb_ as CqlDateTime) as object;
+                }
+                else if (ap_())
+                {
+                    DataType bc_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bc_);
+
+                    return (bd_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (aq_())
+                {
+                    DataType be_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, be_);
+
+                    return (bf_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_());
+            CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter);
+            bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, default);
+            bool? s_ = QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as object);
+            bool? t_ = context.Operators.And(r_, s_);
+            Code<ObservationStatus> u_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
+            ObservationStatus? v_ = u_?.Value;
+            string w_ = context.Operators.Convert<string>(v_);
+            string[] x_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? y_ = context.Operators.In<string>(w_, (IEnumerable<string>)x_);
+            bool? z_ = context.Operators.And(t_, y_);
+            DataType aa_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
+            object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            string ac_ = (ab_ as CqlQuantity)?.unit;
+            bool? ad_ = context.Operators.Equal(ac_, "mg/dL");
+            bool? ae_ = context.Operators.And(z_, ad_);
+            object ag_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
+            bool? ai_ = context.Operators.And(ae_, ah_);
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+            CqlQuantity al_ = context.Operators.Quantity(0m, "mg/dL");
+            bool? am_ = context.Operators.Greater(ak_ as CqlQuantity, al_);
+            bool? an_ = context.Operators.And(ai_, am_);
+
+            return an_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?> h_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?>(f_, g_);
+        (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? i_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)? tuple_ccccqpjvqogtctjhtilehkfoj)
+        {
+            Id bg_ = tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter?.IdElement;
+            string bh_ = bg_?.Value;
+            CqlInterval<CqlDateTime> bi_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_ccccqpjvqogtctjhtilehkfoj?.QualifyingEncounter);
+            Id bj_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IdElement;
+            string bk_ = bj_?.Value;
+            object bl_()
+            {
+                if ((QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as object)) ?? false)
+                {
+                    return "laboratory" as object;
+                }
+                else
+                {
+                    bool? cd_ = QICoreCommon_4_0_000.Instance.isLaboratory(context, tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime as object);
+
+                    return cd_;
+                }
+            };
+            Code<ObservationStatus> bm_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.StatusElement;
+            ObservationStatus? bn_ = bm_?.Value;
+            string bo_ = context.Operators.Convert<string>(bn_);
+            DataType bp_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Value;
+            object bq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            string bt_ = (bs_ as CqlQuantity)?.unit;
+            object bv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bp_);
+            decimal? bw_ = (bv_ as CqlQuantity)?.value;
+            object bx_()
+            {
+                bool ce_()
+                {
+                    DataType ch_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object ci_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ch_);
+                    bool cj_ = ci_ is CqlDateTime;
+
+                    return cj_;
+                };
+                bool cf_()
+                {
+                    DataType ck_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object cl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ck_);
+                    bool cm_ = cl_ is CqlInterval<CqlDateTime>;
+
+                    return cm_;
+                };
+                bool cg_()
+                {
+                    DataType cn_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                    bool cp_ = co_ is CqlDateTime;
+
+                    return cp_;
+                };
+                if (ce_())
+                {
+                    DataType cq_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+
+                    return (cr_ as CqlDateTime) as object;
+                }
+                else if (cf_())
+                {
+                    DataType cs_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+
+                    return (ct_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (cg_())
+                {
+                    DataType cu_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.Effective;
+                    object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+
+                    return (cv_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime by_ = QICoreCommon_4_0_000.Instance.earliest(context, bx_());
+            Instant bz_ = tuple_ccccqpjvqogtctjhtilehkfoj?.CreatinineTestByTime?.IssuedElement;
+            DateTimeOffset? ca_ = bz_?.Value;
+            CqlDateTime cb_ = context.Operators.Convert<CqlDateTime>(ca_);
+            (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? cc_ = (CqlTupleMetadata_XFRBIZcEbIWeUfjZdAFDdJef, bh_, bi_, bk_, bl_(), bo_, bq_ as CqlQuantity, bt_, bw_, by_, cb_);
+
+            return cc_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> j_ = context.Operators.Select<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation CreatinineTestByTime)?, (CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(h_, i_);
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> k_ = context.Operators.Distinct<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(j_);
+        object l_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlDateTime cw_ = @this?.CrLabTime;
+
+            return cw_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> m_ = context.Operators.SortBy<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(k_, l_, System.ComponentModel.ListSortDirection.Ascending);
+
+        return m_;
+    }
+
+
+    [CqlFunctionDefinition("FirstSerumCreatinineIn48Hours")]
+    public IEnumerable<CqlQuantity> FirstSerumCreatinineIn48Hours(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            CqlDateTime g_ = this.EarliestSerumCreatinineTimeIn48Hours(context, QualifyingEncounter);
+            CqlDateTime h_ = LabTests?.CrLabTime;
+            bool? i_ = context.Operators.Equal(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        CqlQuantity d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            CqlQuantity j_ = LabTests?.CrLabResult;
+
+            return j_ as CqlQuantity;
+        };
+        IEnumerable<CqlQuantity> e_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlQuantity>(c_, d_);
+        IEnumerable<CqlQuantity> f_ = context.Operators.Distinct<CqlQuantity>(e_);
+
+        return f_;
+    }
+
+
+    [CqlFunctionDefinition("EarliestSerumCreatinineTimeIn48Hours")]
+    public CqlDateTime EarliestSerumCreatinineTimeIn48Hours(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests48)
+        {
+            string i_ = LabTests48?.CrEncInPtId;
+            string j_ = (QualifyingEncounter is Resource
+        ? (QualifyingEncounter as Resource).IdElement
+        : default)?.Value;
+            bool? k_ = context.Operators.Equal(i_, j_);
+            CqlDateTime l_ = LabTests48?.CrLabTime;
+            CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            CqlDateTime n_ = context.Operators.Start(m_);
+            CqlDateTime p_ = context.Operators.Start(m_);
+            CqlQuantity q_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime r_ = context.Operators.Add(p_, q_);
+            CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
+            bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+            bool? u_ = context.Operators.And(k_, t_);
+
+            return u_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        bool? d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlDateTime v_ = @this?.CrLabTime;
+            bool? w_ = context.Operators.Not((bool?)(v_ is null));
+
+            return w_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> e_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(c_, d_);
+        CqlDateTime f_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlDateTime x_ = @this?.CrLabTime;
+
+            return x_;
+        };
+        IEnumerable<CqlDateTime> g_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlDateTime>(e_, f_);
+        CqlDateTime h_ = context.Operators.Min<CqlDateTime>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Male Encounter with eGFR Less Than 60")]
+    public IEnumerable<Encounter> Male_Encounter_with_eGFR_Less_Than_60(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        bool? b_(Encounter QualifyingEncounter)
+        {
+            decimal? d_ = this.MaleeGFR(context, QualifyingEncounter);
+            bool? e_ = context.Operators.Not((bool?)(d_ is null));
+            decimal? g_ = context.Operators.ConvertIntegerToDecimal(60);
+            bool? h_ = context.Operators.Less(d_ as decimal?, g_);
+            bool? i_ = context.Operators.And(e_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("FemaleeGFR")]
+    public decimal? FemaleeGFR(CqlContext context, Encounter QualifyingEncounter)
+    {
+        decimal? a_()
+        {
+            bool b_()
+            {
+                List<Extension> c_()
+                {
+                    bool j_()
+                    {
+                        Patient k_ = this.Patient(context);
+                        bool l_ = k_ is DomainResource;
+
+                        return l_;
+                    };
+                    if (j_())
+                    {
+                        Patient m_ = this.Patient(context);
+
+                        return (m_ as DomainResource).Extension;
+                    }
+                    else
+                    {
+                        return default;
+                    }
+                };
+                bool? d_(Extension @this)
+                {
+                    string n_ = @this?.Url;
+                    FhirString o_ = context.Operators.Convert<FhirString>(n_);
+                    string p_ = FHIRHelpers_4_4_000.Instance.ToString(context, o_);
+                    bool? q_ = context.Operators.Equal(p_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+
+                    return q_;
+                };
+                IEnumerable<Extension> e_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(c_()), d_);
+                DataType f_(Extension @this)
+                {
+                    DataType r_ = @this?.Value;
+
+                    return r_;
+                };
+                IEnumerable<DataType> g_ = context.Operators.Select<Extension, DataType>(e_, f_);
+                DataType h_ = context.Operators.SingletonFrom<DataType>(g_);
+                bool? i_ = context.Operators.Equal(h_, "248152002");
+
+                return i_ ?? false;
+            };
+            if (b_())
+            {
+                decimal? s_ = context.Operators.ConvertIntegerToDecimal(142);
+                CqlQuantity t_ = this.IndexCreatinine(context, QualifyingEncounter);
+                decimal? u_ = t_?.value;
+                decimal? v_ = context.Operators.Divide(u_, 0.7m);
+                decimal? w_ = context.Operators.ConvertIntegerToDecimal(1);
+                decimal?[] x_ = [
+                    v_,
+                    w_,
+                ];
+                decimal? y_ = context.Operators.Min<decimal?>((IEnumerable<decimal?>)x_);
+                decimal? z_ = context.Operators.Negate(0.241m);
+                decimal? aa_ = context.Operators.Power(y_, z_);
+                decimal? ab_ = context.Operators.Multiply(s_, aa_);
+                decimal? ad_ = t_?.value;
+                decimal? ae_ = context.Operators.Divide(ad_, 0.7m);
+                decimal?[] ag_ = [
+                    ae_,
+                    w_,
+                ];
+                decimal? ah_ = context.Operators.Max<decimal?>((IEnumerable<decimal?>)ag_);
+                decimal? ai_ = context.Operators.Negate(1.200m);
+                decimal? aj_ = context.Operators.Power(ah_, ai_);
+                decimal? ak_ = context.Operators.Multiply(ab_, aj_);
+                Patient al_ = this.Patient(context);
+                Date am_ = al_?.BirthDateElement;
+                string an_ = am_?.Value;
+                CqlDateTime ao_ = context.Operators.ConvertStringToDateTime(an_);
+                CqlInterval<CqlDateTime> ap_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                CqlDateTime aq_ = context.Operators.Start(ap_);
+                int? ar_ = context.Operators.CalculateAgeAt(ao_, aq_, "year");
+                decimal? as_ = context.Operators.ConvertIntegerToDecimal(ar_);
+                decimal? at_ = context.Operators.Power(0.9938m, as_);
+                decimal? au_ = context.Operators.Multiply(ak_, at_);
+                decimal? av_ = context.Operators.Multiply(au_, 1.012m);
+
+                return av_;
+            }
+            else
+            {
+                return default;
+            }
+        };
+
+        return a_();
+    }
+
+
+    [CqlExpressionDefinition("Female Encounter with eGFR Less Than 60")]
+    public IEnumerable<Encounter> Female_Encounter_with_eGFR_Less_Than_60(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        bool? b_(Encounter QualifyingEncounter)
+        {
+            decimal? d_ = this.FemaleeGFR(context, QualifyingEncounter);
+            bool? e_ = context.Operators.Not((bool?)(d_ is null));
+            decimal? g_ = context.Operators.ConvertIntegerToDecimal(60);
+            bool? h_ = context.Operators.Less(d_ as decimal?, g_);
+            bool? i_ = context.Operators.And(e_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Index eGFR Less Than 60 within First 48 Hours")]
+    public IEnumerable<Encounter> Encounter_with_Index_eGFR_Less_Than_60_within_First_48_Hours(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Male_Encounter_with_eGFR_Less_Than_60(context);
+        IEnumerable<Encounter> b_ = this.Female_Encounter_with_eGFR_Less_Than_60(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("LowestSerumCreatinineResult")]
+    public CqlQuantity LowestSerumCreatinineResult(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            string i_ = LabTests?.CrEncInPtId;
+            string j_ = (QualifyingEncounter is Resource
+        ? (QualifyingEncounter as Resource).IdElement
+        : default)?.Value;
+            bool? k_ = context.Operators.Equal(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        bool? d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity l_ = @this?.CrLabResult;
+            bool? m_ = context.Operators.Not((bool?)(l_ is null));
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> e_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(c_, d_);
+        CqlQuantity f_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity n_ = @this?.CrLabResult;
+
+            return n_;
+        };
+        IEnumerable<CqlQuantity> g_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlQuantity>(e_, f_);
+        CqlQuantity h_ = context.Operators.Min<CqlQuantity>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Increase of 0.3 or More Using Lowest Creatinine within 24 Hours")]
+    public IEnumerable<Encounter> Increase_of_0_3_or_More_Using_Lowest_Creatinine_within_24_Hours(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation, Observation>> f_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, c_, e_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? g_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? n_ = (CqlTupleMetadata_FWVGLDcQEISFGIdVNGEWPHUFV, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return n_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> h_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(f_, g_);
+        bool? i_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? tuple_hsukaxezrzqpeqifkirnhhzen)
+        {
+            Code<ObservationStatus> o_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.StatusElement;
+            ObservationStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            Code<ObservationStatus> t_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)r_);
+            bool? y_ = context.Operators.And(s_, x_);
+            DataType z_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
+            object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+            DataType ab_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            CqlQuantity ad_ = context.Operators.Subtract(aa_ as CqlQuantity, ac_ as CqlQuantity);
+            CqlQuantity ae_ = context.Operators.Quantity(0.299m, "mg/dL");
+            bool? af_ = context.Operators.Greater(ad_, ae_);
+            bool? ag_ = context.Operators.And(y_, af_);
+            object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            CqlQuantity aj_ = this.LowestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            bool? ak_ = context.Operators.Equal(ai_ as CqlQuantity, aj_);
+            bool? al_ = context.Operators.And(ag_, ak_);
+            object am_()
+            {
+                bool ck_()
+                {
+                    DataType cn_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cn_);
+                    bool cp_ = co_ is CqlDateTime;
+
+                    return cp_;
+                };
+                bool cl_()
+                {
+                    DataType cq_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                    bool cs_ = cr_ is CqlInterval<CqlDateTime>;
+
+                    return cs_;
+                };
+                bool cm_()
+                {
+                    DataType ct_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+                    bool cv_ = cu_ is CqlDateTime;
+
+                    return cv_;
+                };
+                if (ck_())
+                {
+                    DataType cw_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+
+                    return (cx_ as CqlDateTime) as object;
+                }
+                else if (cl_())
+                {
+                    DataType cy_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object cz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cy_);
+
+                    return (cz_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (cm_())
+                {
+                    DataType da_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+
+                    return (db_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime an_ = QICoreCommon_4_0_000.Instance.earliest(context, am_());
+            object ao_()
+            {
+                bool dc_()
+                {
+                    DataType df_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                    bool dh_ = dg_ is CqlDateTime;
+
+                    return dh_;
+                };
+                bool dd_()
+                {
+                    DataType di_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                    bool dk_ = dj_ is CqlInterval<CqlDateTime>;
+
+                    return dk_;
+                };
+                bool de_()
+                {
+                    DataType dl_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                    bool dn_ = dm_ is CqlDateTime;
+
+                    return dn_;
+                };
+                if (dc_())
+                {
+                    DataType do_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+
+                    return (dp_ as CqlDateTime) as object;
+                }
+                else if (dd_())
+                {
+                    DataType dq_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
+
+                    return (dr_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (de_())
+                {
+                    DataType ds_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+
+                    return (dt_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_());
+            CqlQuantity aq_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime ar_ = context.Operators.Subtract(ap_, aq_);
+            object as_()
+            {
+                bool du_()
+                {
+                    DataType dx_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
+                    bool dz_ = dy_ is CqlDateTime;
+
+                    return dz_;
+                };
+                bool dv_()
+                {
+                    DataType ea_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
+                    bool ec_ = eb_ is CqlInterval<CqlDateTime>;
+
+                    return ec_;
+                };
+                bool dw_()
+                {
+                    DataType ed_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
+                    bool ef_ = ee_ is CqlDateTime;
+
+                    return ef_;
+                };
+                if (du_())
+                {
+                    DataType eg_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
+
+                    return (eh_ as CqlDateTime) as object;
+                }
+                else if (dv_())
+                {
+                    DataType ei_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ej_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ei_);
+
+                    return (ej_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (dw_())
+                {
+                    DataType ek_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
+
+                    return (el_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime at_ = QICoreCommon_4_0_000.Instance.earliest(context, as_());
+            CqlInterval<CqlDateTime> au_ = context.Operators.Interval(ar_, at_, true, true);
+            bool? av_ = context.Operators.In<CqlDateTime>(an_, au_, default);
+            bool? aw_ = context.Operators.And(al_, av_);
+            object ax_()
+            {
+                bool em_()
+                {
+                    DataType ep_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object eq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ep_);
+                    bool er_ = eq_ is CqlDateTime;
+
+                    return er_;
+                };
+                bool en_()
+                {
+                    DataType es_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
+                    bool eu_ = et_ is CqlInterval<CqlDateTime>;
+
+                    return eu_;
+                };
+                bool eo_()
+                {
+                    DataType ev_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
+                    bool ex_ = ew_ is CqlDateTime;
+
+                    return ex_;
+                };
+                if (em_())
+                {
+                    DataType ey_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
+
+                    return (ez_ as CqlDateTime) as object;
+                }
+                else if (en_())
+                {
+                    DataType fa_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fa_);
+
+                    return (fb_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (eo_())
+                {
+                    DataType fc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
+
+                    return (fd_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime ay_ = QICoreCommon_4_0_000.Instance.earliest(context, ax_());
+            CqlInterval<CqlDateTime> az_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            bool? ba_ = context.Operators.In<CqlDateTime>(ay_, az_, default);
+            bool? bb_ = context.Operators.And(aw_, ba_);
+            object bc_()
+            {
+                bool fe_()
+                {
+                    DataType fh_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fh_);
+                    bool fj_ = fi_ is CqlDateTime;
+
+                    return fj_;
+                };
+                bool ff_()
+                {
+                    DataType fk_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fk_);
+                    bool fm_ = fl_ is CqlInterval<CqlDateTime>;
+
+                    return fm_;
+                };
+                bool fg_()
+                {
+                    DataType fn_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fn_);
+                    bool fp_ = fo_ is CqlDateTime;
+
+                    return fp_;
+                };
+                if (fe_())
+                {
+                    DataType fq_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
+
+                    return (fr_ as CqlDateTime) as object;
+                }
+                else if (ff_())
+                {
+                    DataType fs_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object ft_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fs_);
+
+                    return (ft_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fg_())
+                {
+                    DataType fu_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+
+                    return (fv_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bd_ = QICoreCommon_4_0_000.Instance.earliest(context, bc_());
+            CqlDateTime bf_ = context.Operators.Start(az_);
+            CqlDateTime bh_ = context.Operators.Start(az_);
+            CqlQuantity bi_ = context.Operators.Quantity(24m, "hours");
+            CqlDateTime bj_ = context.Operators.Add(bh_, bi_);
+            CqlInterval<CqlDateTime> bk_ = context.Operators.Interval(bf_, bj_, true, true);
+            bool? bl_ = context.Operators.In<CqlDateTime>(bd_, bk_, default);
+            bool? bm_ = context.Operators.And(bb_, bl_);
+            object bn_()
+            {
+                bool fw_()
+                {
+                    DataType fz_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ga_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fz_);
+                    bool gb_ = ga_ is CqlDateTime;
+
+                    return gb_;
+                };
+                bool fx_()
+                {
+                    DataType gc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gc_);
+                    bool ge_ = gd_ is CqlInterval<CqlDateTime>;
+
+                    return ge_;
+                };
+                bool fy_()
+                {
+                    DataType gf_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gf_);
+                    bool gh_ = gg_ is CqlDateTime;
+
+                    return gh_;
+                };
+                if (fw_())
+                {
+                    DataType gi_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
+
+                    return (gj_ as CqlDateTime) as object;
+                }
+                else if (fx_())
+                {
+                    DataType gk_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gk_);
+
+                    return (gl_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fy_())
+                {
+                    DataType gm_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gm_);
+
+                    return (gn_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bo_ = QICoreCommon_4_0_000.Instance.earliest(context, bn_());
+            bool? bq_ = context.Operators.In<CqlDateTime>(bo_, az_, default);
+            bool? br_ = context.Operators.And(bm_, bq_);
+            object bs_()
+            {
+                bool go_()
+                {
+                    DataType gr_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
+                    bool gt_ = gs_ is CqlDateTime;
+
+                    return gt_;
+                };
+                bool gp_()
+                {
+                    DataType gu_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gu_);
+                    bool gw_ = gv_ is CqlInterval<CqlDateTime>;
+
+                    return gw_;
+                };
+                bool gq_()
+                {
+                    DataType gx_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gx_);
+                    bool gz_ = gy_ is CqlDateTime;
+
+                    return gz_;
+                };
+                if (go_())
+                {
+                    DataType ha_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object hb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ha_);
+
+                    return (hb_ as CqlDateTime) as object;
+                }
+                else if (gp_())
+                {
+                    DataType hc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object hd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hc_);
+
+                    return (hd_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (gq_())
+                {
+                    DataType he_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object hf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, he_);
+
+                    return (hf_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bt_ = QICoreCommon_4_0_000.Instance.earliest(context, bs_());
+            CqlDateTime bv_ = context.Operators.Start(az_);
+            CqlDateTime bx_ = context.Operators.Start(az_);
+            CqlDateTime bz_ = context.Operators.Add(bx_, aq_);
+            CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bv_, bz_, true, true);
+            bool? cb_ = context.Operators.In<CqlDateTime>(bt_, ca_, default);
+            bool? cc_ = context.Operators.And(br_, cb_);
+            Id cd_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
+            string ce_ = cd_?.Value;
+            Id cf_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
+            string cg_ = cf_?.Value;
+            bool? ch_ = context.Operators.Equal(ce_, cg_);
+            bool? ci_ = context.Operators.Not(ch_);
+            bool? cj_ = context.Operators.And(cc_, ci_);
+
+            return cj_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> j_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(h_, i_);
+        Encounter k_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? tuple_hsukaxezrzqpeqifkirnhhzen) =>
+            tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter;
+        IEnumerable<Encounter> l_ = context.Operators.Select<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?, Encounter>(j_, k_);
+        IEnumerable<Encounter> m_ = context.Operators.Distinct<Encounter>(l_);
+
+        return m_;
+    }
+
+
+    [CqlFunctionDefinition("EarliestSerumCreatinineResult")]
+    public IEnumerable<CqlQuantity> EarliestSerumCreatinineResult(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            CqlDateTime g_ = this.EarliestSerumCreatinineTime(context, QualifyingEncounter);
+            CqlDateTime h_ = LabTests?.CrLabTime;
+            bool? i_ = context.Operators.Equal(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        CqlQuantity d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            CqlQuantity j_ = LabTests?.CrLabResult;
+
+            return j_ as CqlQuantity;
+        };
+        IEnumerable<CqlQuantity> e_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlQuantity>(c_, d_);
+        IEnumerable<CqlQuantity> f_ = context.Operators.Distinct<CqlQuantity>(e_);
+
+        return f_;
+    }
+
+
+    [CqlFunctionDefinition("EarliestSerumCreatinineTime")]
+    public CqlDateTime EarliestSerumCreatinineTime(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTestsEarly)
+        {
+            string i_ = LabTestsEarly?.CrEncInPtId;
+            string j_ = (QualifyingEncounter is Resource
+        ? (QualifyingEncounter as Resource).IdElement
+        : default)?.Value;
+            bool? k_ = context.Operators.Equal(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        bool? d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlDateTime l_ = @this?.CrLabTime;
+            bool? m_ = context.Operators.Not((bool?)(l_ is null));
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> e_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(c_, d_);
+        CqlDateTime f_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlDateTime n_ = @this?.CrLabTime;
+
+            return n_;
+        };
+        IEnumerable<CqlDateTime> g_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlDateTime>(e_, f_);
+        CqlDateTime h_ = context.Operators.Min<CqlDateTime>(g_);
+
+        return h_;
+    }
+
+
+    [CqlExpressionDefinition("Increase of 0.3 or More Using First Creatinine within First 48 Hours")]
+    public IEnumerable<Encounter> Increase_of_0_3_or_More_Using_First_Creatinine_within_First_48_Hours(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation, Observation>> f_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, c_, e_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? g_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? n_ = (CqlTupleMetadata_FWVGLDcQEISFGIdVNGEWPHUFV, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return n_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> h_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(f_, g_);
+        bool? i_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? tuple_hsukaxezrzqpeqifkirnhhzen)
+        {
+            Code<ObservationStatus> o_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.StatusElement;
+            ObservationStatus? p_ = o_?.Value;
+            string q_ = context.Operators.Convert<string>(p_);
+            string[] r_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? s_ = context.Operators.In<string>(q_, (IEnumerable<string>)r_);
+            Code<ObservationStatus> t_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.StatusElement;
+            ObservationStatus? u_ = t_?.Value;
+            string v_ = context.Operators.Convert<string>(u_);
+            bool? x_ = context.Operators.In<string>(v_, (IEnumerable<string>)r_);
+            bool? y_ = context.Operators.And(s_, x_);
+            DataType z_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Value;
+            object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
+            DataType ab_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Value;
+            object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            CqlQuantity ad_ = context.Operators.Subtract(aa_ as CqlQuantity, ac_ as CqlQuantity);
+            CqlQuantity ae_ = context.Operators.Quantity(0.299m, "mg/dL");
+            bool? af_ = context.Operators.Greater(ad_, ae_);
+            bool? ag_ = context.Operators.And(y_, af_);
+            object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+            IEnumerable<CqlQuantity> aj_ = this.EarliestSerumCreatinineResult(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            CqlQuantity ak_ = context.Operators.SingletonFrom<CqlQuantity>(aj_);
+            bool? al_ = context.Operators.Equal(ai_ as CqlQuantity, ak_);
+            bool? am_ = context.Operators.And(ag_, al_);
+            object an_()
+            {
+                bool cw_()
+                {
+                    DataType cz_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object da_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cz_);
+                    bool db_ = da_ is CqlDateTime;
+
+                    return db_;
+                };
+                bool cx_()
+                {
+                    DataType dc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+                    bool de_ = dd_ is CqlInterval<CqlDateTime>;
+
+                    return de_;
+                };
+                bool cy_()
+                {
+                    DataType df_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                    bool dh_ = dg_ is CqlDateTime;
+
+                    return dh_;
+                };
+                if (cw_())
+                {
+                    DataType di_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+
+                    return (dj_ as CqlDateTime) as object;
+                }
+                else if (cx_())
+                {
+                    DataType dk_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
+
+                    return (dl_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (cy_())
+                {
+                    DataType dm_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
+
+                    return (dn_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime ao_ = QICoreCommon_4_0_000.Instance.earliest(context, an_());
+            object ap_()
+            {
+                bool do_()
+                {
+                    DataType dr_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ds_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dr_);
+                    bool dt_ = ds_ is CqlDateTime;
+
+                    return dt_;
+                };
+                bool dp_()
+                {
+                    DataType du_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
+                    bool dw_ = dv_ is CqlInterval<CqlDateTime>;
+
+                    return dw_;
+                };
+                bool dq_()
+                {
+                    DataType dx_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object dy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dx_);
+                    bool dz_ = dy_ is CqlDateTime;
+
+                    return dz_;
+                };
+                if (do_())
+                {
+                    DataType ea_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object eb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ea_);
+
+                    return (eb_ as CqlDateTime) as object;
+                }
+                else if (dp_())
+                {
+                    DataType ec_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+
+                    return (ed_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (dq_())
+                {
+                    DataType ee_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
+
+                    return (ef_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime aq_ = QICoreCommon_4_0_000.Instance.earliest(context, ap_());
+            CqlQuantity ar_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime as_ = context.Operators.Subtract(aq_, ar_);
+            object at_()
+            {
+                bool eg_()
+                {
+                    DataType ej_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ek_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ej_);
+                    bool el_ = ek_ is CqlDateTime;
+
+                    return el_;
+                };
+                bool eh_()
+                {
+                    DataType em_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object en_ = FHIRHelpers_4_4_000.Instance.ToValue(context, em_);
+                    bool eo_ = en_ is CqlInterval<CqlDateTime>;
+
+                    return eo_;
+                };
+                bool ei_()
+                {
+                    DataType ep_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object eq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ep_);
+                    bool er_ = eq_ is CqlDateTime;
+
+                    return er_;
+                };
+                if (eg_())
+                {
+                    DataType es_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object et_ = FHIRHelpers_4_4_000.Instance.ToValue(context, es_);
+
+                    return (et_ as CqlDateTime) as object;
+                }
+                else if (eh_())
+                {
+                    DataType eu_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
+
+                    return (ev_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ei_())
+                {
+                    DataType ew_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
+
+                    return (ex_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_());
+            CqlInterval<CqlDateTime> av_ = context.Operators.Interval(as_, au_, true, true);
+            bool? aw_ = context.Operators.In<CqlDateTime>(ao_, av_, default);
+            bool? ax_ = context.Operators.And(am_, aw_);
+            object ay_()
+            {
+                bool ey_()
+                {
+                    DataType fb_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
+                    bool fd_ = fc_ is CqlDateTime;
+
+                    return fd_;
+                };
+                bool ez_()
+                {
+                    DataType fe_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object ff_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fe_);
+                    bool fg_ = ff_ is CqlInterval<CqlDateTime>;
+
+                    return fg_;
+                };
+                bool fa_()
+                {
+                    DataType fh_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fh_);
+                    bool fj_ = fi_ is CqlDateTime;
+
+                    return fj_;
+                };
+                if (ey_())
+                {
+                    DataType fk_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fk_);
+
+                    return (fl_ as CqlDateTime) as object;
+                }
+                else if (ez_())
+                {
+                    DataType fm_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
+
+                    return (fn_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fa_())
+                {
+                    DataType fo_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object fp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fo_);
+
+                    return (fp_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime az_ = QICoreCommon_4_0_000.Instance.earliest(context, ay_());
+            CqlInterval<CqlDateTime> ba_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter);
+            bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, default);
+            bool? bc_ = context.Operators.And(ax_, bb_);
+            object bd_()
+            {
+                bool fq_()
+                {
+                    DataType ft_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object fu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ft_);
+                    bool fv_ = fu_ is CqlDateTime;
+
+                    return fv_;
+                };
+                bool fr_()
+                {
+                    DataType fw_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object fx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fw_);
+                    bool fy_ = fx_ is CqlInterval<CqlDateTime>;
+
+                    return fy_;
+                };
+                bool fs_()
+                {
+                    DataType fz_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ga_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fz_);
+                    bool gb_ = ga_ is CqlDateTime;
+
+                    return gb_;
+                };
+                if (fq_())
+                {
+                    DataType gc_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gc_);
+
+                    return (gd_ as CqlDateTime) as object;
+                }
+                else if (fr_())
+                {
+                    DataType ge_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
+
+                    return (gf_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fs_())
+                {
+                    DataType gg_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
+
+                    return (gh_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_());
+            CqlDateTime bg_ = context.Operators.Start(ba_);
+            CqlDateTime bi_ = context.Operators.Start(ba_);
+            CqlDateTime bk_ = context.Operators.Add(bi_, ar_);
+            CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(bg_, bk_, true, true);
+            bool? bm_ = context.Operators.In<CqlDateTime>(be_, bl_, default);
+            bool? bn_ = context.Operators.And(bc_, bm_);
+            object bo_()
+            {
+                bool gi_()
+                {
+                    DataType gl_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gl_);
+                    bool gn_ = gm_ is CqlDateTime;
+
+                    return gn_;
+                };
+                bool gj_()
+                {
+                    DataType go_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, go_);
+                    bool gq_ = gp_ is CqlInterval<CqlDateTime>;
+
+                    return gq_;
+                };
+                bool gk_()
+                {
+                    DataType gr_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gr_);
+                    bool gt_ = gs_ is CqlDateTime;
+
+                    return gt_;
+                };
+                if (gi_())
+                {
+                    DataType gu_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gu_);
+
+                    return (gv_ as CqlDateTime) as object;
+                }
+                else if (gj_())
+                {
+                    DataType gw_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gw_);
+
+                    return (gx_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (gk_())
+                {
+                    DataType gy_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object gz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gy_);
+
+                    return (gz_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bp_ = QICoreCommon_4_0_000.Instance.earliest(context, bo_());
+            bool? br_ = context.Operators.In<CqlDateTime>(bp_, ba_, default);
+            bool? bs_ = context.Operators.And(bn_, br_);
+            object bt_()
+            {
+                bool ha_()
+                {
+                    DataType hd_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object he_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hd_);
+                    bool hf_ = he_ is CqlDateTime;
+
+                    return hf_;
+                };
+                bool hb_()
+                {
+                    DataType hg_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object hh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hg_);
+                    bool hi_ = hh_ is CqlInterval<CqlDateTime>;
+
+                    return hi_;
+                };
+                bool hc_()
+                {
+                    DataType hj_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object hk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hj_);
+                    bool hl_ = hk_ is CqlDateTime;
+
+                    return hl_;
+                };
+                if (ha_())
+                {
+                    DataType hm_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object hn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hm_);
+
+                    return (hn_ as CqlDateTime) as object;
+                }
+                else if (hb_())
+                {
+                    DataType ho_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object hp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ho_);
+
+                    return (hp_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (hc_())
+                {
+                    DataType hq_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.Effective;
+                    object hr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hq_);
+
+                    return (hr_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bu_ = QICoreCommon_4_0_000.Instance.earliest(context, bt_());
+            CqlDateTime bw_ = context.Operators.Start(ba_);
+            CqlDateTime by_ = context.Operators.Start(ba_);
+            CqlDateTime ca_ = context.Operators.Add(by_, ar_);
+            CqlInterval<CqlDateTime> cb_ = context.Operators.Interval(bw_, ca_, true, true);
+            bool? cc_ = context.Operators.In<CqlDateTime>(bu_, cb_, default);
+            bool? cd_ = context.Operators.And(bs_, cc_);
+            object ce_()
+            {
+                bool hs_()
+                {
+                    DataType hv_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object hw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hv_);
+                    bool hx_ = hw_ is CqlDateTime;
+
+                    return hx_;
+                };
+                bool ht_()
+                {
+                    DataType hy_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object hz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, hy_);
+                    bool ia_ = hz_ is CqlInterval<CqlDateTime>;
+
+                    return ia_;
+                };
+                bool hu_()
+                {
+                    DataType ib_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ic_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ib_);
+                    bool id_ = ic_ is CqlDateTime;
+
+                    return id_;
+                };
+                if (hs_())
+                {
+                    DataType ie_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object if_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ie_);
+
+                    return (if_ as CqlDateTime) as object;
+                }
+                else if (ht_())
+                {
+                    DataType ig_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ih_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ig_);
+
+                    return (ih_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (hu_())
+                {
+                    DataType ii_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.Effective;
+                    object ij_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ii_);
+
+                    return (ij_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime cf_ = QICoreCommon_4_0_000.Instance.earliest(context, ce_());
+            CqlDateTime ch_ = context.Operators.Start(ba_);
+            CqlDateTime cj_ = context.Operators.Start(ba_);
+            CqlDateTime cl_ = context.Operators.Add(cj_, ar_);
+            CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ch_, cl_, true, true);
+            bool? cn_ = context.Operators.In<CqlDateTime>(cf_, cm_, default);
+            bool? co_ = context.Operators.And(cd_, cn_);
+            Id cp_ = tuple_hsukaxezrzqpeqifkirnhhzen?.IndexCreatinineLabResult?.IdElement;
+            string cq_ = cp_?.Value;
+            Id cr_ = tuple_hsukaxezrzqpeqifkirnhhzen?.SubsequentCreatinineLabResult?.IdElement;
+            string cs_ = cr_?.Value;
+            bool? ct_ = context.Operators.Equal(cq_, cs_);
+            bool? cu_ = context.Operators.Not(ct_);
+            bool? cv_ = context.Operators.And(co_, cu_);
+
+            return cv_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?> j_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?>(h_, i_);
+        Encounter k_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)? tuple_hsukaxezrzqpeqifkirnhhzen) =>
+            tuple_hsukaxezrzqpeqifkirnhhzen?.QualifyingEncounter;
+        IEnumerable<Encounter> l_ = context.Operators.Select<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation IndexCreatinineLabResult, Observation SubsequentCreatinineLabResult)?, Encounter>(j_, k_);
+        IEnumerable<Encounter> m_ = context.Operators.Distinct<Encounter>(l_);
+
+        return m_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with 0.3 mg dL or More Increase in Creatinine")]
+    public IEnumerable<Encounter> Encounter_with_0_3_mg_dL_or_More_Increase_in_Creatinine(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Increase_of_0_3_or_More_Using_Lowest_Creatinine_within_24_Hours(context);
+        IEnumerable<Encounter> b_ = this.Increase_of_0_3_or_More_Using_First_Creatinine_within_First_48_Hours(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Kidney Dialysis Started 48 Hours or Less After Arrival")]
+    public IEnumerable<Encounter> Encounter_with_Kidney_Dialysis_Started_48_Hours_or_Less_After_Arrival(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hospital_Based_Dialysis_Services(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Encounter> c_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        IEnumerable<ValueTuple<Procedure, Encounter>> d_ = context.Operators.CrossJoin<Procedure, Encounter>(b_, c_);
+        (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? e_(ValueTuple<Procedure, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? l_ = (CqlTupleMetadata_BWWSXdXSFIJQjJNcdEVJKZEGj, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> f_ = context.Operators.Select<ValueTuple<Procedure, Encounter>, (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(d_, e_);
+        bool? g_((CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? tuple_bwwsxdxsfijqjjncdevjkzegj)
+        {
+            object m_()
+            {
+                bool ad_()
+                {
+                    DataType ah_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                    bool aj_ = ai_ is CqlDateTime;
+
+                    return aj_;
+                };
+                bool ae_()
+                {
+                    DataType ak_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                    bool am_ = al_ is CqlInterval<CqlDateTime>;
+
+                    return am_;
+                };
+                bool af_()
+                {
+                    DataType an_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                    bool ap_ = ao_ is CqlQuantity;
+
+                    return ap_;
+                };
+                bool ag_()
+                {
+                    DataType aq_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                    bool as_ = ar_ is CqlInterval<CqlQuantity>;
+
+                    return as_;
+                };
+                if (ad_())
+                {
+                    DataType at_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+
+                    return (au_ as CqlDateTime) as object;
+                }
+                else if (ae_())
+                {
+                    DataType av_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+
+                    return (aw_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (af_())
+                {
+                    DataType ax_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+
+                    return (ay_ as CqlQuantity) as object;
+                }
+                else if (ag_())
+                {
+                    DataType az_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+
+                    return (ba_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+            CqlDateTime o_ = context.Operators.Start(n_);
+            CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlDateTime s_ = context.Operators.Start(p_);
+            CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime u_ = context.Operators.Add(s_, t_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(q_, u_, true, true);
+            bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default);
+            object x_()
+            {
+                bool bb_()
+                {
+                    DataType bf_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                    bool bh_ = bg_ is CqlDateTime;
+
+                    return bh_;
+                };
+                bool bc_()
+                {
+                    DataType bi_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                    bool bk_ = bj_ is CqlInterval<CqlDateTime>;
+
+                    return bk_;
+                };
+                bool bd_()
+                {
+                    DataType bl_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                    bool bn_ = bm_ is CqlQuantity;
+
+                    return bn_;
+                };
+                bool be_()
+                {
+                    DataType bo_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                    bool bq_ = bp_ is CqlInterval<CqlQuantity>;
+
+                    return bq_;
+                };
+                if (bb_())
+                {
+                    DataType br_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+
+                    return (bs_ as CqlDateTime) as object;
+                }
+                else if (bc_())
+                {
+                    DataType bt_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+
+                    return (bu_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bd_())
+                {
+                    DataType bv_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+
+                    return (bw_ as CqlQuantity) as object;
+                }
+                else if (be_())
+                {
+                    DataType bx_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+
+                    return (by_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
+            CqlDateTime z_ = context.Operators.Start(y_);
+            bool? ab_ = context.Operators.In<CqlDateTime>(z_, p_, default);
+            bool? ac_ = context.Operators.And(w_, ab_);
+
+            return ac_;
+        };
+        IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> h_ = context.Operators.Where<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(f_, g_);
+        Encounter i_((CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? tuple_bwwsxdxsfijqjjncdevjkzegj) =>
+            tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter;
+        IEnumerable<Encounter> j_ = context.Operators.Select<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?, Encounter>(h_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Distinct<Encounter>(j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Serum Creatinine Normal")]
+    public CqlQuantity Serum_Creatinine_Normal(CqlContext context)
+    {
+        CqlQuantity a_()
+        {
+            bool b_()
+            {
+                List<Extension> c_()
+                {
+                    bool j_()
+                    {
+                        Patient k_ = this.Patient(context);
+                        bool l_ = k_ is DomainResource;
+
+                        return l_;
+                    };
+                    if (j_())
+                    {
+                        Patient m_ = this.Patient(context);
+
+                        return (m_ as DomainResource).Extension;
+                    }
+                    else
+                    {
+                        return default;
+                    }
+                };
+                bool? d_(Extension @this)
+                {
+                    string n_ = @this?.Url;
+                    FhirString o_ = context.Operators.Convert<FhirString>(n_);
+                    string p_ = FHIRHelpers_4_4_000.Instance.ToString(context, o_);
+                    bool? q_ = context.Operators.Equal(p_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-sex");
+
+                    return q_;
+                };
+                IEnumerable<Extension> e_ = context.Operators.Where<Extension>((IEnumerable<Extension>)(c_()), d_);
+                DataType f_(Extension @this)
+                {
+                    DataType r_ = @this?.Value;
+
+                    return r_;
+                };
+                IEnumerable<DataType> g_ = context.Operators.Select<Extension, DataType>(e_, f_);
+                DataType h_ = context.Operators.SingletonFrom<DataType>(g_);
+                bool? i_ = context.Operators.Equal(h_, "248152002");
+
+                return i_ ?? false;
+            };
+            if (b_())
+            {
+                CqlQuantity s_ = context.Operators.Quantity(1.02m, "mg/dL");
+
+                return s_;
+            }
+            else
+            {
+                CqlQuantity t_ = context.Operators.Quantity(1.18m, "mg/dL");
+
+                return t_;
+            }
+        };
+
+        return a_();
+    }
+
+
+    [CqlFunctionDefinition("HighestSerumCreatinineResult")]
+    public CqlQuantity HighestSerumCreatinineResult(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> a_ = this.Qualifying_Creatinine_Lab_Result_by_Time(context);
+        bool? b_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? LabTests)
+        {
+            string i_ = LabTests?.CrEncInPtId;
+            string j_ = (QualifyingEncounter is Resource
+        ? (QualifyingEncounter as Resource).IdElement
+        : default)?.Value;
+            bool? k_ = context.Operators.Equal(i_, j_);
+
+            return k_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> c_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(a_, b_);
+        bool? d_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity l_ = @this?.CrLabResult;
+            bool? m_ = context.Operators.Not((bool?)(l_ is null));
+
+            return m_;
+        };
+        IEnumerable<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?> e_ = context.Operators.Where<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?>(c_, d_);
+        CqlQuantity f_((CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)? @this)
+        {
+            CqlQuantity n_ = @this?.CrLabResult;
+
+            return n_;
+        };
+        IEnumerable<CqlQuantity> g_ = context.Operators.Select<(CqlTupleMetadata, string CrEncInPtId, CqlInterval<CqlDateTime> CrHospitalization, string CrLabObsId, object CrLabObsCategory, string CrLabObsStatus, CqlQuantity CrLabResult, string CrLabResultUnit, decimal? CrLabResultValue, CqlDateTime CrLabTime, CqlDateTime CrLabTimeIssued)?, CqlQuantity>(e_, f_);
+        CqlQuantity h_ = context.Operators.Max<CqlQuantity>(g_);
+
+        return h_;
+    }
+
+
+    [CqlFunctionDefinition("1.5IncreaseInCreatinine")]
+    public CqlQuantity _1_5IncreaseInCreatinine(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlQuantity a_ = this.HighestSerumCreatinineResult(context, QualifyingEncounter);
+        CqlQuantity b_ = context.Operators.ConvertDecimalToQuantity(1.5m);
+        CqlQuantity c_ = context.Operators.Divide(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with 1.5 Times Serum Creatinine Increase")]
+    public IEnumerable<Encounter> Encounter_with_1_5_Times_Serum_Creatinine_Increase(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation, Observation>> f_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, c_, e_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)? g_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)? n_ = (CqlTupleMetadata_JeYVEdgebecHQGRICIKegVBi, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return n_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?> h_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(f_, g_);
+        bool? i_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)? tuple_gsqsgqbihalobloqrcccgdeiw)
+        {
+            DataType o_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Value;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlQuantity q_ = this.Serum_Creatinine_Normal(context);
+            bool? r_ = context.Operators.Greater(p_ as CqlQuantity, q_);
+            Code<ObservationStatus> s_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.StatusElement;
+            ObservationStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            string[] v_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+            bool? x_ = context.Operators.And(r_, w_);
+            Code<ObservationStatus> y_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.StatusElement;
+            ObservationStatus? z_ = y_?.Value;
+            string aa_ = context.Operators.Convert<string>(z_);
+            bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)v_);
+            bool? ad_ = context.Operators.And(x_, ac_);
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlQuantity ag_ = this.HighestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            bool? ah_ = context.Operators.Equal(af_ as CqlQuantity, ag_);
+            bool? ai_ = context.Operators.And(ad_, ah_);
+            DataType aj_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Value;
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            CqlQuantity al_ = this.LowestSerumCreatinineResult(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            bool? am_ = context.Operators.Equal(ak_ as CqlQuantity, al_);
+            bool? an_ = context.Operators.And(ai_, am_);
+            CqlQuantity ao_ = this._1_5IncreaseInCreatinine(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            object aq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            bool? ar_ = context.Operators.GreaterOrEqual(ao_, aq_ as CqlQuantity);
+            bool? as_ = context.Operators.And(an_, ar_);
+            object at_()
+            {
+                bool cf_()
+                {
+                    DataType ci_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ci_);
+                    bool ck_ = cj_ is CqlDateTime;
+
+                    return ck_;
+                };
+                bool cg_()
+                {
+                    DataType cl_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                    bool cn_ = cm_ is CqlInterval<CqlDateTime>;
+
+                    return cn_;
+                };
+                bool ch_()
+                {
+                    DataType co_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, co_);
+                    bool cq_ = cp_ is CqlDateTime;
+
+                    return cq_;
+                };
+                if (cf_())
+                {
+                    DataType cr_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cr_);
+
+                    return (cs_ as CqlDateTime) as object;
+                }
+                else if (cg_())
+                {
+                    DataType ct_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ct_);
+
+                    return (cu_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ch_())
+                {
+                    DataType cv_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object cw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cv_);
+
+                    return (cw_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_());
+            object av_()
+            {
+                bool cx_()
+                {
+                    DataType da_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object db_ = FHIRHelpers_4_4_000.Instance.ToValue(context, da_);
+                    bool dc_ = db_ is CqlDateTime;
+
+                    return dc_;
+                };
+                bool cy_()
+                {
+                    DataType dd_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object de_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dd_);
+                    bool df_ = de_ is CqlInterval<CqlDateTime>;
+
+                    return df_;
+                };
+                bool cz_()
+                {
+                    DataType dg_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dg_);
+                    bool di_ = dh_ is CqlDateTime;
+
+                    return di_;
+                };
+                if (cx_())
+                {
+                    DataType dj_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dj_);
+
+                    return (dk_ as CqlDateTime) as object;
+                }
+                else if (cy_())
+                {
+                    DataType dl_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+
+                    return (dm_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (cz_())
+                {
+                    DataType dn_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object do_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dn_);
+
+                    return (do_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime aw_ = QICoreCommon_4_0_000.Instance.earliest(context, av_());
+            CqlQuantity ax_ = context.Operators.Quantity(7m, "days");
+            CqlDateTime ay_ = context.Operators.Subtract(aw_, ax_);
+            object az_()
+            {
+                bool dp_()
+                {
+                    DataType ds_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+                    bool du_ = dt_ is CqlDateTime;
+
+                    return du_;
+                };
+                bool dq_()
+                {
+                    DataType dv_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dv_);
+                    bool dx_ = dw_ is CqlInterval<CqlDateTime>;
+
+                    return dx_;
+                };
+                bool dr_()
+                {
+                    DataType dy_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object dz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dy_);
+                    bool ea_ = dz_ is CqlDateTime;
+
+                    return ea_;
+                };
+                if (dp_())
+                {
+                    DataType eb_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ec_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eb_);
+
+                    return (ec_ as CqlDateTime) as object;
+                }
+                else if (dq_())
+                {
+                    DataType ed_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ee_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ed_);
+
+                    return (ee_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (dr_())
+                {
+                    DataType ef_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object eg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ef_);
+
+                    return (eg_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime ba_ = QICoreCommon_4_0_000.Instance.earliest(context, az_());
+            CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ay_, ba_, true, false);
+            bool? bc_ = context.Operators.In<CqlDateTime>(au_, bb_, default);
+            object bd_()
+            {
+                bool eh_()
+                {
+                    DataType ek_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object el_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ek_);
+                    bool em_ = el_ is CqlDateTime;
+
+                    return em_;
+                };
+                bool ei_()
+                {
+                    DataType en_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
+                    bool ep_ = eo_ is CqlInterval<CqlDateTime>;
+
+                    return ep_;
+                };
+                bool ej_()
+                {
+                    DataType eq_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+                    bool es_ = er_ is CqlDateTime;
+
+                    return es_;
+                };
+                if (eh_())
+                {
+                    DataType et_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
+
+                    return (eu_ as CqlDateTime) as object;
+                }
+                else if (ei_())
+                {
+                    DataType ev_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ew_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ev_);
+
+                    return (ew_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ej_())
+                {
+                    DataType ex_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ey_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ex_);
+
+                    return (ey_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime be_ = QICoreCommon_4_0_000.Instance.earliest(context, bd_());
+            bool? bf_ = context.Operators.Not((bool?)(be_ is null));
+            bool? bg_ = context.Operators.And(bc_, bf_);
+            bool? bh_ = context.Operators.And(as_, bg_);
+            object bi_()
+            {
+                bool ez_()
+                {
+                    DataType fc_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fc_);
+                    bool fe_ = fd_ is CqlDateTime;
+
+                    return fe_;
+                };
+                bool fa_()
+                {
+                    DataType ff_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ff_);
+                    bool fh_ = fg_ is CqlInterval<CqlDateTime>;
+
+                    return fh_;
+                };
+                bool fb_()
+                {
+                    DataType fi_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fi_);
+                    bool fk_ = fj_ is CqlDateTime;
+
+                    return fk_;
+                };
+                if (ez_())
+                {
+                    DataType fl_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fl_);
+
+                    return (fm_ as CqlDateTime) as object;
+                }
+                else if (fa_())
+                {
+                    DataType fn_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fn_);
+
+                    return (fo_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fb_())
+                {
+                    DataType fp_ = tuple_gsqsgqbihalobloqrcccgdeiw?.LowCreatinineTest?.Effective;
+                    object fq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fp_);
+
+                    return (fq_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bj_ = QICoreCommon_4_0_000.Instance.earliest(context, bi_());
+            CqlInterval<CqlDateTime> bk_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter);
+            bool? bl_ = context.Operators.In<CqlDateTime>(bj_, bk_, default);
+            bool? bm_ = context.Operators.And(bh_, bl_);
+            object bn_()
+            {
+                bool fr_()
+                {
+                    DataType fu_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object fv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fu_);
+                    bool fw_ = fv_ is CqlDateTime;
+
+                    return fw_;
+                };
+                bool fs_()
+                {
+                    DataType fx_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object fy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fx_);
+                    bool fz_ = fy_ is CqlInterval<CqlDateTime>;
+
+                    return fz_;
+                };
+                bool ft_()
+                {
+                    DataType ga_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ga_);
+                    bool gc_ = gb_ is CqlDateTime;
+
+                    return gc_;
+                };
+                if (fr_())
+                {
+                    DataType gd_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ge_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gd_);
+
+                    return (ge_ as CqlDateTime) as object;
+                }
+                else if (fs_())
+                {
+                    DataType gf_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gf_);
+
+                    return (gg_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ft_())
+                {
+                    DataType gh_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gi_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gh_);
+
+                    return (gi_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bo_ = QICoreCommon_4_0_000.Instance.earliest(context, bn_());
+            CqlDateTime bq_ = context.Operators.Start(bk_);
+            CqlQuantity br_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime bs_ = context.Operators.Add(bq_, br_);
+            CqlDateTime bu_ = context.Operators.Start(bk_);
+            CqlQuantity bv_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime bw_ = context.Operators.Add(bu_, bv_);
+            CqlInterval<CqlDateTime> bx_ = context.Operators.Interval(bs_, bw_, true, true);
+            bool? by_ = context.Operators.In<CqlDateTime>(bo_, bx_, default);
+            bool? bz_ = context.Operators.And(bm_, by_);
+            object ca_()
+            {
+                bool gj_()
+                {
+                    DataType gm_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gm_);
+                    bool go_ = gn_ is CqlDateTime;
+
+                    return go_;
+                };
+                bool gk_()
+                {
+                    DataType gp_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gp_);
+                    bool gr_ = gq_ is CqlInterval<CqlDateTime>;
+
+                    return gr_;
+                };
+                bool gl_()
+                {
+                    DataType gs_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gs_);
+                    bool gu_ = gt_ is CqlDateTime;
+
+                    return gu_;
+                };
+                if (gj_())
+                {
+                    DataType gv_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gv_);
+
+                    return (gw_ as CqlDateTime) as object;
+                }
+                else if (gk_())
+                {
+                    DataType gx_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object gy_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gx_);
+
+                    return (gy_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (gl_())
+                {
+                    DataType gz_ = tuple_gsqsgqbihalobloqrcccgdeiw?.HighCreatinineTest?.Effective;
+                    object ha_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gz_);
+
+                    return (ha_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime cb_ = QICoreCommon_4_0_000.Instance.earliest(context, ca_());
+            bool? cd_ = context.Operators.In<CqlDateTime>(cb_, bk_, default);
+            bool? ce_ = context.Operators.And(bz_, cd_);
+
+            return ce_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?> j_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(h_, i_);
+        Encounter k_((CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)? tuple_gsqsgqbihalobloqrcccgdeiw) =>
+            tuple_gsqsgqbihalobloqrcccgdeiw?.QualifyingEncounter;
+        IEnumerable<Encounter> l_ = context.Operators.Select<(CqlTupleMetadata, Encounter QualifyingEncounter, Observation HighCreatinineTest, Observation LowCreatinineTest)?, Encounter>(j_, k_);
+        IEnumerable<Encounter> m_ = context.Operators.Distinct<Encounter>(l_);
+
+        return m_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with 2 Times Serum Creatinine Increase")]
+    public IEnumerable<Encounter> Encounter_with_2_Times_Serum_Creatinine_Increase(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_1_5_Times_Serum_Creatinine_Increase(context);
+        CqlValueSet b_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<Observation> e_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, b_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        IEnumerable<ValueTuple<Encounter, Observation, Observation>> f_ = context.Operators.CrossJoin<Encounter, Observation, Observation>(a_, c_, e_);
+        (CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)? g_(ValueTuple<Encounter, Observation, Observation> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)? n_ = (CqlTupleMetadata_BDjSiZCAhXcVgEETFRJVEHXOR, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3);
+
+            return n_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?> h_ = context.Operators.Select<ValueTuple<Encounter, Observation, Observation>, (CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(f_, g_);
+        bool? i_((CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)? tuple_bdjsizcahxcvgeetfrjvehxor)
+        {
+            DataType o_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Value;
+            object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlQuantity q_ = this.Serum_Creatinine_Normal(context);
+            bool? r_ = context.Operators.Greater(p_ as CqlQuantity, q_);
+            Code<ObservationStatus> s_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.StatusElement;
+            ObservationStatus? t_ = s_?.Value;
+            string u_ = context.Operators.Convert<string>(t_);
+            string[] v_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? w_ = context.Operators.In<string>(u_, (IEnumerable<string>)v_);
+            bool? x_ = context.Operators.And(r_, w_);
+            Code<ObservationStatus> y_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.StatusElement;
+            ObservationStatus? z_ = y_?.Value;
+            string aa_ = context.Operators.Convert<string>(z_);
+            bool? ac_ = context.Operators.In<string>(aa_, (IEnumerable<string>)v_);
+            bool? ad_ = context.Operators.And(x_, ac_);
+            object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            CqlQuantity ag_ = this.HighestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            bool? ah_ = context.Operators.Equal(af_ as CqlQuantity, ag_);
+            bool? ai_ = context.Operators.And(ad_, ah_);
+            DataType aj_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Value;
+            object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            CqlQuantity al_ = this.LowestSerumCreatinineResult(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            bool? am_ = context.Operators.Equal(ak_ as CqlQuantity, al_);
+            bool? an_ = context.Operators.And(ai_, am_);
+            object ap_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
+            object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+            bool? as_ = context.Operators.GreaterOrEqual(ap_ as CqlQuantity, ar_ as CqlQuantity);
+            bool? at_ = context.Operators.And(an_, as_);
+            object au_()
+            {
+                bool cg_()
+                {
+                    DataType cj_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cj_);
+                    bool cl_ = ck_ is CqlDateTime;
+
+                    return cl_;
+                };
+                bool ch_()
+                {
+                    DataType cm_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object cn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cm_);
+                    bool co_ = cn_ is CqlInterval<CqlDateTime>;
+
+                    return co_;
+                };
+                bool ci_()
+                {
+                    DataType cp_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object cq_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cp_);
+                    bool cr_ = cq_ is CqlDateTime;
+
+                    return cr_;
+                };
+                if (cg_())
+                {
+                    DataType cs_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object ct_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cs_);
+
+                    return (ct_ as CqlDateTime) as object;
+                }
+                else if (ch_())
+                {
+                    DataType cu_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object cv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cu_);
+
+                    return (cv_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ci_())
+                {
+                    DataType cw_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object cx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cw_);
+
+                    return (cx_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime av_ = QICoreCommon_4_0_000.Instance.earliest(context, au_());
+            object aw_()
+            {
+                bool cy_()
+                {
+                    DataType db_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object dc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, db_);
+                    bool dd_ = dc_ is CqlDateTime;
+
+                    return dd_;
+                };
+                bool cz_()
+                {
+                    DataType de_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object df_ = FHIRHelpers_4_4_000.Instance.ToValue(context, de_);
+                    bool dg_ = df_ is CqlInterval<CqlDateTime>;
+
+                    return dg_;
+                };
+                bool da_()
+                {
+                    DataType dh_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object di_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dh_);
+                    bool dj_ = di_ is CqlDateTime;
+
+                    return dj_;
+                };
+                if (cy_())
+                {
+                    DataType dk_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object dl_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dk_);
+
+                    return (dl_ as CqlDateTime) as object;
+                }
+                else if (cz_())
+                {
+                    DataType dm_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object dn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dm_);
+
+                    return (dn_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (da_())
+                {
+                    DataType do_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+
+                    return (dp_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime ax_ = QICoreCommon_4_0_000.Instance.earliest(context, aw_());
+            CqlQuantity ay_ = context.Operators.Quantity(7m, "days");
+            CqlDateTime az_ = context.Operators.Subtract(ax_, ay_);
+            object ba_()
+            {
+                bool dq_()
+                {
+                    DataType dt_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object du_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dt_);
+                    bool dv_ = du_ is CqlDateTime;
+
+                    return dv_;
+                };
+                bool dr_()
+                {
+                    DataType dw_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object dx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dw_);
+                    bool dy_ = dx_ is CqlInterval<CqlDateTime>;
+
+                    return dy_;
+                };
+                bool ds_()
+                {
+                    DataType dz_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ea_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dz_);
+                    bool eb_ = ea_ is CqlDateTime;
+
+                    return eb_;
+                };
+                if (dq_())
+                {
+                    DataType ec_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ed_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ec_);
+
+                    return (ed_ as CqlDateTime) as object;
+                }
+                else if (dr_())
+                {
+                    DataType ee_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ef_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ee_);
+
+                    return (ef_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ds_())
+                {
+                    DataType eg_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object eh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eg_);
+
+                    return (eh_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bb_ = QICoreCommon_4_0_000.Instance.earliest(context, ba_());
+            CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(az_, bb_, true, false);
+            bool? bd_ = context.Operators.In<CqlDateTime>(av_, bc_, default);
+            object be_()
+            {
+                bool ei_()
+                {
+                    DataType el_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object em_ = FHIRHelpers_4_4_000.Instance.ToValue(context, el_);
+                    bool en_ = em_ is CqlDateTime;
+
+                    return en_;
+                };
+                bool ej_()
+                {
+                    DataType eo_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ep_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eo_);
+                    bool eq_ = ep_ is CqlInterval<CqlDateTime>;
+
+                    return eq_;
+                };
+                bool ek_()
+                {
+                    DataType er_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object es_ = FHIRHelpers_4_4_000.Instance.ToValue(context, er_);
+                    bool et_ = es_ is CqlDateTime;
+
+                    return et_;
+                };
+                if (ei_())
+                {
+                    DataType eu_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ev_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eu_);
+
+                    return (ev_ as CqlDateTime) as object;
+                }
+                else if (ej_())
+                {
+                    DataType ew_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
+
+                    return (ex_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (ek_())
+                {
+                    DataType ey_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object ez_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ey_);
+
+                    return (ez_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bf_ = QICoreCommon_4_0_000.Instance.earliest(context, be_());
+            bool? bg_ = context.Operators.Not((bool?)(bf_ is null));
+            bool? bh_ = context.Operators.And(bd_, bg_);
+            bool? bi_ = context.Operators.And(at_, bh_);
+            object bj_()
+            {
+                bool fa_()
+                {
+                    DataType fd_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
+                    bool ff_ = fe_ is CqlDateTime;
+
+                    return ff_;
+                };
+                bool fb_()
+                {
+                    DataType fg_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fg_);
+                    bool fi_ = fh_ is CqlInterval<CqlDateTime>;
+
+                    return fi_;
+                };
+                bool fc_()
+                {
+                    DataType fj_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fj_);
+                    bool fl_ = fk_ is CqlDateTime;
+
+                    return fl_;
+                };
+                if (fa_())
+                {
+                    DataType fm_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fn_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fm_);
+
+                    return (fn_ as CqlDateTime) as object;
+                }
+                else if (fb_())
+                {
+                    DataType fo_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fo_);
+
+                    return (fp_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fc_())
+                {
+                    DataType fq_ = tuple_bdjsizcahxcvgeetfrjvehxor?.LowCreatinineTest?.Effective;
+                    object fr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fq_);
+
+                    return (fr_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bk_ = QICoreCommon_4_0_000.Instance.earliest(context, bj_());
+            CqlInterval<CqlDateTime> bl_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine);
+            bool? bm_ = context.Operators.In<CqlDateTime>(bk_, bl_, default);
+            bool? bn_ = context.Operators.And(bi_, bm_);
+            object bo_()
+            {
+                bool fs_()
+                {
+                    DataType fv_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object fw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fv_);
+                    bool fx_ = fw_ is CqlDateTime;
+
+                    return fx_;
+                };
+                bool ft_()
+                {
+                    DataType fy_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object fz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fy_);
+                    bool ga_ = fz_ is CqlInterval<CqlDateTime>;
+
+                    return ga_;
+                };
+                bool fu_()
+                {
+                    DataType gb_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gb_);
+                    bool gd_ = gc_ is CqlDateTime;
+
+                    return gd_;
+                };
+                if (fs_())
+                {
+                    DataType ge_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ge_);
+
+                    return (gf_ as CqlDateTime) as object;
+                }
+                else if (ft_())
+                {
+                    DataType gg_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gh_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gg_);
+
+                    return (gh_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (fu_())
+                {
+                    DataType gi_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gi_);
+
+                    return (gj_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime bp_ = QICoreCommon_4_0_000.Instance.earliest(context, bo_());
+            CqlDateTime br_ = context.Operators.Start(bl_);
+            CqlQuantity bs_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime bt_ = context.Operators.Add(br_, bs_);
+            CqlDateTime bv_ = context.Operators.Start(bl_);
+            CqlQuantity bw_ = context.Operators.Quantity(30m, "days");
+            CqlDateTime bx_ = context.Operators.Add(bv_, bw_);
+            CqlInterval<CqlDateTime> by_ = context.Operators.Interval(bt_, bx_, true, true);
+            bool? bz_ = context.Operators.In<CqlDateTime>(bp_, by_, default);
+            bool? ca_ = context.Operators.And(bn_, bz_);
+            object cb_()
+            {
+                bool gk_()
+                {
+                    DataType gn_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object go_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gn_);
+                    bool gp_ = go_ is CqlDateTime;
+
+                    return gp_;
+                };
+                bool gl_()
+                {
+                    DataType gq_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gq_);
+                    bool gs_ = gr_ is CqlInterval<CqlDateTime>;
+
+                    return gs_;
+                };
+                bool gm_()
+                {
+                    DataType gt_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gt_);
+                    bool gv_ = gu_ is CqlDateTime;
+
+                    return gv_;
+                };
+                if (gk_())
+                {
+                    DataType gw_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gw_);
+
+                    return (gx_ as CqlDateTime) as object;
+                }
+                else if (gl_())
+                {
+                    DataType gy_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object gz_ = FHIRHelpers_4_4_000.Instance.ToValue(context, gy_);
+
+                    return (gz_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (gm_())
+                {
+                    DataType ha_ = tuple_bdjsizcahxcvgeetfrjvehxor?.HighCreatinineTest?.Effective;
+                    object hb_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ha_);
+
+                    return (hb_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime cc_ = QICoreCommon_4_0_000.Instance.earliest(context, cb_());
+            bool? ce_ = context.Operators.In<CqlDateTime>(cc_, bl_, default);
+            bool? cf_ = context.Operators.And(ca_, ce_);
+
+            return cf_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?> j_ = context.Operators.Where<(CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?>(h_, i_);
+        Encounter k_((CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)? tuple_bdjsizcahxcvgeetfrjvehxor) =>
+            tuple_bdjsizcahxcvgeetfrjvehxor?.EncounterWithHighCreatinine;
+        IEnumerable<Encounter> l_ = context.Operators.Select<(CqlTupleMetadata, Encounter EncounterWithHighCreatinine, Observation HighCreatinineTest, Observation LowCreatinineTest)?, Encounter>(j_, k_);
+        IEnumerable<Encounter> m_ = context.Operators.Distinct<Encounter>(l_);
+
+        return m_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Kidney Dialysis Started 48 Hours or Less After Arrival without High Creatinine")]
+    public IEnumerable<Encounter> Encounter_with_Kidney_Dialysis_Started_48_Hours_or_Less_After_Arrival_without_High_Creatinine(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Kidney_Dialysis_Started_48_Hours_or_Less_After_Arrival(context);
+        bool? b_(Encounter EncounterWithKidneyDialysis48HoursOrAfter)
+        {
+            IEnumerable<Encounter> d_ = this.Encounter_with_2_Times_Serum_Creatinine_Increase(context);
+            bool? e_(Encounter EncounterWithHighCreatinine)
+            {
+                Period i_ = EncounterWithHighCreatinine?.Period;
+                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                Period k_ = EncounterWithKidneyDialysis48HoursOrAfter?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+
+                return m_;
+            };
+            IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            bool? h_ = context.Operators.Not(g_);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with High Risk Diagnosis for AKI")]
+    public IEnumerable<Encounter> Encounter_with_High_Risk_Diagnosis_for_AKI(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        bool? b_(Encounter QualifyingEncounter)
+        {
+            IEnumerable<object> d_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, QualifyingEncounter);
+            bool? e_(object EncounterDiagnosis)
+            {
+                object h_ = context.Operators.LateBoundProperty<object>(EncounterDiagnosis, "code");
+                CqlConcept i_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, h_ as CodeableConcept);
+                CqlValueSet j_ = this.High_Risk_Diagnosis_for_AKI(context);
+                bool? k_ = context.Operators.ConceptInValueSet(i_, j_);
+
+                return k_;
+            };
+            IEnumerable<object> f_ = context.Operators.Where<object>(d_, e_);
+            bool? g_ = context.Operators.Exists<object>(f_);
+
+            return g_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with High Risk Procedures for AKI")]
+    public IEnumerable<Encounter> Encounter_with_High_Risk_Procedures_for_AKI(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        IEnumerable<Encounter> b_(Encounter QualifyingEncounter)
+        {
+            CqlValueSet d_ = this.High_Risk_Procedures_for_AKI(context);
+            IEnumerable<Procedure> e_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+            bool? f_(Procedure HighRiskProcedures)
+            {
+                object j_()
+                {
+                    bool o_()
+                    {
+                        DataType s_ = HighRiskProcedures?.Performed;
+                        object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+                        bool u_ = t_ is CqlDateTime;
+
+                        return u_;
+                    };
+                    bool p_()
+                    {
+                        DataType v_ = HighRiskProcedures?.Performed;
+                        object w_ = FHIRHelpers_4_4_000.Instance.ToValue(context, v_);
+                        bool x_ = w_ is CqlInterval<CqlDateTime>;
+
+                        return x_;
+                    };
+                    bool q_()
+                    {
+                        DataType y_ = HighRiskProcedures?.Performed;
+                        object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+                        bool aa_ = z_ is CqlQuantity;
+
+                        return aa_;
+                    };
+                    bool r_()
+                    {
+                        DataType ab_ = HighRiskProcedures?.Performed;
+                        object ac_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ab_);
+                        bool ad_ = ac_ is CqlInterval<CqlQuantity>;
+
+                        return ad_;
+                    };
+                    if (o_())
+                    {
+                        DataType ae_ = HighRiskProcedures?.Performed;
+                        object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
+
+                        return (af_ as CqlDateTime) as object;
+                    }
+                    else if (p_())
+                    {
+                        DataType ag_ = HighRiskProcedures?.Performed;
+                        object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+
+                        return (ah_ as CqlInterval<CqlDateTime>) as object;
+                    }
+                    else if (q_())
+                    {
+                        DataType ai_ = HighRiskProcedures?.Performed;
+                        object aj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ai_);
+
+                        return (aj_ as CqlQuantity) as object;
+                    }
+                    else if (r_())
+                    {
+                        DataType ak_ = HighRiskProcedures?.Performed;
+                        object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+
+                        return (al_ as CqlInterval<CqlQuantity>) as object;
+                    }
+                    else
+                    {
+                        return null;
+                    }
+                };
+                CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_());
+                CqlDateTime l_ = context.Operators.Start(k_);
+                CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
+
+                return n_;
+            };
+            IEnumerable<Procedure> g_ = context.Operators.Where<Procedure>(e_, f_);
+            Encounter h_(Procedure HighRiskProcedures) =>
+                QualifyingEncounter;
+            IEnumerable<Encounter> i_ = context.Operators.Select<Procedure, Encounter>(g_, h_);
+
+            return i_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Denominator Exclusion")]
+    public IEnumerable<Encounter> Denominator_Exclusion(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Less_Than_2_Creatinine_Results_within_48_Hours_of_Arrival(context);
+        IEnumerable<Encounter> b_ = this.Encounter_with_Index_eGFR_Less_Than_60_within_First_48_Hours(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+        IEnumerable<Encounter> d_ = this.Encounter_with_0_3_mg_dL_or_More_Increase_in_Creatinine(context);
+        IEnumerable<Encounter> e_ = this.Encounter_with_Kidney_Dialysis_Started_48_Hours_or_Less_After_Arrival_without_High_Creatinine(context);
+        IEnumerable<Encounter> f_ = context.Operators.Union<Encounter>(d_, e_);
+        IEnumerable<Encounter> g_ = context.Operators.Union<Encounter>(c_, f_);
+        IEnumerable<Encounter> h_ = this.Encounter_with_High_Risk_Diagnosis_for_AKI(context);
+        IEnumerable<Encounter> i_ = this.Encounter_with_High_Risk_Procedures_for_AKI(context);
+        IEnumerable<Encounter> j_ = context.Operators.Union<Encounter>(h_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Union<Encounter>(g_, j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Kidney Dialysis Started More Than 48 Hours After Arrival")]
+    public IEnumerable<Encounter> Encounter_with_Kidney_Dialysis_Started_More_Than_48_Hours_After_Arrival(CqlContext context)
+    {
+        CqlValueSet a_ = this.Hospital_Based_Dialysis_Services(context);
+        IEnumerable<Procedure> b_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+        IEnumerable<Encounter> c_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        IEnumerable<ValueTuple<Procedure, Encounter>> d_ = context.Operators.CrossJoin<Procedure, Encounter>(b_, c_);
+        (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? e_(ValueTuple<Procedure, Encounter> _valueTuple)
+        {
+            (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? l_ = (CqlTupleMetadata_BWWSXdXSFIJQjJNcdEVJKZEGj, _valueTuple.Item1, _valueTuple.Item2);
+
+            return l_;
+        };
+        IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> f_ = context.Operators.Select<ValueTuple<Procedure, Encounter>, (CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(d_, e_);
+        bool? g_((CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? tuple_bwwsxdxsfijqjjncdevjkzegj)
+        {
+            object m_()
+            {
+                bool ad_()
+                {
+                    DataType ah_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                    bool aj_ = ai_ is CqlDateTime;
+
+                    return aj_;
+                };
+                bool ae_()
+                {
+                    DataType ak_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ak_);
+                    bool am_ = al_ is CqlInterval<CqlDateTime>;
+
+                    return am_;
+                };
+                bool af_()
+                {
+                    DataType an_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+                    bool ap_ = ao_ is CqlQuantity;
+
+                    return ap_;
+                };
+                bool ag_()
+                {
+                    DataType aq_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
+                    bool as_ = ar_ is CqlInterval<CqlQuantity>;
+
+                    return as_;
+                };
+                if (ad_())
+                {
+                    DataType at_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, at_);
+
+                    return (au_ as CqlDateTime) as object;
+                }
+                else if (ae_())
+                {
+                    DataType av_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, av_);
+
+                    return (aw_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (af_())
+                {
+                    DataType ax_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
+
+                    return (ay_ as CqlQuantity) as object;
+                }
+                else if (ag_())
+                {
+                    DataType az_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object ba_ = FHIRHelpers_4_4_000.Instance.ToValue(context, az_);
+
+                    return (ba_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
+            CqlDateTime o_ = context.Operators.Start(n_);
+            CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter);
+            CqlDateTime q_ = context.Operators.Start(p_);
+            CqlQuantity r_ = context.Operators.Quantity(48m, "hours");
+            CqlDateTime s_ = context.Operators.Add(q_, r_);
+            CqlDateTime u_ = context.Operators.End(p_);
+            CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
+            bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default);
+            object x_()
+            {
+                bool bb_()
+                {
+                    DataType bf_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bf_);
+                    bool bh_ = bg_ is CqlDateTime;
+
+                    return bh_;
+                };
+                bool bc_()
+                {
+                    DataType bi_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bi_);
+                    bool bk_ = bj_ is CqlInterval<CqlDateTime>;
+
+                    return bk_;
+                };
+                bool bd_()
+                {
+                    DataType bl_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bl_);
+                    bool bn_ = bm_ is CqlQuantity;
+
+                    return bn_;
+                };
+                bool be_()
+                {
+                    DataType bo_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bo_);
+                    bool bq_ = bp_ is CqlInterval<CqlQuantity>;
+
+                    return bq_;
+                };
+                if (bb_())
+                {
+                    DataType br_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bs_ = FHIRHelpers_4_4_000.Instance.ToValue(context, br_);
+
+                    return (bs_ as CqlDateTime) as object;
+                }
+                else if (bc_())
+                {
+                    DataType bt_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bt_);
+
+                    return (bu_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (bd_())
+                {
+                    DataType bv_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object bw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bv_);
+
+                    return (bw_ as CqlQuantity) as object;
+                }
+                else if (be_())
+                {
+                    DataType bx_ = tuple_bwwsxdxsfijqjjncdevjkzegj?.Dialysis?.Performed;
+                    object by_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bx_);
+
+                    return (by_ as CqlInterval<CqlQuantity>) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
+            CqlDateTime z_ = context.Operators.Start(y_);
+            bool? ab_ = context.Operators.In<CqlDateTime>(z_, p_, default);
+            bool? ac_ = context.Operators.And(w_, ab_);
+
+            return ac_;
+        };
+        IEnumerable<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?> h_ = context.Operators.Where<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?>(f_, g_);
+        Encounter i_((CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)? tuple_bwwsxdxsfijqjjncdevjkzegj) =>
+            tuple_bwwsxdxsfijqjjncdevjkzegj?.QualifyingEncounter;
+        IEnumerable<Encounter> j_ = context.Operators.Select<(CqlTupleMetadata, Procedure Dialysis, Encounter QualifyingEncounter)?, Encounter>(h_, i_);
+        IEnumerable<Encounter> k_ = context.Operators.Distinct<Encounter>(j_);
+
+        return k_;
+    }
+
+
+    [CqlExpressionDefinition("Encounter with Kidney Dialysis Started More Than 48 Hours After Arrival without High Creatinine")]
+    public IEnumerable<Encounter> Encounter_with_Kidney_Dialysis_Started_More_Than_48_Hours_After_Arrival_without_High_Creatinine(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Kidney_Dialysis_Started_More_Than_48_Hours_After_Arrival(context);
+        bool? b_(Encounter EncounterWithDialysisAfter48Hours)
+        {
+            IEnumerable<Encounter> d_ = this.Encounter_with_2_Times_Serum_Creatinine_Increase(context);
+            bool? e_(Encounter EncounterWithHighCreatinine)
+            {
+                Period i_ = EncounterWithHighCreatinine?.Period;
+                CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                Period k_ = EncounterWithDialysisAfter48Hours?.Period;
+                CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
+                bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+
+                return m_;
+            };
+            IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
+            bool? g_ = context.Operators.Exists<Encounter>(f_);
+            bool? h_ = context.Operators.Not(g_);
+
+            return h_;
+        };
+        IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Numerator")]
+    public IEnumerable<Encounter> Numerator(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_2_Times_Serum_Creatinine_Increase(context);
+        IEnumerable<Encounter> b_ = this.Encounter_with_Kidney_Dialysis_Started_More_Than_48_Hours_After_Arrival_without_High_Creatinine(context);
+        IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlFunctionDefinition("SerumCreatinineSequencebyTime")]
+    public IEnumerable<Observation> SerumCreatinineSequencebyTime(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlValueSet a_ = this.Creatinine_Mass_Per_Volume(context);
+        IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-lab"));
+        bool? c_(Observation CreatinineTestByTime)
+        {
+            object h_()
+            {
+                bool x_()
+                {
+                    DataType aa_ = CreatinineTestByTime?.Effective;
+                    object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
+                    bool ac_ = ab_ is CqlDateTime;
+
+                    return ac_;
+                };
+                bool y_()
+                {
+                    DataType ad_ = CreatinineTestByTime?.Effective;
+                    object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
+                    bool af_ = ae_ is CqlInterval<CqlDateTime>;
+
+                    return af_;
+                };
+                bool z_()
+                {
+                    DataType ag_ = CreatinineTestByTime?.Effective;
+                    object ah_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ag_);
+                    bool ai_ = ah_ is CqlDateTime;
+
+                    return ai_;
+                };
+                if (x_())
+                {
+                    DataType aj_ = CreatinineTestByTime?.Effective;
+                    object ak_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aj_);
+
+                    return (ak_ as CqlDateTime) as object;
+                }
+                else if (y_())
+                {
+                    DataType al_ = CreatinineTestByTime?.Effective;
+                    object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
+
+                    return (am_ as CqlInterval<CqlDateTime>) as object;
+                }
+                else if (z_())
+                {
+                    DataType an_ = CreatinineTestByTime?.Effective;
+                    object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, an_);
+
+                    return (ao_ as CqlDateTime) as object;
+                }
+                else
+                {
+                    return null;
+                }
+            };
+            CqlDateTime i_ = QICoreCommon_4_0_000.Instance.earliest(context, h_());
+            CqlInterval<CqlDateTime> j_ = CQMCommon_4_1_000.Instance.hospitalization(context, QualifyingEncounter);
+            bool? k_ = context.Operators.In<CqlDateTime>(i_, j_, default);
+            DataType l_ = CreatinineTestByTime?.Value;
+            object m_ = FHIRHelpers_4_4_000.Instance.ToValue(context, l_);
+            bool? n_ = context.Operators.Not((bool?)(m_ is null));
+            bool? o_ = context.Operators.And(k_, n_);
+            bool? p_ = QICoreCommon_4_0_000.Instance.isLaboratory(context, CreatinineTestByTime as object);
+            bool? q_ = context.Operators.And(o_, p_);
+            Code<ObservationStatus> r_ = CreatinineTestByTime?.StatusElement;
+            ObservationStatus? s_ = r_?.Value;
+            string t_ = context.Operators.Convert<string>(s_);
+            string[] u_ = [
+                "final",
+                "amended",
+                "corrected",
+            ];
+            bool? v_ = context.Operators.In<string>(t_, (IEnumerable<string>)u_);
+            bool? w_ = context.Operators.And(q_, v_);
+
+            return w_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+        Observation e_(Observation CreatinineTestByTime) =>
+            CreatinineTestByTime;
+        IEnumerable<Observation> f_ = context.Operators.Select<Observation, Observation>(d_, e_);
+        IEnumerable<Observation> g_ = context.Operators.Distinct<Observation>(f_);
+
+        return g_;
+    }
+
+
+    [CqlFunctionDefinition("2.0IncreaseInCreatinine")]
+    public CqlQuantity _2_0IncreaseInCreatinine(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlQuantity a_ = this.HighestSerumCreatinineResult(context, QualifyingEncounter);
+        CqlQuantity b_ = context.Operators.ConvertIntegerToQuantity(2);
+        CqlQuantity c_ = context.Operators.Divide(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable Estimated Glomerular Filtration Rate for Females")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> Risk_Variable_Estimated_Glomerular_Filtration_Rate_for_Females(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, decimal? eGFR)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            decimal? g_ = this.FemaleeGFR(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, decimal? eGFR)? h_ = (CqlTupleMetadata_ChQZQhiCBOOJUfBhSOMPAPSKY, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, decimal? eGFR)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, decimal? eGFR)?>(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable Estimated Glomerular Filtration Rate for Males")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> Risk_Variable_Estimated_Glomerular_Filtration_Rate_for_Males(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, decimal? eGFR)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            decimal? g_ = this.MaleeGFR(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, decimal? eGFR)? h_ = (CqlTupleMetadata_ChQZQhiCBOOJUfBhSOMPAPSKY, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, decimal? eGFR)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, decimal? eGFR)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, decimal? eGFR)?>(c_);
+
+        return d_;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable All Encounter Diagnoses with POA Indication")]
+    public IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?> Risk_Variable_All_Encounter_Diagnoses_with_POA_Indication(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        IEnumerable<Claim> b_ = context.Operators.Retrieve<Claim>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-claim"));
+        IEnumerable<ValueTuple<Encounter, Claim>> c_ = context.Operators.CrossJoin<Encounter, Claim>(a_, b_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? d_(ValueTuple<Encounter, Claim> _valueTuple)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? k_ = (CqlTupleMetadata_HJXKcBjYOeaJSUHgPLEXXCjGc, _valueTuple.Item1, _valueTuple.Item2);
+
+            return k_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?> e_ = context.Operators.Select<ValueTuple<Encounter, Claim>, (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?>(c_, d_);
+        bool? f_((CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? tuple_csikdkffnecdbrrkiiwklenqg)
+        {
+            Code<FinancialResourceStatusCodes> l_ = tuple_csikdkffnecdbrrkiiwklenqg?.claim?.StatusElement;
+            FinancialResourceStatusCodes? m_ = l_?.Value;
+            Code<FinancialResourceStatusCodes> n_ = context.Operators.Convert<Code<FinancialResourceStatusCodes>>(m_);
+            bool? o_ = context.Operators.Equal(n_, "active");
+            Code<ClaimUseCode> p_ = tuple_csikdkffnecdbrrkiiwklenqg?.claim?.UseElement;
+            ClaimUseCode? q_ = p_?.Value;
+            Code<ClaimUseCode> r_ = context.Operators.Convert<Code<ClaimUseCode>>(q_);
+            bool? s_ = context.Operators.Equal(r_, "claim");
+            bool? t_ = context.Operators.And(o_, s_);
+            List<Claim.ItemComponent> u_ = tuple_csikdkffnecdbrrkiiwklenqg?.claim?.Item;
+            bool? v_(Claim.ItemComponent I)
+            {
+                List<ResourceReference> z_ = I?.Encounter;
+                bool? aa_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)z_, tuple_csikdkffnecdbrrkiiwklenqg?.QualifyingEncounter);
+                List<Claim.DiagnosisComponent> ab_ = tuple_csikdkffnecdbrrkiiwklenqg?.claim?.Diagnosis;
+                bool? ac_(Claim.DiagnosisComponent D)
+                {
+                    PositiveInt ag_ = D?.SequenceElement;
+                    int? ah_ = ag_?.Value;
+                    List<Claim.ItemComponent> ai_ = tuple_csikdkffnecdbrrkiiwklenqg?.claim?.Item;
+                    bool? aj_(Claim.ItemComponent @this)
+                    {
+                        List<PositiveInt> au_ = @this?.DiagnosisSequenceElement;
+                        int? av_(PositiveInt @this)
+                        {
+                            int? ay_ = @this?.Value;
+
+                            return ay_;
+                        };
+                        IEnumerable<int?> aw_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)au_, av_);
+                        bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
+
+                        return ax_;
+                    };
+                    IEnumerable<Claim.ItemComponent> ak_ = context.Operators.Where<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)ai_, aj_);
+                    IEnumerable<int?> al_(Claim.ItemComponent @this)
+                    {
+                        List<PositiveInt> az_ = @this?.DiagnosisSequenceElement;
+                        int? ba_(PositiveInt @this)
+                        {
+                            int? bc_ = @this?.Value;
+
+                            return bc_;
+                        };
+                        IEnumerable<int?> bb_ = context.Operators.Select<PositiveInt, int?>((IEnumerable<PositiveInt>)az_, ba_);
+
+                        return bb_;
+                    };
+                    IEnumerable<IEnumerable<int?>> am_ = context.Operators.Select<Claim.ItemComponent, IEnumerable<int?>>(ak_, al_);
+                    IEnumerable<int?> an_ = context.Operators.Flatten<int?>(am_);
+                    bool? ao_ = context.Operators.In<int?>(ah_, an_);
+                    CodeableConcept ap_ = D?.OnAdmission;
+                    CqlConcept aq_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ap_);
+                    CqlValueSet ar_ = this.Present_on_Admission_or_Clinically_Undetermined(context);
+                    bool? as_ = context.Operators.ConceptInValueSet(aq_, ar_);
+                    bool? at_ = context.Operators.And(ao_, as_);
+
+                    return at_;
+                };
+                IEnumerable<Claim.DiagnosisComponent> ad_ = context.Operators.Where<Claim.DiagnosisComponent>((IEnumerable<Claim.DiagnosisComponent>)ab_, ac_);
+                bool? ae_ = context.Operators.Exists<Claim.DiagnosisComponent>(ad_);
+                bool? af_ = context.Operators.And(aa_, ae_);
+
+                return af_;
+            };
+            IEnumerable<Claim.ItemComponent> w_ = context.Operators.Where<Claim.ItemComponent>((IEnumerable<Claim.ItemComponent>)u_, v_);
+            bool? x_ = context.Operators.Exists<Claim.ItemComponent>(w_);
+            bool? y_ = context.Operators.And(t_, x_);
+
+            return y_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?> g_ = context.Operators.Where<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?>(e_, f_);
+        (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? h_((CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? tuple_csikdkffnecdbrrkiiwklenqg)
+        {
+            (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)? bd_ = (CqlTupleMetadata_HJXKcBjYOeaJSUHgPLEXXCjGc, tuple_csikdkffnecdbrrkiiwklenqg?.QualifyingEncounter, tuple_csikdkffnecdbrrkiiwklenqg?.claim);
+
+            return bd_;
+        };
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?> i_ = context.Operators.Select<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?, (CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?>(g_, h_);
+        IEnumerable<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?> j_ = context.Operators.Distinct<(CqlTupleMetadata, Encounter QualifyingEncounter, Claim claim)?>(i_);
+
+        return j_;
+    }
+
+
+    [CqlFunctionDefinition("FirstHeartRate")]
+    public CqlQuantity FirstHeartRate(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlCode a_ = this.Heart_rate(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate"));
+        bool? d_(Observation FirstHeartBeats)
+        {
+            DataType k_ = FirstHeartBeats?.Effective;
+            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+            CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_);
+            CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
+            DataType p_ = FirstHeartBeats?.Value;
+            CqlQuantity q_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, p_ as Quantity);
+            bool? r_ = context.Operators.Not((bool?)(q_ is null));
+            bool? s_ = context.Operators.And(o_, r_);
+
+            return s_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType t_ = @this?.Effective;
+            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+            CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
+
+            return v_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.First<Observation>(g_);
+        DataType i_ = h_?.Value;
+        CqlQuantity j_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, i_ as Quantity);
+
+        return j_ as CqlQuantity;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable First Heart Rate in Encounter")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)?> Risk_Variable_First_Heart_Rate_in_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            CqlQuantity g_ = this.FirstHeartRate(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)? h_ = (CqlTupleMetadata_FagZCcMXCLUWREPQINNbEKifA, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, CqlQuantity firstHeartRate)?>(c_);
+
+        return d_;
+    }
+
+
+    [CqlFunctionDefinition("FirstRespiratoryRate")]
+    public CqlQuantity FirstRespiratoryRate(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlCode a_ = this.Respiratory_rate(context);
+        IEnumerable<CqlCode> b_ = context.Operators.ToList<CqlCode>(a_);
+        IEnumerable<Observation> c_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, b_, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate"));
+        bool? d_(Observation FirstRespiration)
+        {
+            DataType k_ = FirstRespiration?.Effective;
+            object l_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
+            CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_);
+            CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
+            DataType p_ = FirstRespiration?.Value;
+            CqlQuantity q_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, p_ as Quantity);
+            bool? r_ = context.Operators.Not((bool?)(q_ is null));
+            bool? s_ = context.Operators.And(o_, r_);
+
+            return s_;
+        };
+        IEnumerable<Observation> e_ = context.Operators.Where<Observation>(c_, d_);
+        object f_(Observation @this)
+        {
+            DataType t_ = @this?.Effective;
+            object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
+            CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_);
+
+            return v_;
+        };
+        IEnumerable<Observation> g_ = context.Operators.SortBy<Observation>(e_, f_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation h_ = context.Operators.First<Observation>(g_);
+        DataType i_ = h_?.Value;
+        CqlQuantity j_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, i_ as Quantity);
+
+        return j_ as CqlQuantity;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable First Respiratory Rate in Encounter")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)?> Risk_Variable_First_Respiratory_Rate_in_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            CqlQuantity g_ = this.FirstRespiratoryRate(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)? h_ = (CqlTupleMetadata_BWTiRIaMgaifWSHaCRbRQdjII, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, CqlQuantity firstRespiratoryRate)?>(c_);
+
+        return d_;
+    }
+
+
+    [CqlFunctionDefinition("FirstSystolicBloodPressure")]
+    public CqlQuantity FirstSystolicBloodPressure(CqlContext context, Encounter QualifyingEncounter)
+    {
+        IEnumerable<Observation> a_ = this.Qualifying_Systolic_Blood_Pressure_Reading(context);
+        bool? b_(Observation SBPReading)
+        {
+            DataType h_ = SBPReading?.Effective;
+            object i_ = FHIRHelpers_4_4_000.Instance.ToValue(context, h_);
+            CqlDateTime j_ = QICoreCommon_4_0_000.Instance.earliest(context, i_);
+            CqlInterval<CqlDateTime> k_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
+
+            return l_;
+        };
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+        CqlQuantity d_(Observation SBPReading)
+        {
+            List<Observation.ComponentComponent> m_ = SBPReading?.Component;
+            bool? n_(Observation.ComponentComponent SBPComponent)
+            {
+                CodeableConcept t_ = SBPComponent?.Code;
+                CqlConcept u_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, t_);
+                CqlCode v_ = this.Systolic_blood_pressure(context);
+                CqlConcept w_ = context.Operators.ConvertCodeToConcept(v_);
+                bool? x_ = context.Operators.Equivalent(u_, w_);
+
+                return x_;
+            };
+            IEnumerable<Observation.ComponentComponent> o_ = context.Operators.Where<Observation.ComponentComponent>((IEnumerable<Observation.ComponentComponent>)m_, n_);
+            CqlQuantity p_(Observation.ComponentComponent SBPComponent)
+            {
+                DataType y_ = SBPComponent?.Value;
+                object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
+
+                return z_ as CqlQuantity;
+            };
+            IEnumerable<CqlQuantity> q_ = context.Operators.Select<Observation.ComponentComponent, CqlQuantity>(o_, p_);
+            IEnumerable<CqlQuantity> r_ = context.Operators.Distinct<CqlQuantity>(q_);
+            CqlQuantity s_ = context.Operators.SingletonFrom<CqlQuantity>(r_);
+
+            return s_;
+        };
+        IEnumerable<CqlQuantity> e_ = context.Operators.Select<Observation, CqlQuantity>(c_, d_);
+        IEnumerable<CqlQuantity> f_ = context.Operators.Distinct<CqlQuantity>(e_);
+        CqlQuantity g_ = context.Operators.First<CqlQuantity>(f_);
+
+        return g_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Systolic Blood Pressure Reading")]
+    public IEnumerable<Observation> Qualifying_Systolic_Blood_Pressure_Reading(CqlContext context)
+    {
+        IEnumerable<Observation> a_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure"));
+        bool? b_(Observation BloodPressure)
+        {
+            DataType d_ = BloodPressure?.Effective;
+            object e_ = FHIRHelpers_4_4_000.Instance.ToValue(context, d_);
+            CqlDateTime f_ = QICoreCommon_4_0_000.Instance.earliest(context, e_);
+            CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
+            bool? h_ = context.Operators.In<CqlDateTime>(f_, g_, "day");
+
+            return h_;
+        };
+        IEnumerable<Observation> c_ = context.Operators.Where<Observation>(a_, b_);
+
+        return c_;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable First Systolic Blood Pressure in Encounter")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)?> Risk_Variable_First_Systolic_Blood_Pressure_in_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            CqlQuantity g_ = this.FirstSystolicBloodPressure(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)? h_ = (CqlTupleMetadata_BfHgdIQNPeXTfGHcOBiXACaRK, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, CqlQuantity firstSystolicBP)?>(c_);
+
+        return d_;
+    }
+
+
+    [CqlFunctionDefinition("FirstBodyTemperature")]
+    public CqlQuantity FirstBodyTemperature(CqlContext context, Encounter QualifyingEncounter)
+    {
+        CqlValueSet a_ = this.Body_temperature(context);
+        IEnumerable<Observation> b_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature"));
+        bool? c_(Observation FirstTemperature)
+        {
+            DataType j_ = FirstTemperature?.Effective;
+            object k_ = FHIRHelpers_4_4_000.Instance.ToValue(context, j_);
+            CqlDateTime l_ = QICoreCommon_4_0_000.Instance.earliest(context, k_);
+            CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
+            bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
+            DataType o_ = FirstTemperature?.Value;
+            CqlQuantity p_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, o_ as Quantity);
+            bool? q_ = context.Operators.Not((bool?)(p_ is null));
+            bool? r_ = context.Operators.And(n_, q_);
+
+            return r_;
+        };
+        IEnumerable<Observation> d_ = context.Operators.Where<Observation>(b_, c_);
+        object e_(Observation @this)
+        {
+            DataType s_ = @this?.Effective;
+            object t_ = FHIRHelpers_4_4_000.Instance.ToValue(context, s_);
+            CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_);
+
+            return u_;
+        };
+        IEnumerable<Observation> f_ = context.Operators.SortBy<Observation>(d_, e_, System.ComponentModel.ListSortDirection.Ascending);
+        Observation g_ = context.Operators.First<Observation>(f_);
+        DataType h_ = g_?.Value;
+        CqlQuantity i_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, h_ as Quantity);
+
+        return i_ as CqlQuantity;
+    }
+
+
+    [CqlExpressionDefinition("Risk Variable First Temperature in Encounter")]
+    public IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)?> Risk_Variable_First_Temperature_in_Encounter(CqlContext context)
+    {
+        IEnumerable<Encounter> a_ = this.Encounter_with_Creatinine_and_without_Obstetrical_Conditions(context);
+        (CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)? b_(Encounter QualifyingEncounter)
+        {
+            Id e_ = QualifyingEncounter?.IdElement;
+            string f_ = e_?.Value;
+            CqlQuantity g_ = this.FirstBodyTemperature(context, QualifyingEncounter);
+            (CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)? h_ = (CqlTupleMetadata_HjOGEZILgEFXhMPHLgWdcOTZ, f_, g_);
+
+            return h_;
+        };
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)?> c_ = context.Operators.Select<Encounter, (CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)?>(a_, b_);
+        IEnumerable<(CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)?> d_ = context.Operators.Distinct<(CqlTupleMetadata, string encounterId, CqlQuantity firstTemperature)?>(c_);
+
+        return d_;
+    }
+
+
+    #endregion Functions and Expressions
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_BDjSiZCAhXcVgEETFRJVEHXOR = new(
+      [typeof(Encounter), typeof(Observation), typeof(Observation)],
+      ["EncounterWithHighCreatinine", "HighCreatinineTest", "LowCreatinineTest"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_BfHgdIQNPeXTfGHcOBiXACaRK = new(
+      [typeof(string), typeof(CqlQuantity)],
+      ["encounterId", "firstSystolicBP"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_BSZZjZXQgCBZNijVbAJbPfNhP = new(
+      [typeof(Encounter), typeof(Observation)],
+      ["Encounter48Hours", "CreatinineTest"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_BWTiRIaMgaifWSHaCRbRQdjII = new(
+      [typeof(string), typeof(CqlQuantity)],
+      ["encounterId", "firstRespiratoryRate"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_BWWSXdXSFIJQjJNcdEVJKZEGj = new(
+      [typeof(Procedure), typeof(Encounter)],
+      ["Dialysis", "QualifyingEncounter"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_ChQZQhiCBOOJUfBhSOMPAPSKY = new(
+      [typeof(string), typeof(decimal?)],
+      ["encounterId", "eGFR"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_FagZCcMXCLUWREPQINNbEKifA = new(
+      [typeof(string), typeof(CqlQuantity)],
+      ["encounterId", "firstHeartRate"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_FWVGLDcQEISFGIdVNGEWPHUFV = new(
+      [typeof(Encounter), typeof(Observation), typeof(Observation)],
+      ["QualifyingEncounter", "IndexCreatinineLabResult", "SubsequentCreatinineLabResult"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_GiiGRATBZEQfMLdbZgPRgTeRJ = new(
+      [typeof(Encounter), typeof(Observation)],
+      ["QualifyingEncounter", "CreatinineTestByTime"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_HjOGEZILgEFXhMPHLgWdcOTZ = new(
+      [typeof(string), typeof(CqlQuantity)],
+      ["encounterId", "firstTemperature"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_HJXKcBjYOeaJSUHgPLEXXCjGc = new(
+      [typeof(Encounter), typeof(Claim)],
+      ["QualifyingEncounter", "claim"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_JeYVEdgebecHQGRICIKegVBi = new(
+      [typeof(Encounter), typeof(Observation), typeof(Observation)],
+      ["QualifyingEncounter", "HighCreatinineTest", "LowCreatinineTest"]);
+
+    private static CqlTupleMetadata CqlTupleMetadata_XFRBIZcEbIWeUfjZdAFDdJef = new(
+      [typeof(string), typeof(CqlInterval<CqlDateTime>), typeof(string), typeof(object), typeof(string), typeof(CqlQuantity), typeof(string), typeof(decimal?), typeof(CqlDateTime), typeof(CqlDateTime)],
+      ["CrEncInPtId", "CrHospitalization", "CrLabObsId", "CrLabObsCategory", "CrLabObsStatus", "CrLabResult", "CrLabResultUnit", "CrLabResultValue", "CrLabTime", "CrLabTimeIssued"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}


### PR DESCRIPTION
This PR fixes QICore 2025 ELM compilation bugs related to missing `resultTypeSpecifier` properties on tuple element values. The fix enhances the `MissingResultTypeSpecifierCorrector` preprocessor to handle additional cases where type specifiers are missing in tuple operations, particularly in CQL expressions that return complex structured data.

Key changes:
- Enhanced the MissingResultTypeSpecifierCorrector with additional logic to handle tuple element type specifications
- Removed previously skipped CQL files from packager configurations
- Updated submodule references and added generated C# files for newly supported measures