### PR TITLE
Remove exception handling for group tag on measure annotations

### DIFF
--- a/Cql/Cql.Packaging/ResourcePackager.cs
+++ b/Cql/Cql.Packaging/ResourcePackager.cs
@@ -207,9 +207,6 @@ file static class MeasurePackager
                              select new { Group = g.value, Population = p.value };
                 foreach (var tuple in tuples)
                 {
-                    if (!int.TryParse(tuple.Group, out var groupNumber))
-                        throw new InvalidOperationException(
-                            $"Definition {def.name} has a @group annotation whose value is {tuple.Group}.  Groups must be positive integers.");
                     if (!Populations.ContainsKey(tuple.Population))
                         throw new InvalidOperationException(
                             $"Definition {def.name} has a @population annotation whose value is {tuple.Population}.  @population must be one of: {string.Join(", ", Populations.Keys)}");


### PR DESCRIPTION
Fixes https://github.com/FirelyTeam/firely-cql-sdk/issues/1080

Currently the AnnotateMeasurePopulations method is breaking when user provides a cql/elm with annotation group tag in non-integer values. NCQA CQLs now use string values for group tags. This exception handling below is blocking to annotate for non-integer group tag values

```
                   if (!int.TryParse(tuple.Group, out var groupNumber))
                        throw new InvalidOperationException(
                            $"Definition {def.name} has a @group annotation whose value is {tuple.Group}.  Groups must be positive integers.");
```

This PR fixes the problem with removal of the exception handling since the group tag can be a integer or non-integer value.