### PR TITLE
1088 sum operation on cqlquantity is not behaving correctly 2

### DIFF
--- a/Cql/CoreTests/CqlContextOperatorTests.cs
+++ b/Cql/CoreTests/CqlContextOperatorTests.cs
@@ -11,7 +11,6 @@
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Operators;
 using Hl7.Cql.Primitives;
-using Hl7.Cql.Runtime;
 using Hl7.Fhir.Model;
 
 namespace CoreTests;
@@ -19,8 +18,7 @@ namespace CoreTests;
 [TestClass]
 public class CqlContextOperatorTests
 {
-	private static CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
-	private static ICqlOperators GetNewOperators() => GetNewContext().Operators;
+    private static ICqlOperators Sut() => FhirCqlContext.WithDataSource().Operators; // Service under test
 
     #region Equal
 
@@ -28,7 +26,7 @@ public class CqlContextOperatorTests
 	public void Equal_FhirCodeAndString_MustEqual()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
@@ -45,7 +43,7 @@ public class CqlContextOperatorTests
 	public void Equal_StringAndFhirCode_MustEqual()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
@@ -62,7 +60,7 @@ public class CqlContextOperatorTests
     public void Equivalent_ConceptAtLeastOneCodeEquivalent_MustBeEquivalent()
     {
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         CqlCode[] divorcedCodes =
         [
@@ -93,7 +91,7 @@ public class CqlContextOperatorTests
     public void Equivalent_ConceptAtLeastOneCodeEquivalentOnNull_MustBeEquivalent()
     {
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         CqlCode?[] divorcedCodes =
         [
@@ -130,7 +128,7 @@ public class CqlContextOperatorTests
 	public void Convert_FhirCodeToString_MustReturnValueFromEnumLiteral()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
@@ -147,7 +145,7 @@ public class CqlContextOperatorTests
 	public void Convert_StringToFhirCode_ThrowNoConversionIsDefined()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
         const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
@@ -166,7 +164,7 @@ public class CqlContextOperatorTests
 	public void Equivalent_FhirCodeAndCqlCode_MustBeEquivalent()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Cancelled;
 		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
@@ -183,7 +181,7 @@ public class CqlContextOperatorTests
 	public void Equivalent_CqlCodeAndFhirCode_MustBeEquivalent()
 	{
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Cancelled;
 		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
@@ -196,15 +194,15 @@ public class CqlContextOperatorTests
 		isEquivalent.Should().BeTrue("CqlCode and equivalent FHIR Code should be equivalent");
 	}
 
-	#endregion
+    #endregion
 
-    #region Sum
+    #region Sum (Quantity)
 
     [TestMethod]
     public void Sum_QuantityOfSameUnits_MustSumValuesWithSameUnit()
     {
         // Arrange
-        var cqlOperators = GetNewOperators();
+        var cqlOperators = Sut();
 
         List<CqlQuantity?> inputSource =
         [
@@ -219,6 +217,124 @@ public class CqlContextOperatorTests
         // Assert
         bool? areEqual = cqlOperators.Equal(expectedValue, computedValue); // NOTE: Cannot call Equal directly on CqlQuantity!
         Assert.IsTrue(areEqual);
+    }
+
+    [TestMethod]
+    public void Sum_QuantityNullSource_ReturnsNull()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        IEnumerable<CqlQuantity?>? inputSource = null;
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Sum_QuantityIgnoresNullEntries_MustSumNonNullValues()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        List<CqlQuantity?> inputSource =
+        [
+            new(value: 1, unit: "day"),
+            null,
+            new(value: 2, unit: "day")
+        ];
+        CqlQuantity expectedValue = new(value: 3, unit: "day");
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        bool? areEqual = cqlOperators.Equal(expectedValue, computedValue);
+        Assert.IsTrue(areEqual);
+    }
+
+    [TestMethod]
+    public void Sum_QuantityWithInconsistentUnits_ReturnsNull()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        List<CqlQuantity?> inputSource =
+        [
+            new(value: 1, unit: "day"),
+            new(value: 1, unit: "week")
+        ];
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Sum (int)
+
+    [TestMethod]
+    public void Sum_IntegerNullSource_ReturnsNull()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        IEnumerable<int?>? inputSource = null;
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Sum_IntegerEmpty_ReturnsNull()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+        int?[] inputSource = [];
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Sum_IntegerIgnoresNullEntries_MustSumNonNullValues()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+        int?[] inputSource = [1, null, 4];
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void Sum_IntegerOverflow_ReturnsNull()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        int?[] inputSource = [int.MaxValue, 1];
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        computedValue.Should().BeNull();
     }
 
     #endregion

--- a/Cql/CoreTests/CqlContextOperatorTests.cs
+++ b/Cql/CoreTests/CqlContextOperatorTests.cs
@@ -9,6 +9,7 @@
 #nullable enable
 
 using Hl7.Cql.Fhir;
+using Hl7.Cql.Operators;
 using Hl7.Cql.Primitives;
 using Hl7.Cql.Runtime;
 using Hl7.Fhir.Model;
@@ -19,22 +20,22 @@ namespace CoreTests;
 public class CqlContextOperatorTests
 {
 	private static CqlContext GetNewContext() => FhirCqlContext.WithDataSource();
+	private static ICqlOperators GetNewOperators() => GetNewContext().Operators;
 
+    #region Equal
 
-	#region Equal
-
-	[TestMethod]
+    [TestMethod]
 	public void Equal_FhirCodeAndString_MustEqual()
 	{
-		// Arrange
-		var rtx = GetNewContext();
+        // Arrange
+        var cqlOperators = GetNewOperators();
 
-		var enumVal = Encounter.EncounterStatus.Finished;
+        var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
 		const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		var isEqual = rtx.Operators.Equal(codeVal, stringVal);
+        var isEqual = cqlOperators.Equal(codeVal, stringVal);
 
 		// Assert
 		isEqual.Should().BeTrue();
@@ -43,15 +44,15 @@ public class CqlContextOperatorTests
 	[TestMethod]
 	public void Equal_StringAndFhirCode_MustEqual()
 	{
-		// Arrange
-		var rtx = GetNewContext();
+        // Arrange
+        var cqlOperators = GetNewOperators();
 
-		var enumVal = Encounter.EncounterStatus.Finished;
+        var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
 		const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		var isEqual = rtx.Operators.Equal(stringVal, codeVal);
+		var isEqual = cqlOperators.Equal(stringVal, codeVal);
 
 		// Assert
 		isEqual.Should().BeTrue();
@@ -61,7 +62,7 @@ public class CqlContextOperatorTests
     public void Equivalent_ConceptAtLeastOneCodeEquivalent_MustBeEquivalent()
     {
         // Arrange
-        CqlContext rtx = GetNewContext();
+        var cqlOperators = GetNewOperators();
 
         CqlCode[] divorcedCodes =
         [
@@ -80,8 +81,8 @@ public class CqlContextOperatorTests
 
 
         // Act
-        bool? isEqualLessOnLeftConcept = rtx.Operators.Equivalent(divorcedConcept, notMarriedConcept);
-        bool? isEqualLessOnRightConcept = rtx.Operators.Equivalent(notMarriedConcept, divorcedConcept);
+        bool? isEqualLessOnLeftConcept = cqlOperators.Equivalent(divorcedConcept, notMarriedConcept);
+        bool? isEqualLessOnRightConcept = cqlOperators.Equivalent(notMarriedConcept, divorcedConcept);
 
         // Assert
         isEqualLessOnLeftConcept.Should().BeTrue();
@@ -92,7 +93,7 @@ public class CqlContextOperatorTests
     public void Equivalent_ConceptAtLeastOneCodeEquivalentOnNull_MustBeEquivalent()
     {
         // Arrange
-        CqlContext rtx = GetNewContext();
+        var cqlOperators = GetNewOperators();
 
         CqlCode?[] divorcedCodes =
         [
@@ -113,8 +114,8 @@ public class CqlContextOperatorTests
 
 
         // Act
-        bool? isEqualLessOnLeftConcept = rtx.Operators.Equivalent(divorcedConcept, notMarriedConcept);
-        bool? isEqualLessOnRightConcept = rtx.Operators.Equivalent(notMarriedConcept, divorcedConcept);
+        bool? isEqualLessOnLeftConcept = cqlOperators.Equivalent(divorcedConcept, notMarriedConcept);
+        bool? isEqualLessOnRightConcept = cqlOperators.Equivalent(notMarriedConcept, divorcedConcept);
 
         // Assert
         isEqualLessOnLeftConcept.Should().BeTrue();
@@ -128,15 +129,15 @@ public class CqlContextOperatorTests
     [TestMethod]
 	public void Convert_FhirCodeToString_MustReturnValueFromEnumLiteral()
 	{
-		// Arrange
-		var rtx = GetNewContext();
+        // Arrange
+        var cqlOperators = GetNewOperators();
 
-		var enumVal = Encounter.EncounterStatus.Finished;
+        var enumVal = Encounter.EncounterStatus.Finished;
 		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
 		const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		var stringValConverted = rtx.Operators.Convert<string>(codeVal);
+		var stringValConverted = cqlOperators.Convert<string>(codeVal);
 
 		// Assert
 		Assert.AreEqual(stringVal, stringValConverted);
@@ -145,12 +146,12 @@ public class CqlContextOperatorTests
 	[TestMethod]
 	public void Convert_StringToFhirCode_ThrowNoConversionIsDefined()
 	{
-		// Arrange
-		var rtx = GetNewContext();
-		const string stringVal = "finished"; // EnumLiteral[xxx]
+        // Arrange
+        var cqlOperators = GetNewOperators();
+        const string stringVal = "finished"; // EnumLiteral[xxx]
 
 		// Act
-		Action act = () => rtx.Operators.Convert<Code<Encounter.EncounterStatus>>(stringVal);
+		Action act = () => cqlOperators.Convert<Code<Encounter.EncounterStatus>>(stringVal);
 
 		// Assert
 		act.Should().Throw<InvalidOperationException>()
@@ -164,15 +165,15 @@ public class CqlContextOperatorTests
 	[TestMethod]
 	public void Equivalent_FhirCodeAndCqlCode_MustBeEquivalent()
 	{
-		// Arrange
-		var rtx = GetNewContext();
+        // Arrange
+        var cqlOperators = GetNewOperators();
 
-		var enumVal = Encounter.EncounterStatus.Cancelled;
+        var enumVal = Encounter.EncounterStatus.Cancelled;
 		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
 		var cqlCode = new CqlCode("cancelled", null, null, null); // This represents the string "CancelledObservationStatus" converted to CqlCode
 
 		// Act
-		var isEquivalent = rtx.Operators.Equivalent(fhirCode, cqlCode);
+		var isEquivalent = cqlOperators.Equivalent(fhirCode, cqlCode);
 
 		// Assert
 		isEquivalent.Should().BeTrue("FHIR Code and equivalent CqlCode should be equivalent");
@@ -181,19 +182,44 @@ public class CqlContextOperatorTests
 	[TestMethod]
 	public void Equivalent_CqlCodeAndFhirCode_MustBeEquivalent()
 	{
-		// Arrange
-		var rtx = GetNewContext();
+        // Arrange
+        var cqlOperators = GetNewOperators();
 
-		var enumVal = Encounter.EncounterStatus.Cancelled;
+        var enumVal = Encounter.EncounterStatus.Cancelled;
 		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
 		var cqlCode = new CqlCode("cancelled", null, null, null);
 
 		// Act
-		var isEquivalent = rtx.Operators.Equivalent(cqlCode, fhirCode);
+		var isEquivalent = cqlOperators.Equivalent(cqlCode, fhirCode);
 
 		// Assert
 		isEquivalent.Should().BeTrue("CqlCode and equivalent FHIR Code should be equivalent");
 	}
 
 	#endregion
+
+    #region Sum
+
+    [TestMethod]
+    public void Sum_QuantityOfSameUnits_MustSumValuesWithSameUnit()
+    {
+        // Arrange
+        var cqlOperators = GetNewOperators();
+
+        List<CqlQuantity?> inputSource =
+        [
+            new(value: 1, unit: "day"),
+            new(value: 5, unit: "day")
+        ];
+        CqlQuantity expectedValue = new CqlQuantity(value: 6, unit: "day");
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        bool? areEqual = cqlOperators.Equal(expectedValue, computedValue); // NOTE: Cannot call Equal directly on CqlQuantity!
+        Assert.IsTrue(areEqual);
+    }
+
+    #endregion
 }

--- a/Cql/CoreTests/CqlContextOperatorTests.cs
+++ b/Cql/CoreTests/CqlContextOperatorTests.cs
@@ -23,38 +23,38 @@ public class CqlContextOperatorTests
     #region Equal
 
     [TestMethod]
-	public void Equal_FhirCodeAndString_MustEqual()
-	{
+    public void Equal_FhirCodeAndString_MustEqual()
+    {
         // Arrange
         var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
-		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
-		const string stringVal = "finished"; // EnumLiteral[xxx]
+        var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+        const string stringVal = "finished"; // EnumLiteral[xxx]
 
-		// Act
+        // Act
         var isEqual = cqlOperators.Equal(codeVal, stringVal);
 
-		// Assert
-		isEqual.Should().BeTrue();
-	}
+        // Assert
+        isEqual.Should().BeTrue();
+    }
 
-	[TestMethod]
-	public void Equal_StringAndFhirCode_MustEqual()
-	{
+    [TestMethod]
+    public void Equal_StringAndFhirCode_MustEqual()
+    {
         // Arrange
         var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
-		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
-		const string stringVal = "finished"; // EnumLiteral[xxx]
+        var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+        const string stringVal = "finished"; // EnumLiteral[xxx]
 
-		// Act
-		var isEqual = cqlOperators.Equal(stringVal, codeVal);
+        // Act
+        var isEqual = cqlOperators.Equal(stringVal, codeVal);
 
-		// Assert
-		isEqual.Should().BeTrue();
-	}
+        // Assert
+        isEqual.Should().BeTrue();
+    }
 
     [TestMethod]
     public void Equivalent_ConceptAtLeastOneCodeEquivalent_MustBeEquivalent()
@@ -95,7 +95,7 @@ public class CqlContextOperatorTests
 
         CqlCode?[] divorcedCodes =
         [
-			null,
+            null,
             new CqlCode("X", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus", null, null)
         ];
 
@@ -104,7 +104,7 @@ public class CqlContextOperatorTests
         CqlCode?[] notMarriedCodes =
         [
             new CqlCode("Y", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus", null, null),
-			null,
+            null,
             new CqlCode("Z", "http://terminology.hl7.org/CodeSystem/v3-MaritalStatus", null, null)
         ];
 
@@ -125,74 +125,74 @@ public class CqlContextOperatorTests
     #region Convert
 
     [TestMethod]
-	public void Convert_FhirCodeToString_MustReturnValueFromEnumLiteral()
-	{
+    public void Convert_FhirCodeToString_MustReturnValueFromEnumLiteral()
+    {
         // Arrange
         var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Finished;
-		var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
-		const string stringVal = "finished"; // EnumLiteral[xxx]
+        var codeVal = new Code<Encounter.EncounterStatus>(enumVal);
+        const string stringVal = "finished"; // EnumLiteral[xxx]
 
-		// Act
-		var stringValConverted = cqlOperators.Convert<string>(codeVal);
+        // Act
+        var stringValConverted = cqlOperators.Convert<string>(codeVal);
 
-		// Assert
-		Assert.AreEqual(stringVal, stringValConverted);
-	}
+        // Assert
+        Assert.AreEqual(stringVal, stringValConverted);
+    }
 
-	[TestMethod]
-	public void Convert_StringToFhirCode_ThrowNoConversionIsDefined()
-	{
+    [TestMethod]
+    public void Convert_StringToFhirCode_ThrowNoConversionIsDefined()
+    {
         // Arrange
         var cqlOperators = Sut();
         const string stringVal = "finished"; // EnumLiteral[xxx]
 
-		// Act
-		Action act = () => cqlOperators.Convert<Code<Encounter.EncounterStatus>>(stringVal);
+        // Act
+        Action act = () => cqlOperators.Convert<Code<Encounter.EncounterStatus>>(stringVal);
 
-		// Assert
-		act.Should().Throw<InvalidOperationException>()
-		   .WithMessage("No conversion from * to * is defined.");
-	}
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+           .WithMessage("No conversion from * to * is defined.");
+    }
 
-	#endregion
+    #endregion
 
-	#region Equivalent
+    #region Equivalent
 
-	[TestMethod]
-	public void Equivalent_FhirCodeAndCqlCode_MustBeEquivalent()
-	{
+    [TestMethod]
+    public void Equivalent_FhirCodeAndCqlCode_MustBeEquivalent()
+    {
         // Arrange
         var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Cancelled;
-		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
-		var cqlCode = new CqlCode("cancelled", null, null, null); // This represents the string "CancelledObservationStatus" converted to CqlCode
+        var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
+        var cqlCode = new CqlCode("cancelled", null, null, null); // This represents the string "CancelledObservationStatus" converted to CqlCode
 
-		// Act
-		var isEquivalent = cqlOperators.Equivalent(fhirCode, cqlCode);
+        // Act
+        var isEquivalent = cqlOperators.Equivalent(fhirCode, cqlCode);
 
-		// Assert
-		isEquivalent.Should().BeTrue("FHIR Code and equivalent CqlCode should be equivalent");
-	}
+        // Assert
+        isEquivalent.Should().BeTrue("FHIR Code and equivalent CqlCode should be equivalent");
+    }
 
-	[TestMethod]
-	public void Equivalent_CqlCodeAndFhirCode_MustBeEquivalent()
-	{
+    [TestMethod]
+    public void Equivalent_CqlCodeAndFhirCode_MustBeEquivalent()
+    {
         // Arrange
         var cqlOperators = Sut();
 
         var enumVal = Encounter.EncounterStatus.Cancelled;
-		var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
-		var cqlCode = new CqlCode("cancelled", null, null, null);
+        var fhirCode = new Code<Encounter.EncounterStatus>(enumVal);
+        var cqlCode = new CqlCode("cancelled", null, null, null);
 
-		// Act
-		var isEquivalent = cqlOperators.Equivalent(cqlCode, fhirCode);
+        // Act
+        var isEquivalent = cqlOperators.Equivalent(cqlCode, fhirCode);
 
-		// Assert
-		isEquivalent.Should().BeTrue("CqlCode and equivalent FHIR Code should be equivalent");
-	}
+        // Assert
+        isEquivalent.Should().BeTrue("CqlCode and equivalent FHIR Code should be equivalent");
+    }
 
     #endregion
 
@@ -273,6 +273,27 @@ public class CqlContextOperatorTests
 
         // Assert
         computedValue.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Sum_QuantityWithNullUnits_MustSumValuesWithDefaultUnit()
+    {
+        // Arrange
+        var cqlOperators = Sut();
+
+        List<CqlQuantity?> inputSource =
+        [
+            new(value: 1, unit: null),
+            new(value: 2, unit: null)
+        ];
+        CqlQuantity expectedValue = new(value: 3, unit: "1");
+
+        // Act
+        var computedValue = cqlOperators.Sum(inputSource);
+
+        // Assert
+        bool? areEqual = cqlOperators.Equal(expectedValue, computedValue);
+        Assert.IsTrue(areEqual);
     }
 
     #endregion

--- a/Cql/CoreTests/CqlQuantityTests.cs
+++ b/Cql/CoreTests/CqlQuantityTests.cs
@@ -7,7 +7,10 @@
  */
 
 #nullable enable
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Operators;
 using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
 
 namespace CoreTests;
 
@@ -76,4 +79,5 @@ public class CqlQuantityTests
 
         Assert.IsNull(negated);
     }
+
 }

--- a/Cql/CoreTests/CqlQuantityTests.cs
+++ b/Cql/CoreTests/CqlQuantityTests.cs
@@ -7,10 +7,8 @@
  */
 
 #nullable enable
-using Hl7.Cql.Fhir;
-using Hl7.Cql.Operators;
+
 using Hl7.Cql.Primitives;
-using Hl7.Cql.Runtime;
 
 namespace CoreTests;
 

--- a/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
@@ -661,30 +661,6 @@ namespace Hl7.Cql.Operators
             }
         }
 
-        public CqlQuantity? Sum2(IEnumerable<CqlQuantity?>? values)
-        {
-            if (values == null)
-                return null;
-        
-            var nonNull = values
-                          .Where(q => q is { value: not null })
-                          .ToArray();
-        
-            if (nonNull.Length == 0)
-                return null;
-        
-            decimal? sum = 0;
-            string? unit = null;
-            foreach (var v in nonNull)
-            {
-                unit ??= (v!.unit ?? "1");
-                if (unit != v!.unit)
-                    throw new NotSupportedException("Unlike units are not supported.");
-                sum += v.value!.Value;
-            }
-            return new CqlQuantity(sum, unit ?? "1");
-        }
-
         public CqlQuantity? Sum(IEnumerable<CqlQuantity?>? values)
         {
             string? unit = null;

--- a/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
@@ -665,14 +665,14 @@ namespace Hl7.Cql.Operators
         {
             if (values == null)
                 return null;
-
+        
             var nonNull = values
                           .Where(q => q is { value: not null })
                           .ToArray();
-
+        
             if (nonNull.Length == 0)
                 return null;
-
+        
             decimal? sum = 0;
             string? unit = null;
             foreach (var v in nonNull)

--- a/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.AggregateFunctions.cs
@@ -661,6 +661,30 @@ namespace Hl7.Cql.Operators
             }
         }
 
+        public CqlQuantity? Sum2(IEnumerable<CqlQuantity?>? values)
+        {
+            if (values == null)
+                return null;
+
+            var nonNull = values
+                          .Where(q => q is { value: not null })
+                          .ToArray();
+
+            if (nonNull.Length == 0)
+                return null;
+
+            decimal? sum = 0;
+            string? unit = null;
+            foreach (var v in nonNull)
+            {
+                unit ??= (v!.unit ?? "1");
+                if (unit != v!.unit)
+                    throw new NotSupportedException("Unlike units are not supported.");
+                sum += v.value!.Value;
+            }
+            return new CqlQuantity(sum, unit ?? "1");
+        }
+
         public CqlQuantity? Sum(IEnumerable<CqlQuantity?>? values)
         {
             string? unit = null;
@@ -670,7 +694,8 @@ namespace Hl7.Cql.Operators
                 switch (quantity)
                 {
                     case { value: { } v, unit: var u }:
-                        u ??= "1";
+                        u ??= "1"; // default unit if none specified
+                        unit ??= u; // set the unit once, if not already set
                         if (unit != u)
                             throw new NotSupportedException("Inconsistent units are not supported.");
 


### PR DESCRIPTION
Fixes:
* #1088 

## Pull request overview

This PR addresses issue #1088 regarding incorrect behavior of the Sum operation on CqlQuantity. The changes include modifications to the Sum method implementation, comprehensive test coverage for Sum operations, and a file refactoring to align the filename with the class name.

**Changes:**
- Modified `Sum(IEnumerable<CqlQuantity?>?)` method to add clarifying comments about unit handling
- Renamed `FhirCodeEqualityTests.cs` → `CqlContextOperatorTests.cs` to match class name convention
- Added comprehensive test coverage for Sum operations on quantities and integers
