### PR TITLE
1115 cms fhir libraries regen elm

### DIFF
--- a/Cql-Sdk-All.sln
+++ b/Cql-Sdk-All.sln
@@ -154,6 +154,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XsdToCSharpConverterTests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrationBenchmarks", "submodules\Firely.Cql.Sdk.Integration.Runner\IntegrationBenchmarks\IntegrationBenchmarks.csproj", "{FCA59C9B-09F1-C863-9451-1D33EB73F786}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ElmReplacerCLI", "submodules\Firely.Cql.Sdk.Integration.Runner\ElmReplacerCLI\ElmReplacerCLI.csproj", "{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -572,6 +574,18 @@ Global
 		{FCA59C9B-09F1-C863-9451-1D33EB73F786}.Release|x64.Build.0 = Release|Any CPU
 		{FCA59C9B-09F1-C863-9451-1D33EB73F786}.Release|x86.ActiveCfg = Release|Any CPU
 		{FCA59C9B-09F1-C863-9451-1D33EB73F786}.Release|x86.Build.0 = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|x64.Build.0 = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -622,6 +636,7 @@ Global
 		{632001E4-FF3B-41BC-A3BE-15B65DF5EC37} = {85401759-2C64-414D-9882-4DB1EA41C2ED}
 		{061FB619-DABC-4630-A4E7-E01CA45D9B75} = {55D1DD84-B6F3-4B15-8A5E-664C25DBF374}
 		{FCA59C9B-09F1-C863-9451-1D33EB73F786} = {0E5F5704-5289-4C65-AD4E-364CD5F60C44}
+		{3B6A9ADF-BA38-AD48-7A50-863CA15CE058} = {0E5F5704-5289-4C65-AD4E-364CD5F60C44}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		FileExplorer = build\|docs\|LibrarySets\|submodules\Firely.Cql.Sdk.Integration.Runner\NodeJsUtils\


### PR DESCRIPTION
DO NOT MERGE 

```
Description:
  Utility for extracting CQL/ELM from FHIR libraries and replacing ELM artifacts in FHIR libraries

Usage:
  Hl7.Cql.ElmReplacer [options]

Options:
  --fhir-input <fhir-input> (REQUIRED)  Input directory containing FHIR library JSON files
  --fhir-output <fhir-output>           Output directory for processed FHIR library JSON files (must be different from
                                        --fhir-input). Required when --elm-input is specified.
  --cql-output <cql-output>             Output directory for extracted CQL files
  --elm-output <elm-output>             Output directory for extracted ELM files
  --elm-input <elm-input>               Input directory containing ELM JSON files to replace in FHIR libraries.
                                        Required when --fhir-output is specified.
  --version                             Show version information
  -?, -h, --help                        Show help and usage information
  ```