### PR TITLE
Spike/remove id example working

### DIFF
--- a/Cql/Cql.Firely/FhirTypeResolver.cs
+++ b/Cql/Cql.Firely/FhirTypeResolver.cs
@@ -123,6 +123,8 @@ namespace Hl7.Cql.Fhir
 
             Types["{http://hl7.org/fhir}SimpleQuantity"] = Types["{http://hl7.org/fhir}Quantity"];
             Types["{http://hl7.org/fhir}MoneyQuantity"] = Types["{http://hl7.org/fhir}Quantity"];
+
+            Types["{http://hl7.org/fhir}Id"] = typeof(Hl7.Fhir.Model.FhirString);
         }
 
         private void AddTypesFromInspector()

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/FHIRHelpers-4.4.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/FHIRHelpers-4.4.000.g.cs
@@ -554,9 +554,9 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
 
                 return j_;
             }
-            else if (value is Id)
+            else if (value is FhirString)
             {
-                string k_ = (value as Id)?.Value;
+                string k_ = (value as FhirString)?.Value;
 
                 return k_ as object;
             }
@@ -2987,15 +2987,6 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
 
     [CqlFunctionDefinition("ToString")]
     public string ToString(CqlContext context, XHtml value)
-    {
-        string a_ = value?.Value;
-
-        return a_;
-    }
-
-
-    [CqlFunctionDefinition("ToString")]
-    public string ToString(CqlContext context, Id value)
     {
         string a_ = value?.Value;
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
@@ -212,13 +212,14 @@ public partial class NHSNHelpers_0_1_000 : ILibrary, ISingleton<NHSNHelpers_0_1_
         bool? b_(Location Locations)
         {
             Id e_ = Locations?.IdElement;
-            string f_ = FHIRHelpers_4_4_000.Instance.ToString(context, e_);
-            FhirString g_ = reference?.ReferenceElement;
-            string h_ = FHIRHelpers_4_4_000.Instance.ToString(context, g_);
-            string i_ = this.GetId(context, h_);
-            bool? j_ = context.Operators.Equal(f_, i_);
+            FhirString f_ = context.Operators.Convert<FhirString>(e_);
+            string g_ = FHIRHelpers_4_4_000.Instance.ToString(context, f_);
+            FhirString h_ = reference?.ReferenceElement;
+            string i_ = FHIRHelpers_4_4_000.Instance.ToString(context, h_);
+            string j_ = this.GetId(context, i_);
+            bool? k_ = context.Operators.Equal(g_, j_);
 
-            return j_;
+            return k_;
         };
         IEnumerable<Location> c_ = context.Operators.Where<Location>(a_, b_);
         Location d_ = context.Operators.SingletonFrom<Location>(c_);

--- a/LibrarySets/dqm-content-qicore-2025/Cql/FHIRHelpers.cql
+++ b/LibrarySets/dqm-content-qicore-2025/Cql/FHIRHelpers.cql
@@ -709,4 +709,3 @@ define function ToString(value string): value.value
 define function ToTime(value time): value.value
 define function ToString(value uri): value.value
 define function ToString(value xhtml): value.value
-define function ToString(value FHIR.id): value.value

--- a/LibrarySets/dqm-content-qicore-2025/Elm/FHIRHelpers.json
+++ b/LibrarySets/dqm-content-qicore-2025/Elm/FHIRHelpers.json
@@ -32227,39 +32227,6 @@
                   "annotation" : [ ]
                }
             } ]
-         }, {
-            "locator" : "712:1-712:52",
-            "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-            "name" : "ToString",
-            "context" : "Unfiltered",
-            "accessLevel" : "Public",
-            "type" : "FunctionDef",
-            "annotation" : [ ],
-            "expression" : {
-               "locator" : "712:42-712:52",
-               "resultTypeName" : "{urn:hl7-org:elm-types:r1}String",
-               "path" : "value",
-               "type" : "Property",
-               "annotation" : [ ],
-               "source" : {
-                  "locator" : "712:42-712:46",
-                  "resultTypeName" : "{http://hl7.org/fhir}id",
-                  "name" : "value",
-                  "type" : "OperandRef",
-                  "annotation" : [ ]
-               }
-            },
-            "operand" : [ {
-               "name" : "value",
-               "annotation" : [ ],
-               "operandTypeSpecifier" : {
-                  "locator" : "712:32-712:38",
-                  "resultTypeName" : "{http://hl7.org/fhir}id",
-                  "name" : "{http://hl7.org/fhir}id",
-                  "type" : "NamedTypeSpecifier",
-                  "annotation" : [ ]
-               }
-            } ]
          } ]
       }
    }

--- a/LibrarySets/dqm-content-qicore-2025/Elm/NHSNHelpers.json
+++ b/LibrarySets/dqm-content-qicore-2025/Elm/NHSNHelpers.json
@@ -3597,7 +3597,7 @@
                         "type" : "FunctionRef",
                         "annotation" : [ ],
                         "signature" : [ {
-                           "name" : "{http://hl7.org/fhir}id",
+                           "name" : "{http://hl7.org/fhir}string",
                            "type" : "NamedTypeSpecifier",
                            "annotation" : [ ]
                         } ],


### PR DESCRIPTION
Showing @baseTwo [regarding ](https://github.com/FirelyTeam/firely-cql-sdk/issues/1044) https://github.com/FirelyTeam/firely-cql-sdk/issues/1044

FHIR.id basetype is FHIR.string in the [modelinfo](https://github.com/FirelyTeam/firely-cql-sdk/blob/f90faf49183fd21b2d18b6405c5fd1ed30e443e5/Cql/Cql.Model/Models/fhir-modelinfo-4.0.1.xml#L11778).

I think we just need to ensure that ID is always converted to FHIR.string then the code here will work properly.

```
Id e_ = Locations?.IdElement;
FhirString f_ = context.Operators.Convert<FhirString>(e_);   <-------- missing conversion
string g_ = FHIRHelpers_4_4_000.Instance.ToString(context, f_);
```

