### PR TITLE
Sign nuget packages instead of the dlls.

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -93,7 +93,7 @@ stages:
     ${{ else }}: # release mode
       useVersionSuffix: false
     # Only sign on release tags or develop branch (not PRs)
-    ${{ if or(startswith(variables['Build.SourceBranch'], 'refs/tags/v'), startswith(variables['Build.SourceBranch'], 'refs/heads/develop')) }}:
+    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
       shouldSign: true
       azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -144,83 +144,6 @@ stages:
               version: 8.x
               includePreviewVersions: false
 
-          - task: AzureCLI@2
-            displayName: 'Sign assemblies with Azure Trusted Signing'
-            condition: and(succeeded(), eq('${{ parameters.shouldSign }}', 'true'), ne('${{ parameters.azureServiceConnectionForSigning }}', ''))
-            inputs:
-              azureSubscription: '${{ parameters.azureServiceConnectionForSigning }}'
-              scriptType: 'pscore'
-              scriptLocation: 'inlineScript'
-              addSpnToEnvironment: true
-              inlineScript: |
-                # Install dotnet sign tool
-                Write-Host "Installing dotnet sign tool..."
-                dotnet tool install --global sign --version 0.9.1-beta.25379.1
-
-                if ($LASTEXITCODE -ne 0) {
-                  Write-Error "Failed to install dotnet sign tool"
-                  exit 1
-                }
-
-                # Get list of files to sign
-                $filesToSign = @()
-                $patterns = "${{ parameters.filesForSigning }}" -split ','
-                $excludePatterns = "${{ parameters.filesToExcludeForSigning }}" -split ','
-
-                foreach ($pattern in $patterns) {
-                  $pattern = $pattern.Trim()
-                  if ($pattern) {
-                    $files = Get-ChildItem -Path $pattern -Recurse -ErrorAction SilentlyContinue
-                    foreach ($file in $files) {
-                      $excluded = $false
-                      foreach ($excludePattern in $excludePatterns) {
-                        $excludePattern = $excludePattern.Trim()
-                        if ($excludePattern -and $file.FullName -like "*$excludePattern*") {
-                          $excluded = $true
-                          break
-                        }
-                      }
-                      if (-not $excluded) {
-                        $filesToSign += $file.FullName
-                      }
-                    }
-                  }
-                }
-
-                if ($filesToSign.Count -eq 0) {
-                  Write-Host "No files to sign"
-                  exit 0
-                }
-
-                Write-Host "Found $($filesToSign.Count) file(s) to sign:"
-                $filesToSign | ForEach-Object { Write-Host "  $_" }
-
-                # Sign each file
-                foreach ($file in $filesToSign) {
-                  Write-Host "`nSigning file: $file"
-
-                  $signArgs = @(
-                    'code',
-                    'trusted-signing',
-                    $file,
-                    '--trusted-signing-account', '${{ parameters.trustedSigningAccountName }}',
-                    '--trusted-signing-certificate-profile', '${{ parameters.certificateProfileName }}',
-                    '--trusted-signing-endpoint', '${{ parameters.trustedSigningAccountEndpoint }}',
-                    '--azure-credential-type', 'azure-cli'
-                  )
-
-                  & sign @signArgs
-
-                  if ($LASTEXITCODE -ne 0) {
-                    Write-Error "Failed to sign file: $file"
-                    exit 1
-                  }
-
-                  Write-Host "Successfully signed: $file"
-                }
-
-                Write-Host "`nAll files signed successfully!"
-
           # Package solution (NuGet packages already restored, no need to restore again)
           - task: DotNetCoreCLI@2
             displayName: 'Package solution'
@@ -244,6 +167,11 @@ stages:
                 trustedSigningAccountName: '${{ parameters.trustedSigningAccountName }}'
                 certificateProfileName: '${{ parameters.certificateProfileName }}'
                 packagePaths: $(Build.ArtifactStagingDirectory)/NuGetPackages/*.nupkg
+
+                  azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
+      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
+      trustedSigningAccountName: 'FirelyCodeSigning'
+      certificateProfileName: 'FirelyCodeSigning'
 
           # Prepare trimmed build artifacts (only bin/obj directories) for test stage
           - task: PowerShell@2

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -168,10 +168,6 @@ stages:
                 certificateProfileName: '${{ parameters.certificateProfileName }}'
                 packagePaths: $(Build.ArtifactStagingDirectory)/NuGetPackages/*.nupkg
 
-                  azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
-      trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
-      trustedSigningAccountName: 'FirelyCodeSigning'
-      certificateProfileName: 'FirelyCodeSigning'
 
           # Prepare trimmed build artifacts (only bin/obj directories) for test stage
           - task: PowerShell@2

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -135,15 +135,6 @@ stages:
               ${{ else }}:
                 arguments: '--configuration ${{ parameters.buildConfiguration }} --no-restore'
 
-          # Sign assemblies (only on release tags or develop branch)
-          - task: UseDotNet@2
-            displayName: 'Install .NET 8 runtime for signing'
-            condition: and(succeeded(), eq('${{ parameters.shouldSign }}', 'true'), ne('${{ parameters.azureServiceConnectionForSigning }}', ''))
-            inputs:
-              packageType: runtime
-              version: 8.x
-              includePreviewVersions: false
-
           # Package solution (NuGet packages already restored, no need to restore again)
           - task: DotNetCoreCLI@2
             displayName: 'Package solution'

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -235,6 +235,16 @@ stages:
               includesymbols: true
               includesource: true
 
+          # Sign NuGet packages with Azure Trusted Signing (skip for PRs)
+          - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+            - template: codesign-nuget-package-using-trusted-signing.yml@templates
+              parameters:
+                azureServiceConnection: '${{ parameters.azureServiceConnectionForSigning }}'
+                trustedSigningAccountEndpoint: '${{ parameters.trustedSigningAccountEndpoint }}'
+                trustedSigningAccountName: '${{ parameters.trustedSigningAccountName }}'
+                certificateProfileName: '${{ parameters.certificateProfileName }}'
+                packagePaths: $(Build.ArtifactStagingDirectory)/NuGetPackages/*.nupkg
+
           # Prepare trimmed build artifacts (only bin/obj directories) for test stage
           - task: PowerShell@2
             displayName: 'Stage build outputs for artifact'


### PR DESCRIPTION
This pull request updates the signing logic in the CI pipelines to streamline and modernize how assemblies and NuGet packages are signed, especially with respect to pull requests. The most important changes are the removal of a custom signing script, the introduction of a reusable template for NuGet package signing, and improved conditional logic to ensure signing only occurs in appropriate build scenarios.

Signing process improvements:

* Removed the custom PowerShell script for signing assemblies with Azure Trusted Signing in `build/build-test-sign.yml`, reducing complexity and potential maintenance overhead.
* Added a new step to sign NuGet packages using the `codesign-nuget-package-using-trusted-signing.yml` template, which is only executed when the build is not triggered by a pull request.

Conditional logic updates:

* Changed the signing condition in `build/azure-pipelines.yml` to use `Build.Reason != PullRequest` instead of checking branch names, ensuring signing only happens for non-PR builds.
* Updated the condition for signing NuGet packages in `build/build-test-sign.yml` to skip signing for pull request builds, aligning with the new logic.

Template usage and parameter passing:

* Introduced parameterized template usage for signing, passing relevant Azure and signing account information to the template for NuGet package signing.