### PR TITLE
Bump version to 2.3.1 and update release notes

### DIFF
--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -10,7 +10,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 			-->
-		<VersionPrefix>2.3.0</VersionPrefix>
+		<VersionPrefix>2.3.1</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 		<!--
 			## Keep FirelySdkVersion in sync between cql-base.props and cql-demo.props

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ There is quite some variation in how CQL is written and interpreted,
 so it is likely at this early stage that there will be deviations from other engines currently available.
 
 ## Release Notes
-This is release version 2.3 of the engine.
-Earlier 1.x releases will be maintained with hotfixes, but will not receive new features.
+This is release version 2.3.1 of the engine.
 
 The releases notes 
 at [firely-cql-sdk/releases](https://github.com/FirelyTeam/firely-cql-sdk/releases) for each major version will document these changes and (major) issues we have encountered.
 
+1.* Releases will be maintained with hotfixes, but will not receive new features.
 
 ## Getting Started
 

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -23,7 +23,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 		-->
-		<VersionPrefix>2.3.0</VersionPrefix>
+		<VersionPrefix>2.3.1</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>


### PR DESCRIPTION
Updated version numbers in cql-sdk.props and cql-demo.props from 2.3.0 to 2.3.1 for new release. Revised README to reflect the new version and clarified maintenance policy for 1.* releases.