### PR TITLE
Feature/1210 regen csharp

### DIFF
--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -245,7 +245,7 @@ public partial class FHIRHelpers_4_0_1 : ILibrary, ISingleton<FHIRHelpers_4_0_1>
             }
             else if (b_())
             {
-                object o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
+                object o_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
                 return o_ as CqlQuantity;
             }
             else if (c_())
@@ -273,7 +273,7 @@ public partial class FHIRHelpers_4_0_1 : ILibrary, ISingleton<FHIRHelpers_4_0_1>
                 string af_ = ae_?.Value;
                 string ag_ = context.Operators.Concatenate(ad_ ?? "", af_ ?? "");
                 string ah_ = context.Operators.Concatenate(ag_ ?? "", ")");
-                object ai_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
+                object ai_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
                 return ai_ as CqlQuantity;
             };
         }
@@ -332,7 +332,7 @@ public partial class FHIRHelpers_4_0_1 : ILibrary, ISingleton<FHIRHelpers_4_0_1>
                 string ab_ = aa_?.Value;
                 string ac_ = context.Operators.Concatenate(z_ ?? "", ab_ ?? "");
                 string ad_ = context.Operators.Concatenate(ac_ ?? "", ")");
-                object ae_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
+                object ae_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
                 return ae_ as CqlQuantity;
             };
         }

--- a/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
@@ -103,7 +103,7 @@ public partial class RR23_1_0_0 : ILibrary, ISingleton<RR23_1_0_0>
                 bool? n_ = ((CqlInterval<CqlDate>)g_)?.lowClosed;
                 bool? p_ = ((CqlInterval<CqlDate>)g_)?.highClosed;
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(i_, l_, n_, p_);
-                bool? r_ = context.Operators.In<CqlDateTime>(f_ as CqlDateTime, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(f_ as CqlDateTime, q_, (string)default);
                 return r_;
             }
 
@@ -159,7 +159,7 @@ public partial class RR23_1_0_0 : ILibrary, ISingleton<RR23_1_0_0>
                     CqlDateTime v_ = context.Operators.Subtract(t_, u_);
                     CqlDateTime x_ = context.Operators.LateBoundProperty<CqlDateTime>(s_, "value");
                     CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, false);
-                    bool? z_ = context.Operators.In<CqlDateTime>(r_ as CqlDateTime, y_, default);
+                    bool? z_ = context.Operators.In<CqlDateTime>(r_ as CqlDateTime, y_, (string)default);
                     CqlDateTime ab_ = context.Operators.LateBoundProperty<CqlDateTime>(s_, "value");
                     bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
                     bool? ad_ = context.Operators.And(z_, ac_);

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -87,8 +87,8 @@ public partial class TestRetrieve_1_0_1 : ILibrary, ISingleton<TestRetrieve_1_0_
     [CqlParameterDefinition("MeasurementPeriod")]
     public object MeasurementPeriod(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<object>(-7600276400685164205L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2013, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2014, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("TestRetrieve-1.0.1", "MeasurementPeriod", c_);
             return d_;

--- a/Cql/Cql.Runtime/PublicAPI.Shipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Shipped.txt
@@ -284,8 +284,7 @@ Hl7.Cql.Operators.ICqlOperators.IntervalSize(Hl7.Cql.Primitives.CqlInterval<deci
 Hl7.Cql.Operators.ICqlOperators.IntervalSize(Hl7.Cql.Primitives.CqlInterval<int?>? argument) -> int?
 Hl7.Cql.Operators.ICqlOperators.IntervalSize(Hl7.Cql.Primitives.CqlInterval<long?>? argument) -> long?
 Hl7.Cql.Operators.ICqlOperators.IsFalse(bool? b) -> bool?
-Hl7.Cql.Operators.ICqlOperators.IsNull<T>(T! value) -> bool?
-Hl7.Cql.Operators.ICqlOperators.IsNullValue<T>(T? value) -> bool?
+Hl7.Cql.Operators.ICqlOperators.IsNull<T>(T value) -> bool?
 Hl7.Cql.Operators.ICqlOperators.IsTrue(bool? b) -> bool?
 Hl7.Cql.Operators.ICqlOperators.Last<T>(System.Collections.Generic.IEnumerable<T>! enumerable) -> T?
 Hl7.Cql.Operators.ICqlOperators.LastPositionOf(string? argument, string? pattern) -> int?

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -51,8 +51,8 @@ public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, I
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(8505406452986970707L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2025, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("DocumentationofCurrentMedicationsFHIR-0.2.000", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -161,7 +161,7 @@ public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, I
                     CqlDateTime n_ = context.Operators.End(m_);
                     Period o_ = QualifyingEncounter?.Period;
                     CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_3_000.Instance.ToInterval(context, o_);
-                    bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, default);
+                    bool? q_ = context.Operators.In<CqlDateTime>(n_, p_, (string)default);
                     Code<EventStatus> r_ = MedicationsDocumented?.StatusElement;
                     EventStatus? s_ = r_?.Value;
                     string t_ = context.Operators.Convert<string>(s_);
@@ -215,7 +215,7 @@ public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, I
                     CqlDateTime q_ = context.Operators.Convert<CqlDateTime>(p_);
                     Period r_ = QualifyingEncounter?.Period;
                     CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_3_000.Instance.ToInterval(context, r_);
-                    bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, (string)default);
                     Code<EventStatus> u_ = MedicationsNotDocumented?.StatusElement;
                     EventStatus? v_ = u_?.Value;
                     string w_ = context.Operators.Convert<string>(v_);

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -255,7 +255,7 @@ public partial class FHIRHelpers_4_3_000 : ILibrary, ISingleton<FHIRHelpers_4_3_
             }
             else if (b_())
             {
-                object o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
+                object o_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
                 return o_ as CqlQuantity;
             }
             else if (c_())
@@ -283,7 +283,7 @@ public partial class FHIRHelpers_4_3_000 : ILibrary, ISingleton<FHIRHelpers_4_3_
                 string af_ = ae_?.Value;
                 string ag_ = context.Operators.Concatenate(ad_ ?? "", af_ ?? "");
                 string ah_ = context.Operators.Concatenate(ag_ ?? "", ")");
-                object ai_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
+                object ai_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
                 return ai_ as CqlQuantity;
             };
         }
@@ -345,7 +345,7 @@ public partial class FHIRHelpers_4_3_000 : ILibrary, ISingleton<FHIRHelpers_4_3_
                 string ab_ = aa_?.Value;
                 string ac_ = context.Operators.Concatenate(z_ ?? "", ab_ ?? "");
                 string ad_ = context.Operators.Concatenate(ac_ ?? "", ")");
-                object ae_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
+                object ae_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
                 return ae_ as CqlQuantity;
             };
         }

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -1019,7 +1019,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
             }
             else if (choice is Timing)
             {
-                object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+                object dy_ = context.Operators.Message<object>((object)null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
                 return dy_ as CqlInterval<CqlDateTime>;
             }
             else
@@ -1158,7 +1158,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
             }
             else if (choice is Timing)
             {
-                object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+                object dy_ = context.Operators.Message<object>((object)null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
                 return dy_ as CqlInterval<CqlDateTime>;
             }
             else
@@ -1964,7 +1964,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, (CqlQuantity)default);
 
         int? g_(CqlInterval<int?> DayNumber) {
             int? j_ = context.Operators.End(DayNumber);
@@ -1988,7 +1988,7 @@ public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, (CqlQuantity)default);
 
         int? g_(CqlInterval<int?> DayNumber) {
             int? j_ = context.Operators.End(DayNumber);

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -45,7 +45,7 @@ public partial class AdultOutpatientEncountersFHIR4_2_2_000 : ILibrary, ISinglet
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-2694172219689873332L, () => {
-            object a_ = context.ResolveParameter("AdultOutpatientEncountersFHIR4-2.2.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("AdultOutpatientEncountersFHIR4-2.2.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -88,7 +88,7 @@ public partial class AdultOutpatientEncountersFHIR4_2_2_000 : ILibrary, ISinglet
                 CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
                 Period u_ = ValidEncounter?.Period;
                 CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, u_ as object);
-                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default);
+                bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, (string)default);
                 bool? x_ = context.Operators.And(s_, w_);
                 return x_;
             }

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -77,7 +77,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-8608999970669603967L, () => {
-            object a_ = context.ResolveParameter("AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -145,7 +145,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 CqlDateTime ak_ = context.Operators.Subtract(ai_, aj_);
                 CqlDateTime am_ = context.Operators.End(ah_);
                 CqlInterval<CqlDateTime> an_ = context.Operators.Interval(ak_, am_, true, true);
-                bool? ao_ = context.Operators.Overlaps(ag_, an_, default);
+                bool? ao_ = context.Operators.Overlaps(ag_, an_, (string)default);
                 bool? ap_ = context.Operators.And(af_, ao_);
                 return ap_;
             }
@@ -171,7 +171,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 Period n_ = LongTermFacilityEncounter?.Period;
                 CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, n_ as object);
                 CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                bool? q_ = context.Operators.Overlaps(o_, p_, default);
+                bool? q_ = context.Operators.Overlaps(o_, p_, (string)default);
                 bool? r_ = context.Operators.And(m_, q_);
                 return r_;
             }
@@ -232,7 +232,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                     CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
                     CqlDateTime ai_ = context.Operators.End(ad_);
                     CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ag_, ai_, true, true);
-                    bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, default);
+                    bool? ak_ = context.Operators.In<CqlDateTime>(ac_, aj_, (string)default);
                     CqlDateTime am_ = context.Operators.End(ad_);
                     bool? an_ = context.Operators.Not((bool?)(am_ is null));
                     bool? ao_ = context.Operators.And(ak_, an_);
@@ -289,7 +289,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
     public IEnumerable<CqlInterval<CqlDateTime>> Long_Term_Care_Overlapping_Periods(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<IEnumerable<CqlInterval<CqlDateTime>>>(-25046034067202445L, () => {
             IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Periods_During_Measurement_Period(context);
-            IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, default);
+            IEnumerable<CqlInterval<CqlDateTime>> b_ = context.Operators.Collapse(a_, (string)default);
             return b_;
         });
 
@@ -314,7 +314,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime r_ = context.Operators.Add(m_, n_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(o_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 bool? v_ = context.Operators.Not((bool?)(m_ is null));
                 bool? w_ = context.Operators.And(t_, v_);
                 return w_;
@@ -341,7 +341,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
             IEnumerable<CqlInterval<CqlDateTime>> a_ = this.Long_Term_Care_Overlapping_Periods(context);
             IEnumerable<CqlInterval<CqlDateTime>> b_ = this.Long_Term_Care_Adjacent_Periods(context);
             IEnumerable<CqlInterval<CqlDateTime>> c_ = context.Operators.Union<CqlInterval<CqlDateTime>>(a_, b_);
-            IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, default);
+            IEnumerable<CqlInterval<CqlDateTime>> d_ = context.Operators.Collapse(c_, (string)default);
 
             int? e_(CqlInterval<CqlDateTime> LTCPeriods) {
                 CqlDateTime i_ = context.Operators.Start(LTCPeriods);
@@ -388,7 +388,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                     CqlDateTime x_ = context.Operators.Subtract(v_, w_);
                     CqlDateTime z_ = context.Operators.End(u_);
                     CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-                    bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default);
+                    bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, (string)default);
                     CqlDateTime ad_ = context.Operators.End(u_);
                     bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
                     bool? af_ = context.Operators.And(ab_, ae_);
@@ -431,7 +431,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 CqlInterval<CqlDateTime> ao_ = this.Measurement_Period(context);
                 FhirDateTime ap_ = FrailtyDeviceOrder?.AuthoredOnElement;
                 CqlInterval<CqlDateTime> aq_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ap_ as object);
-                bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, default);
+                bool? ar_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ao_, aq_, (string)default);
                 bool? as_ = context.Operators.And(an_, ar_);
                 return as_;
             }
@@ -452,7 +452,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 DataType ax_ = FrailtyDeviceApplied?.Effective;
                 CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ax_);
                 CqlInterval<CqlDateTime> az_ = this.Measurement_Period(context);
-                bool? ba_ = context.Operators.Overlaps(ay_, az_, default);
+                bool? ba_ = context.Operators.Overlaps(ay_, az_, (string)default);
                 bool? bb_ = context.Operators.And(aw_, ba_);
                 return bb_;
             }
@@ -466,7 +466,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
             bool? q_(Condition FrailtyDiagnosis) {
                 CqlInterval<CqlDateTime> bc_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, FrailtyDiagnosis);
                 CqlInterval<CqlDateTime> bd_ = this.Measurement_Period(context);
-                bool? be_ = context.Operators.Overlaps(bc_, bd_, default);
+                bool? be_ = context.Operators.Overlaps(bc_, bd_, (string)default);
                 return be_;
             }
 
@@ -483,7 +483,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 Period bi_ = FrailtyEncounter?.Period;
                 CqlInterval<CqlDateTime> bj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, bi_ as object);
                 CqlInterval<CqlDateTime> bk_ = this.Measurement_Period(context);
-                bool? bl_ = context.Operators.Overlaps(bj_, bk_, default);
+                bool? bl_ = context.Operators.Overlaps(bj_, bk_, (string)default);
                 bool? bm_ = context.Operators.And(bh_, bl_);
                 return bm_;
             }
@@ -507,7 +507,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
                 DataType br_ = FrailtySymptom?.Effective;
                 CqlInterval<CqlDateTime> bs_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, br_);
                 CqlInterval<CqlDateTime> bt_ = this.Measurement_Period(context);
-                bool? bu_ = context.Operators.Overlaps(bs_, bt_, default);
+                bool? bu_ = context.Operators.Overlaps(bs_, bt_, (string)default);
                 bool? bv_ = context.Operators.And(bq_, bu_);
                 return bv_;
             }
@@ -531,7 +531,7 @@ public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILib
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(65, 79, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Has_Criteria_Indicating_Frailty(context);
             bool? l_ = context.Operators.And(j_, k_);
             IEnumerable<Encounter> m_ = this.Two_Outpatient_Encounters_with_Advanced_Illness_on_Different_Dates_of_Service(context);

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -85,7 +85,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(4791158273458427164L, () => {
-            object a_ = context.ResolveParameter("BCSEHEDISMY2022-1.0.0", "Measurement Period", null);
+            object a_ = context.ResolveParameter("BCSEHEDISMY2022-1.0.0", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -136,7 +136,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 Period d_ = C?.Period;
                 CqlInterval<CqlDateTime> e_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, d_ as object);
                 CqlInterval<CqlDateTime> f_ = this.Participation_Period(context);
-                bool? g_ = context.Operators.Overlaps(e_, f_, default);
+                bool? g_ = context.Operators.Overlaps(e_, f_, (string)default);
                 return g_;
             }
 
@@ -197,7 +197,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(52, 74, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             Code<AdministrativeGender> l_ = a_?.GenderElement;
             AdministrativeGender? m_ = l_?.Value;
             string n_ = context.Operators.Convert<string>(m_);
@@ -229,7 +229,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime g_ = context.Operators.Start(f_);
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
                 CqlDateTime i_ = context.Operators.End(h_);
-                bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
+                bool? j_ = context.Operators.SameOrBefore(g_, i_, (string)default);
                 return j_;
             }
 
@@ -291,7 +291,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime af_ = context.Operators.End(ae_);
                 CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
                 CqlDateTime ah_ = context.Operators.End(ag_);
-                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
+                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, (string)default);
                 return ai_;
             }
 
@@ -312,7 +312,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime g_ = context.Operators.Start(f_);
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
                 CqlDateTime i_ = context.Operators.End(h_);
-                bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
+                bool? j_ = context.Operators.SameOrBefore(g_, i_, (string)default);
                 return j_;
             }
 
@@ -374,7 +374,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime af_ = context.Operators.End(ae_);
                 CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
                 CqlDateTime ah_ = context.Operators.End(ag_);
-                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
+                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, (string)default);
                 return ai_;
             }
 
@@ -395,7 +395,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime g_ = context.Operators.Start(f_);
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
                 CqlDateTime i_ = context.Operators.End(h_);
-                bool? j_ = context.Operators.SameOrBefore(g_, i_, default);
+                bool? j_ = context.Operators.SameOrBefore(g_, i_, (string)default);
                 return j_;
             }
 
@@ -457,7 +457,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlDateTime af_ = context.Operators.End(ae_);
                 CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
                 CqlDateTime ah_ = context.Operators.End(ag_);
-                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, default);
+                bool? ai_ = context.Operators.SameOrBefore(af_, ah_, (string)default);
                 return ai_;
             }
 
@@ -516,7 +516,7 @@ public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY202
                 CqlInterval<CqlDateTime> g_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, f_);
                 CqlDateTime h_ = context.Operators.End(g_);
                 CqlInterval<CqlDateTime> i_ = this.Participation_Period(context);
-                bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, default);
+                bool? j_ = context.Operators.In<CqlDateTime>(h_, i_, (string)default);
                 return j_;
             }
 

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -73,8 +73,8 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-2207426731370318965L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("BreastCancerScreeningsFHIR-0.0.009", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -142,7 +142,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 Period l_ = TelehealthEncounter?.Period;
                 CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, l_ as object);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                 bool? o_ = context.Operators.And(j_, n_);
                 return o_;
             }
@@ -179,7 +179,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             Code<AdministrativeGender> l_ = a_?.GenderElement;
             string m_ = FHIRHelpers_4_0_001.Instance.ToString(context, l_);
             bool? n_ = context.Operators.Equal(m_, "female");
@@ -231,7 +231,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime q_ = context.Operators.Start(p_);
                 CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
                 CqlDateTime s_ = context.Operators.End(r_);
-                bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, (string)default);
                 return t_;
             }
 
@@ -255,7 +255,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -295,7 +295,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime q_ = context.Operators.Start(p_);
                 CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
                 CqlDateTime s_ = context.Operators.End(r_);
-                bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, (string)default);
                 return t_;
             }
 
@@ -319,7 +319,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -340,7 +340,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -364,7 +364,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -441,7 +441,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -480,7 +480,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -545,7 +545,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlDateTime s_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
+                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
                 CqlDateTime w_ = context.Operators.End(n_);
                 bool? x_ = context.Operators.Not((bool?)(w_ is null));
                 bool? y_ = context.Operators.And(u_, x_);
@@ -585,7 +585,7 @@ public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<B
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlDateTime s_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
+                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
                 CqlDateTime w_ = context.Operators.End(n_);
                 bool? x_ = context.Operators.Not((bool?)(w_ is null));
                 bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -83,8 +83,8 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(8660301701421196239L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("CervicalCancerScreeningFHIR-0.0.005", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -164,7 +164,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
                 Period x_ = ValidEncounter?.Period;
                 CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, x_);
-                bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, default);
+                bool? z_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(w_, y_, (string)default);
                 bool? aa_ = context.Operators.And(v_, z_);
                 return aa_;
             }
@@ -186,7 +186,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(23, 64, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             Code<AdministrativeGender> l_ = a_?.GenderElement;
             string m_ = FHIRHelpers_4_0_001.Instance.ToString(context, l_);
             bool? n_ = context.Operators.Equal(m_, "female");
@@ -221,7 +221,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime o_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
                 CqlDateTime q_ = context.Operators.End(p_);
-                bool? r_ = context.Operators.SameOrBefore(o_, q_, default);
+                bool? r_ = context.Operators.SameOrBefore(o_, q_, (string)default);
                 bool? s_ = context.Operators.And(l_, r_);
                 return s_;
             }
@@ -235,7 +235,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime u_ = context.Operators.Start(t_);
                 CqlInterval<CqlDateTime> v_ = this.Measurement_Period(context);
                 CqlDateTime w_ = context.Operators.End(v_);
-                bool? x_ = context.Operators.SameOrBefore(u_, w_, default);
+                bool? x_ = context.Operators.SameOrBefore(u_, w_, (string)default);
                 return x_;
             }
 
@@ -294,7 +294,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime s_ = context.Operators.Subtract(q_, r_);
                 CqlDateTime u_ = context.Operators.End(p_);
                 CqlInterval<CqlDateTime> v_ = context.Operators.Interval(s_, u_, true, true);
-                bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default);
+                bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, (string)default);
                 CqlDateTime y_ = context.Operators.End(p_);
                 bool? z_ = context.Operators.Not((bool?)(y_ is null));
                 bool? aa_ = context.Operators.And(w_, z_);
@@ -356,7 +356,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
                 CqlDateTime af_ = context.Operators.End(aa_);
                 CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ad_, af_, true, true);
-                bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, default);
+                bool? ah_ = context.Operators.In<CqlDateTime>(z_, ag_, (string)default);
                 CqlDateTime aj_ = context.Operators.End(aa_);
                 bool? ak_ = context.Operators.Not((bool?)(aj_ is null));
                 bool? al_ = context.Operators.And(ah_, ak_);
@@ -444,7 +444,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime m_ = context.Operators.Subtract(k_, l_);
                 CqlDateTime o_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, (string)default);
                 CqlDateTime s_ = context.Operators.End(j_);
                 bool? t_ = context.Operators.Not((bool?)(s_ is null));
                 bool? u_ = context.Operators.And(q_, t_);
@@ -496,7 +496,7 @@ public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<
                 CqlDateTime x_ = context.Operators.Subtract(v_, w_);
                 CqlDateTime z_ = context.Operators.End(u_);
                 CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(x_, z_, true, true);
-                bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, default);
+                bool? ab_ = context.Operators.In<CqlDateTime>(t_, aa_, (string)default);
                 CqlDateTime ad_ = context.Operators.End(u_);
                 bool? ae_ = context.Operators.Not((bool?)(ad_ is null));
                 bool? af_ = context.Operators.And(ab_, ae_);

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -167,8 +167,8 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-7159507046904387638L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("ColorectalCancerScreeningsFHIR-0.0.003", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -236,7 +236,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 Period l_ = TelehealthEncounter?.Period;
                 CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, l_ as object);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                 bool? o_ = context.Operators.And(j_, n_);
                 return o_;
             }
@@ -273,7 +273,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
             IEnumerable<Encounter> l_ = this.Telehealth_Services(context);
             IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -302,7 +302,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -326,7 +326,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -347,7 +347,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -404,7 +404,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime m_ = context.Operators.Subtract(k_, l_);
                 CqlDateTime o_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, false, false);
-                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, (string)default);
                 return q_;
             }
 
@@ -553,7 +553,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 DataType q_ = FecalOccult?.Effective;
                 CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, q_);
                 CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
                 bool? u_ = context.Operators.And(p_, t_);
                 return u_;
             }
@@ -752,7 +752,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime m_ = context.Operators.Subtract(k_, l_);
                 CqlDateTime o_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, (string)default);
                 CqlDateTime s_ = context.Operators.End(j_);
                 bool? t_ = context.Operators.Not((bool?)(s_ is null));
                 bool? u_ = context.Operators.And(q_, t_);
@@ -909,7 +909,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime v_ = context.Operators.Subtract(t_, u_);
                 CqlDateTime x_ = context.Operators.End(s_);
                 CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-                bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default);
+                bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, (string)default);
                 CqlDateTime ab_ = context.Operators.End(s_);
                 bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
                 bool? ad_ = context.Operators.And(z_, ac_);
@@ -1136,7 +1136,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1182,7 +1182,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);
@@ -1221,7 +1221,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -1250,7 +1250,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1290,7 +1290,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1323,7 +1323,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);
@@ -1352,7 +1352,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1392,7 +1392,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1425,7 +1425,7 @@ public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISinglet
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -560,7 +560,7 @@ public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISing
                 string gr_ = this.ErrorLevel(context);
                 string gs_ = period?.unit;
                 string gt_ = context.Operators.Concatenate("Unknown unit ", gs_ ?? "");
-                object gu_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownUnit", gr_, gt_);
+                object gu_ = context.Operators.Message<object>((object)null, "CMDLogic.ToDaily.UnknownUnit", gr_, gt_);
                 return gu_ as decimal?;
             };
         }
@@ -590,7 +590,7 @@ public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISing
                 string e_ = this.ErrorLevel(context);
                 string f_ = frequency?.code;
                 string g_ = context.Operators.Concatenate("Unknown frequency code ", f_ ?? "");
-                object h_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownFrequencyCode", e_, g_);
+                object h_ = context.Operators.Message<object>((object)null, "CMDLogic.ToDaily.UnknownFrequencyCode", e_, g_);
                 return h_ as decimal?;
             };
         }

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -122,7 +122,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(2299050010152453010L, () => {
-            object a_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004", "Measurement Period", null);
+            object a_ = context.ResolveParameter("DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -194,7 +194,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                 CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
                 Period r_ = QualifyingEncounter?.Period;
                 CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, r_);
-                bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, default);
+                bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(q_, s_, (string)default);
                 Code<Encounter.EncounterStatus> u_ = QualifyingEncounter?.StatusElement;
                 string v_ = FHIRHelpers_4_0_001.Instance.ToString(context, u_);
                 bool? w_ = context.Operators.Equal(v_, "finished");
@@ -225,7 +225,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                     CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, DiabeticRetinopathy);
                     Period p_ = ValidQualifyingEncounter?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, p_);
-                    bool? r_ = context.Operators.Overlaps(o_, q_, default);
+                    bool? r_ = context.Operators.Overlaps(o_, q_, (string)default);
                     bool? s_ = context.Operators.And(n_, r_);
                     return s_;
                 }
@@ -322,7 +322,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
 
                     Period n_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, n_);
-                    bool? p_ = context.Operators.In<CqlDateTime>(m_(), o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(m_(), o_, (string)default);
                     return p_;
                 }
 
@@ -412,7 +412,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
 
                     Period o_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, o_);
-                    bool? q_ = context.Operators.In<CqlDateTime>(n_(), p_, default);
+                    bool? q_ = context.Operators.In<CqlDateTime>(n_(), p_, (string)default);
                     return q_;
                 }
 
@@ -501,7 +501,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
 
                     Period n_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, n_);
-                    bool? p_ = context.Operators.In<CqlDateTime>(m_(), o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(m_(), o_, (string)default);
                     return p_;
                 }
 
@@ -586,7 +586,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                     CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, l_);
                     DataType n_ = MacularExam?.Effective;
                     CqlInterval<CqlDateTime> o_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, n_);
-                    bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, default);
+                    bool? p_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, o_, (string)default);
                     return p_;
                 }
 
@@ -645,7 +645,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                     Period o_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, o_);
                     CqlDateTime q_ = context.Operators.Start(p_);
-                    bool? r_ = context.Operators.After(n_, q_, default);
+                    bool? r_ = context.Operators.After(n_, q_, (string)default);
                     return r_;
                 }
 
@@ -686,7 +686,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                     Period p_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, p_);
                     CqlDateTime r_ = context.Operators.Start(q_);
-                    bool? s_ = context.Operators.After(o_, r_, default);
+                    bool? s_ = context.Operators.After(o_, r_, (string)default);
                     return s_;
                 }
 
@@ -726,7 +726,7 @@ public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : 
                     Period o_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, o_);
                     CqlDateTime q_ = context.Operators.Start(p_);
-                    bool? r_ = context.Operators.After(n_, q_, default);
+                    bool? r_ = context.Operators.After(n_, q_, (string)default);
                     return r_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -44,7 +44,7 @@ public partial class DevDays_2023_0_0 : ILibrary, ISingleton<DevDays_2023_0_0>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(7096341437342020688L, () => {
-            object a_ = context.ResolveParameter("DevDays-2023.0.0", "Measurement Period", null);
+            object a_ = context.ResolveParameter("DevDays-2023.0.0", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -83,7 +83,7 @@ public partial class DevDays_2023_0_0 : ILibrary, ISingleton<DevDays_2023_0_0>
                 DataType i_ = c?.Onset;
                 CqlDateTime j_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, i_ as FhirDateTime);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
+                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, (string)default);
                 bool? m_ = context.Operators.And(h_, l_);
                 return m_;
             }
@@ -114,7 +114,7 @@ public partial class DevDays_2023_0_0 : ILibrary, ISingleton<DevDays_2023_0_0>
                 DataType i_ = c?.Onset;
                 CqlDateTime j_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, i_ as FhirDateTime);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
+                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, (string)default);
                 bool? m_ = context.Operators.And(h_, l_);
                 return m_;
             }

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -91,7 +91,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-4520572191774736726L, () => {
-            object a_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015", "Measurement Period", null);
+            object a_ = context.ResolveParameter("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -154,7 +154,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
                 Period i_ = TelehealthEncounter?.Period;
                 CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, i_ as object);
-                bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, default);
+                bool? k_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(h_, j_, (string)default);
                 bool? l_ = context.Operators.And(g_, k_);
                 return l_;
             }
@@ -176,7 +176,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
             IEnumerable<Encounter> l_ = this.Telehealth_Services(context);
             IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -188,7 +188,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
             bool? r_(Condition Diabetes) {
                 CqlInterval<CqlDateTime> v_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Diabetes);
                 CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                bool? x_ = context.Operators.Overlaps(v_, w_, default);
+                bool? x_ = context.Operators.Overlaps(v_, w_, (string)default);
                 return x_;
             }
 
@@ -225,7 +225,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
                 DataType l_ = RecentHbA1c?.Effective;
                 CqlDateTime m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, l_);
                 CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
+                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
                 bool? p_ = context.Operators.And(k_, o_);
                 return p_;
             }
@@ -286,7 +286,7 @@ public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibra
                 DataType k_ = NoHbA1c?.Effective;
                 CqlDateTime l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, k_);
                 CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
+                bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
                 bool? o_ = context.Operators.And(j_, n_);
                 return o_;
             }

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -81,7 +81,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-1910573221940503362L, () => {
-            object a_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.0.010", "Measurement Period", null);
+            object a_ = context.ResolveParameter("DischargedonAntithromboticTherapyFHIR-0.0.010", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -188,7 +188,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                     CqlDateTime j_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, i_);
                     Period k_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 
@@ -264,7 +264,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                     CqlDateTime j_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, i_);
                     Period k_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 
@@ -368,7 +368,7 @@ public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, I
                     CqlDateTime j_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, i_);
                     Period k_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -73,8 +73,8 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(1257896147791166717L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("Exam125FHIR-0.0.009", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -142,7 +142,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 Period l_ = TelehealthEncounter?.Period;
                 CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, l_ as object);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                 bool? o_ = context.Operators.And(j_, n_);
                 return o_;
             }
@@ -179,7 +179,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(51, 74, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             Code<AdministrativeGender> l_ = a_?.GenderElement;
             string m_ = FHIRHelpers_4_0_001.Instance.ToString(context, l_);
             bool? n_ = context.Operators.Equal(m_, "female");
@@ -231,7 +231,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime q_ = context.Operators.Start(p_);
                 CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
                 CqlDateTime s_ = context.Operators.End(r_);
-                bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, (string)default);
                 return t_;
             }
 
@@ -255,7 +255,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -295,7 +295,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime q_ = context.Operators.Start(p_);
                 CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
                 CqlDateTime s_ = context.Operators.End(r_);
-                bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, (string)default);
                 return t_;
             }
 
@@ -319,7 +319,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -340,7 +340,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -364,7 +364,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -441,7 +441,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -480,7 +480,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -545,7 +545,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlDateTime s_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
+                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
                 CqlDateTime w_ = context.Operators.End(n_);
                 bool? x_ = context.Operators.Not((bool?)(w_ is null));
                 bool? y_ = context.Operators.And(u_, x_);
@@ -585,7 +585,7 @@ public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_
                 CqlDateTime q_ = context.Operators.Subtract(o_, p_);
                 CqlDateTime s_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> t_ = context.Operators.Interval(q_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, default);
+                bool? u_ = context.Operators.In<CqlDateTime>(m_, t_, (string)default);
                 CqlDateTime w_ = context.Operators.End(n_);
                 bool? x_ = context.Operators.Not((bool?)(w_ is null));
                 bool? y_ = context.Operators.And(u_, x_);

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -167,8 +167,8 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-3168609378634258819L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2021, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2022, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("Exam130FHIR-0.0.003", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -236,7 +236,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 Period l_ = TelehealthEncounter?.Period;
                 CqlInterval<CqlDateTime> m_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, l_ as object);
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                 bool? o_ = context.Operators.And(j_, n_);
                 return o_;
             }
@@ -273,7 +273,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(51, 75, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = AdultOutpatientEncountersFHIR4_2_2_000.Instance.Qualifying_Encounters(context);
             IEnumerable<Encounter> l_ = this.Telehealth_Services(context);
             IEnumerable<Encounter> m_ = context.Operators.Union<Encounter>(k_, l_);
@@ -302,7 +302,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -326,7 +326,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 bool? n_ = context.Operators.And(g_, m_);
                 return n_;
             }
@@ -347,7 +347,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.SameOrBefore(f_, h_, default);
+                bool? i_ = context.Operators.SameOrBefore(f_, h_, (string)default);
                 return i_;
             }
 
@@ -404,7 +404,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime m_ = context.Operators.Subtract(k_, l_);
                 CqlDateTime o_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, false, false);
-                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, (string)default);
                 return q_;
             }
 
@@ -553,7 +553,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 DataType q_ = FecalOccult?.Effective;
                 CqlDateTime r_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Latest(context, q_);
                 CqlInterval<CqlDateTime> s_ = this.Measurement_Period(context);
-                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
                 bool? u_ = context.Operators.And(p_, t_);
                 return u_;
             }
@@ -752,7 +752,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime m_ = context.Operators.Subtract(k_, l_);
                 CqlDateTime o_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(m_, o_, true, true);
-                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(i_, p_, (string)default);
                 CqlDateTime s_ = context.Operators.End(j_);
                 bool? t_ = context.Operators.Not((bool?)(s_ is null));
                 bool? u_ = context.Operators.And(q_, t_);
@@ -909,7 +909,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime v_ = context.Operators.Subtract(t_, u_);
                 CqlDateTime x_ = context.Operators.End(s_);
                 CqlInterval<CqlDateTime> y_ = context.Operators.Interval(v_, x_, true, true);
-                bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, default);
+                bool? z_ = context.Operators.In<CqlDateTime>(r_, y_, (string)default);
                 CqlDateTime ab_ = context.Operators.End(s_);
                 bool? ac_ = context.Operators.Not((bool?)(ab_ is null));
                 bool? ad_ = context.Operators.And(z_, ac_);
@@ -1136,7 +1136,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1182,7 +1182,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);
@@ -1221,7 +1221,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime p_ = context.Operators.Subtract(n_, o_);
                 CqlDateTime r_ = context.Operators.End(m_);
                 CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                 CqlDateTime v_ = context.Operators.End(m_);
                 bool? w_ = context.Operators.Not((bool?)(v_ is null));
                 bool? x_ = context.Operators.And(t_, w_);
@@ -1250,7 +1250,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1290,7 +1290,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1323,7 +1323,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);
@@ -1352,7 +1352,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1392,7 +1392,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime n_ = context.Operators.Subtract(l_, m_);
                 CqlDateTime p_ = context.Operators.End(k_);
                 CqlInterval<CqlDateTime> q_ = context.Operators.Interval(n_, p_, true, true);
-                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, default);
+                bool? r_ = context.Operators.In<CqlDateTime>(j_, q_, (string)default);
                 CqlDateTime t_ = context.Operators.End(k_);
                 bool? u_ = context.Operators.Not((bool?)(t_ is null));
                 bool? v_ = context.Operators.And(r_, u_);
@@ -1425,7 +1425,7 @@ public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_
                 CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                 CqlDateTime q_ = context.Operators.End(l_);
                 CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                 CqlDateTime u_ = context.Operators.End(l_);
                 bool? v_ = context.Operators.Not((bool?)(u_ is null));
                 bool? w_ = context.Operators.And(s_, v_);

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -183,7 +183,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(3446768974583353708L, () => {
-            object a_ = context.ResolveParameter("FHIR347-0.1.021", "Measurement Period", null);
+            object a_ = context.ResolveParameter("FHIR347-0.1.021", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -224,7 +224,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime af_ = context.Operators.Start(ae_);
                 CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
                 CqlDateTime ah_ = context.Operators.End(ag_);
-                bool? ai_ = context.Operators.Before(af_, ah_, default);
+                bool? ai_ = context.Operators.Before(af_, ah_, (string)default);
                 return ai_;
             }
 
@@ -247,7 +247,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime al_ = context.Operators.Start(ak_);
                 CqlInterval<CqlDateTime> am_ = this.Measurement_Period(context);
                 CqlDateTime an_ = context.Operators.End(am_);
-                bool? ao_ = context.Operators.Before(al_, an_, default);
+                bool? ao_ = context.Operators.Before(al_, an_, (string)default);
                 Code<EventStatus> ap_ = ASCVDProcedure?.StatusElement;
                 string aq_ = FHIRHelpers_4_0_001.Instance.ToString(context, ap_);
                 bool? ar_ = context.Operators.Equal(aq_, "completed");
@@ -292,7 +292,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
                 Period aa_ = ValidEncounter?.Period;
                 CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, aa_);
-                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default);
+                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, (string)default);
                 Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
                 string ae_ = FHIRHelpers_4_0_001.Instance.ToString(context, ad_);
                 bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -356,7 +356,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime k_ = context.Operators.Start(j_);
                 CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
                 CqlDateTime m_ = context.Operators.End(l_);
-                bool? n_ = context.Operators.Before(k_, m_, default);
+                bool? n_ = context.Operators.Before(k_, m_, (string)default);
                 bool? o_ = context.Operators.And(h_, n_);
                 Code<ObservationStatus> p_ = LDL?.StatusElement;
                 string q_ = FHIRHelpers_4_0_001.Instance.ToString(context, p_);
@@ -387,7 +387,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime f_ = context.Operators.Start(e_);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
                 CqlDateTime h_ = context.Operators.End(g_);
-                bool? i_ = context.Operators.Before(f_, h_, default);
+                bool? i_ = context.Operators.Before(f_, h_, (string)default);
                 return i_;
             }
 
@@ -441,7 +441,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
             bool? c_(Condition Diabetes) {
                 CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Diabetes);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
-                bool? h_ = context.Operators.Overlaps(f_, g_, default);
+                bool? h_ = context.Operators.Overlaps(f_, g_, (string)default);
                 return h_;
             }
 
@@ -462,7 +462,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
             CqlDateTime f_ = context.Operators.Start(e_);
             int? g_ = context.Operators.CalculateAgeAt(d_, f_, "year");
             CqlInterval<int?> h_ = context.Operators.Interval(40, 75, true, true);
-            bool? i_ = context.Operators.In<int?>(g_, h_, default);
+            bool? i_ = context.Operators.In<int?>(g_, h_, (string)default);
             bool? j_ = this.Has_Diabetes_Diagnosis(context);
             bool? k_ = context.Operators.And(i_, j_);
             IEnumerable<object> l_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
@@ -544,7 +544,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime h_ = context.Operators.Start(g_);
                 CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
                 CqlDateTime j_ = context.Operators.End(i_);
-                bool? k_ = context.Operators.Before(h_, j_, default);
+                bool? k_ = context.Operators.Before(h_, j_, (string)default);
                 return k_;
             }
 
@@ -568,7 +568,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime z_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, y_);
                 CqlInterval<CqlDateTime> aa_ = this.Measurement_Period(context);
                 CqlDateTime ab_ = context.Operators.End(aa_);
-                bool? ac_ = context.Operators.SameOrBefore(z_, ab_, default);
+                bool? ac_ = context.Operators.SameOrBefore(z_, ab_, (string)default);
                 Code<RequestStatus> ad_ = PalliativeOrHospiceCareOrder?.StatusElement;
                 string ae_ = FHIRHelpers_4_0_001.Instance.ToString(context, ad_);
                 string[] af_ = [
@@ -597,7 +597,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime ao_ = context.Operators.Start(an_);
                 CqlInterval<CqlDateTime> ap_ = this.Measurement_Period(context);
                 CqlDateTime aq_ = context.Operators.End(ap_);
-                bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, default);
+                bool? ar_ = context.Operators.SameOrBefore(ao_, aq_, (string)default);
                 Code<EventStatus> as_ = PalliativeOrHospiceCarePerformed?.StatusElement;
                 string at_ = FHIRHelpers_4_0_001.Instance.ToString(context, as_);
                 bool? au_ = context.Operators.Equal(at_, "completed");
@@ -618,7 +618,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime ay_ = context.Operators.Start(ax_);
                 CqlInterval<CqlDateTime> az_ = this.Measurement_Period(context);
                 CqlDateTime ba_ = context.Operators.End(az_);
-                bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, default);
+                bool? bb_ = context.Operators.SameOrBefore(ay_, ba_, (string)default);
                 Code<Encounter.EncounterStatus> bc_ = PalliativeEncounter?.StatusElement;
                 string bd_ = FHIRHelpers_4_0_001.Instance.ToString(context, bc_);
                 bool? be_ = context.Operators.Equal(bd_, "finished");
@@ -648,7 +648,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
             bool? i_(Condition HepatitisLiverDisease) {
                 CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, HepatitisLiverDisease);
                 CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                bool? n_ = context.Operators.Overlaps(l_, m_, default);
+                bool? n_ = context.Operators.Overlaps(l_, m_, (string)default);
                 return n_;
             }
 
@@ -669,7 +669,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 CqlDateTime g_ = context.Operators.Start(f_);
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
                 CqlDateTime i_ = context.Operators.End(h_);
-                bool? j_ = context.Operators.Before(g_, i_, default);
+                bool? j_ = context.Operators.Before(g_, i_, (string)default);
                 return j_;
             }
 
@@ -688,7 +688,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
             bool? c_(Condition ESRD) {
                 CqlInterval<CqlDateTime> f_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ESRD);
                 CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
-                bool? h_ = context.Operators.Overlaps(f_, g_, default);
+                bool? h_ = context.Operators.Overlaps(f_, g_, (string)default);
                 return h_;
             }
 
@@ -708,7 +708,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 FhirDateTime f_ = StatinReaction?.DateElement;
                 CqlDateTime g_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, f_);
                 CqlInterval<CqlDateTime> h_ = this.Measurement_Period(context);
-                bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, default);
+                bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, (string)default);
                 return i_;
             }
 
@@ -751,7 +751,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
             bool? i_(Condition ExclusionDiagnosis) {
                 CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, ExclusionDiagnosis);
                 CqlInterval<CqlDateTime> m_ = this.Measurement_Period(context);
-                bool? n_ = context.Operators.Overlaps(l_, m_, default);
+                bool? n_ = context.Operators.Overlaps(l_, m_, (string)default);
                 return n_;
             }
 
@@ -862,7 +862,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
                 FhirDateTime bv_ = StatinOrdered?.AuthoredOnElement;
                 CqlDateTime bw_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, bv_);
                 CqlInterval<CqlDateTime> bx_ = this.Measurement_Period(context);
-                bool? by_ = context.Operators.In<CqlDateTime>(bw_, bx_, default);
+                bool? by_ = context.Operators.In<CqlDateTime>(bw_, bx_, (string)default);
                 Code<MedicationRequest.MedicationrequestStatus> bz_ = StatinOrdered?.StatusElement;
                 string ca_ = FHIRHelpers_4_0_001.Instance.ToString(context, bz_);
                 string[] cb_ = [
@@ -1037,7 +1037,7 @@ public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
 
                     CqlInterval<CqlDateTime> cm_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, cl_());
                     CqlInterval<CqlDateTime> cn_ = this.Measurement_Period(context);
-                    bool? co_ = context.Operators.Overlaps(cm_, cn_, default);
+                    bool? co_ = context.Operators.Overlaps(cm_, cn_, (string)default);
                     return co_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -56,7 +56,7 @@ public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(3162054828375168680L, () => {
-            object a_ = context.ResolveParameter("HospiceFHIR4-2.3.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("HospiceFHIR4-2.3.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -101,7 +101,7 @@ public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_
                 CqlInterval<CqlDateTime> aj_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ai_ as object);
                 CqlDateTime ak_ = context.Operators.End(aj_);
                 CqlInterval<CqlDateTime> al_ = this.Measurement_Period(context);
-                bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, default);
+                bool? am_ = context.Operators.In<CqlDateTime>(ak_, al_, (string)default);
                 bool? an_ = context.Operators.And(ah_, am_);
                 return an_;
             }
@@ -126,7 +126,7 @@ public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_
                 CqlInterval<CqlDateTime> aw_ = this.Measurement_Period(context);
                 FhirDateTime ax_ = HospiceOrder?.AuthoredOnElement;
                 CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ax_ as object);
-                bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, default);
+                bool? az_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(aw_, ay_, (string)default);
                 bool? ba_ = context.Operators.And(av_, az_);
                 return ba_;
             }
@@ -143,7 +143,7 @@ public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_
                 DataType be_ = HospicePerformed?.Performed;
                 CqlInterval<CqlDateTime> bf_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, be_);
                 CqlInterval<CqlDateTime> bg_ = this.Measurement_Period(context);
-                bool? bh_ = context.Operators.Overlaps(bf_, bg_, default);
+                bool? bh_ = context.Operators.Overlaps(bf_, bg_, (string)default);
                 bool? bi_ = context.Operators.And(bd_, bh_);
                 return bi_;
             }

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -63,7 +63,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(7229425209739707094L, () => {
-            object a_ = context.ResolveParameter("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006", "Measurement Period", null);
+            object a_ = context.ResolveParameter("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -180,7 +180,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                     CqlDateTime s_ = context.Operators.Start(r_);
                     CqlInterval<CqlDateTime> t_ = EncounterWithHospitalization?.hospitalizationPeriod;
                     CqlDateTime u_ = context.Operators.End(t_);
-                    bool? v_ = context.Operators.Before(s_, u_, default);
+                    bool? v_ = context.Operators.Before(s_, u_, (string)default);
                     bool? w_ = context.Operators.And(q_, v_);
                     return w_;
                 }
@@ -255,7 +255,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                 CqlInterval<CqlDateTime> ak_ = tuple_clxcrdeespovhrdozoxqzeieb?.EncounterWithHospitalization?.hospitalizationPeriod;
                 DataType al_ = tuple_clxcrdeespovhrdozoxqzeieb?.HypoglycemicMedication?.Effective;
                 CqlInterval<CqlDateTime> am_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, al_);
-                bool? an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, am_, default);
+                bool? an_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, am_, (string)default);
                 bool? ao_ = context.Operators.And(aj_, an_);
                 return ao_;
             }
@@ -286,7 +286,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                     DataType m_ = BloodGlucoseLab?.Effective;
                     CqlDateTime n_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, m_ as FhirDateTime);
                     CqlInterval<CqlDateTime> o_ = EncounterWithHospitalization?.hospitalizationPeriod;
-                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
                     Code<ObservationStatus> q_ = BloodGlucoseLab?.StatusElement;
                     string r_ = FHIRHelpers_4_0_001.Instance.ToString(context, q_);
                     bool? s_ = context.Operators.Equal(r_, "final");
@@ -425,7 +425,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, (CqlQuantity)default);
 
         int? g_(CqlInterval<int?> DayExpand) {
             int? j_ = context.Operators.End(DayExpand);
@@ -486,7 +486,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                         DataType am_ = BloodGlucoseLab1?.Effective;
                         CqlDateTime an_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, am_ as FhirDateTime);
                         CqlInterval<CqlDateTime> ao_ = EncounterDay?.dayPeriod;
-                        bool? ap_ = context.Operators.In<CqlDateTime>(an_, ao_, default);
+                        bool? ap_ = context.Operators.In<CqlDateTime>(an_, ao_, (string)default);
                         bool? aq_ = context.Operators.And(al_, ap_);
                         return aq_;
                     }
@@ -507,7 +507,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                         DataType az_ = BloodGlucoseLab2?.Effective;
                         CqlDateTime ba_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, az_ as FhirDateTime);
                         CqlInterval<CqlDateTime> bb_ = EncounterDay?.dayPeriod;
-                        bool? bc_ = context.Operators.In<CqlDateTime>(ba_, bb_, default);
+                        bool? bc_ = context.Operators.In<CqlDateTime>(ba_, bb_, (string)default);
                         bool? bd_ = context.Operators.And(ay_, bc_);
                         return bd_;
                     }
@@ -523,7 +523,7 @@ public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006
                         DataType bh_ = BloodGlucoseLab3?.Effective;
                         CqlDateTime bi_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, bh_ as FhirDateTime);
                         CqlInterval<CqlDateTime> bj_ = EncounterDay?.dayPeriod;
-                        bool? bk_ = context.Operators.In<CqlDateTime>(bi_, bj_, default);
+                        bool? bk_ = context.Operators.In<CqlDateTime>(bi_, bj_, (string)default);
                         bool? bl_ = context.Operators.And(bg_, bk_);
                         return bl_;
                     }

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -71,8 +71,8 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(8711657917987574517L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("HospitalHarmSevereHypoglycemiaFHIR-0.0.012", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -130,7 +130,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                 CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, h_);
                 CqlDateTime j_ = context.Operators.End(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
-                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, default);
+                bool? l_ = context.Operators.In<CqlDateTime>(j_, k_, (string)default);
                 bool? m_ = context.Operators.And(g_, l_);
                 return m_;
             }
@@ -226,7 +226,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                     CqlInterval<CqlDateTime> j_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, i_);
                     CqlDateTime k_ = context.Operators.Start(j_);
                     CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
-                    bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
                     return m_;
                 }
 
@@ -281,7 +281,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlInterval<CqlDateTime> af_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, z_);
                         CqlDateTime ag_ = context.Operators.Start(af_);
                         CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-                        bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, default);
+                        bool? ai_ = context.Operators.In<CqlDateTime>(y_, ah_, (string)default);
                         CqlInterval<CqlDateTime> ak_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, z_);
                         CqlDateTime al_ = context.Operators.Start(ak_);
                         bool? am_ = context.Operators.Not((bool?)(al_ is null));
@@ -297,7 +297,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlInterval<CqlDateTime> ay_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, w_);
                         CqlDateTime az_ = context.Operators.Start(ay_);
                         CqlInterval<CqlDateTime> ba_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
-                        bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, default);
+                        bool? bb_ = context.Operators.In<CqlDateTime>(az_, ba_, (string)default);
                         bool? bc_ = context.Operators.And(aw_, bb_);
                         return bc_;
                     }
@@ -326,7 +326,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlInterval<CqlDateTime> br_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, bl_);
                         CqlDateTime bs_ = context.Operators.Start(br_);
                         CqlInterval<CqlDateTime> bt_ = context.Operators.Interval(bp_, bs_, true, true);
-                        bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, default);
+                        bool? bu_ = context.Operators.In<CqlDateTime>(bk_, bt_, (string)default);
                         CqlInterval<CqlDateTime> bw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, bl_);
                         CqlDateTime bx_ = context.Operators.Start(bw_);
                         bool? by_ = context.Operators.Not((bool?)(bx_ is null));
@@ -342,7 +342,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlInterval<CqlDateTime> ck_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, bi_);
                         CqlDateTime cl_ = context.Operators.Start(ck_);
                         CqlInterval<CqlDateTime> cm_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
-                        bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, default);
+                        bool? cn_ = context.Operators.In<CqlDateTime>(cl_, cm_, (string)default);
                         bool? co_ = context.Operators.And(ci_, cn_);
                         return co_;
                     }
@@ -364,7 +364,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlInterval<CqlDateTime> cw_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, cv_);
                         CqlDateTime cx_ = context.Operators.Start(cw_);
                         CqlInterval<CqlDateTime> cy_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
-                        bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, default);
+                        bool? cz_ = context.Operators.In<CqlDateTime>(cx_, cy_, (string)default);
                         CqlInterval<CqlDateTime> db_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, cv_);
                         CqlDateTime dc_ = context.Operators.Start(db_);
                         DataType dd_ = BloodGlucoseLab?.Effective;
@@ -375,7 +375,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                         CqlQuantity dj_ = context.Operators.Quantity(5m, "minutes");
                         CqlDateTime dk_ = context.Operators.Add(di_, dj_);
                         CqlInterval<CqlDateTime> dl_ = context.Operators.Interval(df_, dk_, false, true);
-                        bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, default);
+                        bool? dm_ = context.Operators.In<CqlDateTime>(dc_, dl_, (string)default);
                         CqlInterval<CqlDateTime> do_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, dd_);
                         CqlDateTime dp_ = context.Operators.Start(do_);
                         bool? dq_ = context.Operators.Not((bool?)(dp_ is null));
@@ -411,7 +411,7 @@ public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISin
                     CqlInterval<CqlDateTime> ei_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, eh_);
                     CqlDateTime ej_ = context.Operators.Start(ei_);
                     CqlInterval<CqlDateTime> ek_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, QualifyingEncounter);
-                    bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, default);
+                    bool? el_ = context.Operators.In<CqlDateTime>(ej_, ek_, (string)default);
                     DataType em_ = BloodGlucoseLab?.Value;
                     CqlQuantity en_ = FHIRHelpers_4_0_001.Instance.ToQuantity(context, em_ as Quantity);
                     CqlQuantity eo_ = context.Operators.Quantity(40m, "mg/dL");

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -118,8 +118,8 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(4314633830159632744L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("HybridHWMFHIR-0.102.005", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -220,7 +220,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlDate ah_ = context.Operators.DateFrom(ag_);
                 int? ai_ = context.Operators.CalculateAgeAt(ad_, ah_, "year");
                 CqlInterval<int?> aj_ = context.Operators.Interval(65, 94, true, true);
-                bool? ak_ = context.Operators.In<int?>(ai_, aj_, default);
+                bool? ak_ = context.Operators.In<int?>(ai_, aj_, (string)default);
                 bool? al_ = context.Operators.And(z_, ak_);
                 return al_;
             }
@@ -271,7 +271,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlQuantity at_ = context.Operators.Quantity(120m, "minutes");
                 CqlDateTime au_ = context.Operators.Add(as_, at_);
                 CqlInterval<CqlDateTime> av_ = context.Operators.Interval(ap_, au_, true, true);
-                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, default);
+                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, (string)default);
                 bool? ax_ = context.Operators.And(ah_, aw_);
                 Code<ObservationStatus> ay_ = Exam?.StatusElement;
                 string az_ = FHIRHelpers_4_0_001.Instance.ToString(context, ay_);
@@ -322,7 +322,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlQuantity by_ = context.Operators.Quantity(120m, "minutes");
                 CqlDateTime bz_ = context.Operators.Add(bx_, by_);
                 CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bu_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, default);
+                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, (string)default);
                 bool? cc_ = context.Operators.And(bm_, cb_);
                 Code<ObservationStatus> cd_ = Exam?.StatusElement;
                 string ce_ = FHIRHelpers_4_0_001.Instance.ToString(context, cd_);
@@ -390,7 +390,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlDateTime ao_ = context.Operators.Start(an_);
                 CqlDateTime aq_ = context.Operators.Add(ao_, ak_);
                 CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(al_, aq_, true, true);
-                bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, default);
+                bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, (string)default);
                 bool? at_ = context.Operators.And(ae_, as_);
                 Code<ObservationStatus> au_ = Lab?.StatusElement;
                 string av_ = FHIRHelpers_4_0_001.Instance.ToString(context, au_);
@@ -435,7 +435,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlDateTime bo_ = context.Operators.Start(bn_);
                 CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
                 CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-                bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
+                bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, (string)default);
                 bool? bt_ = context.Operators.And(be_, bs_);
                 Code<ObservationStatus> bu_ = Lab?.StatusElement;
                 string bv_ = FHIRHelpers_4_0_001.Instance.ToString(context, bu_);
@@ -589,7 +589,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cm_ = context.Operators.Start(cl_);
                     CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(cj_, cm_, true, true);
-                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, default);
+                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, (string)default);
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);
                     bool? cs_ = context.Operators.Not((bool?)(cr_ is null));
@@ -630,7 +630,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     CqlInterval<CqlDateTime> dg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dh_ = context.Operators.Start(dg_);
                     CqlInterval<CqlDateTime> di_ = context.Operators.Interval(de_, dh_, true, true);
-                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, default);
+                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, (string)default);
                     CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dm_ = context.Operators.Start(dl_);
                     bool? dn_ = context.Operators.Not((bool?)(dm_ is null));
@@ -655,7 +655,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, at_);
                 CqlDateTime bk_ = context.Operators.Start(bj_);
                 CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(ax_, bh_ ?? bk_, true, true);
-                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, default);
+                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, (string)default);
                 IEnumerable<Encounter> bo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/StructureDefinition/Encounter"));
 
                 bool? bp_(Encounter LastObs) {
@@ -670,7 +670,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                     CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime ec_ = context.Operators.Start(eb_);
                     CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(dz_, ec_, true, true);
-                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, default);
+                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, (string)default);
                     CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime eh_ = context.Operators.Start(eg_);
                     bool? ei_ = context.Operators.Not((bool?)(eh_ is null));
@@ -728,7 +728,7 @@ public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHI
                 CqlInterval<CqlDateTime> ez_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime fa_ = context.Operators.Start(ez_);
                 CqlInterval<CqlDateTime> fb_ = context.Operators.Interval(ex_, fa_, true, true);
-                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, default);
+                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, (string)default);
                 CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime ff_ = context.Operators.Start(fe_);
                 bool? fg_ = context.Operators.Not((bool?)(ff_ is null));

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -131,8 +131,8 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-5116339458294690597L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("HybridHWRFHIR-1.3.005", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -214,7 +214,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cm_ = context.Operators.Start(cl_);
                     CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(cj_, cm_, true, true);
-                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, default);
+                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, (string)default);
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);
                     bool? cs_ = context.Operators.Not((bool?)(cr_ is null));
@@ -255,7 +255,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     CqlInterval<CqlDateTime> dg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dh_ = context.Operators.Start(dg_);
                     CqlInterval<CqlDateTime> di_ = context.Operators.Interval(de_, dh_, true, true);
-                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, default);
+                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, (string)default);
                     CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dm_ = context.Operators.Start(dl_);
                     bool? dn_ = context.Operators.Not((bool?)(dm_ is null));
@@ -280,7 +280,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, at_);
                 CqlDateTime bk_ = context.Operators.Start(bj_);
                 CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(ax_, bh_ ?? bk_, true, true);
-                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, default);
+                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, (string)default);
                 IEnumerable<Encounter> bo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/StructureDefinition/Encounter"));
 
                 bool? bp_(Encounter LastObs) {
@@ -295,7 +295,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                     CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime ec_ = context.Operators.Start(eb_);
                     CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(dz_, ec_, true, true);
-                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, default);
+                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, (string)default);
                     CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime eh_ = context.Operators.Start(eg_);
                     bool? ei_ = context.Operators.Not((bool?)(eh_ is null));
@@ -353,7 +353,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlInterval<CqlDateTime> ez_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime fa_ = context.Operators.Start(ez_);
                 CqlInterval<CqlDateTime> fb_ = context.Operators.Interval(ex_, fa_, true, true);
-                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, default);
+                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, (string)default);
                 CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime ff_ = context.Operators.Start(fe_);
                 bool? fg_ = context.Operators.Not((bool?)(ff_ is null));
@@ -490,7 +490,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlQuantity at_ = context.Operators.Quantity(120m, "minutes");
                 CqlDateTime au_ = context.Operators.Add(as_, at_);
                 CqlInterval<CqlDateTime> av_ = context.Operators.Interval(ap_, au_, true, true);
-                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, default);
+                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, (string)default);
                 bool? ax_ = context.Operators.And(ah_, aw_);
                 Code<ObservationStatus> ay_ = Exam?.StatusElement;
                 string az_ = FHIRHelpers_4_0_001.Instance.ToString(context, ay_);
@@ -541,7 +541,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlQuantity by_ = context.Operators.Quantity(120m, "minutes");
                 CqlDateTime bz_ = context.Operators.Add(bx_, by_);
                 CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bu_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, default);
+                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, (string)default);
                 bool? cc_ = context.Operators.And(bm_, cb_);
                 Code<ObservationStatus> cd_ = Exam?.StatusElement;
                 string ce_ = FHIRHelpers_4_0_001.Instance.ToString(context, cd_);
@@ -612,7 +612,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlDateTime as_ = context.Operators.Start(ar_);
                 CqlDateTime au_ = context.Operators.Add(as_, ao_);
                 CqlInterval<CqlDateTime> av_ = context.Operators.Interval(ap_, au_, true, true);
-                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, default);
+                bool? aw_ = context.Operators.In<CqlDateTime>(ak_, av_, (string)default);
                 bool? ax_ = context.Operators.And(ah_, aw_);
                 Code<ObservationStatus> ay_ = Exam?.StatusElement;
                 string az_ = FHIRHelpers_4_0_001.Instance.ToString(context, ay_);
@@ -662,7 +662,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlDateTime bx_ = context.Operators.Start(bw_);
                 CqlDateTime bz_ = context.Operators.Add(bx_, bt_);
                 CqlInterval<CqlDateTime> ca_ = context.Operators.Interval(bu_, bz_, true, true);
-                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, default);
+                bool? cb_ = context.Operators.In<CqlDateTime>(bp_, ca_, (string)default);
                 bool? cc_ = context.Operators.And(bm_, cb_);
                 Code<ObservationStatus> cd_ = Exam?.StatusElement;
                 string ce_ = FHIRHelpers_4_0_001.Instance.ToString(context, cd_);
@@ -730,7 +730,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlDateTime ao_ = context.Operators.Start(an_);
                 CqlDateTime aq_ = context.Operators.Add(ao_, ak_);
                 CqlInterval<CqlDateTime> ar_ = context.Operators.Interval(al_, aq_, true, true);
-                bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, default);
+                bool? as_ = context.Operators.In<CqlDateTime>(ag_, ar_, (string)default);
                 bool? at_ = context.Operators.And(ae_, as_);
                 Code<ObservationStatus> au_ = Lab?.StatusElement;
                 string av_ = FHIRHelpers_4_0_001.Instance.ToString(context, au_);
@@ -775,7 +775,7 @@ public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_
                 CqlDateTime bo_ = context.Operators.Start(bn_);
                 CqlDateTime bq_ = context.Operators.Add(bo_, bk_);
                 CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bl_, bq_, true, true);
-                bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, default);
+                bool? bs_ = context.Operators.In<CqlDateTime>(bg_, br_, (string)default);
                 bool? bt_ = context.Operators.And(be_, bs_);
                 Code<ObservationStatus> bu_ = Lab?.StatusElement;
                 string bv_ = FHIRHelpers_4_0_001.Instance.ToString(context, bu_);

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -219,8 +219,8 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-5789223673792619521L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("MATGlobalCommonFunctionsFHIR4-6.1.000", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -268,7 +268,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                 CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, h_);
                 CqlDateTime o_ = context.Operators.End(n_);
                 CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
                 bool? r_ = context.Operators.And(l_, q_);
                 return r_;
             }
@@ -299,7 +299,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
             CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, n_);
             CqlDateTime u_ = context.Operators.Start(t_);
             CqlInterval<CqlDateTime> v_ = context.Operators.Interval(r_, u_, true, true);
-            bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
+            bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, (string)default);
             CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, n_);
             CqlDateTime z_ = context.Operators.Start(y_);
             bool? aa_ = context.Operators.Not((bool?)(z_ is null));
@@ -481,7 +481,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                     CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cm_ = context.Operators.Start(cl_);
                     CqlInterval<CqlDateTime> cn_ = context.Operators.Interval(cj_, cm_, true, true);
-                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, default);
+                    bool? co_ = context.Operators.In<CqlDateTime>(ce_, cn_, (string)default);
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, cf_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);
                     bool? cs_ = context.Operators.Not((bool?)(cr_ is null));
@@ -522,7 +522,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                     CqlInterval<CqlDateTime> dg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dh_ = context.Operators.Start(dg_);
                     CqlInterval<CqlDateTime> di_ = context.Operators.Interval(de_, dh_, true, true);
-                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, default);
+                    bool? dj_ = context.Operators.In<CqlDateTime>(cz_, di_, (string)default);
                     CqlInterval<CqlDateTime> dl_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, da_);
                     CqlDateTime dm_ = context.Operators.Start(dl_);
                     bool? dn_ = context.Operators.Not((bool?)(dm_ is null));
@@ -547,7 +547,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                 CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, at_);
                 CqlDateTime bk_ = context.Operators.Start(bj_);
                 CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(ax_, bh_ ?? bk_, true, true);
-                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, default);
+                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, (string)default);
                 IEnumerable<Encounter> bo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/StructureDefinition/Encounter"));
 
                 bool? bp_(Encounter LastObs) {
@@ -562,7 +562,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                     CqlInterval<CqlDateTime> eb_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime ec_ = context.Operators.Start(eb_);
                     CqlInterval<CqlDateTime> ed_ = context.Operators.Interval(dz_, ec_, true, true);
-                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, default);
+                    bool? ee_ = context.Operators.In<CqlDateTime>(du_, ed_, (string)default);
                     CqlInterval<CqlDateTime> eg_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, dv_);
                     CqlDateTime eh_ = context.Operators.Start(eg_);
                     bool? ei_ = context.Operators.Not((bool?)(eh_ is null));
@@ -620,7 +620,7 @@ public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleto
                 CqlInterval<CqlDateTime> ez_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime fa_ = context.Operators.Start(ez_);
                 CqlInterval<CqlDateTime> fb_ = context.Operators.Interval(ex_, fa_, true, true);
-                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, default);
+                bool? fc_ = context.Operators.In<CqlDateTime>(es_, fb_, (string)default);
                 CqlInterval<CqlDateTime> fe_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, et_);
                 CqlDateTime ff_ = context.Operators.Start(fe_);
                 bool? fg_ = context.Operators.Not((bool?)(ff_ is null));

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -77,7 +77,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-8915744558003842889L, () => {
-            object a_ = context.ResolveParameter("NCQAAdvancedIllnessandFrailty-1.0.0", "Measurement Period", null);
+            object a_ = context.ResolveParameter("NCQAAdvancedIllnessandFrailty-1.0.0", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -105,7 +105,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 DataType z_ = FrailtyDeviceApplied?.Effective;
                 CqlInterval<CqlDateTime> aa_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, z_);
                 CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                bool? ac_ = context.Operators.Overlaps(aa_, ab_, default);
+                bool? ac_ = context.Operators.Overlaps(aa_, ab_, (string)default);
                 return ac_;
             }
 
@@ -118,7 +118,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
             bool? i_(Condition FrailtyDiagnosis) {
                 CqlInterval<CqlDateTime> ad_ = NCQAFHIRBase_1_0_0.Instance.Prevalence_Period(context, FrailtyDiagnosis);
                 CqlInterval<CqlDateTime> ae_ = this.Measurement_Period(context);
-                bool? af_ = context.Operators.Overlaps(ad_, ae_, default);
+                bool? af_ = context.Operators.Overlaps(ad_, ae_, (string)default);
                 return af_;
             }
 
@@ -133,7 +133,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 Period ag_ = FrailtyEncounter?.Period;
                 CqlInterval<CqlDateTime> ah_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, ag_ as object);
                 CqlInterval<CqlDateTime> ai_ = this.Measurement_Period(context);
-                bool? aj_ = context.Operators.Overlaps(ah_, ai_, default);
+                bool? aj_ = context.Operators.Overlaps(ah_, ai_, (string)default);
                 return aj_;
             }
 
@@ -147,7 +147,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 DataType ak_ = FrailtySymptom?.Effective;
                 CqlInterval<CqlDateTime> al_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, ak_);
                 CqlInterval<CqlDateTime> am_ = this.Measurement_Period(context);
-                bool? an_ = context.Operators.Overlaps(al_, am_, default);
+                bool? an_ = context.Operators.Overlaps(al_, am_, (string)default);
                 return an_;
             }
 
@@ -196,7 +196,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 CqlDateTime ak_ = context.Operators.End(ae_);
                 CqlDate al_ = context.Operators.DateFrom(ak_);
                 CqlInterval<CqlDate> am_ = context.Operators.Interval(ai_, al_, true, true);
-                bool? an_ = context.Operators.In<CqlDate>(ad_, am_, default);
+                bool? an_ = context.Operators.In<CqlDate>(ad_, am_, (string)default);
                 bool? ao_ = context.Operators.And(z_, an_);
                 return ao_;
             }
@@ -239,7 +239,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 CqlDateTime u_ = context.Operators.End(o_);
                 CqlDate v_ = context.Operators.DateFrom(u_);
                 CqlInterval<CqlDate> w_ = context.Operators.Interval(s_, v_, true, true);
-                bool? x_ = context.Operators.In<CqlDate>(n_, w_, default);
+                bool? x_ = context.Operators.In<CqlDate>(n_, w_, (string)default);
                 return x_;
             }
 
@@ -314,7 +314,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
             bool? f_((CqlTupleMetadata, CqlDate OutpatientVisit1, CqlDate OutpatientVisit2)? tuple_cmsergtjgkisksqucnzwkeggv) {
                 CqlQuantity m_ = context.Operators.Quantity(1m, "day");
                 CqlDate n_ = context.Operators.Add(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit1, m_);
-                bool? o_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, n_, default);
+                bool? o_ = context.Operators.SameOrAfter(tuple_cmsergtjgkisksqucnzwkeggv?.OutpatientVisit2, n_, (string)default);
                 return o_;
             }
 
@@ -350,7 +350,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 CqlDateTime t_ = context.Operators.End(n_);
                 CqlDate u_ = context.Operators.DateFrom(t_);
                 CqlInterval<CqlDate> v_ = context.Operators.Interval(r_, u_, true, true);
-                bool? w_ = context.Operators.In<CqlDate>(m_, v_, default);
+                bool? w_ = context.Operators.In<CqlDate>(m_, v_, (string)default);
                 bool? x_ = context.Operators.And(i_, w_);
                 return x_;
             }
@@ -383,7 +383,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 CqlDateTime s_ = context.Operators.End(m_);
                 CqlDate t_ = context.Operators.DateFrom(s_);
                 CqlInterval<CqlDate> u_ = context.Operators.Interval(q_, t_, true, true);
-                bool? v_ = context.Operators.In<CqlDate>(l_, u_, default);
+                bool? v_ = context.Operators.In<CqlDate>(l_, u_, (string)default);
                 return v_;
             }
 
@@ -442,7 +442,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
                 CqlDateTime al_ = context.Operators.End(af_);
                 CqlDate am_ = context.Operators.DateFrom(al_);
                 CqlInterval<CqlDate> an_ = context.Operators.Interval(aj_, am_, true, true);
-                bool? ao_ = context.Operators.In<CqlDate>(ae_, an_, default);
+                bool? ao_ = context.Operators.In<CqlDate>(ae_, an_, (string)default);
                 return ao_;
             }
 
@@ -464,7 +464,7 @@ public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Has_Criteria_Indicating_Frailty(context);
             bool? l_ = context.Operators.And(j_, k_);
             bool? m_ = this.Two_Outpatient_Visits_with_Advanced_Illness_on_Different_Dates_of_Service(context);

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -184,7 +184,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                 bool? g_(CqlInterval<CqlDate> I) {
 
                     bool? j_(CqlInterval<CqlDate> J) {
-                        bool? o_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, default);
+                        bool? o_ = context.Operators.IntervalProperlyIncludesInterval<CqlDate>(J, I, (string)default);
                         return o_;
                     }
 
@@ -233,7 +233,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                 bool? g_(CqlInterval<CqlDateTime> I) {
 
                     bool? j_(CqlInterval<CqlDateTime> J) {
-                        bool? o_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, default);
+                        bool? o_ = context.Operators.IntervalProperlyIncludesInterval<CqlDateTime>(J, I, (string)default);
                         return o_;
                     }
 
@@ -245,7 +245,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
                 }
 
                 IEnumerable<CqlInterval<CqlDateTime>> h_ = context.Operators.Where<CqlInterval<CqlDateTime>>(intervals, g_);
-                IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, default);
+                IEnumerable<CqlInterval<CqlDateTime>> i_ = context.Operators.Collapse(h_, (string)default);
                 return i_;
             };
         }
@@ -1046,7 +1046,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
             int? ci_ = i?.StartMinute;
             int? cj_ = i?.StartSecond;
             int? ck_ = i?.StartMillisecond;
-            CqlDateTime cl_ = context.Operators.DateTime(ce_, cf_, cg_, ch_, ci_, cj_, ck_, default);
+            CqlDateTime cl_ = context.Operators.DateTime(ce_, cf_, cg_, ch_, ci_, cj_, ck_, (decimal?)default);
             int? cm_ = i?.EndYear;
             int? cn_ = i?.EndMonth;
             int? co_ = i?.EndDay;
@@ -1054,7 +1054,7 @@ public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
             int? cq_ = i?.EndMinute;
             int? cr_ = i?.EndSecond;
             int? cs_ = i?.EndMillisecond;
-            CqlDateTime ct_ = context.Operators.DateTime(cm_, cn_, co_, cp_, cq_, cr_, cs_, default);
+            CqlDateTime ct_ = context.Operators.DateTime(cm_, cn_, co_, cp_, cq_, cr_, cs_, (decimal?)default);
             CqlInterval<CqlDateTime> cu_ = context.Operators.Interval(cl_, ct_, true, true);
             return cu_;
         }

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -108,7 +108,7 @@ public partial class NCQAEncounter_1_0_0 : ILibrary, ISingleton<NCQAEncounter_1_
             Period e_ = EncounterPeriod?.Period;
             CqlInterval<CqlDateTime> f_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, e_ as object);
             CqlDateTime g_ = context.Operators.End(f_);
-            bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, default);
+            bool? h_ = context.Operators.In<CqlDateTime>(g_, timeperiod, (string)default);
             return h_;
         }
 

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -682,7 +682,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                     CqlQuantity ap_ = context.Operators.Quantity(30m, "days");
                     CqlDate aq_ = context.Operators.Add(ao_ as CqlDate, ap_);
                     CqlInterval<CqlDate> ar_ = context.Operators.Interval(al_, aq_, true, true);
-                    bool? as_ = context.Operators.In<CqlDate>(X, ar_, default);
+                    bool? as_ = context.Operators.In<CqlDate>(X, ar_, (string)default);
                     bool? at_ = context.Operators.Not(as_);
                     return at_;
                 }
@@ -725,7 +725,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                 CqlQuantity bv_ = context.Operators.Quantity(30m, "days");
                                 CqlDate bw_ = context.Operators.Add(bu_ as CqlDate, bv_);
                                 CqlInterval<CqlDate> bx_ = context.Operators.Interval(br_, bw_, true, true);
-                                bool? by_ = context.Operators.In<CqlDate>(X, bx_, default);
+                                bool? by_ = context.Operators.In<CqlDate>(X, bx_, (string)default);
                                 bool? bz_ = context.Operators.Not(by_);
                                 return bz_;
                             }
@@ -768,7 +768,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                             CqlQuantity db_ = context.Operators.Quantity(30m, "days");
                                             CqlDate dc_ = context.Operators.Add(da_ as CqlDate, db_);
                                             CqlInterval<CqlDate> dd_ = context.Operators.Interval(cx_, dc_, true, true);
-                                            bool? de_ = context.Operators.In<CqlDate>(X, dd_, default);
+                                            bool? de_ = context.Operators.In<CqlDate>(X, dd_, (string)default);
                                             bool? df_ = context.Operators.Not(de_);
                                             return df_;
                                         }
@@ -811,7 +811,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                         CqlQuantity eh_ = context.Operators.Quantity(30m, "days");
                                                         CqlDate ei_ = context.Operators.Add(eg_ as CqlDate, eh_);
                                                         CqlInterval<CqlDate> ej_ = context.Operators.Interval(ed_, ei_, true, true);
-                                                        bool? ek_ = context.Operators.In<CqlDate>(X, ej_, default);
+                                                        bool? ek_ = context.Operators.In<CqlDate>(X, ej_, (string)default);
                                                         bool? el_ = context.Operators.Not(ek_);
                                                         return el_;
                                                     }
@@ -854,7 +854,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                     CqlQuantity fn_ = context.Operators.Quantity(30m, "days");
                                                                     CqlDate fo_ = context.Operators.Add(fm_ as CqlDate, fn_);
                                                                     CqlInterval<CqlDate> fp_ = context.Operators.Interval(fj_, fo_, true, true);
-                                                                    bool? fq_ = context.Operators.In<CqlDate>(X, fp_, default);
+                                                                    bool? fq_ = context.Operators.In<CqlDate>(X, fp_, (string)default);
                                                                     bool? fr_ = context.Operators.Not(fq_);
                                                                     return fr_;
                                                                 }
@@ -897,7 +897,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                 CqlQuantity gt_ = context.Operators.Quantity(30m, "days");
                                                                                 CqlDate gu_ = context.Operators.Add(gs_ as CqlDate, gt_);
                                                                                 CqlInterval<CqlDate> gv_ = context.Operators.Interval(gp_, gu_, true, true);
-                                                                                bool? gw_ = context.Operators.In<CqlDate>(X, gv_, default);
+                                                                                bool? gw_ = context.Operators.In<CqlDate>(X, gv_, (string)default);
                                                                                 bool? gx_ = context.Operators.Not(gw_);
                                                                                 return gx_;
                                                                             }
@@ -940,7 +940,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                             CqlQuantity hz_ = context.Operators.Quantity(30m, "days");
                                                                                             CqlDate ia_ = context.Operators.Add(hy_ as CqlDate, hz_);
                                                                                             CqlInterval<CqlDate> ib_ = context.Operators.Interval(hv_, ia_, true, true);
-                                                                                            bool? ic_ = context.Operators.In<CqlDate>(X, ib_, default);
+                                                                                            bool? ic_ = context.Operators.In<CqlDate>(X, ib_, (string)default);
                                                                                             bool? id_ = context.Operators.Not(ic_);
                                                                                             return id_;
                                                                                         }
@@ -983,7 +983,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                                         CqlQuantity jf_ = context.Operators.Quantity(30m, "days");
                                                                                                         CqlDate jg_ = context.Operators.Add(je_ as CqlDate, jf_);
                                                                                                         CqlInterval<CqlDate> jh_ = context.Operators.Interval(jb_, jg_, true, true);
-                                                                                                        bool? ji_ = context.Operators.In<CqlDate>(X, jh_, default);
+                                                                                                        bool? ji_ = context.Operators.In<CqlDate>(X, jh_, (string)default);
                                                                                                         bool? jj_ = context.Operators.Not(ji_);
                                                                                                         return jj_;
                                                                                                     }
@@ -1026,7 +1026,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                                                     CqlQuantity kl_ = context.Operators.Quantity(30m, "days");
                                                                                                                     CqlDate km_ = context.Operators.Add(kk_ as CqlDate, kl_);
                                                                                                                     CqlInterval<CqlDate> kn_ = context.Operators.Interval(kh_, km_, true, true);
-                                                                                                                    bool? ko_ = context.Operators.In<CqlDate>(X, kn_, default);
+                                                                                                                    bool? ko_ = context.Operators.In<CqlDate>(X, kn_, (string)default);
                                                                                                                     bool? kp_ = context.Operators.Not(ko_);
                                                                                                                     return kp_;
                                                                                                                 }
@@ -1069,7 +1069,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                                                                 CqlQuantity lr_ = context.Operators.Quantity(30m, "days");
                                                                                                                                 CqlDate ls_ = context.Operators.Add(lq_ as CqlDate, lr_);
                                                                                                                                 CqlInterval<CqlDate> lt_ = context.Operators.Interval(ln_, ls_, true, true);
-                                                                                                                                bool? lu_ = context.Operators.In<CqlDate>(X, lt_, default);
+                                                                                                                                bool? lu_ = context.Operators.In<CqlDate>(X, lt_, (string)default);
                                                                                                                                 bool? lv_ = context.Operators.Not(lu_);
                                                                                                                                 return lv_;
                                                                                                                             }
@@ -1112,7 +1112,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                                                                             CqlQuantity mx_ = context.Operators.Quantity(30m, "days");
                                                                                                                                             CqlDate my_ = context.Operators.Add(mw_ as CqlDate, mx_);
                                                                                                                                             CqlInterval<CqlDate> mz_ = context.Operators.Interval(mt_, my_, true, true);
-                                                                                                                                            bool? na_ = context.Operators.In<CqlDate>(X, mz_, default);
+                                                                                                                                            bool? na_ = context.Operators.In<CqlDate>(X, mz_, (string)default);
                                                                                                                                             bool? nb_ = context.Operators.Not(na_);
                                                                                                                                             return nb_;
                                                                                                                                         }
@@ -1155,7 +1155,7 @@ public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_
                                                                                                                                                         CqlQuantity ny_ = context.Operators.Quantity(30m, "days");
                                                                                                                                                         CqlDate nz_ = context.Operators.Add(nx_ as CqlDate, ny_);
                                                                                                                                                         CqlInterval<CqlDate> oa_ = context.Operators.Interval(nu_, nz_, true, true);
-                                                                                                                                                        bool? ob_ = context.Operators.In<CqlDate>(X, oa_, default);
+                                                                                                                                                        bool? ob_ = context.Operators.In<CqlDate>(X, oa_, (string)default);
                                                                                                                                                         bool? oc_ = context.Operators.Not(ob_);
                                                                                                                                                         return oc_;
                                                                                                                                                     }

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -71,7 +71,7 @@ public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAH
             CqlDate m_ = context.Operators.Subtract(k_, l_);
             CqlDate p_ = context.Operators.Add(k_, l_);
             CqlInterval<CqlDate> q_ = context.Operators.Interval(m_, p_, true, true);
-            bool? r_ = context.Operators.In<CqlDate>(j_, q_, default);
+            bool? r_ = context.Operators.In<CqlDate>(j_, q_, (string)default);
             bool? t_ = context.Operators.Not((bool?)(k_ is null));
             bool? u_ = context.Operators.And(r_, t_);
             return u_;
@@ -215,12 +215,12 @@ public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAH
         bool? a_() {
 
             bool b_() {
-                bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default);
+                bool? c_ = context.Operators.In<CqlDate>(AnchorDate, participationPeriod, (string)default);
                 bool? d_ = context.Operators.Not(c_);
                 return d_ ?? false;
             }
 
-            if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, default)) ?? false)
+            if ((context.Operators.In<CqlDate>(AnchorDate, participationPeriod, (string)default)) ?? false)
             {
                 IEnumerable<(CqlTupleMetadata, IEnumerable<CqlInterval<CqlDate>> IntervalInfo, IEnumerable<CqlInterval<CqlDate>> Collapsed, IEnumerable<CqlInterval<CqlDate>> Adjacent, IEnumerable<CqlInterval<CqlDate>> CollapsedFinal)?> e_ = this.All_Coverage_Info(context, Coverage, participationPeriod);
 
@@ -241,7 +241,7 @@ public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAH
                 IEnumerable<CqlInterval<CqlDate>> j_ = context.Operators.Flatten<CqlInterval<CqlDate>>(i_);
 
                 bool? k_(CqlInterval<CqlDate> FinalInterval) {
-                    bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, default);
+                    bool? q_ = context.Operators.In<CqlDate>(AnchorDate, FinalInterval, (string)default);
                     return q_;
                 }
 
@@ -274,7 +274,7 @@ public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAH
                     CqlDateTime af_ = context.Operators.End(ab_);
                     CqlDate ag_ = context.Operators.DateFrom(af_);
                     CqlInterval<CqlDate> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-                    bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, default);
+                    bool? ai_ = context.Operators.In<CqlDate>(AnchorDate, ah_, (string)default);
                     return ai_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -33,7 +33,7 @@ public partial class NCQAHospice_1_0_0 : ILibrary, ISingleton<NCQAHospice_1_0_0>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-3851945183777304699L, () => {
-            object a_ = context.ResolveParameter("NCQAHospice-1.0.0", "Measurement Period", null);
+            object a_ = context.ResolveParameter("NCQAHospice-1.0.0", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -62,7 +62,7 @@ public partial class NCQAHospice_1_0_0 : ILibrary, ISingleton<NCQAHospice_1_0_0>
                 DataType n_ = HospiceInt?.Performed;
                 CqlInterval<CqlDateTime> o_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, n_);
                 CqlInterval<CqlDateTime> p_ = this.Measurement_Period(context);
-                bool? q_ = context.Operators.Overlaps(o_, p_, default);
+                bool? q_ = context.Operators.Overlaps(o_, p_, (string)default);
                 return q_;
             }
 
@@ -76,7 +76,7 @@ public partial class NCQAHospice_1_0_0 : ILibrary, ISingleton<NCQAHospice_1_0_0>
                 Period r_ = HospiceEnc?.Period;
                 CqlInterval<CqlDateTime> s_ = NCQAFHIRBase_1_0_0.Instance.Normalize_Interval(context, r_ as object);
                 CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                bool? u_ = context.Operators.Overlaps(s_, t_, default);
+                bool? u_ = context.Operators.Overlaps(s_, t_, (string)default);
                 return u_;
             }
 

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -72,7 +72,7 @@ public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliat
             CqlDateTime am_ = context.Operators.End(Period);
             CqlDate an_ = context.Operators.DateFrom(am_);
             CqlInterval<CqlDate> ao_ = context.Operators.Interval(al_, an_, true, true);
-            bool? ap_ = context.Operators.Overlaps(aj_, ao_, default);
+            bool? ap_ = context.Operators.Overlaps(aj_, ao_, (string)default);
             return ap_;
         }
 
@@ -96,7 +96,7 @@ public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliat
             CqlDateTime bb_ = context.Operators.End(Period);
             CqlDate bc_ = context.Operators.DateFrom(bb_);
             CqlInterval<CqlDate> bd_ = context.Operators.Interval(ba_, bc_, true, true);
-            bool? be_ = context.Operators.Overlaps(ay_, bd_, default);
+            bool? be_ = context.Operators.Overlaps(ay_, bd_, (string)default);
             return be_;
         }
 
@@ -121,7 +121,7 @@ public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliat
             CqlDateTime bq_ = context.Operators.End(Period);
             CqlDate br_ = context.Operators.DateFrom(bq_);
             CqlInterval<CqlDate> bs_ = context.Operators.Interval(bp_, br_, true, true);
-            bool? bt_ = context.Operators.Overlaps(bn_, bs_, default);
+            bool? bt_ = context.Operators.Overlaps(bn_, bs_, (string)default);
             return bt_;
         }
 
@@ -145,7 +145,7 @@ public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliat
             CqlDateTime cd_ = context.Operators.End(Period);
             CqlDate ce_ = context.Operators.DateFrom(cd_);
             CqlInterval<CqlDate> cf_ = context.Operators.Interval(cc_, ce_, true, true);
-            bool? cg_ = context.Operators.Overlaps(ca_, cf_, default);
+            bool? cg_ = context.Operators.Overlaps(ca_, cf_, (string)default);
             return cg_;
         }
 

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -61,7 +61,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-7635985198364237165L, () => {
-            object a_ = context.ResolveParameter("PalliativeCareFHIR-0.6.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("PalliativeCareFHIR-0.6.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -111,7 +111,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
                 DataType ab_ = PalliativeAssessment?.Effective;
                 CqlInterval<CqlDateTime> ac_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ab_);
                 CqlInterval<CqlDateTime> ad_ = this.Measurement_Period(context);
-                bool? ae_ = context.Operators.Overlaps(ac_, ad_, default);
+                bool? ae_ = context.Operators.Overlaps(ac_, ad_, (string)default);
                 bool? af_ = context.Operators.And(aa_, ae_);
                 return af_;
             }
@@ -128,7 +128,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
                 Period an_ = PalliativeEncounter?.Period;
                 CqlInterval<CqlDateTime> ao_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, an_ as object);
                 CqlInterval<CqlDateTime> ap_ = this.Measurement_Period(context);
-                bool? aq_ = context.Operators.Overlaps(ao_, ap_, default);
+                bool? aq_ = context.Operators.Overlaps(ao_, ap_, (string)default);
                 bool? ar_ = context.Operators.And(am_, aq_);
                 return ar_;
             }
@@ -150,7 +150,7 @@ public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<Palliativ
                 DataType aw_ = PalliativeIntervention?.Performed;
                 CqlInterval<CqlDateTime> ax_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, aw_);
                 CqlInterval<CqlDateTime> ay_ = this.Measurement_Period(context);
-                bool? az_ = context.Operators.Overlaps(ax_, ay_, default);
+                bool? az_ = context.Operators.Overlaps(ax_, ay_, (string)default);
                 bool? ba_ = context.Operators.And(av_, az_);
                 return ba_;
             }

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -79,7 +79,7 @@ public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-5232504333520421231L, () => {
-            object a_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008", "Measurement Period", null);
+            object a_ = context.ResolveParameter("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -160,7 +160,7 @@ public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR
                 CqlInterval<CqlDateTime> z_ = this.Measurement_Period(context);
                 Period aa_ = ValidEncounter?.Period;
                 CqlInterval<CqlDateTime> ab_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, aa_ as object);
-                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, default);
+                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(z_, ab_, (string)default);
                 Code<Encounter.EncounterStatus> ad_ = ValidEncounter?.StatusElement;
                 string ae_ = FHIRHelpers_4_0_001.Instance.ToString(context, ad_);
                 bool? af_ = context.Operators.Equal(ae_, "finished");
@@ -252,7 +252,7 @@ public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(5, 11, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -269,7 +269,7 @@ public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(12, 20, true, false);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -284,7 +284,7 @@ public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR
                 CqlInterval<CqlDateTime> f_ = this.Measurement_Period(context);
                 DataType g_ = FluorideApplication?.Performed;
                 CqlInterval<CqlDateTime> h_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, g_);
-                bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, default);
+                bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(f_, h_, (string)default);
                 Code<EventStatus> j_ = FluorideApplication?.StatusElement;
                 string k_ = FHIRHelpers_4_0_001.Instance.ToString(context, j_);
                 bool? l_ = context.Operators.Equal(k_, "completed");

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -75,7 +75,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-6669692820371050143L, () => {
-            object a_ = context.ResolveParameter("SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012", "Measurement Period", null);
+            object a_ = context.ResolveParameter("SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -213,7 +213,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlDateTime bn_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, bm_);
                     Period bo_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, bo_);
-                    bool? bq_ = context.Operators.In<CqlDateTime>(bn_, bp_, default);
+                    bool? bq_ = context.Operators.In<CqlDateTime>(bn_, bp_, (string)default);
                     Code<MedicationRequest.MedicationrequestStatus> br_ = OpioidOrBenzodiazepineDischargeMedication?.StatusElement;
                     string bs_ = FHIRHelpers_4_0_001.Instance.ToString(context, br_);
                     bool? bt_ = context.Operators.Equal(bs_, "active");
@@ -290,7 +290,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlDateTime t_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, s_);
                     Period u_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, u_);
-                    bool? w_ = context.Operators.In<CqlDateTime>(t_, v_, default);
+                    bool? w_ = context.Operators.In<CqlDateTime>(t_, v_, (string)default);
                     return w_;
                 }
 
@@ -319,7 +319,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlDateTime af_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, ae_);
                     Period ag_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ag_);
-                    bool? ai_ = context.Operators.In<CqlDateTime>(af_, ah_, default);
+                    bool? ai_ = context.Operators.In<CqlDateTime>(af_, ah_, (string)default);
                     return ai_;
                 }
 
@@ -340,7 +340,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlDateTime aq_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, ap_);
                     Period ar_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ar_);
-                    bool? at_ = context.Operators.In<CqlDateTime>(aq_, as_, default);
+                    bool? at_ = context.Operators.In<CqlDateTime>(aq_, as_, (string)default);
                     return at_;
                 }
 
@@ -369,7 +369,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlInterval<CqlDateTime> ac_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Prevalence_Period(context, Cancer);
                     Period ad_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> ae_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ad_);
-                    bool? af_ = context.Operators.Overlaps(ac_, ae_, default);
+                    bool? af_ = context.Operators.Overlaps(ac_, ae_, (string)default);
                     return af_;
                 }
 
@@ -383,7 +383,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlDateTime ah_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, ag_);
                     Period ai_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> aj_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ai_);
-                    bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, default);
+                    bool? ak_ = context.Operators.In<CqlDateTime>(ah_, aj_, (string)default);
                     Code<RequestIntent> al_ = PalliativeOrHospiceCareOrder?.IntentElement;
                     string am_ = FHIRHelpers_4_0_001.Instance.ToString(context, al_);
                     bool? an_ = context.Operators.Equal(am_, "order");
@@ -401,7 +401,7 @@ public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrar
                     CqlInterval<CqlDateTime> aq_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.Normalize_Interval(context, ap_);
                     Period ar_ = InpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> as_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, ar_);
-                    bool? at_ = context.Operators.Overlaps(aq_, as_, default);
+                    bool? at_ = context.Operators.Overlaps(aq_, as_, (string)default);
                     return at_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -95,8 +95,8 @@ public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHI
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(6905366931702746391L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("TJCOverallFHIR-1.8.000", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -300,7 +300,7 @@ public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHI
                     FhirDateTime j_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
                     CqlDateTime k_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, (i_ as FhirDateTime) ?? j_);
                     CqlInterval<CqlDateTime> l_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(k_, l_, (string)default);
                     return m_;
                 }
 
@@ -330,7 +330,7 @@ public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHI
                     FhirDateTime l_ = context.Operators.LateBoundProperty<FhirDateTime>(ComfortMeasure, "authoredOn");
                     CqlDateTime m_ = FHIRHelpers_4_0_001.Instance.ToDateTime(context, l_);
                     CqlInterval<CqlDateTime> n_ = MATGlobalCommonFunctionsFHIR4_6_1_000.Instance.HospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, default);
+                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
                     return o_;
                 }
 

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -29,8 +29,8 @@ public partial class VTEFHIR4_4_8_000 : ILibrary, ISingleton<VTEFHIR4_4_8_000>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-3752229714359495963L, () => {
-            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, default);
-            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, default);
+            CqlDateTime a_ = context.Operators.DateTime(2019, 1, 1, 0, 0, 0, 0, (decimal?)default);
+            CqlDateTime b_ = context.Operators.DateTime(2020, 1, 1, 0, 0, 0, 0, (decimal?)default);
             CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
             object d_ = context.ResolveParameter("VTEFHIR4-4.8.000", "Measurement Period", c_);
             return (CqlInterval<CqlDateTime>)d_;
@@ -91,7 +91,7 @@ public partial class VTEFHIR4_4_8_000 : ILibrary, ISingleton<VTEFHIR4_4_8_000>
             CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, n_);
             Period p_ = HospitalLocation?.Period;
             CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_0_001.Instance.ToInterval(context, p_);
-            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
             bool? s_ = context.Operators.And(m_, r_);
             return s_;
         }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
@@ -99,7 +99,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(6517944951610092532L, () => {
-            object a_ = context.ResolveParameter("AHAOverall-4.1.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("AHAOverall-4.1.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -324,7 +324,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     Period n_ = HFOutpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.End(o_);
-                    bool? q_ = context.Operators.Before(m_, p_, default);
+                    bool? q_ = context.Operators.Before(m_, p_, (string)default);
                     return q_;
                 }
 
@@ -361,7 +361,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
                     CqlDateTime w_ = context.Operators.End(v_);
                     CqlDate x_ = context.Operators.DateFrom(w_);
-                    bool? y_ = context.Operators.SameOrBefore(t_, x_, default);
+                    bool? y_ = context.Operators.SameOrBefore(t_, x_, (string)default);
                     return y_;
                 }
 
@@ -512,7 +512,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
                     CqlDateTime w_ = context.Operators.End(v_);
                     CqlDate x_ = context.Operators.DateFrom(w_);
-                    bool? y_ = context.Operators.SameOrBefore(t_, x_, default);
+                    bool? y_ = context.Operators.SameOrBefore(t_, x_, (string)default);
                     return y_;
                 }
 
@@ -647,7 +647,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
                     Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
                     CqlDateTime r_ = context.Operators.End(q_);
-                    bool? s_ = context.Operators.Before(o_, r_, default);
+                    bool? s_ = context.Operators.Before(o_, r_, (string)default);
                     return s_;
                 }
 
@@ -1067,7 +1067,7 @@ public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_00
 
             IEnumerable<CqlInterval<CqlDateTime>> s_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(q_, r_);
             IEnumerable<CqlInterval<CqlDateTime>> t_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(s_);
-            IEnumerable<CqlInterval<CqlDateTime>> u_ = context.Operators.Collapse(t_, default);
+            IEnumerable<CqlInterval<CqlDateTime>> u_ = context.Operators.Collapse(t_, (string)default);
 
             object v_(CqlInterval<CqlDateTime> @this) {
                 CqlDateTime bh_ = context.Operators.Start(@this);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
@@ -53,7 +53,7 @@ public partial class AdultOutpatientEncounters_4_19_000 : ILibrary, ISingleton<A
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(4241500979845946323L, () => {
-            object a_ = context.ResolveParameter("AdultOutpatientEncounters-4.19.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("AdultOutpatientEncounters-4.19.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
@@ -82,7 +82,7 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-892027430157829280L, () => {
-            object a_ = context.ResolveParameter("AdvancedIllnessandFrailty-1.27.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("AdvancedIllnessandFrailty-1.27.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -315,7 +315,7 @@ public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<A
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(66, 80, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Has_Criteria_Indicating_Frailty(context);
             bool? l_ = context.Operators.And(j_, k_);
             bool? m_ = this.Has_Advanced_Illness_in_Year_Before_or_During_Measurement_Period(context);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
@@ -21,7 +21,7 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-2145052723438296680L, () => {
-            object a_ = context.ResolveParameter("Antibiotic-1.11.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("Antibiotic-1.11.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -59,7 +59,7 @@ public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_
                 CqlDateTime u_ = context.Operators.Start(t_);
                 CqlDate v_ = context.Operators.DateFrom(u_);
                 CqlInterval<CqlDate> w_ = context.Operators.Interval(r_, v_, true, true);
-                bool? x_ = context.Operators.In<CqlDate>(l_, w_, default);
+                bool? x_ = context.Operators.In<CqlDate>(l_, w_, (string)default);
                 return x_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
@@ -648,7 +648,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                 string gr_ = this.ErrorLevel(context);
                 string gs_ = period?.unit;
                 string gt_ = context.Operators.Concatenate("Unknown unit ", gs_ ?? "");
-                object gu_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownUnit", gr_, gt_);
+                object gu_ = context.Operators.Message<object>((object)null, "CMDLogic.ToDaily.UnknownUnit", gr_, gt_);
                 return gu_ as decimal?;
             };
         }
@@ -1210,7 +1210,7 @@ public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton
                 string fm_ = this.ErrorLevel(context);
                 string fn_ = frequency?.code;
                 string fo_ = context.Operators.Concatenate("Unknown frequency code ", fn_ ?? "");
-                object fp_ = context.Operators.Message<object>(null, "CMDLogic.ToDaily.UnknownFrequencyCode", fm_, fo_);
+                object fp_ = context.Operators.Message<object>((object)null, "CMDLogic.ToDaily.UnknownFrequencyCode", fm_, fo_);
                 return fp_ as decimal?;
             };
         }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
@@ -79,7 +79,7 @@ public partial class Hospice_6_18_000 : ILibrary, ISingleton<Hospice_6_18_000>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(2116253259980977327L, () => {
-            object a_ = context.ResolveParameter("Hospice-6.18.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("Hospice-6.18.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
@@ -68,7 +68,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(859669092182870447L, () => {
-            object a_ = context.ResolveParameter("PCMaternal-5.25.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("PCMaternal-5.25.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -102,7 +102,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 CqlDate k_ = context.Operators.DateFrom(j_);
                 int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
                 CqlInterval<int?> m_ = context.Operators.Interval(8, 65, true, false);
-                bool? n_ = context.Operators.In<int?>(l_, m_, default);
+                bool? n_ = context.Operators.In<int?>(l_, m_, (string)default);
                 return n_;
             }
 
@@ -141,7 +141,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ck_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);
                     CqlInterval<CqlDateTime> cs_ = context.Operators.Interval(co_, cr_, true, true);
-                    bool? ct_ = context.Operators.In<CqlDateTime>(cj_, cs_, default);
+                    bool? ct_ = context.Operators.In<CqlDateTime>(cj_, cs_, (string)default);
                     CqlInterval<CqlDateTime> cv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ck_);
                     CqlDateTime cw_ = context.Operators.Start(cv_);
                     bool? cx_ = context.Operators.Not((bool?)(cw_ is null));
@@ -187,7 +187,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                     CqlInterval<CqlDateTime> dq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
                     CqlDateTime dr_ = context.Operators.Start(dq_);
                     CqlInterval<CqlDateTime> ds_ = context.Operators.Interval(do_, dr_, true, true);
-                    bool? dt_ = context.Operators.In<CqlDateTime>(dj_, ds_, default);
+                    bool? dt_ = context.Operators.In<CqlDateTime>(dj_, ds_, (string)default);
                     CqlInterval<CqlDateTime> dv_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dk_);
                     CqlDateTime dw_ = context.Operators.Start(dv_);
                     bool? dx_ = context.Operators.Not((bool?)(dw_ is null));
@@ -217,7 +217,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 CqlInterval<CqlDateTime> bj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
                 CqlDateTime bk_ = context.Operators.Start(bj_);
                 CqlInterval<CqlDateTime> bl_ = context.Operators.Interval(ax_, bh_ ?? bk_, true, true);
-                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, default);
+                bool? bm_ = context.Operators.In<CqlDateTime>(ai_, bl_, (string)default);
                 IEnumerable<Encounter> bo_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, aj_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? bp_(Encounter LastObs) {
@@ -232,7 +232,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                     CqlInterval<CqlDateTime> eq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ek_);
                     CqlDateTime er_ = context.Operators.Start(eq_);
                     CqlInterval<CqlDateTime> es_ = context.Operators.Interval(eo_, er_, true, true);
-                    bool? et_ = context.Operators.In<CqlDateTime>(ej_, es_, default);
+                    bool? et_ = context.Operators.In<CqlDateTime>(ej_, es_, (string)default);
                     CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ek_);
                     CqlDateTime ew_ = context.Operators.Start(ev_);
                     bool? ex_ = context.Operators.Not((bool?)(ew_ is null));
@@ -300,7 +300,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                 CqlInterval<CqlDateTime> ft_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fn_);
                 CqlDateTime fu_ = context.Operators.Start(ft_);
                 CqlInterval<CqlDateTime> fv_ = context.Operators.Interval(fr_, fu_, true, true);
-                bool? fw_ = context.Operators.In<CqlDateTime>(fm_, fv_, default);
+                bool? fw_ = context.Operators.In<CqlDateTime>(fm_, fv_, (string)default);
                 CqlInterval<CqlDateTime> fy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fn_);
                 CqlDateTime fz_ = context.Operators.Start(fy_);
                 bool? ga_ = context.Operators.Not((bool?)(fz_ is null));
@@ -424,7 +424,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
                     CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
                     CqlDateTime p_ = context.Operators.Start(o_);
                     CqlInterval<CqlDateTime> q_ = this.hospitalizationWithEDOBTriageObservation(context, EncounterWithAge);
-                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
                     bool? s_ = context.Operators.And(m_, r_);
                     return s_;
                 }
@@ -525,10 +525,10 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
 
             CqlDateTime u_ = QICoreCommon_4_0_000.Instance.earliest(context, t_());
             CqlInterval<CqlDateTime> v_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-            bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, default);
+            bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, (string)default);
             bool? x_ = context.Operators.And(s_, w_);
             object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, k_);
-            bool? ab_ = context.Operators.In<CqlDateTime>(z_ as CqlDateTime, v_, default);
+            bool? ab_ = context.Operators.In<CqlDateTime>(z_ as CqlDateTime, v_, (string)default);
             bool? ac_ = context.Operators.And(x_, ab_);
             return ac_;
         }
@@ -674,7 +674,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
             CqlQuantity w_ = context.Operators.Quantity(42m, "weeks");
             CqlDateTime x_ = context.Operators.Subtract(v_, w_);
             CqlInterval<CqlDateTime> z_ = context.Operators.Interval(x_, v_, true, true);
-            bool? aa_ = context.Operators.In<CqlDateTime>(u_, z_, default);
+            bool? aa_ = context.Operators.In<CqlDateTime>(u_, z_, (string)default);
             bool? ac_ = context.Operators.Not((bool?)(v_ is null));
             bool? ad_ = context.Operators.And(aa_, ac_);
             bool? ae_ = context.Operators.And(s_, ad_);
@@ -827,7 +827,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
             CqlQuantity m_ = context.Operators.Quantity(24m, "hours");
             CqlDateTime n_ = context.Operators.Subtract(l_, m_);
             CqlInterval<CqlDateTime> p_ = context.Operators.Interval(n_, l_, true, true);
-            bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, default);
+            bool? q_ = context.Operators.In<CqlDateTime>(k_, p_, (string)default);
             bool? s_ = context.Operators.Not((bool?)(l_ is null));
             bool? t_ = context.Operators.And(q_, s_);
             DataType u_ = EstimatedGestationalAge?.Value;
@@ -948,7 +948,7 @@ public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_
 
             CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.earliest(context, ai_());
             CqlInterval<CqlDateTime> ak_ = this.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-            bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, default);
+            bool? al_ = context.Operators.In<CqlDateTime>(aj_, ak_, (string)default);
             bool? am_ = context.Operators.And(ah_, al_);
             object ao_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
             bool? ap_ = context.Operators.Not((bool?)(ao_ is null));

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
@@ -55,7 +55,7 @@ public partial class PalliativeCare_1_18_000 : ILibrary, ISingleton<PalliativeCa
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-4886154237025043938L, () => {
-            object a_ = context.ResolveParameter("PalliativeCare-1.18.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("PalliativeCare-1.18.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
@@ -57,7 +57,7 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(5065781295884409926L, () => {
-            object a_ = context.ResolveParameter("TJCOverall-8.25.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("TJCOverall-8.25.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -292,7 +292,7 @@ public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_
                     object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
                     CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
                     CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, default);
+                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
                     return o_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
@@ -37,7 +37,7 @@ public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(8773371835216757249L, () => {
-            object a_ = context.ResolveParameter("VTE-8.18.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("VTE-8.18.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
@@ -318,7 +318,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity w_ = context.Operators.Quantity(42m, "weeks");
             CqlDateTime x_ = context.Operators.Subtract(v_, w_);
             CqlInterval<CqlDateTime> z_ = context.Operators.Interval(x_, v_, true, false);
-            bool? aa_ = context.Operators.In<CqlDateTime>(u_, z_, default);
+            bool? aa_ = context.Operators.In<CqlDateTime>(u_, z_, (string)default);
             bool? ac_ = context.Operators.Not((bool?)(v_ is null));
             bool? ad_ = context.Operators.And(aa_, ac_);
             bool? ae_ = context.Operators.And(s_, ad_);
@@ -453,7 +453,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
+            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
             bool? t_ = context.Operators.Not((bool?)(m_ is null));
             bool? u_ = context.Operators.And(r_, t_);
             Code<ObservationStatus> v_ = Parity?.StatusElement;
@@ -601,7 +601,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
+            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
             bool? t_ = context.Operators.Not((bool?)(m_ is null));
             bool? u_ = context.Operators.And(r_, t_);
             Code<ObservationStatus> v_ = PretermBirth?.StatusElement;
@@ -749,7 +749,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
             CqlQuantity n_ = context.Operators.Quantity(42m, "weeks");
             CqlDateTime o_ = context.Operators.Subtract(m_, n_);
             CqlInterval<CqlDateTime> q_ = context.Operators.Interval(o_, m_, true, false);
-            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
+            bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
             bool? t_ = context.Operators.Not((bool?)(m_ is null));
             bool? u_ = context.Operators.And(r_, t_);
             Code<ObservationStatus> v_ = TermBirth?.StatusElement;
@@ -927,7 +927,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.earliest(context, ai_());
                             CqlDateTime ak_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? al_ = context.Operators.SameOrBefore(aj_, ak_, default);
+                            bool? al_ = context.Operators.SameOrBefore(aj_, ak_, (string)default);
                             Code<ObservationStatus> am_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? an_ = am_?.Value;
                             string ao_ = context.Operators.Convert<string>(an_);
@@ -1064,7 +1064,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime cp_ = QICoreCommon_4_0_000.Instance.earliest(context, co_());
                             CqlDateTime cq_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? cr_ = context.Operators.SameOrBefore(cp_, cq_, default);
+                            bool? cr_ = context.Operators.SameOrBefore(cp_, cq_, (string)default);
                             Code<ObservationStatus> cs_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? ct_ = cs_?.Value;
                             string cu_ = context.Operators.Convert<string>(ct_);
@@ -1201,7 +1201,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime ev_ = QICoreCommon_4_0_000.Instance.earliest(context, eu_());
                             CqlDateTime ew_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? ex_ = context.Operators.SameOrBefore(ev_, ew_, default);
+                            bool? ex_ = context.Operators.SameOrBefore(ev_, ew_, (string)default);
                             Code<ObservationStatus> ey_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? ez_ = ey_?.Value;
                             string fa_ = context.Operators.Convert<string>(ez_);
@@ -1338,7 +1338,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime ha_ = QICoreCommon_4_0_000.Instance.earliest(context, gz_());
                             CqlDateTime hb_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? hc_ = context.Operators.SameOrBefore(ha_, hb_, default);
+                            bool? hc_ = context.Operators.SameOrBefore(ha_, hb_, (string)default);
                             Code<ObservationStatus> hd_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? he_ = hd_?.Value;
                             string hf_ = context.Operators.Convert<string>(he_);
@@ -1473,7 +1473,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime jf_ = QICoreCommon_4_0_000.Instance.earliest(context, je_());
                             CqlDateTime jg_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? jh_ = context.Operators.SameOrBefore(jf_, jg_, default);
+                            bool? jh_ = context.Operators.SameOrBefore(jf_, jg_, (string)default);
                             Code<ObservationStatus> ji_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? jj_ = ji_?.Value;
                             string jk_ = context.Operators.Convert<string>(jj_);
@@ -1608,7 +1608,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                             CqlDateTime lk_ = QICoreCommon_4_0_000.Instance.earliest(context, lj_());
                             CqlDateTime ll_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, ThirtySevenWeeksPlusEncounter);
-                            bool? lm_ = context.Operators.SameOrBefore(lk_, ll_, default);
+                            bool? lm_ = context.Operators.SameOrBefore(lk_, ll_, (string)default);
                             Code<ObservationStatus> ln_ = AbnormalPresentation?.StatusElement;
                             ObservationStatus? lo_ = ln_?.Value;
                             string lp_ = context.Operators.Convert<string>(lo_);
@@ -1693,7 +1693,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
 
                 CqlDateTime e_ = QICoreCommon_4_0_000.Instance.earliest(context, d_());
                 CqlInterval<CqlDateTime> f_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, ThirtySevenWeeksPlusEncounter);
-                bool? g_ = context.Operators.In<CqlDateTime>(e_, f_, default);
+                bool? g_ = context.Operators.In<CqlDateTime>(e_, f_, (string)default);
                 IEnumerable<object> h_ = CQMCommon_4_1_000.Instance.encounterDiagnosis(context, ThirtySevenWeeksPlusEncounter);
 
                 bool? i_(object @this) {
@@ -1916,7 +1916,7 @@ public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<C
                     }
 
                     CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.toInterval(context, k_());
-                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
                     Code<EventStatus> n_ = CSection?.StatusElement;
                     EventStatus? o_ = n_?.Value;
                     string p_ = context.Operators.Convert<string>(o_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
@@ -298,7 +298,7 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     FhirDateTime l_ = FallsDocumentation?.RecordedDateElement;
                     CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
                     CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, default);
+                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
                     return o_;
                 }
 
@@ -556,7 +556,7 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
                     CqlDateTime o_ = context.Operators.Start(n_);
                     CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
                     DataType r_ = BMI?.Value;
                     CqlQuantity s_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, r_ as Quantity);
                     bool? t_ = context.Operators.Not((bool?)(s_ is null));
@@ -941,7 +941,7 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
                     CqlInterval<CqlDateTime> ae_ = QICoreCommon_4_0_000.Instance.toInterval(context, ad_);
                     CqlDateTime af_ = context.Operators.Start(ae_);
                     CqlInterval<CqlDateTime> ag_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? ah_ = context.Operators.In<CqlDateTime>(af_, ag_, default);
+                    bool? ah_ = context.Operators.In<CqlDateTime>(af_, ag_, (string)default);
                     Code<MedicationAdministration.MedicationAdministrationStatusCodes> ai_ = Anticoagulants?.StatusElement;
                     MedicationAdministration.MedicationAdministrationStatusCodes? aj_ = ai_?.Value;
                     string ak_ = context.Operators.Convert<string>(aj_);
@@ -1801,7 +1801,7 @@ public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRH
             CqlInterval<CqlDateTime> f_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, e_);
             CqlDateTime g_ = context.Operators.End(f_);
             CqlInterval<CqlDateTime> h_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, default);
+            bool? i_ = context.Operators.In<CqlDateTime>(g_, h_, (string)default);
             return i_;
         }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
@@ -552,7 +552,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
                     CqlDateTime s_ = context.Operators.Start(r_);
                     CqlInterval<CqlDateTime> t_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, default);
+                    bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
                     bool? v_ = context.Operators.And(p_, u_);
                     return v_;
                 }
@@ -668,7 +668,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
                     CqlDateTime p_ = context.Operators.Start(o_);
                     CqlInterval<CqlDateTime> q_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
                     bool? s_ = context.Operators.And(m_, r_);
                     return s_;
                 }
@@ -777,7 +777,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
                     CqlDateTime p_ = context.Operators.Start(o_);
                     CqlInterval<CqlDateTime> q_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
                     bool? s_ = context.Operators.And(m_, r_);
                     return s_;
                 }
@@ -888,7 +888,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_());
                     CqlDateTime o_ = context.Operators.Start(n_);
                     CqlInterval<CqlDateTime> p_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TwentyWeeksPlusEncounter);
-                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
                     bool? r_ = context.Operators.And(l_, q_);
                     return r_;
                 }
@@ -1073,7 +1073,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_());
                     CqlDateTime t_ = context.Operators.Start(s_);
                     CqlInterval<CqlDateTime> u_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, Encounter);
-                    bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, default);
+                    bool? v_ = context.Operators.In<CqlDateTime>(t_, u_, (string)default);
                     bool? w_ = context.Operators.And(q_, v_);
                     return w_;
                 }
@@ -1447,7 +1447,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
             CqlDateTime n_ = context.Operators.Start(m_);
             CqlInterval<CqlDateTime> o_ = PCMaternal_5_25_000.Instance.hospitalizationWithEDOBTriageObservation(context, TheEncounter);
-            bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
+            bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
             bool? q_ = context.Operators.And(k_, p_);
             return q_;
         }
@@ -2220,7 +2220,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
             bool? b_(Encounter DeliveryEncounter) {
                 int? h_ = PCMaternal_5_25_000.Instance.calculatedGestationalAge(context, DeliveryEncounter);
                 CqlInterval<int?> i_ = context.Operators.Interval(20, 36, true, true);
-                bool? j_ = context.Operators.In<int?>(h_, i_, default);
+                bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
                 CqlQuantity l_ = PCMaternal_5_25_000.Instance.lastEstimatedGestationalAge(context, DeliveryEncounter);
                 CqlQuantity m_ = context.Operators.Quantity(20m, "weeks");
                 bool? n_ = context.Operators.GreaterOrEqual(l_, m_);
@@ -2282,7 +2282,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
                     CqlDateTime ah_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, true);
-                    bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, default);
+                    bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, (string)default);
                     Code<ObservationStatus> ak_ = Hematocrit?.StatusElement;
                     ObservationStatus? al_ = ak_?.Value;
                     string am_ = context.Operators.Convert<string>(al_);
@@ -2326,7 +2326,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime be_ = context.Operators.Subtract(bc_, bd_);
                     CqlDateTime bf_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(be_, bf_, true, true);
-                    bool? bh_ = context.Operators.In<CqlDateTime>(ba_, bg_, default);
+                    bool? bh_ = context.Operators.In<CqlDateTime>(ba_, bg_, (string)default);
                     Code<ObservationStatus> bi_ = Hematocrit?.StatusElement;
                     ObservationStatus? bj_ = bi_?.Value;
                     string bk_ = context.Operators.Convert<string>(bj_);
@@ -2390,7 +2390,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime ag_ = context.Operators.Subtract(ae_, af_);
                     CqlDateTime ah_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ag_, ah_, true, true);
-                    bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, default);
+                    bool? aj_ = context.Operators.In<CqlDateTime>(ac_, ai_, (string)default);
                     Code<ObservationStatus> ak_ = WBC?.StatusElement;
                     ObservationStatus? al_ = ak_?.Value;
                     string am_ = context.Operators.Convert<string>(al_);
@@ -2434,7 +2434,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime be_ = context.Operators.Subtract(bc_, bd_);
                     CqlDateTime bf_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> bg_ = context.Operators.Interval(be_, bf_, true, true);
-                    bool? bh_ = context.Operators.In<CqlDateTime>(ba_, bg_, default);
+                    bool? bh_ = context.Operators.In<CqlDateTime>(ba_, bg_, (string)default);
                     Code<ObservationStatus> bi_ = WBC?.StatusElement;
                     ObservationStatus? bj_ = bi_?.Value;
                     string bk_ = context.Operators.Convert<string>(bj_);
@@ -2497,7 +2497,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime ae_ = context.Operators.Subtract(ac_, ad_);
                     CqlDateTime af_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ae_, af_, true, true);
-                    bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, default);
+                    bool? ah_ = context.Operators.In<CqlDateTime>(aa_, ag_, (string)default);
                     Code<ObservationStatus> ai_ = HeartRate?.StatusElement;
                     ObservationStatus? aj_ = ai_?.Value;
                     string ak_ = context.Operators.Convert<string>(aj_);
@@ -2535,7 +2535,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime ax_ = context.Operators.Subtract(av_, aw_);
                     CqlDateTime ay_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> az_ = context.Operators.Interval(ax_, ay_, true, true);
-                    bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, default);
+                    bool? ba_ = context.Operators.In<CqlDateTime>(at_, az_, (string)default);
                     Code<ObservationStatus> bb_ = HeartRate?.StatusElement;
                     ObservationStatus? bc_ = bb_?.Value;
                     string bd_ = context.Operators.Convert<string>(bc_);
@@ -2593,7 +2593,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime aj_ = context.Operators.Subtract(ah_, ai_);
                     CqlDateTime ak_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> al_ = context.Operators.Interval(aj_, ak_, true, true);
-                    bool? am_ = context.Operators.In<CqlDateTime>(af_, al_, default);
+                    bool? am_ = context.Operators.In<CqlDateTime>(af_, al_, (string)default);
                     Code<ObservationStatus> an_ = BP?.StatusElement;
                     ObservationStatus? ao_ = an_?.Value;
                     string ap_ = context.Operators.Convert<string>(ao_);
@@ -2671,7 +2671,7 @@ public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<C
                     CqlDateTime bv_ = context.Operators.Subtract(bt_, bu_);
                     CqlDateTime bw_ = PCMaternal_5_25_000.Instance.lastTimeOfDelivery(context, TwentyWeeksPlusEncounter);
                     CqlInterval<CqlDateTime> bx_ = context.Operators.Interval(bv_, bw_, true, true);
-                    bool? by_ = context.Operators.In<CqlDateTime>(br_, bx_, default);
+                    bool? by_ = context.Operators.In<CqlDateTime>(br_, bx_, (string)default);
                     Code<ObservationStatus> bz_ = BP?.StatusElement;
                     ObservationStatus? ca_ = bz_?.Value;
                     string cb_ = context.Operators.Convert<string>(ca_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
@@ -153,7 +153,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                     CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
                     Period at_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
-                    bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, default);
+                    bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, (string)default);
                     bool? aw_ = context.Operators.And(aq_, av_);
                     IEnumerable<Task> ax_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
@@ -332,7 +332,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                     CqlDateTime j_ = context.Operators.LateBoundProperty<CqlDateTime>(i_, "value");
                     Period k_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 
@@ -426,7 +426,7 @@ public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleto
                     CqlDateTime j_ = context.Operators.Convert<CqlDateTime>(i_);
                     Period k_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
@@ -165,7 +165,7 @@ public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIR
                     CqlDateTime s_ = context.Operators.Start(r_);
                     Period t_ = InpatientEncounters?.Period;
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, default);
+                    bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
                     bool? w_ = context.Operators.And(o_, v_);
                     object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
@@ -1,0 +1,1164 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.ValueSets;
+using Hl7.Cql.Iso8601;
+using System.Reflection;
+using Hl7.Cql.Operators;
+using Hl7.Fhir.Model;
+using Range = Hl7.Fhir.Model.Range;
+using Task = Hl7.Fhir.Model.Task;
+
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.0.0.0")]
+[CqlLibrary("CMS1173FHIRDiagnosticDelayVTE", "1.0.000")]
+public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleton<CMS1173FHIRDiagnosticDelayVTE_1_0_000>
+{
+    #region ValueSets
+
+    [CqlValueSetDefinition("Anticoagulant Medications", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.19", valueSetVersion: null)]
+    public CqlValueSet Anticoagulant_Medications(CqlContext _) => _Anticoagulant_Medications;
+    private static readonly CqlValueSet _Anticoagulant_Medications = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.19", null);
+
+    [CqlValueSetDefinition("Encounter Inpatient", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", valueSetVersion: null)]
+    public CqlValueSet Encounter_Inpatient(CqlContext _) => _Encounter_Inpatient;
+    private static readonly CqlValueSet _Encounter_Inpatient = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307", null);
+
+    [CqlValueSetDefinition("Ethnicity", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", valueSetVersion: null)]
+    public CqlValueSet Ethnicity(CqlContext _) => _Ethnicity;
+    private static readonly CqlValueSet _Ethnicity = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.114222.4.11.837", null);
+
+    [CqlValueSetDefinition("Hospice Care Ambulatory", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", valueSetVersion: null)]
+    public CqlValueSet Hospice_Care_Ambulatory(CqlContext _) => _Hospice_Care_Ambulatory;
+    private static readonly CqlValueSet _Hospice_Care_Ambulatory = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1108.15", null);
+
+    [CqlValueSetDefinition("Hospice Diagnosis", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", valueSetVersion: null)]
+    public CqlValueSet Hospice_Diagnosis(CqlContext _) => _Hospice_Diagnosis;
+    private static readonly CqlValueSet _Hospice_Diagnosis = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1165", null);
+
+    [CqlValueSetDefinition("Hospice Encounter", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", valueSetVersion: null)]
+    public CqlValueSet Hospice_Encounter(CqlContext _) => _Hospice_Encounter;
+    private static readonly CqlValueSet _Hospice_Encounter = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1003", null);
+
+    [CqlValueSetDefinition("Imaging Related to VTE", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.47", valueSetVersion: null)]
+    public CqlValueSet Imaging_Related_to_VTE(CqlContext _) => _Imaging_Related_to_VTE;
+    private static readonly CqlValueSet _Imaging_Related_to_VTE = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.47", null);
+
+    [CqlValueSetDefinition("Office Visit", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", valueSetVersion: null)]
+    public CqlValueSet Office_Visit(CqlContext _) => _Office_Visit;
+    private static readonly CqlValueSet _Office_Visit = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001", null);
+
+    [CqlValueSetDefinition("Outpatient Encounter", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", valueSetVersion: null)]
+    public CqlValueSet Outpatient_Encounter(CqlContext _) => _Outpatient_Encounter;
+    private static readonly CqlValueSet _Outpatient_Encounter = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1087", null);
+
+    [CqlValueSetDefinition("Palliative Care Diagnosis", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", valueSetVersion: null)]
+    public CqlValueSet Palliative_Care_Diagnosis(CqlContext _) => _Palliative_Care_Diagnosis;
+    private static readonly CqlValueSet _Palliative_Care_Diagnosis = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.1167", null);
+
+    [CqlValueSetDefinition("Palliative Care Encounter", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", valueSetVersion: null)]
+    public CqlValueSet Palliative_Care_Encounter(CqlContext _) => _Palliative_Care_Encounter;
+    private static readonly CqlValueSet _Palliative_Care_Encounter = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1090", null);
+
+    [CqlValueSetDefinition("Palliative Care Intervention", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", valueSetVersion: null)]
+    public CqlValueSet Palliative_Care_Intervention(CqlContext _) => _Palliative_Care_Intervention;
+    private static readonly CqlValueSet _Palliative_Care_Intervention = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1135", null);
+
+    [CqlValueSetDefinition("VTE Diagnoses", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.49", valueSetVersion: null)]
+    public CqlValueSet VTE_Diagnoses(CqlContext _) => _VTE_Diagnoses;
+    private static readonly CqlValueSet _VTE_Diagnoses = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.49", null);
+
+    [CqlValueSetDefinition("VTE Symptoms", valueSetId: "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.51", valueSetVersion: null)]
+    public CqlValueSet VTE_Symptoms(CqlContext _) => _VTE_Symptoms;
+    private static readonly CqlValueSet _VTE_Symptoms = new CqlValueSet("http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1206.51", null);
+
+    #endregion ValueSets
+
+    #region Codes
+
+    [CqlCodeDefinition("Discharge to healthcare facility for hospice care (procedure)", codeId: "428371000124100", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Discharge_to_healthcare_facility_for_hospice_care__procedure_(CqlContext _) => _Discharge_to_healthcare_facility_for_hospice_care__procedure_;
+    private static readonly CqlCode _Discharge_to_healthcare_facility_for_hospice_care__procedure_ = new CqlCode("428371000124100", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Discharge to home for hospice care (procedure)", codeId: "428361000124107", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Discharge_to_home_for_hospice_care__procedure_(CqlContext _) => _Discharge_to_home_for_hospice_care__procedure_;
+    private static readonly CqlCode _Discharge_to_home_for_hospice_care__procedure_ = new CqlCode("428361000124107", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Hospice care [Minimum Data Set]", codeId: "45755-6", codeSystem: "http://loinc.org")]
+    public CqlCode Hospice_care__Minimum_Data_Set_(CqlContext _) => _Hospice_care__Minimum_Data_Set_;
+    private static readonly CqlCode _Hospice_care__Minimum_Data_Set_ = new CqlCode("45755-6", "http://loinc.org");
+
+    [CqlCodeDefinition("Yes (qualifier value)", codeId: "373066001", codeSystem: "http://snomed.info/sct")]
+    public CqlCode Yes__qualifier_value_(CqlContext _) => _Yes__qualifier_value_;
+    private static readonly CqlCode _Yes__qualifier_value_ = new CqlCode("373066001", "http://snomed.info/sct");
+
+    [CqlCodeDefinition("Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)", codeId: "71007-9", codeSystem: "http://loinc.org")]
+    public CqlCode Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_(CqlContext _) => _Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_;
+    private static readonly CqlCode _Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_ = new CqlCode("71007-9", "http://loinc.org");
+
+    #endregion Codes
+
+    #region CodeSystems
+
+    [CqlCodeSystemDefinition("LOINC", codeSystemId: "http://loinc.org", codeSystemVersion: null)]
+    public CqlCodeSystem LOINC(CqlContext _) => _LOINC;
+    private static readonly CqlCodeSystem _LOINC =
+      new CqlCodeSystem("http://loinc.org", null, [
+          _Hospice_care__Minimum_Data_Set_,
+          _Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_]);
+
+    [CqlCodeSystemDefinition("SNOMEDCT", codeSystemId: "http://snomed.info/sct", codeSystemVersion: null)]
+    public CqlCodeSystem SNOMEDCT(CqlContext _) => _SNOMEDCT;
+    private static readonly CqlCodeSystem _SNOMEDCT =
+      new CqlCodeSystem("http://snomed.info/sct", null, [
+          _Discharge_to_healthcare_facility_for_hospice_care__procedure_,
+          _Discharge_to_home_for_hospice_care__procedure_,
+          _Yes__qualifier_value_]);
+
+    #endregion CodeSystems
+
+    #region Parameters
+
+    [CqlParameterDefinition("Measurement Period")]
+    public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(-2155954010635899892L, () => {
+            CqlDateTime a_ = context.Operators.DateTime(2026, 1, 1, 0, 0, 0, 0, 0.0m);
+            CqlDateTime b_ = context.Operators.DateTime(2027, 1, 1, 0, 0, 0, 0, 0.0m);
+            CqlInterval<CqlDateTime> c_ = context.Operators.Interval(a_, b_, true, false);
+            object d_ = context.ResolveParameter("CMS1173FHIRDiagnosticDelayVTE-1.0.000", "Measurement Period", c_);
+            return (CqlInterval<CqlDateTime>)d_;
+        });
+
+
+    #endregion Parameters
+
+    #region Functions and Expressions
+
+    [CqlExpressionDefinition("Patient")]
+    public Patient Patient(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<Patient>(5541395162049134047L, () => {
+            IEnumerable<Patient> a_ = context.Operators.Retrieve<Patient>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"));
+            Patient b_ = context.Operators.SingletonFrom<Patient>(a_);
+            return b_;
+        });
+
+
+    [CqlExpressionDefinition("Qualifying Performed Encounters")]
+    public IEnumerable<Encounter> Qualifying_Performed_Encounters(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(2536520436514206342L, () => {
+            CqlValueSet a_ = this.Office_Visit(context);
+            IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            CqlValueSet c_ = this.Outpatient_Encounter(context);
+            IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+            CqlValueSet f_ = this.Encounter_Inpatient(context);
+            IEnumerable<Encounter> g_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, f_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            IEnumerable<Encounter> h_ = context.Operators.Union<Encounter>(e_, g_);
+
+            bool? i_(Encounter Encounter) {
+                Code<Encounter.EncounterStatus> k_ = Encounter?.StatusElement;
+                Encounter.EncounterStatus? l_ = k_?.Value;
+                Code<Encounter.EncounterStatus> m_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(l_);
+                bool? n_ = context.Operators.Equal(m_, "finished");
+                Period o_ = Encounter?.Period;
+                CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
+                CqlDateTime s_ = context.Operators.Start(r_);
+                CqlQuantity t_ = context.Operators.Quantity(180m, "days");
+                CqlDateTime u_ = context.Operators.Subtract(s_, t_);
+                CqlDateTime w_ = context.Operators.End(r_);
+                CqlInterval<CqlDateTime> x_ = context.Operators.Interval(u_, w_, true, true);
+                bool? y_ = context.Operators.In<CqlDateTime>(q_, x_, "day");
+                bool? z_ = context.Operators.And(n_, y_);
+                return z_;
+            }
+
+            IEnumerable<Encounter> j_ = context.Operators.Where<Encounter>(h_, i_);
+            return j_;
+        });
+
+
+    [CqlFunctionDefinition("isConfirmedCondition")]
+    [CqlTag("description", "Returns true if the given Condition is confirmed")]
+    public bool? isConfirmedCondition(CqlContext context, Condition condition)
+    {
+        CodeableConcept a_ = condition?.VerificationStatus;
+        CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_);
+        CqlCode c_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept d_ = context.Operators.ConvertCodeToConcept(c_);
+        bool? e_ = context.Operators.Equivalent(b_, d_);
+        return e_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Performed VTE Encounters")]
+    public IEnumerable<Encounter> Qualifying_Performed_VTE_Encounters(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(8792642716030250222L, () => {
+            IEnumerable<Encounter> a_ = this.Qualifying_Performed_Encounters(context);
+
+            bool? b_(Encounter VTEEncounter) {
+                List<CodeableConcept> d_ = VTEEncounter?.ReasonCode;
+
+                CqlConcept e_(CodeableConcept @this) {
+                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return o_;
+                }
+
+                IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
+                CqlValueSet g_ = this.VTE_Diagnoses(context);
+                bool? h_ = context.Operators.ConceptsInValueSet(f_, g_);
+                IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+
+                bool? k_(Condition VTECondition) {
+                    bool? p_ = this.isConfirmedCondition(context, VTECondition);
+                    List<ResourceReference> q_ = VTEEncounter?.ReasonReference;
+                    bool? r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, VTECondition);
+                    bool? s_ = context.Operators.And(p_, r_);
+                    return s_;
+                }
+
+                IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+                bool? m_ = context.Operators.Exists<Condition>(l_);
+                bool? n_ = context.Operators.Or(h_, m_);
+                return n_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Qualifying Performed PCP Visits")]
+    public IEnumerable<Encounter> Qualifying_Performed_PCP_Visits(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(-5215233933916997501L, () => {
+            CqlValueSet a_ = this.Outpatient_Encounter(context);
+            IEnumerable<Encounter> b_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            CqlValueSet c_ = this.Office_Visit(context);
+            IEnumerable<Encounter> d_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, c_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+            IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(b_, d_);
+
+            bool? f_(Encounter PCPVisit) {
+                Code<Encounter.EncounterStatus> h_ = PCPVisit?.StatusElement;
+                Encounter.EncounterStatus? i_ = h_?.Value;
+                Code<Encounter.EncounterStatus> j_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(i_);
+                bool? k_ = context.Operators.Equal(j_, "finished");
+                Period l_ = PCPVisit?.Period;
+                CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                CqlDateTime n_ = context.Operators.End(m_);
+                CqlInterval<CqlDateTime> o_ = this.Measurement_Period(context);
+                CqlDateTime p_ = context.Operators.Start(o_);
+                CqlQuantity q_ = context.Operators.Quantity(210m, "days");
+                CqlDateTime r_ = context.Operators.Subtract(p_, q_);
+                CqlDateTime t_ = context.Operators.End(o_);
+                CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
+                bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, "day");
+                bool? w_ = context.Operators.And(k_, v_);
+                return w_;
+            }
+
+            IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+            return g_;
+        });
+
+
+    [CqlFunctionDefinition("isVerified")]
+    [CqlTag("description", "Returns true if the given condition either has no verification status or has a verification status of confirmed, unconfirmed, provisional, or differential")]
+    public bool? isVerified(CqlContext context, object condition)
+    {
+        object a_ = context.Operators.LateBoundProperty<object>(condition, "verificationStatus");
+        CqlConcept b_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_ as CodeableConcept);
+        bool? c_ = context.Operators.Not((bool?)(b_ is null));
+        CqlConcept e_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_ as CodeableConcept);
+        CqlCode f_ = QICoreCommon_4_0_000.Instance.confirmed(context);
+        CqlConcept g_ = context.Operators.ConvertCodeToConcept(f_);
+        bool? h_ = context.Operators.Equivalent(e_, g_);
+        CqlConcept j_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_ as CodeableConcept);
+        CqlCode k_ = QICoreCommon_4_0_000.Instance.unconfirmed(context);
+        CqlConcept l_ = context.Operators.ConvertCodeToConcept(k_);
+        bool? m_ = context.Operators.Equivalent(j_, l_);
+        bool? n_ = context.Operators.Or(h_, m_);
+        CqlConcept p_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_ as CodeableConcept);
+        CqlCode q_ = QICoreCommon_4_0_000.Instance.provisional(context);
+        CqlConcept r_ = context.Operators.ConvertCodeToConcept(q_);
+        bool? s_ = context.Operators.Equivalent(p_, r_);
+        bool? t_ = context.Operators.Or(n_, s_);
+        CqlConcept v_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, a_ as CodeableConcept);
+        CqlCode w_ = QICoreCommon_4_0_000.Instance.differential(context);
+        CqlConcept x_ = context.Operators.ConvertCodeToConcept(w_);
+        bool? y_ = context.Operators.Equivalent(v_, x_);
+        bool? z_ = context.Operators.Or(t_, y_);
+        bool? aa_ = context.Operators.Implies(c_, z_);
+        return aa_;
+    }
+
+
+    [CqlExpressionDefinition("Qualifying Performed PCP Visits With VTE Symptom")]
+    public IEnumerable<Encounter> Qualifying_Performed_PCP_Visits_With_VTE_Symptom(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(-1971924271945246505L, () => {
+            IEnumerable<Encounter> a_ = this.Qualifying_Performed_PCP_Visits(context);
+
+            bool? b_(Encounter IndexPCPVisit) {
+                List<CodeableConcept> d_ = IndexPCPVisit?.ReasonCode;
+
+                CqlConcept e_(CodeableConcept @this) {
+                    CqlConcept o_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, @this);
+                    return o_;
+                }
+
+                IEnumerable<CqlConcept> f_ = context.Operators.Select<CodeableConcept, CqlConcept>((IEnumerable<CodeableConcept>)d_, e_);
+                CqlValueSet g_ = this.VTE_Symptoms(context);
+                bool? h_ = context.Operators.ConceptsInValueSet(f_, g_);
+                IEnumerable<Condition> j_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, g_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+
+                bool? k_(Condition VTESymptomCondition) {
+                    bool? p_ = this.isVerified(context, VTESymptomCondition as object);
+                    List<ResourceReference> q_ = IndexPCPVisit?.ReasonReference;
+                    bool? r_ = QICoreCommon_4_0_000.Instance.references(context, (IEnumerable<ResourceReference>)q_, VTESymptomCondition);
+                    bool? s_ = context.Operators.And(p_, r_);
+                    return s_;
+                }
+
+                IEnumerable<Condition> l_ = context.Operators.Where<Condition>(j_, k_);
+                bool? m_ = context.Operators.Exists<Condition>(l_);
+                bool? n_ = context.Operators.Or(h_, m_);
+                return n_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Qualifying VTE Imaging Diagnostic Report")]
+    public IEnumerable<DiagnosticReport> Qualifying_VTE_Imaging_Diagnostic_Report(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<DiagnosticReport>>(-8519356969433798899L, () => {
+            CqlValueSet a_ = this.Imaging_Related_to_VTE(context);
+            IEnumerable<DiagnosticReport> b_ = context.Operators.Retrieve<DiagnosticReport>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-diagnosticreport-note"));
+
+            bool? c_(DiagnosticReport VTEDiagnosticReport) {
+                Code<DiagnosticReport.DiagnosticReportStatus> e_ = VTEDiagnosticReport?.StatusElement;
+                DiagnosticReport.DiagnosticReportStatus? f_ = e_?.Value;
+                string g_ = context.Operators.Convert<string>(f_);
+                string[] h_ = [
+                    "final",
+                    "amended",
+                    "corrected",
+                ];
+                bool? i_ = context.Operators.In<string>(g_, (IEnumerable<string>)h_);
+                return i_;
+            }
+
+            IEnumerable<DiagnosticReport> d_ = context.Operators.Where<DiagnosticReport>(b_, c_);
+            return d_;
+        });
+
+
+    [CqlExpressionDefinition("AntiCoagulant Therapy Ordered")]
+    public IEnumerable<MedicationRequest> AntiCoagulant_Therapy_Ordered(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<MedicationRequest>>(-231287711048350331L, () => {
+            CqlValueSet a_ = this.Anticoagulant_Medications(context);
+            IEnumerable<MedicationRequest> b_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, a_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+            IEnumerable<MedicationRequest> c_ = context.Operators.Retrieve<MedicationRequest>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medicationrequest"));
+
+            IEnumerable<MedicationRequest> d_(MedicationRequest MR) {
+                IEnumerable<Medication> i_ = context.Operators.Retrieve<Medication>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-medication"));
+
+                bool? j_(Medication M) {
+                    object n_ = context.Operators.LateBoundProperty<object>(M, "id.value");
+                    object o_ = context.Operators.LateBoundProperty<object>(MR, "medication.reference.value");
+                    IEnumerable<string> p_ = context.Operators.Split((string)o_, "/");
+                    string q_ = context.Operators.Last<string>(p_);
+                    bool? r_ = context.Operators.Equal(n_, q_);
+                    CodeableConcept s_ = M?.Code;
+                    CqlConcept t_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, s_);
+                    CqlValueSet u_ = this.Anticoagulant_Medications(context);
+                    bool? v_ = context.Operators.ConceptInValueSet(t_, u_);
+                    bool? w_ = context.Operators.And(r_, v_);
+                    return w_;
+                }
+
+                IEnumerable<Medication> k_ = context.Operators.Where<Medication>(i_, j_);
+                MedicationRequest l_(Medication M) => MR;
+                IEnumerable<MedicationRequest> m_ = context.Operators.Select<Medication, MedicationRequest>(k_, l_);
+                return m_;
+            }
+
+            IEnumerable<MedicationRequest> e_ = context.Operators.SelectMany<MedicationRequest, MedicationRequest>(c_, d_);
+            IEnumerable<MedicationRequest> f_ = context.Operators.Union<MedicationRequest>(b_, e_);
+
+            bool? g_(MedicationRequest AntiCoagulant) {
+                Code<MedicationRequest.MedicationrequestStatus> x_ = AntiCoagulant?.StatusElement;
+                MedicationRequest.MedicationrequestStatus? y_ = x_?.Value;
+                string z_ = context.Operators.Convert<string>(y_);
+                string[] aa_ = [
+                    "active",
+                    "completed",
+                ];
+                bool? ab_ = context.Operators.In<string>(z_, (IEnumerable<string>)aa_);
+                Code<MedicationRequest.MedicationRequestIntent> ac_ = AntiCoagulant?.IntentElement;
+                MedicationRequest.MedicationRequestIntent? ad_ = ac_?.Value;
+                string ae_ = context.Operators.Convert<string>(ad_);
+                bool? af_ = context.Operators.Equal(ae_, "order");
+                bool? ag_ = context.Operators.And(ab_, af_);
+                return ag_;
+            }
+
+            IEnumerable<MedicationRequest> h_ = context.Operators.Where<MedicationRequest>(f_, g_);
+            return h_;
+        });
+
+
+    [CqlExpressionDefinition("Qualified VTE Encounters")]
+    public IEnumerable<Encounter> Qualified_VTE_Encounters(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(4136544579450247243L, () => {
+            IEnumerable<Encounter> a_ = this.Qualifying_Performed_VTE_Encounters(context);
+            IEnumerable<Encounter> b_ = this.Qualifying_Performed_PCP_Visits_With_VTE_Symptom(context);
+            IEnumerable<DiagnosticReport> c_ = this.Qualifying_VTE_Imaging_Diagnostic_Report(context);
+            IEnumerable<MedicationRequest> d_ = this.AntiCoagulant_Therapy_Ordered(context);
+            IEnumerable<ValueTuple<Encounter, Encounter, DiagnosticReport, MedicationRequest>> e_ = context.Operators.CrossJoin<Encounter, Encounter, DiagnosticReport, MedicationRequest>(a_, b_, c_, d_);
+
+            (CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)? f_(ValueTuple<Encounter, Encounter, DiagnosticReport, MedicationRequest> _valueTuple) {
+                (CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)? m_ = (CqlTupleMetadata_GAFATFEJifSPXLKbTBWFddDeY, _valueTuple.Item1, _valueTuple.Item2, _valueTuple.Item3, _valueTuple.Item4);
+                return m_;
+            }
+
+            IEnumerable<(CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?> g_ = context.Operators.Select<ValueTuple<Encounter, Encounter, DiagnosticReport, MedicationRequest>, (CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?>(e_, f_);
+
+            bool? h_((CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)? tuple_bundjkpliiuyymiejivrqjjcd) {
+                DataType n_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEStudy?.Effective;
+                object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
+                CqlDateTime q_ = context.Operators.Start(p_);
+                Period r_ = tuple_bundjkpliiuyymiejivrqjjcd?.VTEEncounter?.Period;
+                CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
+                bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
+                FhirDateTime u_ = tuple_bundjkpliiuyymiejivrqjjcd?.AntiCoagulantOrdered?.AuthoredOnElement;
+                CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
+                object x_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlQuantity y_ = context.Operators.Quantity(12m, "hours");
+                CqlDateTime z_ = context.Operators.Subtract(x_ as CqlDateTime, y_);
+                object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(z_, ab_ as CqlDateTime, true, false);
+                bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, (string)default);
+                object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                bool? ag_ = context.Operators.Not((bool?)(af_ is null));
+                bool? ah_ = context.Operators.And(ad_, ag_);
+                CqlDateTime aj_ = context.Operators.Convert<CqlDateTime>(u_);
+                object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                object an_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlDateTime ap_ = context.Operators.Add(an_ as CqlDateTime, y_);
+                CqlInterval<CqlDate> aq_ = context.Operators.Interval((CqlDate)al_, (CqlDate)(ap_ as object), false, true);
+                CqlInterval<object> ar_ = context.Operators.Convert<CqlInterval<object>>(aq_);
+                object as_ = ar_?.low;
+                object au_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                object aw_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlDateTime ay_ = context.Operators.Add(aw_ as CqlDateTime, y_);
+                CqlInterval<CqlDate> az_ = context.Operators.Interval((CqlDate)au_, (CqlDate)(ay_ as object), false, true);
+                CqlInterval<object> ba_ = context.Operators.Convert<CqlInterval<object>>(az_);
+                object bb_ = ba_?.high;
+                object bd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                object bf_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlDateTime bh_ = context.Operators.Add(bf_ as CqlDateTime, y_);
+                CqlInterval<CqlDate> bi_ = context.Operators.Interval((CqlDate)bd_, (CqlDate)(bh_ as object), false, true);
+                CqlInterval<object> bj_ = context.Operators.Convert<CqlInterval<object>>(bi_);
+                bool? bk_ = bj_?.lowClosed;
+                object bm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                object bo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlDateTime bq_ = context.Operators.Add(bo_ as CqlDateTime, y_);
+                CqlInterval<CqlDate> br_ = context.Operators.Interval((CqlDate)bm_, (CqlDate)(bq_ as object), false, true);
+                CqlInterval<object> bs_ = context.Operators.Convert<CqlInterval<object>>(br_);
+                bool? bt_ = bs_?.highClosed;
+                CqlInterval<CqlDateTime> bu_ = context.Operators.Interval(as_ as CqlDateTime, bb_ as CqlDateTime, bk_, bt_);
+                bool? bv_ = context.Operators.In<CqlDateTime>(aj_, bu_, (string)default);
+                object bx_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                bool? by_ = context.Operators.Not((bool?)(bx_ is null));
+                bool? bz_ = context.Operators.And(bv_, by_);
+                bool? ca_ = context.Operators.Or(ah_, bz_);
+                bool? cb_ = context.Operators.And(t_, ca_);
+                Period cc_ = tuple_bundjkpliiuyymiejivrqjjcd?.IndexPCP?.Period;
+                CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
+                CqlDateTime ce_ = context.Operators.Start(cd_);
+                object cg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlQuantity ch_ = context.Operators.Quantity(30m, "days");
+                CqlDateTime ci_ = context.Operators.Subtract(cg_ as CqlDateTime, ch_);
+                object ck_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                CqlInterval<CqlDateTime> cl_ = context.Operators.Interval(ci_, ck_ as CqlDateTime, true, true);
+                bool? cm_ = context.Operators.In<CqlDateTime>(ce_, cl_, (string)default);
+                object co_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
+                bool? cp_ = context.Operators.Not((bool?)(co_ is null));
+                bool? cq_ = context.Operators.And(cm_, cp_);
+                bool? cr_ = context.Operators.And(cb_, cq_);
+                return cr_;
+            }
+
+            IEnumerable<(CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?> i_ = context.Operators.Where<(CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?>(g_, h_);
+            Encounter j_((CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)? tuple_bundjkpliiuyymiejivrqjjcd) => tuple_bundjkpliiuyymiejivrqjjcd?.VTEEncounter;
+            IEnumerable<Encounter> k_ = context.Operators.Select<(CqlTupleMetadata, Encounter VTEEncounter, Encounter IndexPCP, DiagnosticReport VTEStudy, MedicationRequest AntiCoagulantOrdered)?, Encounter>(i_, j_);
+            IEnumerable<Encounter> l_ = context.Operators.Distinct<Encounter>(k_);
+            return l_;
+        });
+
+
+    [CqlExpressionDefinition("Qualified VTE Encounters During Measurement Period")]
+    public IEnumerable<Encounter> Qualified_VTE_Encounters_During_Measurement_Period(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(1440120495755591922L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters(context);
+
+            bool? b_(Encounter QualifiedVTEEncounter) {
+                Period d_ = QualifiedVTEEncounter?.Period;
+                CqlInterval<CqlDateTime> e_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, d_);
+                CqlDateTime f_ = context.Operators.Start(e_);
+                CqlInterval<CqlDateTime> g_ = this.Measurement_Period(context);
+                bool? h_ = context.Operators.In<CqlDateTime>(f_, g_, "day");
+                return h_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Initial Population")]
+    public IEnumerable<Encounter> Initial_Population(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(6831690428904324054L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters_During_Measurement_Period(context);
+
+            bool? b_(Encounter QualifiedEncounter) {
+                Patient d_ = this.Patient(context);
+                Date e_ = d_?.BirthDateElement;
+                string f_ = e_?.Value;
+                CqlDate g_ = context.Operators.ConvertStringToDate(f_);
+                Period h_ = QualifiedEncounter?.Period;
+                CqlInterval<CqlDateTime> i_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, h_);
+                CqlDateTime j_ = context.Operators.Start(i_);
+                CqlDate k_ = context.Operators.DateFrom(j_);
+                int? l_ = context.Operators.CalculateAgeAt(g_, k_, "year");
+                bool? m_ = context.Operators.GreaterOrEqual(l_, 18);
+                return m_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Denominator")]
+    public IEnumerable<Encounter> Denominator(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(7523999450907459220L, () => {
+            IEnumerable<Encounter> a_ = this.Initial_Population(context);
+            return a_;
+        });
+
+
+    [CqlExpressionDefinition("Qualified VTE Encounter With Hospice Services Within Previous 90 Days")]
+    public IEnumerable<Encounter> Qualified_VTE_Encounter_With_Hospice_Services_Within_Previous_90_Days(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(-9163851338437726610L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters(context);
+
+            bool? b_(Encounter QualifiedVTEEncounter) {
+                CqlValueSet d_ = this.Encounter_Inpatient(context);
+                IEnumerable<Encounter> e_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, d_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+
+                bool? f_(Encounter InpatientEncounter) {
+                    Encounter.HospitalizationComponent at_ = InpatientEncounter?.Hospitalization;
+                    CodeableConcept au_ = at_?.DischargeDisposition;
+                    CqlConcept av_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, au_);
+                    CqlCode aw_ = this.Discharge_to_home_for_hospice_care__procedure_(context);
+                    CqlConcept ax_ = context.Operators.ConvertCodeToConcept(aw_);
+                    bool? ay_ = context.Operators.Equivalent(av_, ax_);
+                    CodeableConcept ba_ = at_?.DischargeDisposition;
+                    CqlConcept bb_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, ba_);
+                    CqlCode bc_ = this.Discharge_to_healthcare_facility_for_hospice_care__procedure_(context);
+                    CqlConcept bd_ = context.Operators.ConvertCodeToConcept(bc_);
+                    bool? be_ = context.Operators.Equivalent(bb_, bd_);
+                    bool? bf_ = context.Operators.Or(ay_, be_);
+                    Period bg_ = InpatientEncounter?.Period;
+                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bg_);
+                    CqlDateTime bi_ = context.Operators.End(bh_);
+                    Period bj_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> bk_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
+                    CqlDateTime bl_ = context.Operators.Start(bk_);
+                    CqlQuantity bm_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime bn_ = context.Operators.Subtract(bl_, bm_);
+                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bj_);
+                    CqlDateTime bq_ = context.Operators.End(bp_);
+                    CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bn_, bq_, true, true);
+                    bool? bs_ = context.Operators.In<CqlDateTime>(bi_, br_, "day");
+                    bool? bt_ = context.Operators.And(bf_, bs_);
+                    Code<Encounter.EncounterStatus> bu_ = InpatientEncounter?.StatusElement;
+                    Encounter.EncounterStatus? bv_ = bu_?.Value;
+                    Code<Encounter.EncounterStatus> bw_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(bv_);
+                    bool? bx_ = context.Operators.Equal(bw_, "finished");
+                    bool? by_ = context.Operators.And(bt_, bx_);
+                    return by_;
+                }
+
+                IEnumerable<Encounter> g_ = context.Operators.Where<Encounter>(e_, f_);
+                bool? h_ = context.Operators.Exists<Encounter>(g_);
+                CqlValueSet i_ = this.Hospice_Encounter(context);
+                IEnumerable<Encounter> j_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, i_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+
+                bool? k_(Encounter HospiceEncounter) {
+                    Period bz_ = HospiceEncounter?.Period;
+                    CqlInterval<CqlDateTime> ca_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bz_);
+                    Period cb_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> cc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cb_);
+                    CqlDateTime cd_ = context.Operators.Start(cc_);
+                    CqlQuantity ce_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime cf_ = context.Operators.Subtract(cd_, ce_);
+                    CqlInterval<CqlDateTime> ch_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cb_);
+                    CqlDateTime ci_ = context.Operators.End(ch_);
+                    CqlInterval<CqlDateTime> cj_ = context.Operators.Interval(cf_, ci_, true, true);
+                    bool? ck_ = context.Operators.Overlaps(ca_, cj_, "day");
+                    return ck_;
+                }
+
+                IEnumerable<Encounter> l_ = context.Operators.Where<Encounter>(j_, k_);
+                bool? m_ = context.Operators.Exists<Encounter>(l_);
+                bool? n_ = context.Operators.Or(h_, m_);
+                CqlCode o_ = this.Hospice_care__Minimum_Data_Set_(context);
+                IEnumerable<CqlCode> p_ = context.Operators.ToList<CqlCode>(o_);
+                IEnumerable<Observation> q_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, p_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+
+                bool? r_(Observation HospiceAssessment) {
+                    DataType cl_ = HospiceAssessment?.Value;
+                    object cm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cl_);
+                    CqlCode cn_ = this.Yes__qualifier_value_(context);
+                    CqlConcept co_ = context.Operators.ConvertCodeToConcept(cn_);
+                    bool? cp_ = context.Operators.Equivalent(cm_ as CqlConcept, co_);
+                    DataType cq_ = HospiceAssessment?.Effective;
+                    object cr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, cq_);
+                    CqlInterval<CqlDateTime> cs_ = QICoreCommon_4_0_000.Instance.toInterval(context, cr_);
+                    Period ct_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
+                    CqlDateTime cv_ = context.Operators.Start(cu_);
+                    CqlQuantity cw_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime cx_ = context.Operators.Subtract(cv_, cw_);
+                    CqlInterval<CqlDateTime> cz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ct_);
+                    CqlDateTime da_ = context.Operators.End(cz_);
+                    CqlInterval<CqlDateTime> db_ = context.Operators.Interval(cx_, da_, true, true);
+                    bool? dc_ = context.Operators.Overlaps(cs_, db_, "day");
+                    bool? dd_ = context.Operators.And(cp_, dc_);
+                    return dd_;
+                }
+
+                IEnumerable<Observation> s_ = context.Operators.Where<Observation>(q_, r_);
+                bool? t_ = context.Operators.Exists<Observation>(s_);
+                bool? u_ = context.Operators.Or(n_, t_);
+                CqlValueSet v_ = this.Hospice_Care_Ambulatory(context);
+                IEnumerable<ServiceRequest> w_ = context.Operators.Retrieve<ServiceRequest>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-servicerequest"));
+
+                bool? x_(ServiceRequest HospiceOrder) {
+                    FhirDateTime de_ = HospiceOrder?.AuthoredOnElement;
+                    CqlDateTime df_ = context.Operators.Convert<CqlDateTime>(de_);
+                    Period dg_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
+                    CqlDateTime di_ = context.Operators.Start(dh_);
+                    CqlQuantity dj_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime dk_ = context.Operators.Subtract(di_, dj_);
+                    CqlInterval<CqlDateTime> dm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
+                    CqlDateTime dn_ = context.Operators.End(dm_);
+                    CqlInterval<CqlDateTime> do_ = context.Operators.Interval(dk_, dn_, true, true);
+                    bool? dp_ = context.Operators.In<CqlDateTime>(df_, do_, "day");
+                    Code<RequestStatus> dq_ = HospiceOrder?.StatusElement;
+                    RequestStatus? dr_ = dq_?.Value;
+                    Code<RequestStatus> ds_ = context.Operators.Convert<Code<RequestStatus>>(dr_);
+                    string dt_ = context.Operators.Convert<string>(ds_);
+                    string[] du_ = [
+                        "active",
+                        "completed",
+                    ];
+                    bool? dv_ = context.Operators.In<string>(dt_, (IEnumerable<string>)du_);
+                    bool? dw_ = context.Operators.And(dp_, dv_);
+                    return dw_;
+                }
+
+                IEnumerable<ServiceRequest> y_ = context.Operators.Where<ServiceRequest>(w_, x_);
+                bool? z_ = context.Operators.Exists<ServiceRequest>(y_);
+                bool? aa_ = context.Operators.Or(u_, z_);
+                IEnumerable<Procedure> ac_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+
+                bool? ad_(Procedure HospicePerformed) {
+
+                    object dx_() {
+
+                        bool ej_() {
+                            DataType en_ = HospicePerformed?.Performed;
+                            object eo_ = FHIRHelpers_4_4_000.Instance.ToValue(context, en_);
+                            bool ep_ = eo_ is CqlDateTime;
+                            return ep_;
+                        }
+
+
+                        bool ek_() {
+                            DataType eq_ = HospicePerformed?.Performed;
+                            object er_ = FHIRHelpers_4_4_000.Instance.ToValue(context, eq_);
+                            bool es_ = er_ is CqlInterval<CqlDateTime>;
+                            return es_;
+                        }
+
+
+                        bool el_() {
+                            DataType et_ = HospicePerformed?.Performed;
+                            object eu_ = FHIRHelpers_4_4_000.Instance.ToValue(context, et_);
+                            bool ev_ = eu_ is CqlQuantity;
+                            return ev_;
+                        }
+
+
+                        bool em_() {
+                            DataType ew_ = HospicePerformed?.Performed;
+                            object ex_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ew_);
+                            bool ey_ = ex_ is CqlInterval<CqlQuantity>;
+                            return ey_;
+                        }
+
+                        if (ej_())
+                        {
+                            DataType ez_ = HospicePerformed?.Performed;
+                            object fa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ez_);
+                            return (fa_ as CqlDateTime) as object;
+                        }
+                        else if (ek_())
+                        {
+                            DataType fb_ = HospicePerformed?.Performed;
+                            object fc_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fb_);
+                            return (fc_ as CqlInterval<CqlDateTime>) as object;
+                        }
+                        else if (el_())
+                        {
+                            DataType fd_ = HospicePerformed?.Performed;
+                            object fe_ = FHIRHelpers_4_4_000.Instance.ToValue(context, fd_);
+                            return (fe_ as CqlQuantity) as object;
+                        }
+                        else if (em_())
+                        {
+                            DataType ff_ = HospicePerformed?.Performed;
+                            object fg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ff_);
+                            return (fg_ as CqlInterval<CqlQuantity>) as object;
+                        }
+                        else
+                        {
+                            return null;
+                        };
+                    }
+
+                    CqlInterval<CqlDateTime> dy_ = QICoreCommon_4_0_000.Instance.toInterval(context, dx_());
+                    Period dz_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> ea_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dz_);
+                    CqlDateTime eb_ = context.Operators.Start(ea_);
+                    CqlQuantity ec_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime ed_ = context.Operators.Subtract(eb_, ec_);
+                    CqlInterval<CqlDateTime> ef_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dz_);
+                    CqlDateTime eg_ = context.Operators.End(ef_);
+                    CqlInterval<CqlDateTime> eh_ = context.Operators.Interval(ed_, eg_, true, true);
+                    bool? ei_ = context.Operators.Overlaps(dy_, eh_, "day");
+                    return ei_;
+                }
+
+                IEnumerable<Procedure> ae_ = context.Operators.Where<Procedure>(ac_, ad_);
+                bool? af_ = context.Operators.Exists<Procedure>(ae_);
+                bool? ag_ = context.Operators.Or(aa_, af_);
+                CqlValueSet ah_ = this.Hospice_Diagnosis(context);
+                IEnumerable<Condition> ai_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+
+                bool? aj_(Condition HospiceCareDiagnosis) {
+                    CqlInterval<CqlDateTime> fh_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareDiagnosis as object);
+                    Period fi_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> fj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fi_);
+                    CqlDateTime fk_ = context.Operators.Start(fj_);
+                    CqlQuantity fl_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime fm_ = context.Operators.Subtract(fk_, fl_);
+                    CqlInterval<CqlDateTime> fo_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fi_);
+                    CqlDateTime fp_ = context.Operators.End(fo_);
+                    CqlInterval<CqlDateTime> fq_ = context.Operators.Interval(fm_, fp_, true, true);
+                    bool? fr_ = context.Operators.Overlaps(fh_, fq_, "day");
+                    bool? fs_ = this.isVerified(context, HospiceCareDiagnosis as object);
+                    bool? ft_ = context.Operators.And(fr_, fs_);
+                    return ft_;
+                }
+
+                IEnumerable<Condition> ak_ = context.Operators.Where<Condition>(ai_, aj_);
+                bool? al_ = context.Operators.Exists<Condition>(ak_);
+                bool? am_ = context.Operators.Or(ag_, al_);
+                IEnumerable<Condition> ao_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, ah_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+
+                bool? ap_(Condition HospiceCareConcern) {
+                    CqlInterval<CqlDateTime> fu_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, HospiceCareConcern as object);
+                    Period fv_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> fw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fv_);
+                    CqlDateTime fx_ = context.Operators.Start(fw_);
+                    CqlQuantity fy_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime fz_ = context.Operators.Subtract(fx_, fy_);
+                    CqlInterval<CqlDateTime> gb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fv_);
+                    CqlDateTime gc_ = context.Operators.End(gb_);
+                    CqlInterval<CqlDateTime> gd_ = context.Operators.Interval(fz_, gc_, true, true);
+                    bool? ge_ = context.Operators.Overlaps(fu_, gd_, "day");
+                    bool? gf_ = this.isVerified(context, HospiceCareConcern as object);
+                    bool? gg_ = context.Operators.And(ge_, gf_);
+                    return gg_;
+                }
+
+                IEnumerable<Condition> aq_ = context.Operators.Where<Condition>(ao_, ap_);
+                bool? ar_ = context.Operators.Exists<Condition>(aq_);
+                bool? as_ = context.Operators.Or(am_, ar_);
+                return as_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Qualified VTE Encounter With Palliative Care Within Previous 90 Days")]
+    public IEnumerable<Encounter> Qualified_VTE_Encounter_With_Palliative_Care_Within_Previous_90_Days(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(6905458705983036257L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters(context);
+
+            bool? b_(Encounter QualifiedVTEEncounter) {
+                CqlCode d_ = this.Functional_Assessment_of_Chronic_Illness_Therapy___Palliative_Care_Questionnaire__FACIT_Pal_(context);
+                IEnumerable<CqlCode> e_ = context.Operators.ToList<CqlCode>(d_);
+                IEnumerable<Observation> f_ = context.Operators.Retrieve<Observation>(new RetrieveParameters(default, default, e_, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-observation-screening-assessment"));
+
+                bool? g_(Observation PalliativeAssessment) {
+                    DataType ah_ = PalliativeAssessment?.Effective;
+                    object ai_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ah_);
+                    CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_);
+                    Period ak_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> al_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+                    CqlDateTime am_ = context.Operators.Start(al_);
+                    CqlQuantity an_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime ao_ = context.Operators.Subtract(am_, an_);
+                    CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
+                    CqlDateTime ar_ = context.Operators.End(aq_);
+                    CqlInterval<CqlDateTime> as_ = context.Operators.Interval(ao_, ar_, true, true);
+                    bool? at_ = context.Operators.Overlaps(aj_, as_, "day");
+                    Code<ObservationStatus> au_ = PalliativeAssessment?.StatusElement;
+                    ObservationStatus? av_ = au_?.Value;
+                    string aw_ = context.Operators.Convert<string>(av_);
+                    string[] ax_ = [
+                        "final",
+                        "amended",
+                        "corrected",
+                    ];
+                    bool? ay_ = context.Operators.In<string>(aw_, (IEnumerable<string>)ax_);
+                    bool? az_ = context.Operators.And(at_, ay_);
+                    return az_;
+                }
+
+                IEnumerable<Observation> h_ = context.Operators.Where<Observation>(f_, g_);
+                bool? i_ = context.Operators.Exists<Observation>(h_);
+                CqlValueSet j_ = this.Palliative_Care_Diagnosis(context);
+                IEnumerable<Condition> k_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-encounter-diagnosis"));
+
+                bool? l_(Condition PalliativeCareDiagnosis) {
+                    CqlInterval<CqlDateTime> ba_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareDiagnosis as object);
+                    Period bb_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
+                    CqlDateTime bd_ = context.Operators.Start(bc_);
+                    CqlQuantity be_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime bf_ = context.Operators.Subtract(bd_, be_);
+                    CqlInterval<CqlDateTime> bh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bb_);
+                    CqlDateTime bi_ = context.Operators.End(bh_);
+                    CqlInterval<CqlDateTime> bj_ = context.Operators.Interval(bf_, bi_, true, true);
+                    bool? bk_ = context.Operators.Overlaps(ba_, bj_, "day");
+                    bool? bl_ = this.isVerified(context, PalliativeCareDiagnosis as object);
+                    bool? bm_ = context.Operators.And(bk_, bl_);
+                    return bm_;
+                }
+
+                IEnumerable<Condition> m_ = context.Operators.Where<Condition>(k_, l_);
+                bool? n_ = context.Operators.Exists<Condition>(m_);
+                bool? o_ = context.Operators.Or(i_, n_);
+                IEnumerable<Condition> q_ = context.Operators.Retrieve<Condition>(new RetrieveParameters(default, j_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-condition-problems-health-concerns"));
+
+                bool? r_(Condition PalliativeCareConcern) {
+                    CqlInterval<CqlDateTime> bn_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PalliativeCareConcern as object);
+                    Period bo_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> bp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
+                    CqlDateTime bq_ = context.Operators.Start(bp_);
+                    CqlQuantity br_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime bs_ = context.Operators.Subtract(bq_, br_);
+                    CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
+                    CqlDateTime bv_ = context.Operators.End(bu_);
+                    CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bs_, bv_, true, true);
+                    bool? bx_ = context.Operators.Overlaps(bn_, bw_, "day");
+                    bool? by_ = this.isVerified(context, PalliativeCareConcern as object);
+                    bool? bz_ = context.Operators.And(bx_, by_);
+                    return bz_;
+                }
+
+                IEnumerable<Condition> s_ = context.Operators.Where<Condition>(q_, r_);
+                bool? t_ = context.Operators.Exists<Condition>(s_);
+                bool? u_ = context.Operators.Or(o_, t_);
+                CqlValueSet v_ = this.Palliative_Care_Encounter(context);
+                IEnumerable<Encounter> w_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, v_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
+
+                bool? x_(Encounter PalliativeEncounter) {
+                    Period ca_ = PalliativeEncounter?.Period;
+                    CqlInterval<CqlDateTime> cb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ca_);
+                    Period cc_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> cd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
+                    CqlDateTime ce_ = context.Operators.Start(cd_);
+                    CqlQuantity cf_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime cg_ = context.Operators.Subtract(ce_, cf_);
+                    CqlInterval<CqlDateTime> ci_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cc_);
+                    CqlDateTime cj_ = context.Operators.End(ci_);
+                    CqlInterval<CqlDateTime> ck_ = context.Operators.Interval(cg_, cj_, true, true);
+                    bool? cl_ = context.Operators.Overlaps(cb_, ck_, "day");
+                    return cl_;
+                }
+
+                IEnumerable<Encounter> y_ = context.Operators.Where<Encounter>(w_, x_);
+                bool? z_ = context.Operators.Exists<Encounter>(y_);
+                bool? aa_ = context.Operators.Or(u_, z_);
+                CqlValueSet ab_ = this.Palliative_Care_Intervention(context);
+                IEnumerable<Procedure> ac_ = context.Operators.Retrieve<Procedure>(new RetrieveParameters(default, ab_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-procedure"));
+
+                bool? ad_(Procedure PalliativeIntervention) {
+
+                    object cm_() {
+
+                        bool cy_() {
+                            DataType dc_ = PalliativeIntervention?.Performed;
+                            object dd_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
+                            bool de_ = dd_ is CqlDateTime;
+                            return de_;
+                        }
+
+
+                        bool cz_() {
+                            DataType df_ = PalliativeIntervention?.Performed;
+                            object dg_ = FHIRHelpers_4_4_000.Instance.ToValue(context, df_);
+                            bool dh_ = dg_ is CqlInterval<CqlDateTime>;
+                            return dh_;
+                        }
+
+
+                        bool da_() {
+                            DataType di_ = PalliativeIntervention?.Performed;
+                            object dj_ = FHIRHelpers_4_4_000.Instance.ToValue(context, di_);
+                            bool dk_ = dj_ is CqlQuantity;
+                            return dk_;
+                        }
+
+
+                        bool db_() {
+                            DataType dl_ = PalliativeIntervention?.Performed;
+                            object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dl_);
+                            bool dn_ = dm_ is CqlInterval<CqlQuantity>;
+                            return dn_;
+                        }
+
+                        if (cy_())
+                        {
+                            DataType do_ = PalliativeIntervention?.Performed;
+                            object dp_ = FHIRHelpers_4_4_000.Instance.ToValue(context, do_);
+                            return (dp_ as CqlDateTime) as object;
+                        }
+                        else if (cz_())
+                        {
+                            DataType dq_ = PalliativeIntervention?.Performed;
+                            object dr_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dq_);
+                            return (dr_ as CqlInterval<CqlDateTime>) as object;
+                        }
+                        else if (da_())
+                        {
+                            DataType ds_ = PalliativeIntervention?.Performed;
+                            object dt_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ds_);
+                            return (dt_ as CqlQuantity) as object;
+                        }
+                        else if (db_())
+                        {
+                            DataType du_ = PalliativeIntervention?.Performed;
+                            object dv_ = FHIRHelpers_4_4_000.Instance.ToValue(context, du_);
+                            return (dv_ as CqlInterval<CqlQuantity>) as object;
+                        }
+                        else
+                        {
+                            return null;
+                        };
+                    }
+
+                    CqlInterval<CqlDateTime> cn_ = QICoreCommon_4_0_000.Instance.toInterval(context, cm_());
+                    Period co_ = QualifiedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> cp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
+                    CqlDateTime cq_ = context.Operators.Start(cp_);
+                    CqlQuantity cr_ = context.Operators.Quantity(90m, "days");
+                    CqlDateTime cs_ = context.Operators.Subtract(cq_, cr_);
+                    CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
+                    CqlDateTime cv_ = context.Operators.End(cu_);
+                    CqlInterval<CqlDateTime> cw_ = context.Operators.Interval(cs_, cv_, true, true);
+                    bool? cx_ = context.Operators.Overlaps(cn_, cw_, "day");
+                    return cx_;
+                }
+
+                IEnumerable<Procedure> ae_ = context.Operators.Where<Procedure>(ac_, ad_);
+                bool? af_ = context.Operators.Exists<Procedure>(ae_);
+                bool? ag_ = context.Operators.Or(aa_, af_);
+                return ag_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.Where<Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Qualified VTE Encounter With Other Qualified VTE Encounter Documented Within Previous 6 Months")]
+    public IEnumerable<Encounter> Qualified_VTE_Encounter_With_Other_Qualified_VTE_Encounter_Documented_Within_Previous_6_Months(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(5744213313538605082L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters(context);
+
+            IEnumerable<Encounter> b_(Encounter CurrentQualifiedVTE) {
+                IEnumerable<Encounter> d_ = this.Qualified_VTE_Encounters(context);
+
+                bool? e_(Encounter PreviousQualifiedVTE) {
+                    Period i_ = PreviousQualifiedVTE?.Period;
+                    CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                    CqlDateTime k_ = context.Operators.Start(j_);
+                    Period l_ = CurrentQualifiedVTE?.Period;
+                    CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                    CqlDateTime n_ = context.Operators.Start(m_);
+                    CqlQuantity o_ = context.Operators.Quantity(6m, "months");
+                    CqlDateTime p_ = context.Operators.Subtract(n_, o_);
+                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                    CqlDateTime s_ = context.Operators.Start(r_);
+                    CqlInterval<CqlDateTime> t_ = context.Operators.Interval(p_, s_, true, false);
+                    bool? u_ = context.Operators.In<CqlDateTime>(k_, t_, (string)default);
+                    CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                    CqlDateTime x_ = context.Operators.Start(w_);
+                    bool? y_ = context.Operators.Not((bool?)(x_ is null));
+                    bool? z_ = context.Operators.And(u_, y_);
+                    return z_;
+                }
+
+                IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
+                Encounter g_(Encounter PreviousQualifiedVTE) => CurrentQualifiedVTE;
+                IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
+                return h_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Denominator Exclusions")]
+    public IEnumerable<Encounter> Denominator_Exclusions(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(2926763216967038693L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounter_With_Hospice_Services_Within_Previous_90_Days(context);
+            IEnumerable<Encounter> b_ = this.Qualified_VTE_Encounter_With_Palliative_Care_Within_Previous_90_Days(context);
+            IEnumerable<Encounter> c_ = context.Operators.Union<Encounter>(a_, b_);
+            IEnumerable<Encounter> d_ = this.Qualified_VTE_Encounter_With_Other_Qualified_VTE_Encounter_Documented_Within_Previous_6_Months(context);
+            IEnumerable<Encounter> e_ = context.Operators.Union<Encounter>(c_, d_);
+            return e_;
+        });
+
+
+    [CqlExpressionDefinition("Qualifying Delayed VTE Encounter")]
+    public IEnumerable<Encounter> Qualifying_Delayed_VTE_Encounter(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(1933165867950008933L, () => {
+            IEnumerable<Encounter> a_ = this.Qualified_VTE_Encounters_During_Measurement_Period(context);
+
+            IEnumerable<Encounter> b_(Encounter DelayedVTEEncounter) {
+                IEnumerable<Encounter> d_ = this.Qualifying_Performed_PCP_Visits_With_VTE_Symptom(context);
+
+                bool? e_(Encounter IndexPCPVisit) {
+                    Period i_ = DelayedVTEEncounter?.Period;
+                    CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
+                    CqlDateTime k_ = context.Operators.Start(j_);
+                    Period l_ = IndexPCPVisit?.Period;
+                    CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                    CqlDateTime n_ = context.Operators.End(m_);
+                    CqlQuantity o_ = context.Operators.Quantity(2m, "day");
+                    CqlDateTime p_ = context.Operators.Add(n_, o_);
+                    CqlInterval<CqlDateTime> r_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
+                    CqlDateTime s_ = context.Operators.End(r_);
+                    CqlQuantity t_ = context.Operators.Quantity(30m, "days");
+                    CqlDateTime u_ = context.Operators.Add(s_, t_);
+                    CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
+                    bool? w_ = context.Operators.In<CqlDateTime>(k_, v_, "day");
+                    return w_;
+                }
+
+                IEnumerable<Encounter> f_ = context.Operators.Where<Encounter>(d_, e_);
+                Encounter g_(Encounter IndexPCPVisit) => DelayedVTEEncounter;
+                IEnumerable<Encounter> h_ = context.Operators.Select<Encounter, Encounter>(f_, g_);
+                return h_;
+            }
+
+            IEnumerable<Encounter> c_ = context.Operators.SelectMany<Encounter, Encounter>(a_, b_);
+            return c_;
+        });
+
+
+    [CqlExpressionDefinition("Numerator")]
+    public IEnumerable<Encounter> Numerator(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<Encounter>>(2150200294726777213L, () => {
+            IEnumerable<Encounter> a_ = this.Qualifying_Delayed_VTE_Encounter(context);
+            return a_;
+        });
+
+
+    [CqlExpressionDefinition("SDE Ethnicity")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Ethnicity(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<(CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)?>(-4641750971103456558L, () => {
+            (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Ethnicity(context);
+            return a_;
+        });
+
+
+    [CqlExpressionDefinition("SDE Payer")]
+    public IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> SDE_Payer(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?>>(6534542512085165381L, () => {
+            IEnumerable<(CqlTupleMetadata, CqlConcept code, CqlInterval<CqlDateTime> period)?> a_ = SupplementalDataElements_5_1_000.Instance.SDE_Payer(context);
+            return a_;
+        });
+
+
+    [CqlExpressionDefinition("SDE Race")]
+    public (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? SDE_Race(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<(CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)?>(5664667190711607769L, () => {
+            (CqlTupleMetadata, IEnumerable<CqlCode> codes, string display)? a_ = SupplementalDataElements_5_1_000.Instance.SDE_Race(context);
+            return a_;
+        });
+
+
+    [CqlExpressionDefinition("SDE Sex")]
+    public CqlCode SDE_Sex(CqlContext context) =>
+        ((ICqlContextInternals)context).GetOrCompute<CqlCode>(7998407842162547825L, () => {
+            CqlCode a_ = SupplementalDataElements_5_1_000.Instance.SDE_Sex(context);
+            return a_;
+        });
+
+
+    #endregion Functions and Expressions
+
+    #region Singleton Lifetime Members
+
+    private CMS1173FHIRDiagnosticDelayVTE_1_0_000() {}
+
+    public static CMS1173FHIRDiagnosticDelayVTE_1_0_000 Instance { get; } = new();
+
+    #endregion
+
+    #region ILibrary Implementation
+
+    public string Name => "CMS1173FHIRDiagnosticDelayVTE";
+    public string Version => "1.0.000";
+    public ILibrary[] Dependencies => [CQMCommon_4_1_000.Instance, FHIRHelpers_4_4_000.Instance, QICoreCommon_4_0_000.Instance, SupplementalDataElements_5_1_000.Instance];
+
+    #endregion ILibrary Implementation
+
+    #region CqlTupleMetadata Properties
+
+    private static CqlTupleMetadata CqlTupleMetadata_GAFATFEJifSPXLKbTBWFddDeY = new(
+       [typeof(Encounter), typeof(Encounter), typeof(DiagnosticReport), typeof(MedicationRequest)],
+       ["VTEEncounter", "IndexPCP", "VTEStudy", "AntiCoagulantOrdered"]);
+
+    #endregion CqlTupleMetadata Properties
+
+}

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
@@ -802,14 +802,14 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDate r_ = context.Operators.DateFrom(q_);
                 CqlQuantity s_ = context.Operators.Quantity(1m, "day");
                 CqlDate t_ = context.Operators.Add(r_, s_);
-                bool? u_ = context.Operators.SameOrAfter(o_, t_, default);
+                bool? u_ = context.Operators.SameOrAfter(o_, t_, (string)default);
                 CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_cnghazroxajthpiccbiajbrxv?.PolioVaccination3 as CqlDate);
                 CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
                 CqlDate x_ = context.Operators.DateFrom(w_);
                 CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
                 CqlDate aa_ = context.Operators.DateFrom(z_);
                 CqlDate ac_ = context.Operators.Add(aa_, s_);
-                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, default);
+                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, (string)default);
                 bool? ae_ = context.Operators.And(u_, ad_);
                 return ae_;
             }
@@ -892,7 +892,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, (s_ as CqlDateTime) as object);
                 CqlDate u_ = context.Operators.DateFrom(t_);
                 CqlInterval<CqlDate> v_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? w_ = context.Operators.In<CqlDate>(u_, v_, default);
+                bool? w_ = context.Operators.In<CqlDate>(u_, v_, (string)default);
                 return w_;
             }
 
@@ -918,7 +918,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_ as object);
                 CqlDate ae_ = context.Operators.DateFrom(ad_);
                 CqlInterval<CqlDate> af_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, (string)default);
                 return ag_;
             }
 
@@ -1323,14 +1323,14 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDate r_ = context.Operators.DateFrom(q_);
                 CqlQuantity s_ = context.Operators.Quantity(1m, "day");
                 CqlDate t_ = context.Operators.Add(r_, s_);
-                bool? u_ = context.Operators.SameOrAfter(o_, t_, default);
+                bool? u_ = context.Operators.SameOrAfter(o_, t_, (string)default);
                 CqlDateTime v_ = context.Operators.ConvertDateToDateTime(tuple_eztgahauwggsdgadcgqnnipgw?.HepatitisBVaccination3 as CqlDate);
                 CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, v_);
                 CqlDate x_ = context.Operators.DateFrom(w_);
                 CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
                 CqlDate aa_ = context.Operators.DateFrom(z_);
                 CqlDate ac_ = context.Operators.Add(aa_, s_);
-                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, default);
+                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, (string)default);
                 bool? ae_ = context.Operators.And(u_, ad_);
                 return ae_;
             }
@@ -1420,21 +1420,21 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDate r_ = context.Operators.DateFrom(q_);
                 CqlQuantity s_ = context.Operators.Quantity(1m, "day");
                 CqlDate t_ = context.Operators.Add(r_, s_);
-                bool? u_ = context.Operators.SameOrAfter(o_, t_, default);
+                bool? u_ = context.Operators.SameOrAfter(o_, t_, (string)default);
                 CqlDateTime w_ = QICoreCommon_4_0_000.Instance.earliest(context, p_);
                 CqlDate x_ = context.Operators.DateFrom(w_);
                 CqlDateTime y_ = context.Operators.ConvertDateToDateTime(tuple_hdfambzgbwdpfetgqnfbceeeg?.NewBornVaccine3 as CqlDate);
                 CqlDateTime z_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
                 CqlDate aa_ = context.Operators.DateFrom(z_);
                 CqlDate ac_ = context.Operators.Add(aa_, s_);
-                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, default);
+                bool? ad_ = context.Operators.SameOrAfter(x_, ac_, (string)default);
                 bool? ae_ = context.Operators.And(u_, ad_);
                 CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.earliest(context, m_);
                 CqlDate ah_ = context.Operators.DateFrom(ag_);
                 CqlDateTime aj_ = QICoreCommon_4_0_000.Instance.earliest(context, y_);
                 CqlDate ak_ = context.Operators.DateFrom(aj_);
                 CqlDate am_ = context.Operators.Add(ak_, s_);
-                bool? an_ = context.Operators.SameOrAfter(ah_, am_, default);
+                bool? an_ = context.Operators.SameOrAfter(ah_, am_, (string)default);
                 bool? ao_ = context.Operators.And(ae_, an_);
                 return ao_;
             }
@@ -1497,7 +1497,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, (s_ as CqlDateTime) as object);
                 CqlDate u_ = context.Operators.DateFrom(t_);
                 CqlInterval<CqlDate> v_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? w_ = context.Operators.In<CqlDate>(u_, v_, default);
+                bool? w_ = context.Operators.In<CqlDate>(u_, v_, (string)default);
                 return w_;
             }
 
@@ -1523,7 +1523,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_ as object);
                 CqlDate ae_ = context.Operators.DateFrom(ad_);
                 CqlInterval<CqlDate> af_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, (string)default);
                 return ag_;
             }
 
@@ -1656,14 +1656,14 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDate s_ = context.Operators.DateFrom(r_);
                 CqlQuantity t_ = context.Operators.Quantity(1m, "day");
                 CqlDate u_ = context.Operators.Add(s_, t_);
-                bool? v_ = context.Operators.SameOrAfter(p_, u_, default);
+                bool? v_ = context.Operators.SameOrAfter(p_, u_, (string)default);
                 CqlDateTime w_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination3 as CqlDate);
                 CqlDateTime x_ = QICoreCommon_4_0_000.Instance.earliest(context, w_);
                 CqlDate y_ = context.Operators.DateFrom(x_);
                 CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
                 CqlDate ab_ = context.Operators.DateFrom(aa_);
                 CqlDate ad_ = context.Operators.Add(ab_, t_);
-                bool? ae_ = context.Operators.SameOrAfter(y_, ad_, default);
+                bool? ae_ = context.Operators.SameOrAfter(y_, ad_, (string)default);
                 bool? af_ = context.Operators.And(v_, ae_);
                 CqlDateTime ag_ = context.Operators.ConvertDateToDateTime(tuple_ddpdeojhpyesfhgcocbnoippp?.PneumococcalVaccination4 as CqlDate);
                 CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_);
@@ -1671,7 +1671,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ak_ = QICoreCommon_4_0_000.Instance.earliest(context, w_);
                 CqlDate al_ = context.Operators.DateFrom(ak_);
                 CqlDate an_ = context.Operators.Add(al_, t_);
-                bool? ao_ = context.Operators.SameOrAfter(ai_, an_, default);
+                bool? ao_ = context.Operators.SameOrAfter(ai_, an_, (string)default);
                 bool? ap_ = context.Operators.And(af_, ao_);
                 return ap_;
             }
@@ -1729,7 +1729,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime t_ = QICoreCommon_4_0_000.Instance.earliest(context, (s_ as CqlDateTime) as object);
                 CqlDate u_ = context.Operators.DateFrom(t_);
                 CqlInterval<CqlDate> v_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? w_ = context.Operators.In<CqlDate>(u_, v_, default);
+                bool? w_ = context.Operators.In<CqlDate>(u_, v_, (string)default);
                 return w_;
             }
 
@@ -1755,7 +1755,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDateTime ad_ = QICoreCommon_4_0_000.Instance.earliest(context, ac_ as object);
                 CqlDate ae_ = context.Operators.DateFrom(ad_);
                 CqlInterval<CqlDate> af_ = this.Date_of_First_Birthday_to_Date_of_Second_Birthday(context);
-                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDate>(ae_, af_, (string)default);
                 return ag_;
             }
 
@@ -2112,7 +2112,7 @@ public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<C
                 CqlDate q_ = context.Operators.DateFrom(p_);
                 CqlQuantity r_ = context.Operators.Quantity(1m, "day");
                 CqlDate s_ = context.Operators.Add(q_, r_);
-                bool? t_ = context.Operators.SameOrAfter(n_, s_, default);
+                bool? t_ = context.Operators.SameOrAfter(n_, s_, (string)default);
                 return t_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
@@ -139,7 +139,7 @@ public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIR
                     CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_);
                     CqlDateTime y_ = context.Operators.Start(x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                    bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, default);
+                    bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, (string)default);
                     bool? ac_ = context.Operators.And(u_, ab_);
                     return ac_;
                 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
@@ -299,7 +299,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlInterval<CqlDateTime> bd_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
                     CqlDateTime be_ = context.Operators.Start(bd_);
                     CqlInterval<CqlDateTime> bf_ = context.Operators.Interval(bb_, be_, true, true);
-                    bool? bg_ = context.Operators.In<CqlDateTime>(aw_, bf_, default);
+                    bool? bg_ = context.Operators.In<CqlDateTime>(aw_, bf_, (string)default);
                     CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
                     CqlDateTime bj_ = context.Operators.Start(bi_);
                     bool? bk_ = context.Operators.Not((bool?)(bj_ is null));
@@ -412,7 +412,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
                     CqlDateTime p_ = QICoreCommon_4_0_000.Instance.earliest(context, o_ as object);
                     CqlInterval<CqlDateTime> q_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, ElectiveEncounter);
-                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(p_, q_, (string)default);
                     bool? s_ = context.Operators.And(m_, r_);
                     object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
                     CqlDateTime v_ = QICoreCommon_4_0_000.Instance.earliest(context, u_ as object);
@@ -421,7 +421,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlQuantity aa_ = context.Operators.Quantity(3m, "days");
                     CqlDateTime ab_ = context.Operators.Add(z_, aa_);
                     CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(x_, ab_, false, true);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(v_, ac_, (string)default);
                     CqlDateTime af_ = context.Operators.Start(q_);
                     bool? ag_ = context.Operators.Not((bool?)(af_ is null));
                     bool? ah_ = context.Operators.And(ad_, ag_);
@@ -574,7 +574,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlInterval<CqlDateTime> c_ = QICoreCommon_4_0_000.Instance.toInterval(context, b_());
                 CqlDateTime d_ = context.Operators.Start(c_);
                 CqlInterval<CqlDateTime> e_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, enc);
-                bool? f_ = context.Operators.In<CqlDateTime>(d_, e_, default);
+                bool? f_ = context.Operators.In<CqlDateTime>(d_, e_, (string)default);
                 return f_;
             }
             else if (choice is Observation)
@@ -584,7 +584,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
                 CqlDateTime ah_ = context.Operators.Start(ag_);
                 CqlInterval<CqlDateTime> ai_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, enc);
-                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, default);
+                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ai_, (string)default);
                 return aj_;
             }
             else if (choice is Observation)
@@ -594,7 +594,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlInterval<CqlDateTime> am_ = QICoreCommon_4_0_000.Instance.toInterval(context, al_);
                 CqlDateTime an_ = context.Operators.Start(am_);
                 CqlInterval<CqlDateTime> ao_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, enc);
-                bool? ap_ = context.Operators.In<CqlDateTime>(an_, ao_, default);
+                bool? ap_ = context.Operators.In<CqlDateTime>(an_, ao_, (string)default);
                 return ap_;
             }
             else
@@ -906,7 +906,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlDateTime s_ = context.Operators.Start(r_);
                     CqlQuantity t_ = context.Operators.Quantity(1m, "hour");
                     CqlDateTime u_ = context.Operators.Subtract(s_, t_);
-                    bool? v_ = context.Operators.Before(p_, u_, default);
+                    bool? v_ = context.Operators.Before(p_, u_, (string)default);
                     bool? w_ = context.Operators.And(m_, v_);
                     bool? x_ = this.startsDuringHospitalization(context, Ventilation as object, EncounterWithSurgery);
                     bool? y_ = context.Operators.And(w_, x_);
@@ -1142,7 +1142,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.toInterval(context, z_());
                     CqlDateTime ab_ = context.Operators.Start(aa_);
                     CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, false);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
 
                     object ae_() {
 
@@ -1405,7 +1405,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlInterval<CqlDateTime> fc_ = QICoreCommon_4_0_000.Instance.toInterval(context, fb_());
                     CqlDateTime fd_ = context.Operators.Start(fc_);
                     CqlInterval<CqlDateTime> fe_ = context.Operators.Interval(fa_, fd_, true, false);
-                    bool? ff_ = context.Operators.In<CqlDateTime>(ev_, fe_, default);
+                    bool? ff_ = context.Operators.In<CqlDateTime>(ev_, fe_, (string)default);
 
                     object fg_() {
 
@@ -1676,7 +1676,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
                     CqlDateTime z_ = context.Operators.Start(y_);
                     CqlInterval<CqlDateTime> aa_ = context.Operators.Interval(w_, z_, true, false);
-                    bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, default);
+                    bool? ab_ = context.Operators.In<CqlDateTime>(r_, aa_, (string)default);
 
                     object ac_() {
 
@@ -2571,7 +2571,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         CqlQuantity j_ = context.Operators.Quantity(30m, "days");
         CqlDateTime k_ = context.Operators.Add(i_, j_);
         CqlInterval<CqlDateTime> l_ = context.Operators.Interval(f_, k_, false, true);
-        bool? m_ = context.Operators.In<CqlDateTime>(c_, l_, default);
+        bool? m_ = context.Operators.In<CqlDateTime>(c_, l_, (string)default);
 
         object n_() {
 
@@ -2794,7 +2794,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
 
             CqlInterval<CqlDateTime> o_ = QICoreCommon_4_0_000.Instance.toInterval(context, n_());
             CqlDateTime p_ = context.Operators.Start(o_);
-            bool? q_ = context.Operators.Before(m_, p_, default);
+            bool? q_ = context.Operators.Before(m_, p_, (string)default);
             bool? r_ = context.Operators.And(j_, q_);
             return r_;
         }
@@ -2914,7 +2914,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 Period s_ = EncounterLocation?.Period;
                 CqlInterval<CqlDateTime> t_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, s_);
                 CqlDateTime u_ = context.Operators.Start(t_);
-                bool? v_ = context.Operators.In<CqlDateTime>(u_, intrvl, default);
+                bool? v_ = context.Operators.In<CqlDateTime>(u_, intrvl, (string)default);
                 bool? w_ = context.Operators.And(r_, v_);
                 return w_;
             }
@@ -3086,7 +3086,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 }
 
                 CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
-                bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, default);
+                bool? y_ = context.Operators.In<CqlDateTime>(v_, x_, (string)default);
                 bool? z_ = context.Operators.And(s_, y_);
                 return z_;
             }
@@ -3257,7 +3257,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
 
                     CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
                     CqlDateTime w_ = context.Operators.End(v_);
-                    bool? x_ = context.Operators.After(t_, w_, default);
+                    bool? x_ = context.Operators.After(t_, w_, (string)default);
                     bool? y_ = context.Operators.And(q_, x_);
 
                     object z_() {
@@ -3665,7 +3665,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
 
                 CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_());
                 CqlDateTime aa_ = context.Operators.End(z_);
-                bool? ab_ = context.Operators.After(x_, aa_, default);
+                bool? ab_ = context.Operators.After(x_, aa_, (string)default);
                 bool? ac_ = context.Operators.And(u_, ab_);
                 CqlInterval<CqlDateTime> ad_ = this.interval(context, tuple_qajmwefzjrlyudjfgicwdhsi?.OxygenSupport);
                 CqlDateTime ae_ = context.Operators.Start(ad_);
@@ -3810,7 +3810,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlInterval<CqlDateTime> aj_ = QICoreCommon_4_0_000.Instance.toInterval(context, ai_());
                 CqlDateTime ak_ = context.Operators.Start(aj_);
                 CqlInterval<CqlDateTime> al_ = context.Operators.Interval(ah_, ak_, true, true);
-                bool? am_ = context.Operators.In<CqlDateTime>(ae_, al_, default);
+                bool? am_ = context.Operators.In<CqlDateTime>(ae_, al_, (string)default);
                 bool? an_ = context.Operators.And(ac_, am_);
 
                 object ao_() {
@@ -3963,7 +3963,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 }
 
                 CqlInterval<CqlDateTime> d_ = QICoreCommon_4_0_000.Instance.toInterval(context, c_());
-                bool? e_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(b_, d_, default);
+                bool? e_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(b_, d_, (string)default);
                 return e_;
             }
             else if (choice is Observation)
@@ -3972,7 +3972,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 DataType ae_ = (choice as Observation)?.Effective;
                 object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
                 CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
-                bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ad_, ag_, default);
+                bool? ah_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ad_, ag_, (string)default);
                 return ah_;
             }
             else
@@ -4298,7 +4298,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 }
 
                 CqlInterval<CqlDateTime> w_ = QICoreCommon_4_0_000.Instance.toInterval(context, v_());
-                bool? x_ = context.Operators.After(u_(), w_, default);
+                bool? x_ = context.Operators.After(u_(), w_, (string)default);
                 bool? y_ = context.Operators.And(t_, x_);
                 CqlInterval<CqlDateTime> z_ = this.interval(context, tuple_bmexejitjfqtagoadebdecoag?.OxygenSupport);
                 CqlDateTime aa_ = context.Operators.Start(z_);
@@ -4443,7 +4443,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 CqlInterval<CqlDateTime> af_ = QICoreCommon_4_0_000.Instance.toInterval(context, ae_());
                 CqlDateTime ag_ = context.Operators.Start(af_);
                 CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ad_, ag_, true, true);
-                bool? ai_ = context.Operators.In<CqlDateTime>(aa_, ah_, default);
+                bool? ai_ = context.Operators.In<CqlDateTime>(aa_, ah_, (string)default);
                 bool? aj_ = context.Operators.And(y_, ai_);
                 return aj_;
             }
@@ -4611,7 +4611,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                 }
 
                 CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
-                bool? z_ = context.Operators.In<CqlDateTime>(w_, y_, default);
+                bool? z_ = context.Operators.In<CqlDateTime>(w_, y_, (string)default);
                 bool? aa_ = context.Operators.And(t_, z_);
                 return aa_;
             }
@@ -4823,7 +4823,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlDateTime x_ = context.Operators.End(w_);
                     CqlQuantity y_ = context.Operators.Quantity(48m, "hours");
                     CqlDateTime z_ = context.Operators.Add(x_, y_);
-                    bool? aa_ = context.Operators.After(u_, z_, default);
+                    bool? aa_ = context.Operators.After(u_, z_, (string)default);
                     bool? ab_ = context.Operators.And(r_, aa_);
                     IEnumerable<Procedure> ac_ = this.Extubation_With_Preceding_Noninvasive_Oxygen(context);
 
@@ -5046,7 +5046,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlDateTime s_ = context.Operators.End(r_);
                     CqlQuantity t_ = context.Operators.Quantity(48m, "hours");
                     CqlDateTime u_ = context.Operators.Add(s_, t_);
-                    bool? v_ = context.Operators.SameOrAfter(p_, u_, default);
+                    bool? v_ = context.Operators.SameOrAfter(p_, u_, (string)default);
                     bool? w_ = context.Operators.And(m_, v_);
 
                     object x_() {
@@ -5265,7 +5265,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlQuantity ag_ = context.Operators.Quantity(72m, "hours");
                     CqlDateTime ah_ = context.Operators.Add(af_, ag_);
                     CqlInterval<CqlDateTime> ai_ = context.Operators.Interval(ac_, ah_, false, true);
-                    bool? aj_ = context.Operators.In<CqlDateTime>(z_, ai_, default);
+                    bool? aj_ = context.Operators.In<CqlDateTime>(z_, ai_, (string)default);
 
                     object ak_() {
 
@@ -5640,7 +5640,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
                     CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.toInterval(context, m_);
                     CqlDateTime o_ = context.Operators.Start(n_);
                     CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+                    bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
                     DataType r_ = BMI?.Value;
                     CqlQuantity s_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, r_ as Quantity);
                     bool? t_ = context.Operators.Not((bool?)(s_ is null));
@@ -5993,7 +5993,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
         object b_ = FHIRHelpers_4_4_000.Instance.ToValue(context, a_);
         CqlDateTime c_ = QICoreCommon_4_0_000.Instance.earliest(context, b_ as object);
         CqlInterval<CqlDateTime> d_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, encounter);
-        bool? e_ = context.Operators.In<CqlDateTime>(c_, d_, default);
+        bool? e_ = context.Operators.In<CqlDateTime>(c_, d_, (string)default);
         List<ResourceReference> f_ = procedure?.PartOf;
         bool? g_ = context.Operators.Not((bool?)(((IEnumerable<ResourceReference>)f_) is null));
         bool? h_ = context.Operators.And(e_, g_);
@@ -6056,7 +6056,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
 
         CqlDateTime b_ = QICoreCommon_4_0_000.Instance.earliest(context, a_());
         CqlInterval<CqlDateTime> c_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, encounter);
-        bool? d_ = context.Operators.In<CqlDateTime>(b_, c_, default);
+        bool? d_ = context.Operators.In<CqlDateTime>(b_, c_, (string)default);
         DataType e_ = observation?.Value;
         object f_ = FHIRHelpers_4_4_000.Instance.ToValue(context, e_);
         bool? g_ = context.Operators.Not((bool?)(f_ is null));
@@ -6629,7 +6629,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
             CqlDateTime q_ = context.Operators.Start(p_);
             CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default);
+            bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, (string)default);
             bool? t_ = context.Operators.And(m_, s_);
             DataType u_ = FirstBodyMass?.Value;
             CqlQuantity v_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, u_ as Quantity);
@@ -6695,7 +6695,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
             CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
+            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
             bool? u_ = context.Operators.And(o_, t_);
             DataType v_ = FirstTemperature?.Value;
             CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
@@ -6971,7 +6971,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
             CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
+            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
             bool? u_ = context.Operators.And(o_, t_);
             DataType v_ = FirstHeartBeats?.Value;
             CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
@@ -7562,7 +7562,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
             CqlDateTime r_ = QICoreCommon_4_0_000.Instance.earliest(context, q_);
             CqlInterval<CqlDateTime> s_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, default);
+            bool? t_ = context.Operators.In<CqlDateTime>(r_, s_, (string)default);
             bool? u_ = context.Operators.And(o_, t_);
             DataType v_ = FirstRespiration?.Value;
             CqlQuantity w_ = FHIRHelpers_4_4_000.Instance.ToQuantity(context, v_ as Quantity);
@@ -7731,7 +7731,7 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             object n_ = FHIRHelpers_4_4_000.Instance.ToValue(context, m_);
             CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_);
             CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-            bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+            bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
             bool? r_ = context.Operators.And(l_, q_);
             return r_;
         }
@@ -8046,11 +8046,11 @@ public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRH
             CqlDateTime n_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
             CqlDateTime o_ = QICoreCommon_4_0_000.Instance.latest(context, n_ as object);
             CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_ as object);
-            bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, p_, default);
+            bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(l_, p_, (string)default);
             CqlDateTime s_ = context.Operators.LateBoundProperty<CqlDateTime>(m_, "value");
             CqlDateTime t_ = QICoreCommon_4_0_000.Instance.latest(context, s_ as object);
             CqlInterval<CqlDateTime> u_ = QICoreCommon_4_0_000.Instance.toInterval(context, t_ as object);
-            bool? w_ = context.Operators.Before(u_, l_, default);
+            bool? w_ = context.Operators.Before(u_, l_, (string)default);
             bool? x_ = context.Operators.Or(q_, w_);
             bool? y_ = context.Operators.And(k_, x_);
             DataType z_ = SMStatus?.Value;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
@@ -343,7 +343,7 @@ public partial class CMS122FHIRDiabetesAssessGT9Pct_1_0_000 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
@@ -192,14 +192,14 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDEvalManagementInMP?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, default);
+                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
                     bool? s_ = context.Operators.Or(m_, r_);
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, default);
+                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
                     bool? y_ = context.Operators.Or(s_, x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlDateTime ab_ = context.Operators.End(aa_);
@@ -210,7 +210,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime aj_ = context.Operators.Start(ai_);
                     CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, default);
+                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
@@ -312,24 +312,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime an_ = context.Operators.Start(am_);
             CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, true, false);
-            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, default);
+            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, (string)default);
             CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime as_ = context.Operators.Start(ar_);
             bool? at_ = context.Operators.Not((bool?)(as_ is null));
             bool? au_ = context.Operators.And(ap_, at_);
             CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, default);
+            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, (string)default);
             bool? ba_ = context.Operators.Or(au_, az_);
             CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, default);
+            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
             bool? bg_ = context.Operators.Or(ba_, bf_);
             CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlDateTime bj_ = context.Operators.Start(bi_);
             CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime bm_ = context.Operators.Start(bl_);
-            bool? bn_ = context.Operators.SameAs(bj_, bm_, default);
+            bool? bn_ = context.Operators.SameAs(bj_, bm_, (string)default);
             bool? bo_ = context.Operators.Or(bg_, bn_);
             bool? bp_ = context.Operators.And(ac_, bo_);
             return bp_;
@@ -365,14 +365,14 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, default);
+                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
                     bool? s_ = context.Operators.Or(m_, r_);
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, default);
+                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
                     bool? y_ = context.Operators.Or(s_, x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlDateTime ab_ = context.Operators.End(aa_);
@@ -383,7 +383,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime aj_ = context.Operators.Start(ai_);
                     CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, default);
+                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
@@ -466,7 +466,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                 CqlDateTime e_ = this.edTreatmentRoomTimeArrivalTime(context, EDEvalManagementInMP);
                 CqlQuantity f_ = context.Operators.Quantity(61m, "minutes");
                 CqlDateTime g_ = context.Operators.Subtract(e_, f_);
-                bool? h_ = context.Operators.SameOrBefore(d_, g_, default);
+                bool? h_ = context.Operators.SameOrBefore(d_, g_, (string)default);
                 return h_;
             }
 
@@ -506,7 +506,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Encounter k_ = this.lastEDEncounter(context, EncounterInpatient);
             Period l_ = k_?.Period;
             CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-            bool? n_ = context.Operators.In<CqlDateTime>(j_, m_, default);
+            bool? n_ = context.Operators.In<CqlDateTime>(j_, m_, (string)default);
             Code<RequestIntent> o_ = AdmitOrder?.IntentElement;
             RequestIntent? p_ = o_?.Value;
             Code<RequestIntent> q_ = context.Operators.Convert<Code<RequestIntent>>(p_);
@@ -572,7 +572,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlInterval<CqlDateTime> p_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
             CqlDateTime q_ = context.Operators.Start(p_);
             CqlInterval<CqlDateTime> r_ = context.Operators.Interval(n_, q_, true, true);
-            bool? s_ = context.Operators.In<CqlDateTime>(i_, r_, default);
+            bool? s_ = context.Operators.In<CqlDateTime>(i_, r_, (string)default);
             CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
             CqlDateTime v_ = context.Operators.Start(u_);
             bool? w_ = context.Operators.Not((bool?)(v_ is null));
@@ -581,7 +581,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlDateTime aa_ = context.Operators.Start(z_);
             CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
             CqlDateTime ad_ = context.Operators.Start(ac_);
-            bool? ae_ = context.Operators.Before(aa_, ad_, default);
+            bool? ae_ = context.Operators.Before(aa_, ad_, (string)default);
             bool? af_ = context.Operators.And(x_, ae_);
             CqlInterval<CqlDateTime> ag_ = this.Measurement_Period(context);
             CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, g_);
@@ -674,24 +674,24 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime an_ = context.Operators.Start(am_);
             CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, true, false);
-            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, default);
+            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, (string)default);
             CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime as_ = context.Operators.Start(ar_);
             bool? at_ = context.Operators.Not((bool?)(as_ is null));
             bool? au_ = context.Operators.And(ap_, at_);
             CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, default);
+            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, (string)default);
             bool? ba_ = context.Operators.Or(au_, az_);
             CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, default);
+            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
             bool? bg_ = context.Operators.Or(ba_, bf_);
             CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlDateTime bj_ = context.Operators.Start(bi_);
             CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime bm_ = context.Operators.Start(bl_);
-            bool? bn_ = context.Operators.SameAs(bj_, bm_, default);
+            bool? bn_ = context.Operators.SameAs(bj_, bm_, (string)default);
             bool? bo_ = context.Operators.Or(bg_, bn_);
             bool? bp_ = context.Operators.And(ac_, bo_);
             return bp_;
@@ -727,7 +727,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
                     CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
                     CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                    bool? m_ = context.Operators.SameOrBefore(i_, l_, default);
+                    bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
                     return m_;
                 }
 
@@ -755,7 +755,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Encounter m_ = this.lastEDEncounter(context, EncounterInpatient);
             Period n_ = m_?.Period;
             CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
-            bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, default);
+            bool? p_ = context.Operators.In<CqlDateTime>(l_, o_, (string)default);
             object q_ = context.Operators.LateBoundProperty<object>(EDEvaluation, "status");
             string r_ = context.Operators.LateBoundProperty<string>(q_, "value");
             string[] s_ = [
@@ -820,7 +820,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
                     CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
                     CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                    bool? m_ = context.Operators.SameOrBefore(i_, l_, default);
+                    bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
                     return m_;
                 }
 
@@ -846,7 +846,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Encounter k_ = this.lastEDEncounter(context, Encounter);
             Period l_ = k_?.Period;
             CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-            bool? n_ = context.Operators.In<CqlDateTime>(j_, m_, default);
+            bool? n_ = context.Operators.In<CqlDateTime>(j_, m_, (string)default);
             return n_;
         }
 
@@ -907,7 +907,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
                     CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
                     CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                    bool? m_ = context.Operators.SameOrBefore(i_, l_, default);
+                    bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
                     return m_;
                 }
 
@@ -934,7 +934,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
             Encounter l_ = this.lastEDEncounter(context, InpatientEncounter);
             Period m_ = l_?.Period;
             CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-            bool? o_ = context.Operators.In<CqlDateTime>(k_, n_, default);
+            bool? o_ = context.Operators.In<CqlDateTime>(k_, n_, (string)default);
             return o_;
         }
 
@@ -968,7 +968,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlDateTime j_ = this.edDepartureTime(context, EDEncounter);
                     CqlQuantity k_ = context.Operators.Quantity(241m, "minutes");
                     CqlDateTime l_ = context.Operators.Subtract(j_, k_);
-                    bool? m_ = context.Operators.SameOrBefore(i_, l_, default);
+                    bool? m_ = context.Operators.SameOrBefore(i_, l_, (string)default);
                     return m_;
                 }
 
@@ -1011,7 +1011,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                     Period l_ = EDObsEncounter?.Period;
                     CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                    bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                    bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                     Code<Encounter.EncounterStatus> o_ = EDObsEncounter?.StatusElement;
                     Encounter.EncounterStatus? p_ = o_?.Value;
                     Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
@@ -1044,7 +1044,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDObs?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 
@@ -1069,7 +1069,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                 CqlDateTime e_ = this.edDepartureTime(context, EDEncounter);
                 CqlQuantity f_ = context.Operators.Quantity(481m, "minutes");
                 CqlDateTime g_ = context.Operators.Subtract(e_, f_);
-                bool? h_ = context.Operators.SameOrBefore(d_, g_, default);
+                bool? h_ = context.Operators.SameOrBefore(d_, g_, (string)default);
                 return h_;
             }
 
@@ -1091,7 +1091,7 @@ public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244F
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDObs?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
@@ -151,7 +151,7 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(24, 64, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
 
             List<Extension> k_() {
 
@@ -282,7 +282,7 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
                 CqlDateTime q_ = context.Operators.End(p_);
                 CqlInterval<CqlDateTime> r_ = this.Measurement_Period(context);
                 CqlDateTime s_ = context.Operators.End(r_);
-                bool? t_ = context.Operators.SameOrBefore(q_, s_, default);
+                bool? t_ = context.Operators.SameOrBefore(q_, s_, (string)default);
                 return t_;
             }
 
@@ -298,7 +298,7 @@ public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISinglet
                 CqlDateTime at_ = context.Operators.Start(as_);
                 CqlInterval<CqlDateTime> au_ = this.Measurement_Period(context);
                 CqlDateTime av_ = context.Operators.End(au_);
-                bool? aw_ = context.Operators.SameOrBefore(at_, av_, default);
+                bool? aw_ = context.Operators.SameOrBefore(at_, av_, (string)default);
                 return aw_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
@@ -113,7 +113,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(42, 74, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
 
             List<Extension> k_() {
 
@@ -218,7 +218,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime ae_ = context.Operators.Start(ad_);
                 CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
                 CqlDateTime ag_ = context.Operators.End(af_);
-                bool? ah_ = context.Operators.SameOrBefore(ae_, ag_, default);
+                bool? ah_ = context.Operators.SameOrBefore(ae_, ag_, (string)default);
                 return ah_;
             }
 
@@ -303,7 +303,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime h_ = context.Operators.End(g_);
                 CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
                 CqlDateTime j_ = context.Operators.End(i_);
-                bool? k_ = context.Operators.SameOrBefore(h_, j_, default);
+                bool? k_ = context.Operators.SameOrBefore(h_, j_, (string)default);
                 return k_;
             }
 
@@ -362,7 +362,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime ae_ = context.Operators.Start(ad_);
                 CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
                 CqlDateTime ag_ = context.Operators.End(af_);
-                bool? ah_ = context.Operators.SameOrBefore(ae_, ag_, default);
+                bool? ah_ = context.Operators.SameOrBefore(ae_, ag_, (string)default);
                 return ah_;
             }
 
@@ -447,7 +447,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime h_ = context.Operators.End(g_);
                 CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
                 CqlDateTime j_ = context.Operators.End(i_);
-                bool? k_ = context.Operators.SameOrBefore(h_, j_, default);
+                bool? k_ = context.Operators.SameOrBefore(h_, j_, (string)default);
                 return k_;
             }
 
@@ -470,7 +470,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime j_ = context.Operators.Start(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 return m_;
             }
 
@@ -555,7 +555,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
                 CqlDateTime h_ = context.Operators.End(g_);
                 CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
                 CqlDateTime j_ = context.Operators.End(i_);
-                bool? k_ = context.Operators.SameOrBefore(h_, j_, default);
+                bool? k_ = context.Operators.SameOrBefore(h_, j_, (string)default);
                 return k_;
             }
 
@@ -679,7 +679,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(42, 51, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -696,7 +696,7 @@ public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(52, 74, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
@@ -175,14 +175,14 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDEvalManagementinMP?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, default);
+                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
                     bool? s_ = context.Operators.Or(m_, r_);
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, default);
+                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
                     bool? y_ = context.Operators.Or(s_, x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlDateTime ab_ = context.Operators.End(aa_);
@@ -193,7 +193,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime aj_ = context.Operators.Start(ai_);
                     CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, default);
+                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
@@ -295,24 +295,24 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime an_ = context.Operators.Start(am_);
             CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, true, false);
-            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, default);
+            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, (string)default);
             CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime as_ = context.Operators.Start(ar_);
             bool? at_ = context.Operators.Not((bool?)(as_ is null));
             bool? au_ = context.Operators.And(ap_, at_);
             CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, default);
+            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, (string)default);
             bool? ba_ = context.Operators.Or(au_, az_);
             CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, default);
+            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
             bool? bg_ = context.Operators.Or(ba_, bf_);
             CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlDateTime bj_ = context.Operators.Start(bi_);
             CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime bm_ = context.Operators.Start(bl_);
-            bool? bn_ = context.Operators.SameAs(bj_, bm_, default);
+            bool? bn_ = context.Operators.SameAs(bj_, bm_, (string)default);
             bool? bo_ = context.Operators.Or(bg_, bn_);
             bool? bp_ = context.Operators.And(ac_, bo_);
             return bp_;
@@ -348,14 +348,14 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDEncounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, default);
+                    bool? m_ = context.Operators.OverlapsBefore(j_, l_, (string)default);
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
-                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+                    bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
                     bool? s_ = context.Operators.Or(m_, r_);
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, default);
+                    bool? x_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(u_, w_, (string)default);
                     bool? y_ = context.Operators.Or(s_, x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     CqlDateTime ab_ = context.Operators.End(aa_);
@@ -366,7 +366,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime aj_ = context.Operators.Start(ai_);
                     CqlInterval<CqlDateTime> ak_ = context.Operators.Interval(ag_, aj_, true, false);
-                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, default);
+                    bool? al_ = context.Operators.In<CqlDateTime>(ab_, ak_, (string)default);
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     bool? ap_ = context.Operators.Not((bool?)(ao_ is null));
@@ -449,7 +449,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 CqlDateTime e_ = this.edTreatmentRoomTimeArrivalTime(context, EDEvalManagementinMP);
                 CqlQuantity f_ = context.Operators.Quantity(61m, "minutes");
                 CqlDateTime g_ = context.Operators.Subtract(e_, f_);
-                bool? h_ = context.Operators.SameOrBefore(d_, g_, default);
+                bool? h_ = context.Operators.SameOrBefore(d_, g_, (string)default);
                 return h_;
             }
 
@@ -489,7 +489,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             CqlDateTime k_ = context.Operators.Convert<CqlDateTime>(j_);
             Period l_ = EDEncounter?.Period;
             CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-            bool? n_ = context.Operators.In<CqlDateTime>(k_, m_, default);
+            bool? n_ = context.Operators.In<CqlDateTime>(k_, m_, (string)default);
             Code<RequestIntent> o_ = TransferOrder?.IntentElement;
             RequestIntent? p_ = o_?.Value;
             Code<RequestIntent> q_ = context.Operators.Convert<Code<RequestIntent>>(p_);
@@ -588,24 +588,24 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
             CqlInterval<CqlDateTime> am_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime an_ = context.Operators.Start(am_);
             CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, true, false);
-            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, default);
+            bool? ap_ = context.Operators.In<CqlDateTime>(af_, ao_, (string)default);
             CqlInterval<CqlDateTime> ar_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime as_ = context.Operators.Start(ar_);
             bool? at_ = context.Operators.Not((bool?)(as_ is null));
             bool? au_ = context.Operators.And(ap_, at_);
             CqlInterval<CqlDateTime> aw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlInterval<CqlDateTime> ay_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
-            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, default);
+            bool? az_ = context.Operators.OverlapsBefore(aw_, ay_, (string)default);
             bool? ba_ = context.Operators.Or(au_, az_);
             CqlInterval<CqlDateTime> bc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
-            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, default);
+            bool? bf_ = context.Operators.OverlapsBefore(bc_, be_, (string)default);
             bool? bg_ = context.Operators.Or(ba_, bf_);
             CqlInterval<CqlDateTime> bi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, y_);
             CqlDateTime bj_ = context.Operators.Start(bi_);
             CqlInterval<CqlDateTime> bl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
             CqlDateTime bm_ = context.Operators.Start(bl_);
-            bool? bn_ = context.Operators.SameAs(bj_, bm_, default);
+            bool? bn_ = context.Operators.SameAs(bj_, bm_, (string)default);
             bool? bo_ = context.Operators.Or(bg_, bn_);
             bool? bp_ = context.Operators.And(ac_, bo_);
             return bp_;
@@ -638,7 +638,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 CqlDateTime e_ = this.edDepartureTime(context, EDEncounter);
                 CqlQuantity f_ = context.Operators.Quantity(241m, "minutes");
                 CqlDateTime g_ = context.Operators.Subtract(e_, f_);
-                bool? h_ = context.Operators.SameOrBefore(d_, g_, default);
+                bool? h_ = context.Operators.SameOrBefore(d_, g_, (string)default);
                 return h_;
             }
 
@@ -661,7 +661,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                     Period l_ = EDObsEncounter?.Period;
                     CqlInterval<CqlDateTime> m_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, l_);
-                    bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                    bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                     Code<Encounter.EncounterStatus> o_ = EDObsEncounter?.StatusElement;
                     Encounter.EncounterStatus? p_ = o_?.Value;
                     Code<Encounter.EncounterStatus> q_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(p_);
@@ -694,7 +694,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDObs?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 
@@ -719,7 +719,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                 CqlDateTime e_ = this.edDepartureTime(context, EDEncounter);
                 CqlQuantity f_ = context.Operators.Quantity(481m, "minutes");
                 CqlDateTime g_ = context.Operators.Subtract(e_, f_);
-                bool? h_ = context.Operators.SameOrBefore(d_, g_, default);
+                bool? h_ = context.Operators.SameOrBefore(d_, g_, (string)default);
                 return h_;
             }
 
@@ -741,7 +741,7 @@ public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264
                     CqlInterval<CqlDateTime> j_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, i_);
                     Period k_ = EDObs?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
@@ -217,7 +217,7 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 CqlDate q_ = context.Operators.Subtract(j_, p_);
                 CqlDate t_ = context.Operators.Add(j_, p_);
                 CqlInterval<CqlDate> u_ = context.Operators.Interval(q_, t_, true, true);
-                bool? v_ = context.Operators.In<CqlDate>(n_, u_, default);
+                bool? v_ = context.Operators.In<CqlDate>(n_, u_, (string)default);
                 bool? x_ = context.Operators.Not((bool?)(j_ is null));
                 bool? y_ = context.Operators.And(v_, x_);
                 bool? z_ = context.Operators.And(k_, y_);
@@ -274,7 +274,7 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 CqlDate am_ = context.Operators.Subtract(ak_, al_);
                 CqlDate ap_ = context.Operators.Add(ak_, al_);
                 CqlInterval<CqlDate> aq_ = context.Operators.Interval(am_, ap_, true, true);
-                bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, default);
+                bool? ar_ = context.Operators.In<CqlDate>(aj_, aq_, (string)default);
                 bool? at_ = context.Operators.Not((bool?)(ak_ is null));
                 bool? au_ = context.Operators.And(ar_, at_);
                 return au_;
@@ -364,7 +364,7 @@ public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton
                 CqlQuantity aq_ = context.Operators.Quantity(105m, "days");
                 CqlDate ar_ = context.Operators.Subtract(ab_, aq_);
                 CqlInterval<CqlDate> at_ = context.Operators.Interval(ar_, ab_, true, false);
-                bool? au_ = context.Operators.Overlaps(ao_, at_, default);
+                bool? au_ = context.Operators.Overlaps(ao_, at_, (string)default);
                 bool? av_ = context.Operators.And(ac_, au_);
                 return av_;
             }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
@@ -466,7 +466,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
 
                     CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.toInterval(context, w_());
                     CqlDateTime y_ = context.Operators.Start(x_);
-                    bool? z_ = context.Operators.Before(v_, y_, default);
+                    bool? z_ = context.Operators.Before(v_, y_, (string)default);
                     Code<ObservationStatus> aa_ = ProstateCancerStaging?.StatusElement;
                     ObservationStatus? ab_ = aa_?.Value;
                     string ac_ = context.Operators.Convert<string>(ab_);
@@ -577,7 +577,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                     DataType t_ = MostRecentProstateCancerStaging?.Effective;
                     object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
                     CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_);
-                    bool? w_ = context.Operators.Before(s_(), v_, default);
+                    bool? w_ = context.Operators.Before(s_(), v_, (string)default);
                     Code<ObservationStatus> x_ = PSATest?.StatusElement;
                     ObservationStatus? y_ = x_?.Value;
                     string z_ = context.Operators.Convert<string>(y_);
@@ -712,7 +712,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
 
                     CqlInterval<CqlDateTime> y_ = QICoreCommon_4_0_000.Instance.toInterval(context, x_());
                     CqlDateTime z_ = context.Operators.Start(y_);
-                    bool? aa_ = context.Operators.Before(w_, z_, default);
+                    bool? aa_ = context.Operators.Before(w_, z_, (string)default);
                     Code<ObservationStatus> ab_ = GleasonScore?.StatusElement;
                     ObservationStatus? ac_ = ab_?.Value;
                     string ad_ = context.Operators.Convert<string>(ac_);
@@ -796,7 +796,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                     CqlDateTime o_ = context.Operators.Start(n_);
                     CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as object);
                     CqlDateTime q_ = context.Operators.Start(p_);
-                    bool? r_ = context.Operators.After(o_, q_, default);
+                    bool? r_ = context.Operators.After(o_, q_, (string)default);
                     return r_;
                 }
 
@@ -859,7 +859,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                     CqlDateTime o_ = context.Operators.Start(n_);
                     CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as object);
                     CqlDateTime q_ = context.Operators.Start(p_);
-                    bool? r_ = context.Operators.After(o_, q_, default);
+                    bool? r_ = context.Operators.After(o_, q_, (string)default);
                     bool? s_ = this.isVerified(context, ProstateCancerPain);
                     bool? t_ = context.Operators.And(r_, s_);
                     return t_;
@@ -955,7 +955,7 @@ public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton
                     CqlDateTime m_ = context.Operators.Start(l_);
                     CqlInterval<CqlDateTime> n_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveProstateCancer as object);
                     CqlDateTime o_ = context.Operators.Start(n_);
-                    bool? p_ = context.Operators.After(m_, o_, default);
+                    bool? p_ = context.Operators.After(m_, o_, (string)default);
                     Code<EventStatus> q_ = SalvageTherapy?.StatusElement;
                     EventStatus? r_ = q_?.Value;
                     string s_ = context.Operators.Convert<string>(r_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
@@ -118,7 +118,7 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(46, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = AdultOutpatientEncounters_4_19_000.Instance.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);
@@ -651,7 +651,7 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(46, 49, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -668,7 +668,7 @@ public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISinglet
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(50, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
@@ -187,7 +187,7 @@ public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CM
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
@@ -311,7 +311,7 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
                     CqlDateTime ab_ = context.Operators.Start(aa_);
                     CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
                     CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
                     CqlDateTime ag_ = context.Operators.Start(af_);
                     bool? ah_ = context.Operators.Not((bool?)(ag_ is null));
@@ -347,7 +347,7 @@ public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISinglet
                     CqlInterval<CqlDateTime> ba_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
                     CqlDateTime bb_ = context.Operators.Start(ba_);
                     CqlInterval<CqlDateTime> bc_ = context.Operators.Interval(ay_, bb_, true, true);
-                    bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, default);
+                    bool? bd_ = context.Operators.In<CqlDateTime>(at_, bc_, (string)default);
                     CqlInterval<CqlDateTime> bf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, au_);
                     CqlDateTime bg_ = context.Operators.Start(bf_);
                     bool? bh_ = context.Operators.Not((bool?)(bg_ is null));

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
@@ -474,7 +474,7 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 CqlDate jq_ = context.Operators.Start(jp_);
                 CqlDateTime jr_ = context.Operators.ConvertDateToDateTime(jq_);
                 CqlInterval<CqlDateTime> js_ = this.Intake_Period(context);
-                bool? jt_ = context.Operators.In<CqlDateTime>(jr_, js_, default);
+                bool? jt_ = context.Operators.In<CqlDateTime>(jr_, js_, (string)default);
                 return jt_;
             }
 
@@ -739,7 +739,7 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 CqlDate pb_ = context.Operators.Start(pa_);
                 CqlDateTime pc_ = context.Operators.ConvertDateToDateTime(pb_);
                 CqlInterval<CqlDateTime> pd_ = this.Intake_Period(context);
-                bool? pe_ = context.Operators.In<CqlDateTime>(pc_, pd_, default);
+                bool? pe_ = context.Operators.In<CqlDateTime>(pc_, pd_, (string)default);
                 return pe_;
             }
 
@@ -1023,7 +1023,7 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                     CqlDateTime xk_ = context.Operators.ConvertDateToDateTime(xj_);
                     CqlDate xl_ = context.Operators.DateFrom(xk_);
                     CqlInterval<CqlDate> xm_ = context.Operators.Interval(xh_, xl_, true, false);
-                    bool? xn_ = context.Operators.Overlaps(xb_, xm_, default);
+                    bool? xn_ = context.Operators.Overlaps(xb_, xm_, (string)default);
                     return xn_;
                 }
 
@@ -1219,7 +1219,7 @@ public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISinglet
                 CqlDateTime j_ = context.Operators.Start(i_);
                 CqlInterval<CqlDateTime> k_ = this.Measurement_Period(context);
                 CqlDateTime l_ = context.Operators.End(k_);
-                bool? m_ = context.Operators.SameOrBefore(j_, l_, default);
+                bool? m_ = context.Operators.SameOrBefore(j_, l_, (string)default);
                 return m_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
@@ -153,11 +153,11 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
                     Period u_ = ValidEncounters?.Period;
                     CqlInterval<CqlDateTime> v_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                    bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, default);
+                    bool? w_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(t_, v_, (string)default);
                     CqlInterval<CqlDateTime> x_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SUDDiagnosis);
                     CqlDateTime y_ = context.Operators.Start(x_);
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
-                    bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, default);
+                    bool? ab_ = context.Operators.In<CqlDateTime>(y_, aa_, (string)default);
                     bool? ac_ = context.Operators.And(w_, ab_);
                     CqlDateTime ae_ = context.Operators.Start(x_);
                     CqlDateTime ag_ = context.Operators.End(t_);
@@ -762,7 +762,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity ad_ = context.Operators.Quantity(14m, "days");
                     CqlDate ae_ = context.Operators.Add(ac_, ad_);
                     CqlInterval<CqlDate> af_ = context.Operators.Interval(y_, ae_, true, false);
-                    bool? ag_ = context.Operators.In<CqlDate>(u_, af_, default);
+                    bool? ag_ = context.Operators.In<CqlDate>(u_, af_, (string)default);
                     object ah_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitProcedure, "id");
                     string ai_ = context.Operators.LateBoundProperty<string>(ah_, "value");
                     Id aj_ = FirstSUDEpisode?.IdElement;
@@ -875,7 +875,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity dg_ = context.Operators.Quantity(14m, "days");
                     CqlDate dh_ = context.Operators.Add(df_, dg_);
                     CqlInterval<CqlDate> di_ = context.Operators.Interval(db_, dh_, true, false);
-                    bool? dj_ = context.Operators.In<CqlDate>(cx_, di_, default);
+                    bool? dj_ = context.Operators.In<CqlDate>(cx_, di_, (string)default);
                     object dk_ = context.Operators.LateBoundProperty<object>(PsychosocialVisitEncounter, "id");
                     string dl_ = context.Operators.LateBoundProperty<string>(dk_, "value");
                     Id dm_ = FirstSUDEpisode?.IdElement;
@@ -993,7 +993,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity ca_ = context.Operators.Quantity(14m, "days");
                     CqlDate cb_ = context.Operators.Add(bz_, ca_);
                     CqlInterval<CqlDate> cc_ = context.Operators.Interval(bv_, cb_, true, false);
-                    bool? cd_ = context.Operators.In<CqlDate>(br_, cc_, default);
+                    bool? cd_ = context.Operators.In<CqlDate>(br_, cc_, (string)default);
                     return cd_;
                 }
 
@@ -1106,7 +1106,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity db_ = context.Operators.Quantity(14m, "days");
                     CqlDate dc_ = context.Operators.Add(da_, db_);
                     CqlInterval<CqlDate> dd_ = context.Operators.Interval(cw_, dc_, true, false);
-                    bool? de_ = context.Operators.In<CqlDate>(cs_, dd_, default);
+                    bool? de_ = context.Operators.In<CqlDate>(cs_, dd_, (string)default);
                     return de_;
                 }
 
@@ -1296,7 +1296,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity ak_ = context.Operators.Quantity(34m, "days");
                     CqlDate al_ = context.Operators.Add(InitiationTreatmentDate, ak_);
                     CqlInterval<CqlDate> am_ = context.Operators.Interval(InitiationTreatmentDate, al_, false, true);
-                    bool? an_ = context.Operators.In<CqlDate>(aj_, am_, default);
+                    bool? an_ = context.Operators.In<CqlDate>(aj_, am_, (string)default);
                     bool? ao_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
                     bool? ap_ = context.Operators.And(an_, ao_);
                     object aq_ = context.Operators.LateBoundProperty<object>(ShortActingTreatment, "period");
@@ -1305,7 +1305,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlDate at_ = context.Operators.DateFrom(as_);
                     CqlDate av_ = context.Operators.Add(InitiationTreatmentDate, ak_);
                     CqlInterval<CqlDate> aw_ = context.Operators.Interval(InitiationTreatmentDate, av_, false, true);
-                    bool? ax_ = context.Operators.In<CqlDate>(at_, aw_, default);
+                    bool? ax_ = context.Operators.In<CqlDate>(at_, aw_, (string)default);
                     bool? az_ = context.Operators.And(ax_, ao_);
                     bool? ba_ = context.Operators.Or(ap_, az_);
                     return ba_;
@@ -1369,7 +1369,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity dc_ = context.Operators.Quantity(34m, "days");
                     CqlDate dd_ = context.Operators.Add(InitiationTreatmentDate, dc_);
                     CqlInterval<CqlDate> de_ = context.Operators.Interval(InitiationTreatmentDate, dd_, false, true);
-                    bool? df_ = context.Operators.In<CqlDate>(db_, de_, default);
+                    bool? df_ = context.Operators.In<CqlDate>(db_, de_, (string)default);
                     bool? dg_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
                     bool? dh_ = context.Operators.And(df_, dg_);
                     return dh_;
@@ -1443,7 +1443,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity at_ = context.Operators.Quantity(34m, "days");
                     CqlDate au_ = context.Operators.Add(InitiationTreatmentDate, at_);
                     CqlInterval<CqlDate> av_ = context.Operators.Interval(InitiationTreatmentDate, au_, false, true);
-                    bool? aw_ = context.Operators.In<CqlDate>(as_, av_, default);
+                    bool? aw_ = context.Operators.In<CqlDate>(as_, av_, (string)default);
                     bool? ax_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
                     bool? ay_ = context.Operators.And(aw_, ax_);
                     return ay_;
@@ -1540,7 +1540,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
                     CqlQuantity bm_ = context.Operators.Quantity(34m, "days");
                     CqlDate bn_ = context.Operators.Add(InitiationTreatmentDate, bm_);
                     CqlInterval<CqlDate> bo_ = context.Operators.Interval(InitiationTreatmentDate, bn_, false, true);
-                    bool? bp_ = context.Operators.In<CqlDate>(bl_, bo_, default);
+                    bool? bp_ = context.Operators.In<CqlDate>(bl_, bo_, (string)default);
                     bool? bq_ = context.Operators.Not((bool?)(InitiationTreatmentDate is null));
                     bool? br_ = context.Operators.And(bp_, bq_);
                     return br_;
@@ -1613,7 +1613,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(13, 17, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -1630,7 +1630,7 @@ public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleto
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 64, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
@@ -292,7 +292,7 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                     DataType n_ = MacularExam?.Effective;
                     object o_ = FHIRHelpers_4_4_000.Instance.ToValue(context, n_);
                     CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.toInterval(context, o_);
-                    bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, default);
+                    bool? q_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(m_, p_, (string)default);
                     return q_;
                 }
 
@@ -352,7 +352,7 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                     Period n_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.Start(o_);
-                    bool? q_ = context.Operators.After(m_, p_, default);
+                    bool? q_ = context.Operators.After(m_, p_, (string)default);
                     CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
                     CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
                     bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
@@ -396,7 +396,7 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                     Period n_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.Start(o_);
-                    bool? q_ = context.Operators.After(m_, p_, default);
+                    bool? q_ = context.Operators.After(m_, p_, (string)default);
                     CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
                     CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
                     bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, "day");
@@ -440,10 +440,10 @@ public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingl
                     Period n_ = EncounterDiabeticRetinopathy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.Start(o_);
-                    bool? q_ = context.Operators.After(m_, p_, default);
+                    bool? q_ = context.Operators.After(m_, p_, (string)default);
                     CqlDateTime s_ = context.Operators.Convert<CqlDateTime>(l_);
                     CqlInterval<CqlDateTime> t_ = this.Measurement_Period(context);
-                    bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, default);
+                    bool? u_ = context.Operators.In<CqlDateTime>(s_, t_, (string)default);
                     bool? v_ = context.Operators.And(q_, u_);
                     return v_;
                 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
@@ -240,7 +240,7 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
                 DataType o_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
                 object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
                 Code<ObservationStatus> s_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.StatusElement;
                 ObservationStatus? t_ = s_?.Value;
                 string u_ = context.Operators.Convert<string>(t_);
@@ -264,13 +264,13 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
                     DataType aq_ = MostRecentPriorHeartRate?.Effective;
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
+                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, (string)default);
                     object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
                     DataType ax_ = tuple_fufpmqdratbglhghdwfuubanf?.HeartRate?.Effective;
                     object ay_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ax_);
                     CqlInterval<CqlDateTime> az_ = QICoreCommon_4_0_000.Instance.toInterval(context, ay_);
-                    bool? ba_ = context.Operators.Before(aw_, az_, default);
+                    bool? ba_ = context.Operators.Before(aw_, az_, (string)default);
                     bool? bb_ = context.Operators.And(at_, ba_);
                     return bb_;
                 }
@@ -634,7 +634,7 @@ public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISinglet
                     Period p_ = ModerateOrSevereLVSDHFOutpatientEncounter?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
                     CqlDateTime r_ = context.Operators.End(q_);
-                    bool? s_ = context.Operators.Before(o_, r_, default);
+                    bool? s_ = context.Operators.Before(o_, r_, (string)default);
                     return s_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
@@ -402,7 +402,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     Period m_ = ValidQualifyingEncounter?.Period;
                     CqlInterval<CqlDateTime> n_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
                     CqlDateTime o_ = context.Operators.End(n_);
-                    bool? p_ = context.Operators.Before(l_, o_, default);
+                    bool? p_ = context.Operators.Before(l_, o_, (string)default);
                     Code<EventStatus> q_ = CardiacSurgeryProcedure?.StatusElement;
                     EventStatus? r_ = q_?.Value;
                     string s_ = context.Operators.Convert<string>(r_);
@@ -648,7 +648,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     Period n_ = CADEncounterMI?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.End(o_);
-                    bool? q_ = context.Operators.Before(m_, p_, default);
+                    bool? q_ = context.Operators.Before(m_, p_, (string)default);
                     Code<EventStatus> r_ = ImplantedCardiacPacer?.StatusElement;
                     EventStatus? s_ = r_?.Value;
                     string t_ = context.Operators.Convert<string>(s_);
@@ -705,7 +705,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 DataType o_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
                 object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
                 Code<ObservationStatus> s_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.StatusElement;
                 ObservationStatus? t_ = s_?.Value;
                 string u_ = context.Operators.Convert<string>(t_);
@@ -729,7 +729,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     DataType aq_ = MostRecentPriorHeartRateExam?.Effective;
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
+                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, (string)default);
                     Code<ObservationStatus> au_ = MostRecentPriorHeartRateExam?.StatusElement;
                     ObservationStatus? av_ = au_?.Value;
                     string aw_ = context.Operators.Convert<string>(av_);
@@ -745,7 +745,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     DataType bd_ = tuple_ezawxthbubhdjanfnawxfxgjj?.HeartRateExam?.Effective;
                     object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
                     CqlInterval<CqlDateTime> bf_ = QICoreCommon_4_0_000.Instance.toInterval(context, be_);
-                    bool? bg_ = context.Operators.Before(bc_, bf_, default);
+                    bool? bg_ = context.Operators.Before(bc_, bf_, (string)default);
                     bool? bh_ = context.Operators.And(az_, bg_);
                     return bh_;
                 }
@@ -800,7 +800,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     Period n_ = EncounterWithCADProxy?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.End(o_);
-                    bool? q_ = context.Operators.Before(m_, p_, default);
+                    bool? q_ = context.Operators.Before(m_, p_, (string)default);
                     return q_;
                 }
 
@@ -975,7 +975,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
 
                     IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
                     IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
-                    IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                    IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, (string)default);
 
                     object ad_(CqlInterval<CqlDateTime> @this) {
                         CqlDateTime av_ = context.Operators.Start(@this);
@@ -1122,7 +1122,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
 
                     IEnumerable<CqlInterval<CqlDateTime>> aa_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(y_, z_);
                     IEnumerable<CqlInterval<CqlDateTime>> ab_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(aa_);
-                    IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, default);
+                    IEnumerable<CqlInterval<CqlDateTime>> ac_ = context.Operators.Collapse(ab_, (string)default);
 
                     object ad_(CqlInterval<CqlDateTime> @this) {
                         CqlDateTime av_ = context.Operators.Start(@this);
@@ -1343,7 +1343,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     Period n_ = CADEncounterModerateOrSevereLVSD?.Period;
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
                     CqlDateTime p_ = context.Operators.End(o_);
-                    bool? q_ = context.Operators.Before(m_, p_, default);
+                    bool? q_ = context.Operators.Before(m_, p_, (string)default);
                     return q_;
                 }
 
@@ -1395,7 +1395,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                 DataType o_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
                 object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                 CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+                bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
                 Code<ObservationStatus> s_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.StatusElement;
                 ObservationStatus? t_ = s_?.Value;
                 string u_ = context.Operators.Convert<string>(t_);
@@ -1419,7 +1419,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     DataType aq_ = MostRecentPriorHeartRateExam?.Effective;
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlInterval<CqlDateTime> as_ = QICoreCommon_4_0_000.Instance.toInterval(context, ar_);
-                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, default);
+                    bool? at_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ap_, as_, (string)default);
                     Code<ObservationStatus> au_ = MostRecentPriorHeartRateExam?.StatusElement;
                     ObservationStatus? av_ = au_?.Value;
                     string aw_ = context.Operators.Convert<string>(av_);
@@ -1435,7 +1435,7 @@ public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingle
                     DataType bd_ = tuple_dyeiilrxycxwhkhdhbjdnjgdc?.HeartRateExam?.Effective;
                     object be_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bd_);
                     CqlInterval<CqlDateTime> bf_ = QICoreCommon_4_0_000.Instance.toInterval(context, be_);
-                    bool? bg_ = context.Operators.Before(bc_, bf_, default);
+                    bool? bg_ = context.Operators.Before(bc_, bf_, (string)default);
                     bool? bh_ = context.Operators.And(az_, bg_);
                     return bh_;
                 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
@@ -552,7 +552,7 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
                 CqlDate m_ = context.Operators.DateFrom(l_);
                 int? n_ = context.Operators.CalculateAgeAt(j_, m_, "year");
                 CqlInterval<int?> o_ = context.Operators.Interval(3, 17, true, true);
-                bool? p_ = context.Operators.In<int?>(n_, o_, default);
+                bool? p_ = context.Operators.In<int?>(n_, o_, (string)default);
                 return p_;
             }
 
@@ -579,7 +579,7 @@ public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISinglet
                 CqlDate m_ = context.Operators.DateFrom(l_);
                 int? n_ = context.Operators.CalculateAgeAt(j_, m_, "year");
                 CqlInterval<int?> o_ = context.Operators.Interval(18, 64, true, true);
-                bool? p_ = context.Operators.In<int?>(n_, o_, default);
+                bool? p_ = context.Operators.In<int?>(n_, o_, (string)default);
                 return p_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
@@ -276,7 +276,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                     };
                 }
 
-                bool? q_ = context.Operators.SameOrBefore(o_, p_(), default);
+                bool? q_ = context.Operators.SameOrBefore(o_, p_(), (string)default);
                 bool? r_ = context.Operators.And(l_, q_);
                 return r_;
             }
@@ -309,7 +309,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             bool? s_(object SexualActivityDiagnosis) {
                 CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, SexualActivityDiagnosis);
                 CqlInterval<CqlDateTime> w_ = this.Measurement_Period(context);
-                bool? x_ = context.Operators.Overlaps(v_, w_, default);
+                bool? x_ = context.Operators.Overlaps(v_, w_, (string)default);
                 return x_;
             }
 
@@ -363,7 +363,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 bool? ai_ = z_?.highClosed;
                 CqlInterval<CqlDateTime> aj_ = context.Operators.Interval(ab_, ae_, ag_, ai_);
                 CqlInterval<CqlDateTime> ak_ = this.Measurement_Period(context);
-                bool? al_ = context.Operators.Overlaps(aj_, ak_, default);
+                bool? al_ = context.Operators.Overlaps(aj_, ak_, (string)default);
                 return al_;
             }
 
@@ -592,7 +592,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(16, 24, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
 
             List<Extension> k_() {
 
@@ -710,7 +710,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 FhirDateTime au_ = PregnancyTest?.AuthoredOnElement;
                 CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(au_);
                 CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_ as object);
-                bool? ax_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(at_, aw_, default);
+                bool? ax_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(at_, aw_, (string)default);
                 return ax_;
             }
 
@@ -787,7 +787,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
                 FhirDateTime cv_ = PregnancyTestOrder?.AuthoredOnElement;
                 CqlDateTime cw_ = context.Operators.Convert<CqlDateTime>(cv_);
                 CqlInterval<CqlDateTime> cx_ = QICoreCommon_4_0_000.Instance.toInterval(context, cw_ as object);
-                bool? cy_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cu_, cx_, default);
+                bool? cy_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(cu_, cx_, (string)default);
                 return cy_;
             }
 
@@ -915,7 +915,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(16, 20, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -932,7 +932,7 @@ public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(21, 24, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
@@ -285,7 +285,7 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                 CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
                 bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, "day");
                 CqlInterval<CqlDateTime> w_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? x_ = context.Operators.OverlapsBefore(p_, w_, default);
+                bool? x_ = context.Operators.OverlapsBefore(p_, w_, (string)default);
                 bool? y_ = context.Operators.Or(t_, x_);
                 return y_;
             }
@@ -458,7 +458,7 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                     CqlQuantity aq_ = context.Operators.Quantity(3m, "days");
                     CqlDateTime ar_ = context.Operators.Add(ap_, aq_);
                     CqlInterval<CqlDateTime> as_ = context.Operators.Interval(am_, ar_, true, true);
-                    bool? at_ = context.Operators.In<CqlDateTime>(aj_, as_, default);
+                    bool? at_ = context.Operators.In<CqlDateTime>(aj_, as_, (string)default);
                     CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ak_);
                     CqlDateTime aw_ = context.Operators.Start(av_);
                     bool? ax_ = context.Operators.Not((bool?)(aw_ is null));
@@ -530,7 +530,7 @@ public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleto
                 CqlDate m_ = context.Operators.DateFrom(l_);
                 int? n_ = context.Operators.CalculateAgeAt(j_, m_, "year");
                 CqlInterval<int?> o_ = context.Operators.Interval(18, 64, true, true);
-                bool? p_ = context.Operators.In<int?>(n_, o_, default);
+                bool? p_ = context.Operators.In<int?>(n_, o_, (string)default);
                 return p_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
@@ -168,7 +168,7 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(3, 17, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);
@@ -196,7 +196,7 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             bool? g_(object PregnancyDiag) {
                 CqlInterval<CqlDateTime> i_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyDiag);
                 CqlInterval<CqlDateTime> j_ = this.Measurement_Period(context);
-                bool? k_ = context.Operators.Overlaps(i_, j_, default);
+                bool? k_ = context.Operators.Overlaps(i_, j_, (string)default);
                 return k_;
             }
 
@@ -483,7 +483,7 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(3, 11, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -500,7 +500,7 @@ public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleto
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(12, 17, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
@@ -376,7 +376,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 CqlInterval<CqlDateTime> ax_ = this.Measurement_Period(context);
                 Period ay_ = ValidEncounters?.Period;
                 CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ay_);
-                bool? ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ax_, az_, default);
+                bool? ba_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ax_, az_, (string)default);
                 return ba_;
             }
 
@@ -434,7 +434,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 FhirDateTime l_ = OrderMedication1?.AuthoredOnElement;
                 CqlDateTime m_ = context.Operators.Convert<CqlDateTime>(l_);
                 CqlInterval<CqlDateTime> n_ = this.Measurement_Period(context);
-                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
+                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
                 MedicationRequest.DispenseRequestComponent p_ = OrderMedication1?.DispenseRequest;
                 UnsignedInt q_ = p_?.NumberOfRepeatsAllowedElement;
                 int? r_ = q_?.Value;
@@ -448,10 +448,10 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 bool? aa_ = context.Operators.Equivalent(w_, z_);
                 bool? ab_ = context.Operators.Not(aa_);
                 CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(l_);
-                bool? af_ = context.Operators.In<CqlDateTime>(ad_, n_, default);
+                bool? af_ = context.Operators.In<CqlDateTime>(ad_, n_, (string)default);
                 bool? ag_ = context.Operators.And(ab_, af_);
                 CqlDateTime ai_ = context.Operators.Convert<CqlDateTime>(x_);
-                bool? ak_ = context.Operators.In<CqlDateTime>(ai_, n_, default);
+                bool? ak_ = context.Operators.In<CqlDateTime>(ai_, n_, (string)default);
                 bool? al_ = context.Operators.And(ag_, ak_);
                 bool? am_ = context.Operators.Or(t_, al_);
                 CqlDateTime ao_ = context.Operators.Convert<CqlDateTime>(l_);
@@ -460,7 +460,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 CqlDate as_ = context.Operators.DateFrom(ar_);
                 bool? at_ = context.Operators.Equivalent(ap_, as_);
                 CqlDateTime av_ = context.Operators.Convert<CqlDateTime>(l_);
-                bool? ax_ = context.Operators.In<CqlDateTime>(av_, n_, default);
+                bool? ax_ = context.Operators.In<CqlDateTime>(av_, n_, (string)default);
                 bool? ay_ = context.Operators.And(at_, ax_);
                 CqlInterval<CqlDate> az_ = CumulativeMedicationDuration_6_0_000.Instance.medicationRequestPeriod(context, OrderMedication1);
                 CqlDate ba_ = context.Operators.Start(az_);
@@ -475,11 +475,11 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 bool? bj_ = context.Operators.And(ay_, bi_);
                 CqlDate bl_ = context.Operators.Start(az_);
                 CqlDateTime bm_ = context.Operators.ConvertDateToDateTime(bl_);
-                bool? bo_ = context.Operators.In<CqlDateTime>(bm_, n_, default);
+                bool? bo_ = context.Operators.In<CqlDateTime>(bm_, n_, (string)default);
                 bool? bp_ = context.Operators.And(bj_, bo_);
                 CqlDate br_ = context.Operators.Start(bd_);
                 CqlDateTime bs_ = context.Operators.ConvertDateToDateTime(br_);
-                bool? bu_ = context.Operators.In<CqlDateTime>(bs_, n_, default);
+                bool? bu_ = context.Operators.In<CqlDateTime>(bs_, n_, (string)default);
                 bool? bv_ = context.Operators.And(bp_, bu_);
                 bool? bw_ = context.Operators.Or(am_, bv_);
                 return bw_;
@@ -1654,7 +1654,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 FhirDateTime ad_ = AntipsychoticMedication?.AuthoredOnElement;
                 CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
                 CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-                bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
                 return ag_;
             }
 
@@ -1810,7 +1810,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 FhirDateTime ad_ = BenzodiazepineMedication?.AuthoredOnElement;
                 CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(ad_);
                 CqlInterval<CqlDateTime> af_ = this.Measurement_Period(context);
-                bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
                 return ag_;
             }
 
@@ -1846,7 +1846,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 CqlDateTime ad_ = context.Operators.Subtract(ab_, ac_);
                 CqlDateTime ae_ = this.Antipsychotic_Index_Prescription_Start_Date(context);
                 CqlInterval<CqlDateTime> af_ = context.Operators.Interval(ad_, ae_, true, true);
-                bool? ag_ = context.Operators.Overlaps(z_, af_, default);
+                bool? ag_ = context.Operators.Overlaps(z_, af_, (string)default);
                 return ag_;
             }
 
@@ -1873,7 +1873,7 @@ public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleto
                 CqlDateTime al_ = context.Operators.Subtract(aj_, ak_);
                 CqlDateTime am_ = this.Benzodiazepine_Index_Prescription_Start_Date(context);
                 CqlInterval<CqlDateTime> an_ = context.Operators.Interval(al_, am_, true, true);
-                bool? ao_ = context.Operators.Overlaps(ah_, an_, default);
+                bool? ao_ = context.Operators.Overlaps(ah_, an_, (string)default);
                 return ao_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
@@ -166,7 +166,7 @@ public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISing
                 }
 
                 CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_());
-                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, default);
+                bool? n_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(k_, m_, (string)default);
                 Code<EventStatus> o_ = ChemoAdministration?.StatusElement;
                 EventStatus? p_ = o_?.Value;
                 string q_ = context.Operators.Convert<string>(p_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
@@ -267,7 +267,7 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
                     Period j_ = ValidEncounter?.Period;
                     CqlInterval<CqlDateTime> k_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                     CqlInterval<CqlDateTime> l_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, Depression);
-                    bool? m_ = context.Operators.Overlaps(k_, l_, default);
+                    bool? m_ = context.Operators.Overlaps(k_, l_, (string)default);
                     CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, j_);
                     CqlDateTime p_ = context.Operators.End(o_);
                     CqlInterval<CqlDateTime> q_ = this.Denominator_Identification_Period(context);
@@ -1016,7 +1016,7 @@ public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingl
                 CqlDate o_ = context.Operators.DateFrom(n_);
                 int? p_ = context.Operators.CalculateAgeAt(j_, o_, "year");
                 CqlInterval<int?> q_ = context.Operators.Interval(12, 17, true, true);
-                bool? r_ = context.Operators.In<int?>(p_, q_, default);
+                bool? r_ = context.Operators.In<int?>(p_, q_, (string)default);
                 return r_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
@@ -126,7 +126,7 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
                 CqlQuantity n_ = context.Operators.Quantity(6m, "months");
                 CqlDateTime o_ = context.Operators.Add(m_, n_);
                 CqlInterval<CqlDateTime> p_ = context.Operators.Interval(k_, o_, true, false);
-                bool? q_ = context.Operators.Overlaps(i_, p_, default);
+                bool? q_ = context.Operators.Overlaps(i_, p_, (string)default);
                 return q_;
             }
 
@@ -147,7 +147,7 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<object> k_ = this.Essential_Hypertension_Diagnosis(context);
             bool? l_ = context.Operators.Exists<object>(k_);
             bool? m_ = context.Operators.And(j_, l_);
@@ -193,7 +193,7 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
             bool? y_(object PregnancyESRDDiagnosis) {
                 CqlInterval<CqlDateTime> aa_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, PregnancyESRDDiagnosis);
                 CqlInterval<CqlDateTime> ab_ = this.Measurement_Period(context);
-                bool? ac_ = context.Operators.Overlaps(aa_, ab_, default);
+                bool? ac_ = context.Operators.Overlaps(aa_, ab_, (string)default);
                 return ac_;
             }
 
@@ -281,7 +281,7 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
                 CqlDateTime k_ = context.Operators.End(j_);
                 CqlInterval<CqlDateTime> l_ = this.Measurement_Period(context);
                 CqlDateTime m_ = context.Operators.End(l_);
-                bool? n_ = context.Operators.SameOrBefore(k_, m_, default);
+                bool? n_ = context.Operators.SameOrBefore(k_, m_, (string)default);
                 return n_;
             }
 
@@ -303,7 +303,7 @@ public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<
                 CqlDateTime h_ = context.Operators.Start(g_);
                 CqlInterval<CqlDateTime> i_ = this.Measurement_Period(context);
                 CqlDateTime j_ = context.Operators.End(i_);
-                bool? k_ = context.Operators.SameOrBefore(h_, j_, default);
+                bool? k_ = context.Operators.SameOrBefore(h_, j_, (string)default);
                 return k_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
@@ -386,7 +386,7 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
                     }
 
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_());
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     return t_;
                 }
@@ -421,7 +421,7 @@ public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISinglet
                     object q_ = context.Operators.LateBoundProperty<object>(ObservationSuicideRiskAssmt, "effective");
                     object r_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
                     CqlInterval<CqlDateTime> s_ = QICoreCommon_4_0_000.Instance.toInterval(context, r_);
-                    bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, default);
+                    bool? t_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(p_, s_, (string)default);
                     object u_ = context.Operators.LateBoundProperty<object>(ObservationSuicideRiskAssmt, "status");
                     string v_ = context.Operators.LateBoundProperty<string>(u_, "value");
                     string[] w_ = [

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
@@ -363,7 +363,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlQuantity p_ = context.Operators.Quantity(1m, "mm[Hg]");
                 CqlQuantity q_ = context.Operators.Quantity(120m, "mm[Hg]");
                 CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, false);
-                bool? s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, default);
+                bool? s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, (string)default);
 
                 bool? u_(Observation BloodPressure) {
                     DataType bg_ = BloodPressure?.Effective;
@@ -415,7 +415,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ad_);
                 CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
                 CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(p_, ag_, true, false);
-                bool? ai_ = context.Operators.In<CqlQuantity>(ae_ as CqlQuantity, ah_, default);
+                bool? ai_ = context.Operators.In<CqlQuantity>(ae_ as CqlQuantity, ah_, (string)default);
                 bool? aj_ = context.Operators.And(s_, ai_);
                 return aj_;
             }
@@ -484,7 +484,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlQuantity p_ = context.Operators.Quantity(120m, "mm[Hg]");
                 CqlQuantity q_ = context.Operators.Quantity(129m, "mm[Hg]");
                 CqlInterval<CqlQuantity> r_ = context.Operators.Interval(p_, q_, true, true);
-                bool? s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, default);
+                bool? s_ = context.Operators.In<CqlQuantity>(o_ as CqlQuantity, r_, (string)default);
 
                 bool? u_(Observation BloodPressure) {
                     DataType bg_ = BloodPressure?.Effective;
@@ -537,7 +537,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlQuantity af_ = context.Operators.Quantity(1m, "mm[Hg]");
                 CqlQuantity ag_ = context.Operators.Quantity(80m, "mm[Hg]");
                 CqlInterval<CqlQuantity> ah_ = context.Operators.Interval(af_, ag_, true, false);
-                bool? ai_ = context.Operators.In<CqlQuantity>(ae_ as CqlQuantity, ah_, default);
+                bool? ai_ = context.Operators.In<CqlQuantity>(ae_ as CqlQuantity, ah_, (string)default);
                 bool? aj_ = context.Operators.And(s_, ai_);
                 return aj_;
             }
@@ -733,7 +733,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                     CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
                     CqlDateTime bv_ = context.Operators.Start(bu_);
                     CqlInterval<CqlDateTime> bw_ = context.Operators.Interval(bs_, bv_, true, true);
-                    bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, default);
+                    bool? bx_ = context.Operators.In<CqlDateTime>(bn_, bw_, (string)default);
                     CqlInterval<CqlDateTime> bz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bo_);
                     CqlDateTime ca_ = context.Operators.Start(bz_);
                     bool? cb_ = context.Operators.Not((bool?)(ca_ is null));
@@ -794,7 +794,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                     CqlInterval<CqlDateTime> dc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cw_);
                     CqlDateTime dd_ = context.Operators.Start(dc_);
                     CqlInterval<CqlDateTime> de_ = context.Operators.Interval(da_, dd_, true, true);
-                    bool? df_ = context.Operators.In<CqlDateTime>(cv_, de_, default);
+                    bool? df_ = context.Operators.In<CqlDateTime>(cv_, de_, (string)default);
                     CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cw_);
                     CqlDateTime di_ = context.Operators.Start(dh_);
                     bool? dj_ = context.Operators.Not((bool?)(di_ is null));
@@ -855,7 +855,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                     CqlInterval<CqlDateTime> ek_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
                     CqlDateTime el_ = context.Operators.Start(ek_);
                     CqlInterval<CqlDateTime> em_ = context.Operators.Interval(ei_, el_, true, true);
-                    bool? en_ = context.Operators.In<CqlDateTime>(ed_, em_, default);
+                    bool? en_ = context.Operators.In<CqlDateTime>(ed_, em_, (string)default);
                     CqlInterval<CqlDateTime> ep_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ee_);
                     CqlDateTime eq_ = context.Operators.Start(ep_);
                     bool? er_ = context.Operators.Not((bool?)(eq_ is null));
@@ -916,7 +916,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                     CqlInterval<CqlDateTime> fs_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fm_);
                     CqlDateTime ft_ = context.Operators.Start(fs_);
                     CqlInterval<CqlDateTime> fu_ = context.Operators.Interval(fq_, ft_, true, true);
-                    bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, default);
+                    bool? fv_ = context.Operators.In<CqlDateTime>(fl_, fu_, (string)default);
                     CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fm_);
                     CqlDateTime fy_ = context.Operators.Start(fx_);
                     bool? fz_ = context.Operators.Not((bool?)(fy_ is null));
@@ -1330,7 +1330,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlQuantity r_ = context.Operators.Quantity(130m, "mm[Hg]");
                 CqlQuantity s_ = context.Operators.Quantity(139m, "mm[Hg]");
                 CqlInterval<CqlQuantity> t_ = context.Operators.Interval(r_, s_, true, true);
-                bool? u_ = context.Operators.In<CqlQuantity>(q_ as CqlQuantity, t_, default);
+                bool? u_ = context.Operators.In<CqlQuantity>(q_ as CqlQuantity, t_, (string)default);
 
                 bool? w_(Observation BloodPressure) {
                     DataType cn_ = BloodPressure?.Effective;
@@ -1383,7 +1383,7 @@ public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingle
                 CqlQuantity ah_ = context.Operators.Quantity(80m, "mm[Hg]");
                 CqlQuantity ai_ = context.Operators.Quantity(89m, "mm[Hg]");
                 CqlInterval<CqlQuantity> aj_ = context.Operators.Interval(ah_, ai_, true, true);
-                bool? ak_ = context.Operators.In<CqlQuantity>(ag_ as CqlQuantity, aj_, default);
+                bool? ak_ = context.Operators.In<CqlQuantity>(ag_ as CqlQuantity, aj_, (string)default);
                 bool? al_ = context.Operators.Or(u_, ak_);
 
                 bool? an_(Observation BloodPressure) {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
@@ -249,7 +249,7 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(12, 16, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -593,7 +593,7 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
                 CqlDateTime ao_ = context.Operators.Start(an_);
                 CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+                bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, (string)default);
                 object as_ = context.Operators.LateBoundProperty<object>(tuple_ewmohjtdtinujhphqjvbwmmhh?.FollowUpPositiveAdolescentScreen, "authoredOn");
                 CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
                 CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
@@ -1051,7 +1051,7 @@ public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingle
                 CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_());
                 CqlDateTime ao_ = context.Operators.Start(an_);
                 CqlInterval<CqlDateTime> aq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, default);
+                bool? ar_ = context.Operators.In<CqlDateTime>(ao_, aq_, (string)default);
                 object as_ = context.Operators.LateBoundProperty<object>(tuple_cgtoaqsajoehgwcararimqzsa?.FollowUpPositiveAdultScreen, "authoredOn");
                 CqlDateTime at_ = context.Operators.LateBoundProperty<CqlDateTime>(as_, "value");
                 CqlInterval<CqlDateTime> av_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
@@ -443,7 +443,7 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(20, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -569,7 +569,7 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(40, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Has_Diabetes_Diagnosis(context);
             bool? l_ = context.Operators.And(j_, k_);
             IEnumerable<object> m_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);
@@ -652,7 +652,7 @@ public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(40, 75, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Ten_Year_CVD_Risk_is_High(context);
             bool? l_ = context.Operators.And(j_, k_);
             IEnumerable<object> m_ = this.ASCVD_Diagnosis_or_Procedure_before_End_of_Measurement_Period(context);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
@@ -140,7 +140,7 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(15, 65, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);
@@ -181,7 +181,7 @@ public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS34
                 CqlDate u_ = context.Operators.DateFrom(t_);
                 int? v_ = context.Operators.CalculateAgeAt(p_, u_, "year");
                 CqlInterval<int?> w_ = context.Operators.Interval(15, 65, true, true);
-                bool? x_ = context.Operators.In<int?>(v_, w_, default);
+                bool? x_ = context.Operators.In<int?>(v_, w_, (string)default);
                 bool? y_ = context.Operators.And(l_, x_);
                 object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, q_);
                 CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
@@ -802,7 +802,7 @@ public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<C
                     object bt_ = context.Operators.LateBoundProperty<object>(PalliativeOrHospiceCare, "authoredOn");
                     CqlDateTime bu_ = context.Operators.LateBoundProperty<CqlDateTime>(bt_, "value");
                     CqlInterval<CqlDateTime> bv_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? bw_ = context.Operators.In<CqlDateTime>(bs_ ?? bu_, bv_, default);
+                    bool? bw_ = context.Operators.In<CqlDateTime>(bs_ ?? bu_, bv_, (string)default);
                     return bw_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
@@ -397,7 +397,7 @@ public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISin
                     CqlDateTime t_ = context.Operators.End(s_);
                     FhirDateTime u_ = FirstReferral?.AuthoredOnElement;
                     CqlDateTime v_ = context.Operators.Convert<CqlDateTime>(u_);
-                    bool? w_ = context.Operators.After(t_, v_, default);
+                    bool? w_ = context.Operators.After(t_, v_, (string)default);
                     bool? x_ = context.Operators.And(q_, w_);
                     CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
                     CqlDateTime aa_ = context.Operators.End(z_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
@@ -633,7 +633,7 @@ public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingle
                     CqlInterval<CqlDateTime> v_ = QICoreCommon_4_0_000.Instance.toInterval(context, u_());
                     CqlDateTime w_ = context.Operators.Start(v_);
                     CqlInterval<CqlDateTime> x_ = context.Operators.Interval(t_, w_, true, true);
-                    bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, default);
+                    bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, (string)default);
 
                     object z_() {
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
@@ -266,7 +266,7 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
 
                 IEnumerable<CqlInterval<CqlDateTime>> bj_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bh_, bi_);
                 IEnumerable<CqlInterval<CqlDateTime>> bk_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bj_);
-                IEnumerable<CqlInterval<CqlDateTime>> bl_ = context.Operators.Collapse(bk_, default);
+                IEnumerable<CqlInterval<CqlDateTime>> bl_ = context.Operators.Collapse(bk_, (string)default);
 
                 object bm_(CqlInterval<CqlDateTime> @this) {
                     CqlDateTime dl_ = context.Operators.Start(@this);
@@ -331,7 +331,7 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
 
                 IEnumerable<CqlInterval<CqlDateTime>> ce_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(cc_, cd_);
                 IEnumerable<CqlInterval<CqlDateTime>> cf_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(ce_);
-                IEnumerable<CqlInterval<CqlDateTime>> cg_ = context.Operators.Collapse(cf_, default);
+                IEnumerable<CqlInterval<CqlDateTime>> cg_ = context.Operators.Collapse(cf_, (string)default);
 
                 object ch_(CqlInterval<CqlDateTime> @this) {
                     CqlDateTime dy_ = context.Operators.Start(@this);
@@ -474,7 +474,7 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
 
                 IEnumerable<CqlInterval<CqlDateTime>> bb_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(az_, ba_);
                 IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bb_);
-                IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Collapse(bc_, default);
+                IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Collapse(bc_, (string)default);
 
                 object be_(CqlInterval<CqlDateTime> @this) {
                     CqlDateTime cr_ = context.Operators.Start(@this);
@@ -539,7 +539,7 @@ public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingl
 
                 IEnumerable<CqlInterval<CqlDateTime>> bw_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bu_, bv_);
                 IEnumerable<CqlInterval<CqlDateTime>> bx_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bw_);
-                IEnumerable<CqlInterval<CqlDateTime>> by_ = context.Operators.Collapse(bx_, default);
+                IEnumerable<CqlInterval<CqlDateTime>> by_ = context.Operators.Collapse(bx_, (string)default);
 
                 object bz_(CqlInterval<CqlDateTime> @this) {
                     CqlDateTime de_ = context.Operators.Start(@this);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
@@ -1039,7 +1039,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
                     IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(bc_, bd_);
                     IEnumerable<CqlInterval<CqlDateTime>> bf_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(be_);
-                    IEnumerable<CqlInterval<CqlDateTime>> bg_ = context.Operators.Collapse(bf_, default);
+                    IEnumerable<CqlInterval<CqlDateTime>> bg_ = context.Operators.Collapse(bf_, (string)default);
 
                     object bh_(CqlInterval<CqlDateTime> @this) {
                         CqlDateTime cn_ = context.Operators.Start(@this);
@@ -1740,7 +1740,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
 
                     IEnumerable<CqlInterval<CqlDateTime>> bc_ = context.Operators.Select<object, CqlInterval<CqlDateTime>>(ba_, bb_);
                     IEnumerable<CqlInterval<CqlDateTime>> bd_ = context.Operators.Distinct<CqlInterval<CqlDateTime>>(bc_);
-                    IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Collapse(bd_, default);
+                    IEnumerable<CqlInterval<CqlDateTime>> be_ = context.Operators.Collapse(bd_, (string)default);
 
                     object bf_(CqlInterval<CqlDateTime> @this) {
                         CqlDateTime ck_ = context.Operators.Start(@this);
@@ -1885,7 +1885,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     CqlInterval<CqlDateTime> bp_ = QICoreCommon_4_0_000.Instance.toInterval(context, bo_());
                     CqlDateTime bq_ = context.Operators.Start(bp_);
                     CqlInterval<CqlDateTime> br_ = context.Operators.Interval(bn_, bq_, true, false);
-                    bool? bs_ = context.Operators.In<CqlDateTime>(bi_, br_, default);
+                    bool? bs_ = context.Operators.In<CqlDateTime>(bi_, br_, (string)default);
 
                     object bt_() {
 
@@ -2195,7 +2195,7 @@ public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingl
                     CqlInterval<CqlDateTime> ge_ = QICoreCommon_4_0_000.Instance.toInterval(context, gd_());
                     CqlDateTime gf_ = context.Operators.Start(ge_);
                     CqlInterval<CqlDateTime> gg_ = context.Operators.Interval(gc_, gf_, true, false);
-                    bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, default);
+                    bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, (string)default);
 
                     object gi_() {
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
@@ -181,7 +181,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     Period ab_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> ac_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ab_);
                     CqlDateTime ad_ = context.Operators.Start(ac_);
-                    bool? ae_ = context.Operators.Before(aa_, ad_, default);
+                    bool? ae_ = context.Operators.Before(aa_, ad_, (string)default);
                     bool? af_ = context.Operators.And(x_, ae_);
                     return af_;
                 }
@@ -219,7 +219,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     Period ce_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> cf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ce_);
                     CqlDateTime cg_ = context.Operators.Start(cf_);
-                    bool? ch_ = context.Operators.Before(cd_, cg_, default);
+                    bool? ch_ = context.Operators.Before(cd_, cg_, (string)default);
                     bool? ci_ = context.Operators.And(bz_, ch_);
                     bool? cj_ = context.Operators.Implies(bm_, ci_);
                     return cj_;
@@ -302,7 +302,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     Period cx_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> cy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cx_);
                     CqlDateTime cz_ = context.Operators.End(cy_);
-                    bool? da_ = context.Operators.SameOrBefore(cw_, cz_, default);
+                    bool? da_ = context.Operators.SameOrBefore(cw_, cz_, (string)default);
                     bool? db_ = context.Operators.And(cu_, da_);
                     return db_;
                 }
@@ -341,7 +341,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     Period eu_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> ev_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eu_);
                     CqlDateTime ew_ = context.Operators.Start(ev_);
-                    bool? ex_ = context.Operators.Before(et_, ew_, default);
+                    bool? ex_ = context.Operators.Before(et_, ew_, (string)default);
                     bool? ey_ = context.Operators.And(ep_, ex_);
                     bool? ez_ = context.Operators.Implies(ec_, ey_);
                     return ez_;
@@ -391,7 +391,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     Period ah_ = IschemicStrokeEncounter?.Period;
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
                     CqlDateTime aj_ = context.Operators.End(ai_);
-                    bool? ak_ = context.Operators.SameOrBefore(ag_, aj_, default);
+                    bool? ak_ = context.Operators.SameOrBefore(ag_, aj_, (string)default);
                     bool? al_ = context.Operators.And(ac_, ak_);
                     bool? am_ = context.Operators.Implies(p_, al_);
                     return am_;
@@ -515,7 +515,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     object l_ = context.Operators.LateBoundProperty<object>(ComfortMeasure, "authoredOn");
                     CqlDateTime m_ = context.Operators.LateBoundProperty<CqlDateTime>(l_, "value");
                     CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, Encounter);
-                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, default);
+                    bool? o_ = context.Operators.In<CqlDateTime>(k_ ?? m_, n_, (string)default);
                     return o_;
                 }
 
@@ -641,7 +641,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     CqlDateTime as_ = context.Operators.Convert<CqlDateTime>(ar_);
                     Period at_ = Encounter?.Period;
                     CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, at_);
-                    bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, default);
+                    bool? av_ = context.Operators.In<CqlDateTime>(as_, au_, (string)default);
                     bool? aw_ = context.Operators.And(aq_, av_);
                     IEnumerable<Task> ax_ = context.Operators.Retrieve<Task>(new RetrieveParameters(default, default, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-taskrejected"));
 
@@ -820,7 +820,7 @@ public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleto
                     CqlDateTime j_ = context.Operators.LateBoundProperty<CqlDateTime>(i_, "value");
                     Period k_ = Encounter?.Period;
                     CqlInterval<CqlDateTime> l_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, k_);
-                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, default);
+                    bool? m_ = context.Operators.In<CqlDateTime>(j_, l_, (string)default);
                     return m_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
@@ -403,7 +403,7 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     CqlDateTime o_ = context.Operators.Subtract(m_, n_);
                     CqlDateTime q_ = context.Operators.End(l_);
                     CqlInterval<CqlDateTime> r_ = context.Operators.Interval(o_, q_, true, false);
-                    bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, default);
+                    bool? s_ = context.Operators.In<CqlDateTime>(k_, r_, (string)default);
                     return s_;
                 }
 
@@ -457,7 +457,7 @@ public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISinglet
                     FhirDateTime m_ = PriorTPA?.RecordedDateElement;
                     CqlDateTime n_ = context.Operators.Convert<CqlDateTime>(m_);
                     CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, IschemicStrokeEncounter);
-                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
                     CodeableConcept q_ = PriorTPA?.VerificationStatus;
                     CqlConcept r_ = FHIRHelpers_4_4_000.Instance.ToConcept(context, q_);
                     bool? s_ = context.Operators.Not((bool?)(r_ is null));

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
@@ -98,7 +98,7 @@ public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);
@@ -294,7 +294,7 @@ public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(1, 5, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -311,7 +311,7 @@ public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(6, 12, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 
@@ -328,7 +328,7 @@ public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingle
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(13, 20, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             return j_;
         });
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
@@ -86,7 +86,7 @@ public partial class CMS75FHIRChildrenDentalDecay_1_0_000 : ILibrary, ISingleton
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(1, 20, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             IEnumerable<Encounter> k_ = this.Qualifying_Encounters(context);
             bool? l_ = context.Operators.Exists<Encounter>(k_);
             bool? m_ = context.Operators.And(j_, l_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
@@ -195,7 +195,7 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 CqlDateTime r_ = context.Operators.Subtract(p_, q_);
                 CqlDateTime t_ = context.Operators.Start(o_);
                 CqlInterval<CqlDateTime> u_ = context.Operators.Interval(r_, t_, true, true);
-                bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, default);
+                bool? v_ = context.Operators.In<CqlDateTime>(n_, u_, (string)default);
                 bool? w_ = this.verificationStatusIsNotInvalid(context, NewBPHDiagnosis);
                 bool? x_ = context.Operators.And(v_, w_);
                 return x_;
@@ -677,7 +677,7 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                     CqlDateTime o_ = USSAssessment?.effectiveDatetime;
                     int? p_ = context.Operators.DifferenceBetween(n_, o_, "month");
                     CqlInterval<int?> q_ = context.Operators.Interval(6, 12, true, true);
-                    bool? r_ = context.Operators.In<int?>(p_, q_, default);
+                    bool? r_ = context.Operators.In<int?>(p_, q_, (string)default);
                     return r_;
                 }
 
@@ -785,7 +785,7 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                     CqlQuantity t_ = context.Operators.Quantity(31m, "days");
                     CqlDateTime u_ = context.Operators.Add(s_, t_);
                     CqlInterval<CqlDateTime> v_ = context.Operators.Interval(p_, u_, true, true);
-                    bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, default);
+                    bool? w_ = context.Operators.In<CqlDateTime>(m_, v_, (string)default);
                     Code<Encounter.EncounterStatus> x_ = UrologyHospitalServices?.StatusElement;
                     Encounter.EncounterStatus? y_ = x_?.Value;
                     Code<Encounter.EncounterStatus> z_ = context.Operators.Convert<Code<Encounter.EncounterStatus>>(y_);
@@ -823,10 +823,10 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                 bool? l_((CqlTupleMetadata, CqlDateTime effectiveDatetime, int? valueInteger)? FollowUpUSSAssessment) {
                     CqlInterval<CqlDateTime> p_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MorbidObesityDiagnosis);
                     CqlInterval<CqlDateTime> q_ = this.Measurement_Period(context);
-                    bool? r_ = context.Operators.Overlaps(p_, q_, default);
+                    bool? r_ = context.Operators.Overlaps(p_, q_, (string)default);
                     CqlDateTime t_ = context.Operators.Start(p_);
                     CqlDateTime u_ = FollowUpUSSAssessment?.effectiveDatetime;
-                    bool? v_ = context.Operators.SameOrBefore(t_, u_, default);
+                    bool? v_ = context.Operators.SameOrBefore(t_, u_, (string)default);
                     bool? w_ = context.Operators.And(r_, v_);
                     return w_;
                 }
@@ -886,7 +886,7 @@ public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingl
                     object ae_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
                     CqlDateTime af_ = QICoreCommon_4_0_000.Instance.earliest(context, ae_);
                     CqlDateTime ag_ = FollowUpUSSAssessment?.effectiveDatetime;
-                    bool? ah_ = context.Operators.SameOrBefore(af_, ag_, default);
+                    bool? ah_ = context.Operators.SameOrBefore(af_, ag_, (string)default);
                     bool? ai_ = context.Operators.And(ac_, ah_);
                     return ai_;
                 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
@@ -157,7 +157,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
                     CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
                     CqlDateTime l_ = context.Operators.Start(k_);
                     CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                    bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
+                    bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
                     return n_;
                 }
 
@@ -257,7 +257,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
                 CqlDateTime o_ = QICoreCommon_4_0_000.Instance.earliest(context, n_());
                 CqlInterval<CqlDateTime> p_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fadhmfgiduzpspclbhmqonodh?.InpatientHospitalization);
-                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, default);
+                bool? q_ = context.Operators.In<CqlDateTime>(o_, p_, (string)default);
                 Code<ObservationStatus> r_ = tuple_fadhmfgiduzpspclbhmqonodh?.GlucoseTest?.StatusElement;
                 ObservationStatus? s_ = r_?.Value;
                 string t_ = context.Operators.Convert<string>(s_);
@@ -382,7 +382,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
                 CqlDateTime al_ = QICoreCommon_4_0_000.Instance.earliest(context, ak_());
                 CqlInterval<CqlDateTime> am_ = context.Operators.Interval(aj_, al_, true, true);
-                bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, default);
+                bool? an_ = context.Operators.In<CqlDateTime>(af_, am_, (string)default);
 
                 object ao_() {
 
@@ -621,7 +621,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
                 CqlQuantity t_ = context.Operators.Quantity(5m, "minutes");
                 CqlDateTime u_ = context.Operators.Add(s_, t_);
                 CqlInterval<CqlDateTime> v_ = context.Operators.Interval(q_, u_, false, true);
-                bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, default);
+                bool? w_ = context.Operators.In<CqlDateTime>(o_, v_, (string)default);
 
                 object x_() {
 
@@ -727,7 +727,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
                 CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_());
                 CqlInterval<CqlDateTime> ad_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_fcmdncyhjlqsajxzjwdiopqvk?.InpatientHospitalization);
-                bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, default);
+                bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, (string)default);
                 bool? af_ = context.Operators.And(aa_, ae_);
 
                 object ag_() {
@@ -780,7 +780,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
                 }
 
                 CqlDateTime ah_ = QICoreCommon_4_0_000.Instance.earliest(context, ag_());
-                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ad_, default);
+                bool? aj_ = context.Operators.In<CqlDateTime>(ah_, ad_, (string)default);
                 bool? ak_ = context.Operators.And(af_, aj_);
                 Id al_ = tuple_fcmdncyhjlqsajxzjwdiopqvk?.FollowupGlucoseTest?.IdElement;
                 string am_ = al_?.Value;
@@ -920,7 +920,7 @@ public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRH
 
                 CqlDateTime m_ = QICoreCommon_4_0_000.Instance.earliest(context, l_());
                 CqlInterval<CqlDateTime> n_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_hqaveihellnsvbjqtehcabtjc?.InpatientHospitalization);
-                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, default);
+                bool? o_ = context.Operators.In<CqlDateTime>(m_, n_, (string)default);
                 return o_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
@@ -170,7 +170,7 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                     CqlInterval<CqlDateTime> k_ = QICoreCommon_4_0_000.Instance.toInterval(context, j_);
                     CqlDateTime l_ = context.Operators.Start(k_);
                     CqlInterval<CqlDateTime> m_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientEncounter);
-                    bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, default);
+                    bool? n_ = context.Operators.In<CqlDateTime>(l_, m_, (string)default);
                     List<Encounter.LocationComponent> o_ = InpatientEncounter?.Location;
 
                     bool? p_(Encounter.LocationComponent EncounterLocation) {
@@ -192,7 +192,7 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                         CqlDateTime ae_ = context.Operators.Start(ad_);
                         Period af_ = EncounterLocation?.Period;
                         CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, af_);
-                        bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, default);
+                        bool? ah_ = context.Operators.In<CqlDateTime>(ae_, ag_, (string)default);
                         bool? ai_ = context.Operators.And(aa_, ah_);
                         return ai_;
                     }
@@ -317,7 +317,7 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                     CqlDateTime bs_ = context.Operators.Start(br_);
                     Period bt_ = EncounterLocation?.Period;
                     CqlInterval<CqlDateTime> bu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bt_);
-                    bool? bv_ = context.Operators.In<CqlDateTime>(bs_, bu_, default);
+                    bool? bv_ = context.Operators.In<CqlDateTime>(bs_, bu_, (string)default);
                     bool? bw_ = context.Operators.And(bo_, bv_);
                     return bw_;
                 }
@@ -330,12 +330,12 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                 CqlInterval<CqlDateTime> t_ = QICoreCommon_4_0_000.Instance.toInterval(context, s_);
                 CqlDateTime u_ = context.Operators.Start(t_);
                 CqlInterval<CqlDateTime> v_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, tuple_htckrtcfdeaiwittzheehxihp?.InpatientHospitalization);
-                bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, default);
+                bool? w_ = context.Operators.In<CqlDateTime>(u_, v_, (string)default);
                 DataType x_ = tuple_htckrtcfdeaiwittzheehxihp?.OpioidGiven?.Effective;
                 object y_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
                 CqlInterval<CqlDateTime> z_ = QICoreCommon_4_0_000.Instance.toInterval(context, y_);
                 CqlDateTime aa_ = context.Operators.Start(z_);
-                bool? ac_ = context.Operators.In<CqlDateTime>(aa_, v_, default);
+                bool? ac_ = context.Operators.In<CqlDateTime>(aa_, v_, (string)default);
                 bool? ad_ = context.Operators.And(w_, ac_);
                 object af_ = FHIRHelpers_4_4_000.Instance.ToValue(context, x_);
                 CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
@@ -349,7 +349,7 @@ public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRH
                 CqlInterval<CqlDateTime> aq_ = QICoreCommon_4_0_000.Instance.toInterval(context, ap_);
                 CqlDateTime ar_ = context.Operators.Start(aq_);
                 CqlInterval<CqlDateTime> as_ = context.Operators.Interval(an_, ar_, true, false);
-                bool? at_ = context.Operators.In<CqlDateTime>(ah_, as_, default);
+                bool? at_ = context.Operators.In<CqlDateTime>(ah_, as_, (string)default);
                 object av_ = FHIRHelpers_4_4_000.Instance.ToValue(context, r_);
                 CqlInterval<CqlDateTime> aw_ = QICoreCommon_4_0_000.Instance.toInterval(context, av_);
                 CqlDateTime ax_ = context.Operators.Start(aw_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
@@ -207,7 +207,7 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
         object f_ = context.Operators.LateBoundProperty<object>(observation, "effective");
         object g_ = FHIRHelpers_4_4_000.Instance.ToValue(context, f_);
         CqlInterval<CqlDateTime> h_ = QICoreCommon_4_0_000.Instance.toInterval(context, g_);
-        bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, default);
+        bool? i_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(e_, h_, (string)default);
         bool? j_ = context.Operators.And(d_, i_);
 
         bool? k_() {
@@ -301,7 +301,7 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
                     CqlQuantity q_ = context.Operators.Quantity(72m, "hours");
                     CqlDateTime r_ = context.Operators.Add(p_, q_);
                     CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
-                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                     return t_;
                 }
 
@@ -362,7 +362,7 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
                     CqlQuantity q_ = context.Operators.Quantity(24m, "hours");
                     CqlDateTime r_ = context.Operators.Add(p_, q_);
                     CqlInterval<CqlDateTime> s_ = context.Operators.Interval(n_, r_, true, true);
-                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                     return t_;
                 }
 
@@ -433,7 +433,7 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
                     CqlDateTime p_ = context.Operators.Add(n_, o_);
                     CqlDateTime r_ = context.Operators.End(m_);
                     CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                     return t_;
                 }
 
@@ -494,7 +494,7 @@ public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHP
                     CqlDateTime p_ = context.Operators.Add(n_, o_);
                     CqlDateTime r_ = context.Operators.End(m_);
                     CqlInterval<CqlDateTime> s_ = context.Operators.Interval(p_, r_, true, true);
-                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(l_, s_, (string)default);
                     return t_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
@@ -190,7 +190,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                     CqlDateTime ae_ = context.Operators.Start(ad_);
                     CqlInterval<CqlDateTime> af_ = Hospitalization?.hospitalizationPeriod;
                     CqlDateTime ag_ = context.Operators.End(af_);
-                    bool? ah_ = context.Operators.Before(ae_, ag_, default);
+                    bool? ah_ = context.Operators.Before(ae_, ag_, (string)default);
                     bool? ai_ = context.Operators.And(ac_, ah_);
                     return ai_;
                 }
@@ -225,7 +225,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                     CqlDateTime bl_ = context.Operators.Start(bk_);
                     CqlInterval<CqlDateTime> bm_ = Hospitalization?.hospitalizationPeriod;
                     CqlDateTime bn_ = context.Operators.End(bm_);
-                    bool? bo_ = context.Operators.Before(bl_, bn_, default);
+                    bool? bo_ = context.Operators.Before(bl_, bn_, (string)default);
                     bool? bp_ = context.Operators.And(bj_, bo_);
                     bool? bq_ = context.Operators.Implies(am_, bp_);
                     return bq_;
@@ -320,7 +320,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 DataType al_ = tuple_brdbxsuhdqixbcfmgdsacwig?.HypoglycemicMed?.Effective;
                 object am_ = FHIRHelpers_4_4_000.Instance.ToValue(context, al_);
                 CqlInterval<CqlDateTime> an_ = QICoreCommon_4_0_000.Instance.toInterval(context, am_);
-                bool? ao_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, an_, default);
+                bool? ao_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(ak_, an_, (string)default);
                 bool? ap_ = context.Operators.And(aj_, ao_);
                 return ap_;
             }
@@ -400,7 +400,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
                     CqlDateTime n_ = QICoreCommon_4_0_000.Instance.earliest(context, m_());
                     CqlInterval<CqlDateTime> o_ = Hospitalization?.hospitalizationPeriod;
-                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
                     Code<ObservationStatus> q_ = GlucoseTest?.StatusElement;
                     ObservationStatus? r_ = q_?.Value;
                     string s_ = context.Operators.Convert<string>(r_);
@@ -586,7 +586,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
                         CqlDateTime ap_ = QICoreCommon_4_0_000.Instance.earliest(context, ao_());
                         CqlInterval<CqlDateTime> aq_ = EncounterDay?.dayPeriod;
-                        bool? ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, default);
+                        bool? ar_ = context.Operators.In<CqlDateTime>(ap_, aq_, (string)default);
                         bool? as_ = context.Operators.And(an_, ar_);
                         return as_;
                     }
@@ -662,7 +662,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
                         CqlDateTime bw_ = QICoreCommon_4_0_000.Instance.earliest(context, bv_());
                         CqlInterval<CqlDateTime> bx_ = EncounterDay?.dayPeriod;
-                        bool? by_ = context.Operators.In<CqlDateTime>(bw_, bx_, default);
+                        bool? by_ = context.Operators.In<CqlDateTime>(bw_, bx_, (string)default);
                         bool? bz_ = context.Operators.And(bu_, by_);
                         return bz_;
                     }
@@ -733,7 +733,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
                         CqlDateTime cy_ = QICoreCommon_4_0_000.Instance.earliest(context, cx_());
                         CqlInterval<CqlDateTime> cz_ = EncounterDay?.dayPeriod;
-                        bool? da_ = context.Operators.In<CqlDateTime>(cy_, cz_, default);
+                        bool? da_ = context.Operators.In<CqlDateTime>(cy_, cz_, (string)default);
                         bool? db_ = context.Operators.And(cw_, da_);
                         return db_;
                     }
@@ -895,7 +895,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 CqlQuantity ae_ = context.Operators.Quantity(6m, "hours");
                 CqlDateTime af_ = context.Operators.Add(ad_, ae_);
                 CqlInterval<CqlDateTime> ag_ = context.Operators.Interval(ab_, af_, true, true);
-                bool? ah_ = context.Operators.In<CqlDateTime>(x_, ag_, default);
+                bool? ah_ = context.Operators.In<CqlDateTime>(x_, ag_, (string)default);
                 bool? ai_ = context.Operators.And(v_, ah_);
                 return ai_;
             }
@@ -984,7 +984,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 CqlQuantity v_ = context.Operators.Quantity(6m, "hour");
                 CqlDateTime w_ = context.Operators.Add(u_, v_);
                 CqlInterval<CqlDateTime> x_ = context.Operators.Interval(s_, w_, true, true);
-                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, default);
+                bool? y_ = context.Operators.In<CqlDateTime>(o_, x_, (string)default);
 
                 object z_() {
 
@@ -1090,7 +1090,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
 
                 CqlDateTime ag_ = QICoreCommon_4_0_000.Instance.earliest(context, af_());
                 CqlInterval<CqlDateTime> ah_ = context.Operators.Interval(ae_, ag_, true, false);
-                bool? ai_ = context.Operators.In<CqlDateTime>(aa_, ah_, default);
+                bool? ai_ = context.Operators.In<CqlDateTime>(aa_, ah_, (string)default);
                 bool? aj_ = context.Operators.And(y_, ai_);
                 Id ak_ = tuple_ghpnfyjsiaqamntcrzhgtgped?.EarlierGlucoseTest?.IdElement;
                 string al_ = ak_?.Value;
@@ -1236,7 +1236,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                 CqlQuantity ad_ = context.Operators.Quantity(6m, "hours");
                 CqlDateTime ae_ = context.Operators.Add(ac_, ad_);
                 CqlInterval<CqlDateTime> af_ = context.Operators.Interval(aa_, ae_, true, true);
-                bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, default);
+                bool? ag_ = context.Operators.In<CqlDateTime>(w_, af_, (string)default);
                 bool? ah_ = context.Operators.And(u_, ag_);
                 return ah_;
             }
@@ -1328,7 +1328,7 @@ public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIR
                     CqlInterval<CqlDateTime> m_ = QICoreCommon_4_0_000.Instance.toInterval(context, l_ as object);
                     CqlDateTime n_ = context.Operators.Start(j_ ?? m_);
                     CqlInterval<CqlDateTime> o_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, InpatientHospitalization);
-                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, default);
+                    bool? p_ = context.Operators.In<CqlDateTime>(n_, o_, (string)default);
                     return p_;
                 }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
@@ -230,7 +230,7 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
             CqlDate g_ = context.Operators.DateFrom(f_);
             int? h_ = context.Operators.CalculateAgeAt(d_, g_, "year");
             CqlInterval<int?> i_ = context.Operators.Interval(18, 85, true, true);
-            bool? j_ = context.Operators.In<int?>(h_, i_, default);
+            bool? j_ = context.Operators.In<int?>(h_, i_, (string)default);
             bool? k_ = this.Has_Active_Diabetes_Overlaps_Start_Of_Measurement_Period(context);
             bool? l_ = context.Operators.And(j_, k_);
             bool? m_ = this.Has_Outpatient_Visit_During_Measurement_Period(context);
@@ -472,7 +472,7 @@ public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<C
                 DataType z_ = tuple_celfnsuejxkbgcpwlebsiij?.UrineAlbuminTest?.Effective;
                 object aa_ = FHIRHelpers_4_4_000.Instance.ToValue(context, z_);
                 CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.toInterval(context, aa_);
-                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, ab_, default);
+                bool? ac_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(y_, ab_, (string)default);
                 return ac_;
             }
 

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
@@ -554,7 +554,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     DataType p_ = MalnutritionRiskScreening?.Effective;
                     object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     DataType u_ = MalnutritionRiskScreening?.Value;
                     object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
@@ -598,7 +598,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     DataType p_ = MalnutritionRiskScreening?.Effective;
                     object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     DataType u_ = MalnutritionRiskScreening?.Value;
                     object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
@@ -679,7 +679,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
             DataType o_ = NutritionAssessment?.Effective;
             object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
             CqlInterval<CqlDateTime> q_ = QICoreCommon_4_0_000.Instance.toInterval(context, p_);
-            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, default);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(n_, q_, (string)default);
             bool? s_ = context.Operators.And(m_, r_);
             DataType t_ = NutritionAssessment?.Value;
             object u_ = FHIRHelpers_4_4_000.Instance.ToValue(context, t_);
@@ -775,7 +775,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     DataType p_ = NutritionAssessment?.Effective;
                     object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     DataType u_ = NutritionAssessment?.Value;
                     object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
@@ -881,7 +881,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     DataType p_ = NutritionAssessment?.Effective;
                     object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     DataType u_ = NutritionAssessment?.Value;
                     object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
@@ -983,7 +983,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     DataType p_ = NutritionAssessment?.Effective;
                     object q_ = FHIRHelpers_4_4_000.Instance.ToValue(context, p_);
                     CqlInterval<CqlDateTime> r_ = QICoreCommon_4_0_000.Instance.toInterval(context, q_);
-                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, default);
+                    bool? s_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     DataType u_ = NutritionAssessment?.Value;
                     object v_ = FHIRHelpers_4_4_000.Instance.ToValue(context, u_);
@@ -1097,7 +1097,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
             bool? c_(Condition MalnutritionDiagnosis) {
                 CqlInterval<CqlDateTime> e_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, MalnutritionDiagnosis as object);
                 CqlInterval<CqlDateTime> f_ = this.Measurement_Period(context);
-                bool? g_ = context.Operators.Overlaps(e_, f_, default);
+                bool? g_ = context.Operators.Overlaps(e_, f_, (string)default);
                 bool? h_ = this.isVerified(context, MalnutritionDiagnosis as object);
                 bool? i_ = context.Operators.And(g_, h_);
                 return i_;
@@ -1202,7 +1202,7 @@ public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<
                     object p_ = FHIRHelpers_4_4_000.Instance.ToValue(context, o_);
                     CqlDateTime q_ = QICoreCommon_4_0_000.Instance.earliest(context, p_ as object);
                     CqlInterval<CqlDateTime> r_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservation(context, QualifyingEncounter);
-                    bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, default);
+                    bool? s_ = context.Operators.In<CqlDateTime>(q_, r_, (string)default);
                     bool? t_ = context.Operators.And(n_, s_);
                     return t_;
                 }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
@@ -384,7 +384,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime ab_ = context.Operators.Start(aa_);
                     Period ac_ = EDEncounterinMP?.Period;
                     CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    bool? ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, default);
+                    bool? ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, (string)default);
                     bool? af_ = context.Operators.Or(z_, ae_);
                     return af_;
                 }
@@ -450,11 +450,11 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> ag_ = QICoreCommon_4_0_000.Instance.toInterval(context, af_);
                     Period ah_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
-                    bool? aj_ = context.Operators.Overlaps(ag_, ai_, default);
+                    bool? aj_ = context.Operators.Overlaps(ag_, ai_, (string)default);
                     object al_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ae_);
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ah_);
                     CqlDateTime ao_ = context.Operators.End(an_);
-                    bool? ap_ = context.Operators.Before(al_ as CqlDateTime, ao_, default);
+                    bool? ap_ = context.Operators.Before(al_ as CqlDateTime, ao_, (string)default);
                     bool? aq_ = context.Operators.Or(aj_, ap_);
                     bool? ar_ = context.Operators.And(ad_, aq_);
                     return ar_;
@@ -490,7 +490,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period p_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
                     CqlDateTime r_ = context.Operators.End(q_);
-                    bool? s_ = context.Operators.Before((k_ ?? m_) ?? o_, r_, default);
+                    bool? s_ = context.Operators.Before((k_ ?? m_) ?? o_, r_, (string)default);
                     Code<AdverseEvent.AdverseEventActuality> t_ = ThrombolyticAdverseEvent?.ActualityElement;
                     AdverseEvent.AdverseEventActuality? u_ = t_?.Value;
                     Code<AdverseEvent.AdverseEventActuality> v_ = context.Operators.Convert<Code<AdverseEvent.AdverseEventActuality>>(u_);
@@ -541,7 +541,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> ab_ = QICoreCommon_4_0_000.Instance.prevalenceInterval(context, ActiveExclusionDx);
                     Period ac_ = EDwithSTEMI?.Period;
                     CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    bool? ae_ = context.Operators.OverlapsBefore(ab_, ad_, default);
+                    bool? ae_ = context.Operators.OverlapsBefore(ab_, ad_, (string)default);
                     return ae_;
                 }
 
@@ -616,7 +616,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
                     CqlDateTime av_ = context.Operators.Start(au_);
                     CqlInterval<CqlDateTime> aw_ = context.Operators.Interval(as_, av_, true, true);
-                    bool? ax_ = context.Operators.In<CqlDateTime>(an_, aw_, default);
+                    bool? ax_ = context.Operators.In<CqlDateTime>(an_, aw_, (string)default);
                     CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
                     CqlDateTime ba_ = context.Operators.Start(az_);
                     bool? bb_ = context.Operators.Not((bool?)(ba_ is null));
@@ -656,11 +656,11 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period r_ = EDwithSTEMI?.Period;
                     CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
                     CqlDateTime t_ = context.Operators.Start(s_);
-                    bool? u_ = context.Operators.SameOrBefore(q_, t_, default);
+                    bool? u_ = context.Operators.SameOrBefore(q_, t_, (string)default);
                     CqlDateTime w_ = context.Operators.End(p_);
                     CqlInterval<CqlDateTime> y_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
                     CqlDateTime z_ = context.Operators.Start(y_);
-                    bool? aa_ = context.Operators.SameOrAfter(w_, z_, default);
+                    bool? aa_ = context.Operators.SameOrAfter(w_, z_, (string)default);
                     bool? ab_ = context.Operators.And(u_, aa_);
                     return ab_;
                 }
@@ -729,7 +729,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime an_ = context.Operators.Start(am_);
                     Period ao_ = EDwithSTEMI?.Period;
                     CqlInterval<CqlDateTime> ap_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
-                    bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, default);
+                    bool? aq_ = context.Operators.In<CqlDateTime>(an_, ap_, (string)default);
                     CqlDateTime as_ = context.Operators.Start(am_);
                     CqlInterval<CqlDateTime> au_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
                     CqlDateTime av_ = context.Operators.Start(au_);
@@ -738,7 +738,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> az_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
                     CqlDateTime ba_ = context.Operators.Start(az_);
                     CqlInterval<CqlDateTime> bb_ = context.Operators.Interval(ax_, ba_, true, false);
-                    bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, default);
+                    bool? bc_ = context.Operators.In<CqlDateTime>(as_, bb_, (string)default);
                     CqlInterval<CqlDateTime> be_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ao_);
                     CqlDateTime bf_ = context.Operators.Start(be_);
                     bool? bg_ = context.Operators.Not((bool?)(bf_ is null));
@@ -842,7 +842,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
                     CqlDateTime t_ = context.Operators.Start(s_);
                     CqlInterval<CqlDateTime> u_ = context.Operators.Interval(q_, t_, true, false);
-                    bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, default);
+                    bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, (string)default);
                     CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
                     CqlDateTime y_ = context.Operators.Start(x_);
                     bool? z_ = context.Operators.Not((bool?)(y_ is null));
@@ -914,7 +914,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> ac_ = QICoreCommon_4_0_000.Instance.toInterval(context, ab_());
                     CqlDateTime ad_ = context.Operators.Start(ac_);
                     CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
-                    bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, default);
+                    bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
                     bool? ah_ = context.Operators.Or(aa_, ag_);
                     Code<EventStatus> ai_ = MajorSurgery?.StatusElement;
                     EventStatus? aj_ = ai_?.Value;
@@ -1016,7 +1016,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime o_ = context.Operators.Start(n_);
                     Period p_ = EDwithSTEMI?.Period;
                     CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-                    bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(o_, q_, (string)default);
 
                     object s_() {
 
@@ -1090,7 +1090,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
                     CqlDateTime ac_ = context.Operators.Start(ab_);
                     CqlInterval<CqlDateTime> ad_ = context.Operators.Interval(z_, ac_, true, false);
-                    bool? ae_ = context.Operators.In<CqlDateTime>(u_, ad_, default);
+                    bool? ae_ = context.Operators.In<CqlDateTime>(u_, ad_, (string)default);
                     CqlInterval<CqlDateTime> ag_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
                     CqlDateTime ah_ = context.Operators.Start(ag_);
                     bool? ai_ = context.Operators.Not((bool?)(ah_ is null));
@@ -1144,7 +1144,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> aa_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, u_);
                     CqlDateTime ab_ = context.Operators.Start(aa_);
                     CqlInterval<CqlDateTime> ac_ = context.Operators.Interval(y_, ab_, true, true);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(t_, ac_, (string)default);
                     return ad_;
                 }
 
@@ -1243,7 +1243,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
                     CqlDateTime t_ = context.Operators.Start(s_);
                     CqlInterval<CqlDateTime> u_ = context.Operators.Interval(q_, t_, true, false);
-                    bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, default);
+                    bool? v_ = context.Operators.In<CqlDateTime>(l_, u_, (string)default);
                     CqlInterval<CqlDateTime> x_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, m_);
                     CqlDateTime y_ = context.Operators.Start(x_);
                     bool? z_ = context.Operators.Not((bool?)(y_ is null));
@@ -1334,7 +1334,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period bl_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> bm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
                     CqlDateTime bn_ = context.Operators.Start(bm_);
-                    bool? bo_ = context.Operators.SameOrBefore(bk_, bn_, default);
+                    bool? bo_ = context.Operators.SameOrBefore(bk_, bn_, (string)default);
                     bool? bp_ = context.Operators.And(bh_, bo_);
                     CqlInterval<CqlDateTime> br_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bi_);
                     CqlInterval<CqlDateTime> bt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bl_);
@@ -1362,7 +1362,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period cg_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> ch_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cg_);
                     CqlDateTime ci_ = context.Operators.Start(ch_);
-                    bool? cj_ = context.Operators.SameOrBefore(cf_, ci_, default);
+                    bool? cj_ = context.Operators.SameOrBefore(cf_, ci_, (string)default);
                     CqlInterval<CqlDateTime> cl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cd_);
                     CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cg_);
                     CqlDateTime co_ = context.Operators.Start(cn_);
@@ -1397,7 +1397,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period dg_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> dh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, dg_);
                     CqlDateTime di_ = context.Operators.Start(dh_);
-                    bool? dj_ = context.Operators.SameOrBefore(df_, di_, default);
+                    bool? dj_ = context.Operators.SameOrBefore(df_, di_, (string)default);
                     bool? dk_ = context.Operators.And(db_, dj_);
                     object dm_ = FHIRHelpers_4_4_000.Instance.ToValue(context, dc_);
                     CqlInterval<CqlDateTime> dn_ = QICoreCommon_4_0_000.Instance.toInterval(context, dm_);
@@ -1431,7 +1431,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlInterval<CqlDateTime> eh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eb_);
                     CqlDateTime ei_ = context.Operators.Start(eh_);
                     CqlInterval<CqlDateTime> ej_ = context.Operators.Interval(ef_, ei_, true, false);
-                    bool? ek_ = context.Operators.In<CqlDateTime>(ea_, ej_, default);
+                    bool? ek_ = context.Operators.In<CqlDateTime>(ea_, ej_, (string)default);
                     CqlInterval<CqlDateTime> em_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eb_);
                     CqlDateTime en_ = context.Operators.Start(em_);
                     bool? eo_ = context.Operators.Not((bool?)(en_ is null));
@@ -1515,7 +1515,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period et_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, et_);
                     CqlDateTime ev_ = context.Operators.Start(eu_);
-                    bool? ew_ = context.Operators.SameOrBefore(es_, ev_, default);
+                    bool? ew_ = context.Operators.SameOrBefore(es_, ev_, (string)default);
 
                     object ex_() {
 
@@ -1608,7 +1608,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     Period hi_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> hj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hi_);
                     CqlDateTime hk_ = context.Operators.Start(hj_);
-                    bool? hl_ = context.Operators.SameOrAfter(hh_, hk_, default);
+                    bool? hl_ = context.Operators.SameOrAfter(hh_, hk_, (string)default);
                     return hl_;
                 }
 
@@ -1645,7 +1645,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime s_ = context.Operators.LateBoundProperty<CqlDateTime>(r_, "value");
                     Period t_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, t_);
-                    bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, default);
+                    bool? v_ = context.Operators.In<CqlDateTime>(s_, u_, (string)default);
                     bool? w_ = context.Operators.And(q_, v_);
                     return w_;
                 }
@@ -1712,7 +1712,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime q_ = context.Operators.Start(p_);
                     Period r_ = EDwithSTEMI?.Period;
                     CqlInterval<CqlDateTime> s_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, r_);
-                    bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, default);
+                    bool? t_ = context.Operators.In<CqlDateTime>(q_, s_, (string)default);
                     return t_;
                 }
 
@@ -1770,7 +1770,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime ab_ = context.Operators.Convert<CqlDateTime>(aa_);
                     Period ac_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> ad_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ac_);
-                    bool? ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, default);
+                    bool? ae_ = context.Operators.In<CqlDateTime>(ab_, ad_, (string)default);
                     bool? af_ = context.Operators.And(u_, ae_);
                     return af_;
                 }
@@ -1841,7 +1841,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlDateTime ad_ = context.Operators.Convert<CqlDateTime>(ac_);
                     Period ae_ = EDwSTEMI?.Period;
                     CqlInterval<CqlDateTime> af_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ae_);
-                    bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, default);
+                    bool? ag_ = context.Operators.In<CqlDateTime>(ad_, af_, (string)default);
                     bool? ah_ = context.Operators.And(w_, ag_);
                     return ah_;
                 }
@@ -1976,7 +1976,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlQuantity am_ = context.Operators.Quantity(30m, "minutes");
                     CqlDateTime an_ = context.Operators.Add(ak_, am_);
                     CqlInterval<CqlDateTime> ao_ = context.Operators.Interval(ak_, an_, false, true);
-                    bool? ap_ = context.Operators.In<CqlDateTime>(aj_, ao_, default);
+                    bool? ap_ = context.Operators.In<CqlDateTime>(aj_, ao_, (string)default);
                     bool? ar_ = context.Operators.Not((bool?)(ak_ is null));
                     bool? as_ = context.Operators.And(ap_, ar_);
                     bool? at_ = context.Operators.And(af_, as_);
@@ -2074,7 +2074,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                     CqlQuantity o_ = context.Operators.Quantity(90m, "minutes");
                     CqlDateTime p_ = context.Operators.Add(m_, o_);
                     CqlInterval<CqlDateTime> q_ = context.Operators.Interval(m_, p_, false, true);
-                    bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, default);
+                    bool? r_ = context.Operators.In<CqlDateTime>(l_, q_, (string)default);
                     bool? t_ = context.Operators.Not((bool?)(m_ is null));
                     bool? u_ = context.Operators.And(r_, t_);
                     Code<EventStatus> v_ = PCI?.StatusElement;
@@ -2165,7 +2165,7 @@ public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS9
                 CqlQuantity g_ = context.Operators.Quantity(45m, "minutes");
                 CqlDateTime h_ = context.Operators.Add(e_, g_);
                 CqlInterval<CqlDateTime> i_ = context.Operators.Interval(e_, h_, false, true);
-                bool? j_ = context.Operators.In<CqlDateTime>(d_, i_, default);
+                bool? j_ = context.Operators.In<CqlDateTime>(d_, i_, (string)default);
                 bool? l_ = context.Operators.Not((bool?)(e_ is null));
                 bool? m_ = context.Operators.And(j_, l_);
                 Encounter.HospitalizationComponent n_ = EDwithSTEMI?.Hospitalization;

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
@@ -191,7 +191,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = Temperature?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -228,7 +228,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = Temperature?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -285,7 +285,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = HeartRate?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -322,7 +322,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = HeartRate?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -380,7 +380,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
                     CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
                     CqlInterval<CqlDateTime> ad_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, default);
+                    bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, (string)default);
                     Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
                     ObservationStatus? ag_ = af_?.Value;
                     string ah_ = context.Operators.Convert<string>(ag_);
@@ -418,7 +418,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
                     CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_);
                     CqlInterval<CqlDateTime> av_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? aw_ = context.Operators.In<CqlDateTime>(au_, av_, default);
+                    bool? aw_ = context.Operators.In<CqlDateTime>(au_, av_, (string)default);
                     Code<ObservationStatus> ax_ = O2Saturation?.StatusElement;
                     ObservationStatus? ay_ = ax_?.Value;
                     string az_ = context.Operators.Convert<string>(ay_);
@@ -475,7 +475,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = Respirations?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -512,7 +512,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = Respirations?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -569,7 +569,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
                     CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
                     CqlInterval<CqlDateTime> af_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, default);
+                    bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
                     Code<ObservationStatus> ah_ = BP?.StatusElement;
                     ObservationStatus? ai_ = ah_?.Value;
                     string aj_ = context.Operators.Convert<string>(ai_);
@@ -641,7 +641,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_);
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = BP?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -763,7 +763,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = bicarbonatelab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -850,7 +850,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = bicarbonatelab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -957,7 +957,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = CreatinineLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1044,7 +1044,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = CreatinineLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1151,7 +1151,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = GlucoseLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1238,7 +1238,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = GlucoseLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1345,7 +1345,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = HematocritLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1432,7 +1432,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = HematocritLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1539,7 +1539,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = PotassiumLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1626,7 +1626,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = PotassiumLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1733,7 +1733,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = SodiumLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1820,7 +1820,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = SodiumLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1927,7 +1927,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = WhiteBloodCellLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -2014,7 +2014,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = WhiteBloodCellLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -2072,7 +2072,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = WeightExam?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -2109,7 +2109,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = WeightExam?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -2169,7 +2169,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     Encounter z_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
                     Period aa_ = z_?.Period;
                     CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(y_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(y_, ab_, (string)default);
                     CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(x_);
                     Period ag_ = z_?.Period;
                     CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
@@ -2180,7 +2180,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
-                    bool? aq_ = context.Operators.In<CqlDateTime>(ae_, ap_, default);
+                    bool? aq_ = context.Operators.In<CqlDateTime>(ae_, ap_, (string)default);
                     Period as_ = z_?.Period;
                     CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
                     CqlDateTime au_ = context.Operators.Start(at_);
@@ -2294,7 +2294,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     Encounter bv_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
                     Period bw_ = bv_?.Period;
                     CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bw_);
-                    bool? by_ = context.Operators.In<CqlDateTime>(bu_, bx_, default);
+                    bool? by_ = context.Operators.In<CqlDateTime>(bu_, bx_, (string)default);
 
                     object bz_() {
 
@@ -2370,7 +2370,7 @@ public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary,
                     CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
                     CqlDateTime cl_ = context.Operators.Start(ck_);
                     CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ch_, cl_, true, true);
-                    bool? cn_ = context.Operators.In<CqlDateTime>(cb_, cm_, default);
+                    bool? cn_ = context.Operators.In<CqlDateTime>(cb_, cm_, (string)default);
                     Period cp_ = bv_?.Period;
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
@@ -148,7 +148,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     CqlDate ac_ = context.Operators.DateFrom(ab_);
                     int? ad_ = context.Operators.CalculateAgeAt(y_, ac_, "year");
                     CqlInterval<int?> ae_ = context.Operators.Interval(65, 94, true, true);
-                    bool? af_ = context.Operators.In<int?>(ad_, ae_, default);
+                    bool? af_ = context.Operators.In<int?>(ad_, ae_, (string)default);
                     bool? ag_ = context.Operators.And(u_, af_);
                     CqlInterval<CqlDateTime> ai_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, z_);
                     CqlDateTime aj_ = context.Operators.End(ai_);
@@ -192,7 +192,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = Temperature?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -229,7 +229,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = Temperature?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -286,7 +286,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object z_ = FHIRHelpers_4_4_000.Instance.ToValue(context, y_);
                     CqlDateTime aa_ = QICoreCommon_4_0_000.Instance.earliest(context, z_);
                     CqlInterval<CqlDateTime> ab_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(aa_, ab_, (string)default);
                     Code<ObservationStatus> ad_ = HeartRate?.StatusElement;
                     ObservationStatus? ae_ = ad_?.Value;
                     string af_ = context.Operators.Convert<string>(ae_);
@@ -323,7 +323,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object ar_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aq_);
                     CqlDateTime as_ = QICoreCommon_4_0_000.Instance.earliest(context, ar_);
                     CqlInterval<CqlDateTime> at_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, default);
+                    bool? au_ = context.Operators.In<CqlDateTime>(as_, at_, (string)default);
                     Code<ObservationStatus> av_ = HeartRate?.StatusElement;
                     ObservationStatus? aw_ = av_?.Value;
                     string ax_ = context.Operators.Convert<string>(aw_);
@@ -381,7 +381,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object ab_ = FHIRHelpers_4_4_000.Instance.ToValue(context, aa_);
                     CqlDateTime ac_ = QICoreCommon_4_0_000.Instance.earliest(context, ab_);
                     CqlInterval<CqlDateTime> ad_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, default);
+                    bool? ae_ = context.Operators.In<CqlDateTime>(ac_, ad_, (string)default);
                     Code<ObservationStatus> af_ = O2Saturation?.StatusElement;
                     ObservationStatus? ag_ = af_?.Value;
                     string ah_ = context.Operators.Convert<string>(ag_);
@@ -419,7 +419,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object at_ = FHIRHelpers_4_4_000.Instance.ToValue(context, as_);
                     CqlDateTime au_ = QICoreCommon_4_0_000.Instance.earliest(context, at_);
                     CqlInterval<CqlDateTime> av_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? aw_ = context.Operators.In<CqlDateTime>(au_, av_, default);
+                    bool? aw_ = context.Operators.In<CqlDateTime>(au_, av_, (string)default);
                     Code<ObservationStatus> ax_ = O2Saturation?.StatusElement;
                     ObservationStatus? ay_ = ax_?.Value;
                     string az_ = context.Operators.Convert<string>(ay_);
@@ -476,7 +476,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object ad_ = FHIRHelpers_4_4_000.Instance.ToValue(context, ac_);
                     CqlDateTime ae_ = QICoreCommon_4_0_000.Instance.earliest(context, ad_);
                     CqlInterval<CqlDateTime> af_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, default);
+                    bool? ag_ = context.Operators.In<CqlDateTime>(ae_, af_, (string)default);
                     Code<ObservationStatus> ah_ = BP?.StatusElement;
                     ObservationStatus? ai_ = ah_?.Value;
                     string aj_ = context.Operators.Convert<string>(ai_);
@@ -548,7 +548,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     object bk_ = FHIRHelpers_4_4_000.Instance.ToValue(context, bj_);
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_);
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = BP?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -670,7 +670,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = BicarbonateLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -757,7 +757,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = BicarbonateLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -864,7 +864,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = CreatinineLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -951,7 +951,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = CreatinineLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1058,7 +1058,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = HematocritLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1145,7 +1145,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = HematocritLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1252,7 +1252,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = PlateletLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1339,7 +1339,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = PlateletLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1446,7 +1446,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = SodiumLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1533,7 +1533,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = SodiumLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1640,7 +1640,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime ab_ = QICoreCommon_4_0_000.Instance.earliest(context, aa_());
                     CqlInterval<CqlDateTime> ac_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, default);
+                    bool? ad_ = context.Operators.In<CqlDateTime>(ab_, ac_, (string)default);
                     Code<ObservationStatus> ae_ = WhiteBloodCellLab?.StatusElement;
                     ObservationStatus? af_ = ae_?.Value;
                     string ag_ = context.Operators.Convert<string>(af_);
@@ -1727,7 +1727,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
 
                     CqlDateTime bl_ = QICoreCommon_4_0_000.Instance.earliest(context, bk_());
                     CqlInterval<CqlDateTime> bm_ = CQMCommon_4_1_000.Instance.hospitalizationWithObservationAndOutpatientSurgeryService(context, EncounterInpatient);
-                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, default);
+                    bool? bn_ = context.Operators.In<CqlDateTime>(bl_, bm_, (string)default);
                     Code<ObservationStatus> bo_ = WhiteBloodCellLab?.StatusElement;
                     ObservationStatus? bp_ = bo_?.Value;
                     string bq_ = context.Operators.Convert<string>(bp_);
@@ -1788,7 +1788,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     Encounter z_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
                     Period aa_ = z_?.Period;
                     CqlInterval<CqlDateTime> ab_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, aa_);
-                    bool? ac_ = context.Operators.In<CqlDateTime>(y_, ab_, default);
+                    bool? ac_ = context.Operators.In<CqlDateTime>(y_, ab_, (string)default);
                     CqlDateTime ae_ = context.Operators.Convert<CqlDateTime>(x_);
                     Period ag_ = z_?.Period;
                     CqlInterval<CqlDateTime> ah_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ag_);
@@ -1799,7 +1799,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     CqlInterval<CqlDateTime> an_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, am_);
                     CqlDateTime ao_ = context.Operators.Start(an_);
                     CqlInterval<CqlDateTime> ap_ = context.Operators.Interval(ak_, ao_, true, true);
-                    bool? aq_ = context.Operators.In<CqlDateTime>(ae_, ap_, default);
+                    bool? aq_ = context.Operators.In<CqlDateTime>(ae_, ap_, (string)default);
                     Period as_ = z_?.Period;
                     CqlInterval<CqlDateTime> at_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, as_);
                     CqlDateTime au_ = context.Operators.Start(at_);
@@ -1913,7 +1913,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     Encounter bv_ = CQMCommon_4_1_000.Instance.edVisit(context, EncounterInpatient);
                     Period bw_ = bv_?.Period;
                     CqlInterval<CqlDateTime> bx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bw_);
-                    bool? by_ = context.Operators.In<CqlDateTime>(bu_, bx_, default);
+                    bool? by_ = context.Operators.In<CqlDateTime>(bu_, bx_, (string)default);
 
                     object bz_() {
 
@@ -1989,7 +1989,7 @@ public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, I
                     CqlInterval<CqlDateTime> ck_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cj_);
                     CqlDateTime cl_ = context.Operators.Start(ck_);
                     CqlInterval<CqlDateTime> cm_ = context.Operators.Interval(ch_, cl_, true, true);
-                    bool? cn_ = context.Operators.In<CqlDateTime>(cb_, cm_, default);
+                    bool? cn_ = context.Operators.In<CqlDateTime>(cb_, cm_, (string)default);
                     Period cp_ = bv_?.Period;
                     CqlInterval<CqlDateTime> cq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, cp_);
                     CqlDateTime cr_ = context.Operators.Start(cq_);

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
@@ -172,7 +172,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
     [CqlParameterDefinition("Measurement Period")]
     public CqlInterval<CqlDateTime> Measurement_Period(CqlContext context) =>
         ((ICqlContextInternals)context).GetOrCompute<CqlInterval<CqlDateTime>>(8782724425627446250L, () => {
-            object a_ = context.ResolveParameter("CQMCommon-4.1.000", "Measurement Period", null);
+            object a_ = context.ResolveParameter("CQMCommon-4.1.000", "Measurement Period", (object)null);
             return (CqlInterval<CqlDateTime>)a_;
         });
 
@@ -276,7 +276,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
             CqlDateTime v_ = context.Operators.Start(u_);
             CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-            bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default);
+            bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, (string)default);
             CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
             CqlDateTime aa_ = context.Operators.Start(z_);
             bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -323,7 +323,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             CqlInterval<CqlDateTime> u_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
             CqlDateTime v_ = context.Operators.Start(u_);
             CqlInterval<CqlDateTime> w_ = context.Operators.Interval(s_, v_, true, true);
-            bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, default);
+            bool? x_ = context.Operators.In<CqlDateTime>(n_, w_, (string)default);
             CqlInterval<CqlDateTime> z_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, o_);
             CqlDateTime aa_ = context.Operators.Start(z_);
             bool? ab_ = context.Operators.Not((bool?)(aa_ is null));
@@ -793,7 +793,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ge_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fy_);
                         CqlDateTime gf_ = context.Operators.Start(ge_);
                         CqlInterval<CqlDateTime> gg_ = context.Operators.Interval(gc_, gf_, true, true);
-                        bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, default);
+                        bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, (string)default);
                         CqlInterval<CqlDateTime> gj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fy_);
                         CqlDateTime gk_ = context.Operators.Start(gj_);
                         bool? gl_ = context.Operators.Not((bool?)(gk_ is null));
@@ -839,7 +839,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> he_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gy_);
                         CqlDateTime hf_ = context.Operators.Start(he_);
                         CqlInterval<CqlDateTime> hg_ = context.Operators.Interval(hc_, hf_, true, true);
-                        bool? hh_ = context.Operators.In<CqlDateTime>(gx_, hg_, default);
+                        bool? hh_ = context.Operators.In<CqlDateTime>(gx_, hg_, (string)default);
                         CqlInterval<CqlDateTime> hj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gy_);
                         CqlDateTime hk_ = context.Operators.Start(hj_);
                         bool? hl_ = context.Operators.Not((bool?)(hk_ is null));
@@ -865,7 +865,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> ex_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eh_);
                     CqlDateTime ey_ = context.Operators.Start(ex_);
                     CqlInterval<CqlDateTime> ez_ = context.Operators.Interval(el_, ev_ ?? ey_, true, true);
-                    bool? fa_ = context.Operators.In<CqlDateTime>(dw_, ez_, default);
+                    bool? fa_ = context.Operators.In<CqlDateTime>(dw_, ez_, (string)default);
                     IEnumerable<Encounter> fc_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, dx_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? fd_(Encounter LastObs) {
@@ -884,7 +884,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ie_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hy_);
                         CqlDateTime if_ = context.Operators.Start(ie_);
                         CqlInterval<CqlDateTime> ig_ = context.Operators.Interval(ic_, if_, true, true);
-                        bool? ih_ = context.Operators.In<CqlDateTime>(hx_, ig_, default);
+                        bool? ih_ = context.Operators.In<CqlDateTime>(hx_, ig_, (string)default);
                         CqlInterval<CqlDateTime> ij_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hy_);
                         CqlDateTime ik_ = context.Operators.Start(ij_);
                         bool? il_ = context.Operators.Not((bool?)(ik_ is null));
@@ -948,7 +948,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> jh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jb_);
                     CqlDateTime ji_ = context.Operators.Start(jh_);
                     CqlInterval<CqlDateTime> jj_ = context.Operators.Interval(jf_, ji_, true, true);
-                    bool? jk_ = context.Operators.In<CqlDateTime>(ja_, jj_, default);
+                    bool? jk_ = context.Operators.In<CqlDateTime>(ja_, jj_, (string)default);
                     CqlInterval<CqlDateTime> jm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jb_);
                     CqlDateTime jn_ = context.Operators.Start(jm_);
                     bool? jo_ = context.Operators.Not((bool?)(jn_ is null));
@@ -1005,7 +1005,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> mi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mc_);
                         CqlDateTime mj_ = context.Operators.Start(mi_);
                         CqlInterval<CqlDateTime> mk_ = context.Operators.Interval(mg_, mj_, true, true);
-                        bool? ml_ = context.Operators.In<CqlDateTime>(mb_, mk_, default);
+                        bool? ml_ = context.Operators.In<CqlDateTime>(mb_, mk_, (string)default);
                         CqlInterval<CqlDateTime> mn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mc_);
                         CqlDateTime mo_ = context.Operators.Start(mn_);
                         bool? mp_ = context.Operators.Not((bool?)(mo_ is null));
@@ -1051,7 +1051,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ni_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nc_);
                         CqlDateTime nj_ = context.Operators.Start(ni_);
                         CqlInterval<CqlDateTime> nk_ = context.Operators.Interval(ng_, nj_, true, true);
-                        bool? nl_ = context.Operators.In<CqlDateTime>(nb_, nk_, default);
+                        bool? nl_ = context.Operators.In<CqlDateTime>(nb_, nk_, (string)default);
                         CqlInterval<CqlDateTime> nn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nc_);
                         CqlDateTime no_ = context.Operators.Start(nn_);
                         bool? np_ = context.Operators.Not((bool?)(no_ is null));
@@ -1077,7 +1077,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> lb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kl_);
                     CqlDateTime lc_ = context.Operators.Start(lb_);
                     CqlInterval<CqlDateTime> ld_ = context.Operators.Interval(kp_, kz_ ?? lc_, true, true);
-                    bool? le_ = context.Operators.In<CqlDateTime>(ka_, ld_, default);
+                    bool? le_ = context.Operators.In<CqlDateTime>(ka_, ld_, (string)default);
                     IEnumerable<Encounter> lg_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, kb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? lh_(Encounter LastObs) {
@@ -1096,7 +1096,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> oi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oc_);
                         CqlDateTime oj_ = context.Operators.Start(oi_);
                         CqlInterval<CqlDateTime> ok_ = context.Operators.Interval(og_, oj_, true, true);
-                        bool? ol_ = context.Operators.In<CqlDateTime>(ob_, ok_, default);
+                        bool? ol_ = context.Operators.In<CqlDateTime>(ob_, ok_, (string)default);
                         CqlInterval<CqlDateTime> on_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oc_);
                         CqlDateTime oo_ = context.Operators.Start(on_);
                         bool? op_ = context.Operators.Not((bool?)(oo_ is null));
@@ -1159,7 +1159,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> pl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
                     CqlDateTime pm_ = context.Operators.Start(pl_);
                     CqlInterval<CqlDateTime> pn_ = context.Operators.Interval(pj_, pm_, true, true);
-                    bool? po_ = context.Operators.In<CqlDateTime>(pe_, pn_, default);
+                    bool? po_ = context.Operators.In<CqlDateTime>(pe_, pn_, (string)default);
                     CqlInterval<CqlDateTime> pq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
                     CqlDateTime pr_ = context.Operators.Start(pq_);
                     bool? ps_ = context.Operators.Not((bool?)(pr_ is null));
@@ -1185,7 +1185,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bn_);
                 CqlDateTime co_ = context.Operators.Start(cn_);
                 CqlInterval<CqlDateTime> cp_ = context.Operators.Interval(br_, cb_ ?? cl_ ?? co_, true, true);
-                bool? cq_ = context.Operators.In<CqlDateTime>(as_, cp_, default);
+                bool? cq_ = context.Operators.In<CqlDateTime>(as_, cp_, (string)default);
                 IEnumerable<Encounter> cs_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? ct_(Encounter LastED) {
@@ -1215,7 +1215,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> sm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sg_);
                         CqlDateTime sn_ = context.Operators.Start(sm_);
                         CqlInterval<CqlDateTime> so_ = context.Operators.Interval(sk_, sn_, true, true);
-                        bool? sp_ = context.Operators.In<CqlDateTime>(sf_, so_, default);
+                        bool? sp_ = context.Operators.In<CqlDateTime>(sf_, so_, (string)default);
                         CqlInterval<CqlDateTime> sr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sg_);
                         CqlDateTime ss_ = context.Operators.Start(sr_);
                         bool? st_ = context.Operators.Not((bool?)(ss_ is null));
@@ -1261,7 +1261,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> tm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
                         CqlDateTime tn_ = context.Operators.Start(tm_);
                         CqlInterval<CqlDateTime> to_ = context.Operators.Interval(tk_, tn_, true, true);
-                        bool? tp_ = context.Operators.In<CqlDateTime>(tf_, to_, default);
+                        bool? tp_ = context.Operators.In<CqlDateTime>(tf_, to_, (string)default);
                         CqlInterval<CqlDateTime> tr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
                         CqlDateTime ts_ = context.Operators.Start(tr_);
                         bool? tt_ = context.Operators.Not((bool?)(ts_ is null));
@@ -1287,7 +1287,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> rf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qp_);
                     CqlDateTime rg_ = context.Operators.Start(rf_);
                     CqlInterval<CqlDateTime> rh_ = context.Operators.Interval(qt_, rd_ ?? rg_, true, true);
-                    bool? ri_ = context.Operators.In<CqlDateTime>(qe_, rh_, default);
+                    bool? ri_ = context.Operators.In<CqlDateTime>(qe_, rh_, (string)default);
                     IEnumerable<Encounter> rk_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, qf_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? rl_(Encounter LastObs) {
@@ -1306,7 +1306,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> um_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
                         CqlDateTime un_ = context.Operators.Start(um_);
                         CqlInterval<CqlDateTime> uo_ = context.Operators.Interval(uk_, un_, true, true);
-                        bool? up_ = context.Operators.In<CqlDateTime>(uf_, uo_, default);
+                        bool? up_ = context.Operators.In<CqlDateTime>(uf_, uo_, (string)default);
                         CqlInterval<CqlDateTime> ur_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
                         CqlDateTime us_ = context.Operators.Start(ur_);
                         bool? ut_ = context.Operators.Not((bool?)(us_ is null));
@@ -1369,7 +1369,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> vp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vj_);
                     CqlDateTime vq_ = context.Operators.Start(vp_);
                     CqlInterval<CqlDateTime> vr_ = context.Operators.Interval(vn_, vq_, true, true);
-                    bool? vs_ = context.Operators.In<CqlDateTime>(vi_, vr_, default);
+                    bool? vs_ = context.Operators.In<CqlDateTime>(vi_, vr_, (string)default);
                     CqlInterval<CqlDateTime> vu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vj_);
                     CqlDateTime vv_ = context.Operators.Start(vu_);
                     bool? vw_ = context.Operators.Not((bool?)(vv_ is null));
@@ -1443,7 +1443,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> yt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yn_);
                     CqlDateTime yu_ = context.Operators.Start(yt_);
                     CqlInterval<CqlDateTime> yv_ = context.Operators.Interval(yr_, yu_, true, true);
-                    bool? yw_ = context.Operators.In<CqlDateTime>(ym_, yv_, default);
+                    bool? yw_ = context.Operators.In<CqlDateTime>(ym_, yv_, (string)default);
                     CqlInterval<CqlDateTime> yy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yn_);
                     CqlDateTime yz_ = context.Operators.Start(yy_);
                     bool? za_ = context.Operators.Not((bool?)(yz_ is null));
@@ -1489,7 +1489,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> zt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, zn_);
                     CqlDateTime zu_ = context.Operators.Start(zt_);
                     CqlInterval<CqlDateTime> zv_ = context.Operators.Interval(zr_, zu_, true, true);
-                    bool? zw_ = context.Operators.In<CqlDateTime>(zm_, zv_, default);
+                    bool? zw_ = context.Operators.In<CqlDateTime>(zm_, zv_, (string)default);
                     CqlInterval<CqlDateTime> zy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, zn_);
                     CqlDateTime zz_ = context.Operators.Start(zy_);
                     bool? aza_ = context.Operators.Not((bool?)(zz_ is null));
@@ -1515,7 +1515,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> xm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ww_);
                 CqlDateTime xn_ = context.Operators.Start(xm_);
                 CqlInterval<CqlDateTime> xo_ = context.Operators.Interval(xa_, xk_ ?? xn_, true, true);
-                bool? xp_ = context.Operators.In<CqlDateTime>(wl_, xo_, default);
+                bool? xp_ = context.Operators.In<CqlDateTime>(wl_, xo_, (string)default);
                 IEnumerable<Encounter> xr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, wm_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? xs_(Encounter LastObs) {
@@ -1534,7 +1534,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> azt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, azn_);
                     CqlDateTime azu_ = context.Operators.Start(azt_);
                     CqlInterval<CqlDateTime> azv_ = context.Operators.Interval(azr_, azu_, true, true);
-                    bool? azw_ = context.Operators.In<CqlDateTime>(azm_, azv_, default);
+                    bool? azw_ = context.Operators.In<CqlDateTime>(azm_, azv_, (string)default);
                     CqlInterval<CqlDateTime> azy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, azn_);
                     CqlDateTime azz_ = context.Operators.Start(azy_);
                     bool? bza_ = context.Operators.Not((bool?)(azz_ is null));
@@ -1598,7 +1598,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> bzw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bzq_);
                 CqlDateTime bzx_ = context.Operators.Start(bzw_);
                 CqlInterval<CqlDateTime> bzy_ = context.Operators.Interval(bzu_, bzx_, true, true);
-                bool? bzz_ = context.Operators.In<CqlDateTime>(bzp_, bzy_, default);
+                bool? bzz_ = context.Operators.In<CqlDateTime>(bzp_, bzy_, (string)default);
                 CqlInterval<CqlDateTime> czb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bzq_);
                 CqlDateTime czc_ = context.Operators.Start(czb_);
                 bool? czd_ = context.Operators.Not((bool?)(czc_ is null));
@@ -1683,7 +1683,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ge_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fy_);
                         CqlDateTime gf_ = context.Operators.Start(ge_);
                         CqlInterval<CqlDateTime> gg_ = context.Operators.Interval(gc_, gf_, true, true);
-                        bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, default);
+                        bool? gh_ = context.Operators.In<CqlDateTime>(fx_, gg_, (string)default);
                         CqlInterval<CqlDateTime> gj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fy_);
                         CqlDateTime gk_ = context.Operators.Start(gj_);
                         bool? gl_ = context.Operators.Not((bool?)(gk_ is null));
@@ -1729,7 +1729,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> he_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gy_);
                         CqlDateTime hf_ = context.Operators.Start(he_);
                         CqlInterval<CqlDateTime> hg_ = context.Operators.Interval(hc_, hf_, true, true);
-                        bool? hh_ = context.Operators.In<CqlDateTime>(gx_, hg_, default);
+                        bool? hh_ = context.Operators.In<CqlDateTime>(gx_, hg_, (string)default);
                         CqlInterval<CqlDateTime> hj_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, gy_);
                         CqlDateTime hk_ = context.Operators.Start(hj_);
                         bool? hl_ = context.Operators.Not((bool?)(hk_ is null));
@@ -1755,7 +1755,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> ex_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eh_);
                     CqlDateTime ey_ = context.Operators.Start(ex_);
                     CqlInterval<CqlDateTime> ez_ = context.Operators.Interval(el_, ev_ ?? ey_, true, true);
-                    bool? fa_ = context.Operators.In<CqlDateTime>(dw_, ez_, default);
+                    bool? fa_ = context.Operators.In<CqlDateTime>(dw_, ez_, (string)default);
                     IEnumerable<Encounter> fc_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, dx_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? fd_(Encounter LastObs) {
@@ -1774,7 +1774,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ie_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hy_);
                         CqlDateTime if_ = context.Operators.Start(ie_);
                         CqlInterval<CqlDateTime> ig_ = context.Operators.Interval(ic_, if_, true, true);
-                        bool? ih_ = context.Operators.In<CqlDateTime>(hx_, ig_, default);
+                        bool? ih_ = context.Operators.In<CqlDateTime>(hx_, ig_, (string)default);
                         CqlInterval<CqlDateTime> ij_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, hy_);
                         CqlDateTime ik_ = context.Operators.Start(ij_);
                         bool? il_ = context.Operators.Not((bool?)(ik_ is null));
@@ -1838,7 +1838,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> jh_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jb_);
                     CqlDateTime ji_ = context.Operators.Start(jh_);
                     CqlInterval<CqlDateTime> jj_ = context.Operators.Interval(jf_, ji_, true, true);
-                    bool? jk_ = context.Operators.In<CqlDateTime>(ja_, jj_, default);
+                    bool? jk_ = context.Operators.In<CqlDateTime>(ja_, jj_, (string)default);
                     CqlInterval<CqlDateTime> jm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, jb_);
                     CqlDateTime jn_ = context.Operators.Start(jm_);
                     bool? jo_ = context.Operators.Not((bool?)(jn_ is null));
@@ -1895,7 +1895,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> mi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mc_);
                         CqlDateTime mj_ = context.Operators.Start(mi_);
                         CqlInterval<CqlDateTime> mk_ = context.Operators.Interval(mg_, mj_, true, true);
-                        bool? ml_ = context.Operators.In<CqlDateTime>(mb_, mk_, default);
+                        bool? ml_ = context.Operators.In<CqlDateTime>(mb_, mk_, (string)default);
                         CqlInterval<CqlDateTime> mn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, mc_);
                         CqlDateTime mo_ = context.Operators.Start(mn_);
                         bool? mp_ = context.Operators.Not((bool?)(mo_ is null));
@@ -1941,7 +1941,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> ni_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nc_);
                         CqlDateTime nj_ = context.Operators.Start(ni_);
                         CqlInterval<CqlDateTime> nk_ = context.Operators.Interval(ng_, nj_, true, true);
-                        bool? nl_ = context.Operators.In<CqlDateTime>(nb_, nk_, default);
+                        bool? nl_ = context.Operators.In<CqlDateTime>(nb_, nk_, (string)default);
                         CqlInterval<CqlDateTime> nn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, nc_);
                         CqlDateTime no_ = context.Operators.Start(nn_);
                         bool? np_ = context.Operators.Not((bool?)(no_ is null));
@@ -1967,7 +1967,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> lb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, kl_);
                     CqlDateTime lc_ = context.Operators.Start(lb_);
                     CqlInterval<CqlDateTime> ld_ = context.Operators.Interval(kp_, kz_ ?? lc_, true, true);
-                    bool? le_ = context.Operators.In<CqlDateTime>(ka_, ld_, default);
+                    bool? le_ = context.Operators.In<CqlDateTime>(ka_, ld_, (string)default);
                     IEnumerable<Encounter> lg_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, kb_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? lh_(Encounter LastObs) {
@@ -1986,7 +1986,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> oi_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oc_);
                         CqlDateTime oj_ = context.Operators.Start(oi_);
                         CqlInterval<CqlDateTime> ok_ = context.Operators.Interval(og_, oj_, true, true);
-                        bool? ol_ = context.Operators.In<CqlDateTime>(ob_, ok_, default);
+                        bool? ol_ = context.Operators.In<CqlDateTime>(ob_, ok_, (string)default);
                         CqlInterval<CqlDateTime> on_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, oc_);
                         CqlDateTime oo_ = context.Operators.Start(on_);
                         bool? op_ = context.Operators.Not((bool?)(oo_ is null));
@@ -2049,7 +2049,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> pl_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
                     CqlDateTime pm_ = context.Operators.Start(pl_);
                     CqlInterval<CqlDateTime> pn_ = context.Operators.Interval(pj_, pm_, true, true);
-                    bool? po_ = context.Operators.In<CqlDateTime>(pe_, pn_, default);
+                    bool? po_ = context.Operators.In<CqlDateTime>(pe_, pn_, (string)default);
                     CqlInterval<CqlDateTime> pq_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, pf_);
                     CqlDateTime pr_ = context.Operators.Start(pq_);
                     bool? ps_ = context.Operators.Not((bool?)(pr_ is null));
@@ -2075,7 +2075,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> cn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bn_);
                 CqlDateTime co_ = context.Operators.Start(cn_);
                 CqlInterval<CqlDateTime> cp_ = context.Operators.Interval(br_, cb_ ?? cl_ ?? co_, true, true);
-                bool? cq_ = context.Operators.In<CqlDateTime>(as_, cp_, default);
+                bool? cq_ = context.Operators.In<CqlDateTime>(as_, cp_, (string)default);
                 IEnumerable<Encounter> cs_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, at_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? ct_(Encounter LastED) {
@@ -2105,7 +2105,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> sm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sg_);
                         CqlDateTime sn_ = context.Operators.Start(sm_);
                         CqlInterval<CqlDateTime> so_ = context.Operators.Interval(sk_, sn_, true, true);
-                        bool? sp_ = context.Operators.In<CqlDateTime>(sf_, so_, default);
+                        bool? sp_ = context.Operators.In<CqlDateTime>(sf_, so_, (string)default);
                         CqlInterval<CqlDateTime> sr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, sg_);
                         CqlDateTime ss_ = context.Operators.Start(sr_);
                         bool? st_ = context.Operators.Not((bool?)(ss_ is null));
@@ -2151,7 +2151,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> tm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
                         CqlDateTime tn_ = context.Operators.Start(tm_);
                         CqlInterval<CqlDateTime> to_ = context.Operators.Interval(tk_, tn_, true, true);
-                        bool? tp_ = context.Operators.In<CqlDateTime>(tf_, to_, default);
+                        bool? tp_ = context.Operators.In<CqlDateTime>(tf_, to_, (string)default);
                         CqlInterval<CqlDateTime> tr_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, tg_);
                         CqlDateTime ts_ = context.Operators.Start(tr_);
                         bool? tt_ = context.Operators.Not((bool?)(ts_ is null));
@@ -2177,7 +2177,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> rf_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, qp_);
                     CqlDateTime rg_ = context.Operators.Start(rf_);
                     CqlInterval<CqlDateTime> rh_ = context.Operators.Interval(qt_, rd_ ?? rg_, true, true);
-                    bool? ri_ = context.Operators.In<CqlDateTime>(qe_, rh_, default);
+                    bool? ri_ = context.Operators.In<CqlDateTime>(qe_, rh_, (string)default);
                     IEnumerable<Encounter> rk_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, qf_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                     bool? rl_(Encounter LastObs) {
@@ -2196,7 +2196,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                         CqlInterval<CqlDateTime> um_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
                         CqlDateTime un_ = context.Operators.Start(um_);
                         CqlInterval<CqlDateTime> uo_ = context.Operators.Interval(uk_, un_, true, true);
-                        bool? up_ = context.Operators.In<CqlDateTime>(uf_, uo_, default);
+                        bool? up_ = context.Operators.In<CqlDateTime>(uf_, uo_, (string)default);
                         CqlInterval<CqlDateTime> ur_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ug_);
                         CqlDateTime us_ = context.Operators.Start(ur_);
                         bool? ut_ = context.Operators.Not((bool?)(us_ is null));
@@ -2259,7 +2259,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> vp_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vj_);
                     CqlDateTime vq_ = context.Operators.Start(vp_);
                     CqlInterval<CqlDateTime> vr_ = context.Operators.Interval(vn_, vq_, true, true);
-                    bool? vs_ = context.Operators.In<CqlDateTime>(vi_, vr_, default);
+                    bool? vs_ = context.Operators.In<CqlDateTime>(vi_, vr_, (string)default);
                     CqlInterval<CqlDateTime> vu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, vj_);
                     CqlDateTime vv_ = context.Operators.Start(vu_);
                     bool? vw_ = context.Operators.Not((bool?)(vv_ is null));
@@ -2333,7 +2333,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> yt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yn_);
                     CqlDateTime yu_ = context.Operators.Start(yt_);
                     CqlInterval<CqlDateTime> yv_ = context.Operators.Interval(yr_, yu_, true, true);
-                    bool? yw_ = context.Operators.In<CqlDateTime>(ym_, yv_, default);
+                    bool? yw_ = context.Operators.In<CqlDateTime>(ym_, yv_, (string)default);
                     CqlInterval<CqlDateTime> yy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, yn_);
                     CqlDateTime yz_ = context.Operators.Start(yy_);
                     bool? za_ = context.Operators.Not((bool?)(yz_ is null));
@@ -2379,7 +2379,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> zt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, zn_);
                     CqlDateTime zu_ = context.Operators.Start(zt_);
                     CqlInterval<CqlDateTime> zv_ = context.Operators.Interval(zr_, zu_, true, true);
-                    bool? zw_ = context.Operators.In<CqlDateTime>(zm_, zv_, default);
+                    bool? zw_ = context.Operators.In<CqlDateTime>(zm_, zv_, (string)default);
                     CqlInterval<CqlDateTime> zy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, zn_);
                     CqlDateTime zz_ = context.Operators.Start(zy_);
                     bool? aza_ = context.Operators.Not((bool?)(zz_ is null));
@@ -2405,7 +2405,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> xm_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ww_);
                 CqlDateTime xn_ = context.Operators.Start(xm_);
                 CqlInterval<CqlDateTime> xo_ = context.Operators.Interval(xa_, xk_ ?? xn_, true, true);
-                bool? xp_ = context.Operators.In<CqlDateTime>(wl_, xo_, default);
+                bool? xp_ = context.Operators.In<CqlDateTime>(wl_, xo_, (string)default);
                 IEnumerable<Encounter> xr_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, wm_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? xs_(Encounter LastObs) {
@@ -2424,7 +2424,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> azt_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, azn_);
                     CqlDateTime azu_ = context.Operators.Start(azt_);
                     CqlInterval<CqlDateTime> azv_ = context.Operators.Interval(azr_, azu_, true, true);
-                    bool? azw_ = context.Operators.In<CqlDateTime>(azm_, azv_, default);
+                    bool? azw_ = context.Operators.In<CqlDateTime>(azm_, azv_, (string)default);
                     CqlInterval<CqlDateTime> azy_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, azn_);
                     CqlDateTime azz_ = context.Operators.Start(azy_);
                     bool? bza_ = context.Operators.Not((bool?)(azz_ is null));
@@ -2488,7 +2488,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> bzw_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bzq_);
                 CqlDateTime bzx_ = context.Operators.Start(bzw_);
                 CqlInterval<CqlDateTime> bzy_ = context.Operators.Interval(bzu_, bzx_, true, true);
-                bool? bzz_ = context.Operators.In<CqlDateTime>(bzp_, bzy_, default);
+                bool? bzz_ = context.Operators.In<CqlDateTime>(bzp_, bzy_, (string)default);
                 CqlInterval<CqlDateTime> czb_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, bzq_);
                 CqlDateTime czc_ = context.Operators.Start(czb_);
                 bool? czd_ = context.Operators.Not((bool?)(czc_ is null));
@@ -2567,7 +2567,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
                     CqlDateTime cv_ = context.Operators.Start(cu_);
                     CqlInterval<CqlDateTime> cw_ = context.Operators.Interval(cs_, cv_, true, true);
-                    bool? cx_ = context.Operators.In<CqlDateTime>(cn_, cw_, default);
+                    bool? cx_ = context.Operators.In<CqlDateTime>(cn_, cw_, (string)default);
                     CqlInterval<CqlDateTime> cz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
                     CqlDateTime da_ = context.Operators.Start(cz_);
                     bool? db_ = context.Operators.Not((bool?)(da_ is null));
@@ -2613,7 +2613,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, do_);
                     CqlDateTime dv_ = context.Operators.Start(du_);
                     CqlInterval<CqlDateTime> dw_ = context.Operators.Interval(ds_, dv_, true, true);
-                    bool? dx_ = context.Operators.In<CqlDateTime>(dn_, dw_, default);
+                    bool? dx_ = context.Operators.In<CqlDateTime>(dn_, dw_, (string)default);
                     CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, do_);
                     CqlDateTime ea_ = context.Operators.Start(dz_);
                     bool? eb_ = context.Operators.Not((bool?)(ea_ is null));
@@ -2639,7 +2639,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
                 CqlDateTime bo_ = context.Operators.Start(bn_);
                 CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bb_, bl_ ?? bo_, true, true);
-                bool? bq_ = context.Operators.In<CqlDateTime>(am_, bp_, default);
+                bool? bq_ = context.Operators.In<CqlDateTime>(am_, bp_, (string)default);
                 IEnumerable<Encounter> bs_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, an_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? bt_(Encounter LastObs) {
@@ -2658,7 +2658,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eo_);
                     CqlDateTime ev_ = context.Operators.Start(eu_);
                     CqlInterval<CqlDateTime> ew_ = context.Operators.Interval(es_, ev_, true, true);
-                    bool? ex_ = context.Operators.In<CqlDateTime>(en_, ew_, default);
+                    bool? ex_ = context.Operators.In<CqlDateTime>(en_, ew_, (string)default);
                     CqlInterval<CqlDateTime> ez_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eo_);
                     CqlDateTime fa_ = context.Operators.Start(ez_);
                     bool? fb_ = context.Operators.Not((bool?)(fa_ is null));
@@ -2722,7 +2722,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fr_);
                 CqlDateTime fy_ = context.Operators.Start(fx_);
                 CqlInterval<CqlDateTime> fz_ = context.Operators.Interval(fv_, fy_, true, true);
-                bool? ga_ = context.Operators.In<CqlDateTime>(fq_, fz_, default);
+                bool? ga_ = context.Operators.In<CqlDateTime>(fq_, fz_, (string)default);
                 CqlInterval<CqlDateTime> gc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fr_);
                 CqlDateTime gd_ = context.Operators.Start(gc_);
                 bool? ge_ = context.Operators.Not((bool?)(gd_ is null));
@@ -2800,7 +2800,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> cu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
                     CqlDateTime cv_ = context.Operators.Start(cu_);
                     CqlInterval<CqlDateTime> cw_ = context.Operators.Interval(cs_, cv_, true, true);
-                    bool? cx_ = context.Operators.In<CqlDateTime>(cn_, cw_, default);
+                    bool? cx_ = context.Operators.In<CqlDateTime>(cn_, cw_, (string)default);
                     CqlInterval<CqlDateTime> cz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, co_);
                     CqlDateTime da_ = context.Operators.Start(cz_);
                     bool? db_ = context.Operators.Not((bool?)(da_ is null));
@@ -2846,7 +2846,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> du_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, do_);
                     CqlDateTime dv_ = context.Operators.Start(du_);
                     CqlInterval<CqlDateTime> dw_ = context.Operators.Interval(ds_, dv_, true, true);
-                    bool? dx_ = context.Operators.In<CqlDateTime>(dn_, dw_, default);
+                    bool? dx_ = context.Operators.In<CqlDateTime>(dn_, dw_, (string)default);
                     CqlInterval<CqlDateTime> dz_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, do_);
                     CqlDateTime ea_ = context.Operators.Start(dz_);
                     bool? eb_ = context.Operators.Not((bool?)(ea_ is null));
@@ -2872,7 +2872,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> bn_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, ax_);
                 CqlDateTime bo_ = context.Operators.Start(bn_);
                 CqlInterval<CqlDateTime> bp_ = context.Operators.Interval(bb_, bl_ ?? bo_, true, true);
-                bool? bq_ = context.Operators.In<CqlDateTime>(am_, bp_, default);
+                bool? bq_ = context.Operators.In<CqlDateTime>(am_, bp_, (string)default);
                 IEnumerable<Encounter> bs_ = context.Operators.Retrieve<Encounter>(new RetrieveParameters(default, an_, default, "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-encounter"));
 
                 bool? bt_(Encounter LastObs) {
@@ -2891,7 +2891,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                     CqlInterval<CqlDateTime> eu_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eo_);
                     CqlDateTime ev_ = context.Operators.Start(eu_);
                     CqlInterval<CqlDateTime> ew_ = context.Operators.Interval(es_, ev_, true, true);
-                    bool? ex_ = context.Operators.In<CqlDateTime>(en_, ew_, default);
+                    bool? ex_ = context.Operators.In<CqlDateTime>(en_, ew_, (string)default);
                     CqlInterval<CqlDateTime> ez_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, eo_);
                     CqlDateTime fa_ = context.Operators.Start(ez_);
                     bool? fb_ = context.Operators.Not((bool?)(fa_ is null));
@@ -2955,7 +2955,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
                 CqlInterval<CqlDateTime> fx_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fr_);
                 CqlDateTime fy_ = context.Operators.Start(fx_);
                 CqlInterval<CqlDateTime> fz_ = context.Operators.Interval(fv_, fy_, true, true);
-                bool? ga_ = context.Operators.In<CqlDateTime>(fq_, fz_, default);
+                bool? ga_ = context.Operators.In<CqlDateTime>(fq_, fz_, (string)default);
                 CqlInterval<CqlDateTime> gc_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, fr_);
                 CqlDateTime gd_ = context.Operators.Start(gc_);
                 bool? ge_ = context.Operators.Not((bool?)(gd_ is null));
@@ -3039,7 +3039,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
             Period p_ = HospitalLocation?.Period;
             CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
             bool? s_ = context.Operators.And(m_, r_);
             return s_;
         }
@@ -3082,7 +3082,7 @@ public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
             CqlInterval<CqlDateTime> o_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, n_);
             Period p_ = HospitalLocation?.Period;
             CqlInterval<CqlDateTime> q_ = FHIRHelpers_4_4_000.Instance.ToInterval(context, p_);
-            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, default);
+            bool? r_ = context.Operators.IntervalIncludesInterval<CqlDateTime>(o_, q_, (string)default);
             bool? s_ = context.Operators.And(m_, r_);
             return s_;
         }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
@@ -255,7 +255,7 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
             }
             else if (b_())
             {
-                object o_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
+                object o_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.ComparatorQuantityNotSupported", "Error", "FHIR Quantity value has a comparator and cannot be converted to a System.Quantity value.");
                 return o_ as CqlQuantity;
             }
             else if (c_())
@@ -283,7 +283,7 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
                 string af_ = ae_?.Value;
                 string ag_ = context.Operators.Concatenate(ad_ ?? "", af_ ?? "");
                 string ah_ = context.Operators.Concatenate(ag_ ?? "", ")");
-                object ai_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
+                object ai_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ah_);
                 return ai_ as CqlQuantity;
             };
         }
@@ -345,7 +345,7 @@ public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_
                 string ab_ = aa_?.Value;
                 string ac_ = context.Operators.Concatenate(z_ ?? "", ab_ ?? "");
                 string ad_ = context.Operators.Concatenate(ac_ ?? "", ")");
-                object ae_ = context.Operators.Message<object>(null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
+                object ae_ = context.Operators.Message<object>((object)null, "FHIRHelpers.ToQuantity.InvalidFHIRQuantity", "Error", ad_);
                 return ae_ as CqlQuantity;
             };
         }

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
@@ -1077,7 +1077,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
             }
             else if (choice is Timing)
             {
-                object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+                object dy_ = context.Operators.Message<object>((object)null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
                 return dy_ as CqlInterval<CqlDateTime>;
             }
             else
@@ -1216,7 +1216,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
             }
             else if (choice is Timing)
             {
-                object dy_ = context.Operators.Message<object>(null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
+                object dy_ = context.Operators.Message<object>((object)null, "NOT_IMPLEMENTED", "Error", "Calculation of an interval from a Timing value is not supported");
                 return dy_ as CqlInterval<CqlDateTime>;
             }
             else
@@ -2104,7 +2104,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, (CqlQuantity)default);
 
         int? g_(CqlInterval<int?> DayNumber) {
             int? j_ = context.Operators.End(DayNumber);
@@ -2128,7 +2128,7 @@ public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_
         CqlInterval<int?>[] e_ = [
             d_,
         ];
-        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, default);
+        IEnumerable<CqlInterval<int?>> f_ = context.Operators.Expand((IEnumerable<CqlInterval<int?>>)e_, (CqlQuantity)default);
 
         int? g_(CqlInterval<int?> DayNumber) {
             int? j_ = context.Operators.End(DayNumber);

--- a/build-elm.ps1
+++ b/build-elm.ps1
@@ -1,6 +1,0 @@
-$solutionFile = "Cql-sdk.slnf"
-$configuration = "Debug"
-
-dotnet build $solutionFile `
-    -c $configuration `
-    -p:ElmToCSharpEnabled=true

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,150 @@
+#!/usr/bin/env pwsh
+#
+# Build script for Firely CQL SDK
+# Provides interactive options for runtime selection and CQL tooling features
+#
+
+param(
+    [Parameter(HelpMessage="Target framework: net8.0 or net10.0")]
+    [ValidateSet("net8.0", "net10.0")]
+    [string]$Framework,
+    
+    [Parameter(HelpMessage="Enable CqlToElm conversion")]
+    [switch]$EnableCqlToElm,
+    
+    [Parameter(HelpMessage="Enable ElmToCSharp conversion")]
+    [switch]$EnableElmToCSharp,
+    
+    [Parameter(HelpMessage="Build configuration: Debug or Release")]
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Debug"
+)
+
+# ANSI color codes
+$Green = "`e[32m"
+$Yellow = "`e[33m"
+$Blue = "`e[34m"
+$Reset = "`e[0m"
+
+Write-Host "${Blue}===========================================================================" -ForegroundColor Blue
+Write-Host "Firely CQL SDK Build Script" -ForegroundColor Blue
+Write-Host "===========================================================================${Reset}" -ForegroundColor Blue
+Write-Host ""
+
+# Interactive prompts if parameters not provided
+if (-not $Framework -or -not $PSBoundParameters.ContainsKey('Configuration')) {
+    Write-Host "${Yellow}Select target framework and configuration:${Reset}" -ForegroundColor Yellow
+    Write-Host "  1. .NET 8 / Debug"
+    Write-Host "  2. .NET 8 / Release"
+    Write-Host "  3. .NET 10 / Debug"
+    Write-Host "  4. .NET 10 / Release"
+    Write-Host ""
+    $choice = Read-Host "Enter choice (1-4)"
+
+    switch ($choice) {
+        "1" { 
+            $Framework = "net8.0"
+            $Configuration = "Debug"
+        }
+        "2" { 
+            $Framework = "net8.0"
+            $Configuration = "Release"
+        }
+        "3" { 
+            $Framework = "net10.0"
+            $Configuration = "Debug"
+        }
+        "4" { 
+            $Framework = "net10.0"
+            $Configuration = "Release"
+        }
+        default { 
+            Write-Host "${Red}Invalid choice. Defaulting to .NET 8 / Debug${Reset}" -ForegroundColor Red
+            $Framework = "net8.0"
+            $Configuration = "Debug"
+        }
+    }
+}
+
+if (-not $EnableCqlToElm.IsPresent -and -not $EnableElmToCSharp.IsPresent) {
+    Write-Host ""
+    Write-Host "${Yellow}Select code generation options:${Reset}" -ForegroundColor Yellow
+    Write-Host "  1. None (both disabled)"
+    Write-Host "  2. CqlToElm only (converts CQL files to ELM JSON)"
+    Write-Host "  3. ElmToCSharp only (generates C# code from ELM)"
+    Write-Host "  4. Both enabled (CqlToElm + ElmToCSharp)"
+    Write-Host ""
+    $codeGenChoice = Read-Host "Enter choice (1-4, default: 1)"
+
+    switch ($codeGenChoice) {
+        "1" { 
+            $EnableCqlToElm = $false
+            $EnableElmToCSharp = $false
+        }
+        "2" { 
+            $EnableCqlToElm = $true
+            $EnableElmToCSharp = $false
+        }
+        "3" { 
+            $EnableCqlToElm = $false
+            $EnableElmToCSharp = $true
+        }
+        "4" { 
+            $EnableCqlToElm = $true
+            $EnableElmToCSharp = $true
+        }
+        default { 
+            $EnableCqlToElm = $false
+            $EnableElmToCSharp = $false
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "${Green}===========================================================================" -ForegroundColor Green
+Write-Host "Build Configuration:" -ForegroundColor Green
+Write-Host "===========================================================================${Reset}" -ForegroundColor Green
+Write-Host "  Framework:        ${Framework}"
+Write-Host "  Configuration:    ${Configuration}"
+Write-Host "  CqlToElm:         $(if ($EnableCqlToElm) { 'Enabled' } else { 'Disabled' })"
+Write-Host "  ElmToCSharp:      $(if ($EnableElmToCSharp) { 'Enabled' } else { 'Disabled' })"
+Write-Host ""
+
+# Build MSBuild properties
+$properties = @(
+    "/p:Configuration=$Configuration"
+    "/p:TargetFramework=$Framework"
+)
+
+if ($EnableCqlToElm) {
+    $properties += "/p:CqlToElmEnabled=true"
+}
+
+if ($EnableElmToCSharp) {
+    $properties += "/p:ElmToCSharpEnabled=true"
+}
+
+# Execute build
+Write-Host "${Blue}Building solution...${Reset}" -ForegroundColor Blue
+Write-Host ""
+
+$solutionFile = "Cql-Sdk-All.sln"
+$buildCommand = "dotnet build `"$solutionFile`" $($properties -join ' ')"
+
+Write-Host "Command: $buildCommand" -ForegroundColor DarkGray
+Write-Host ""
+
+& dotnet build $solutionFile $properties
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ""
+    Write-Host "${Green}===========================================================================" -ForegroundColor Green
+    Write-Host "Build completed successfully!" -ForegroundColor Green
+    Write-Host "===========================================================================${Reset}" -ForegroundColor Green
+} else {
+    Write-Host ""
+    Write-Host "${Red}===========================================================================" -ForegroundColor Red
+    Write-Host "Build failed with exit code $LASTEXITCODE" -ForegroundColor Red
+    Write-Host "===========================================================================${Reset}" -ForegroundColor Red
+    exit $LASTEXITCODE
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# Build script for Firely CQL SDK
+# Provides interactive options for runtime selection and CQL tooling features
+#
+
+set -e
+
+# ANSI color codes
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+# Default values
+FRAMEWORK=""
+CONFIGURATION="Debug"
+ENABLE_CQL_TO_ELM=""
+ENABLE_ELM_TO_CSHARP=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --framework)
+            FRAMEWORK="$2"
+            shift 2
+            ;;
+        --configuration)
+            CONFIGURATION="$2"
+            shift 2
+            ;;
+        --enable-cql-to-elm)
+            ENABLE_CQL_TO_ELM="true"
+            shift
+            ;;
+        --enable-elm-to-csharp)
+            ENABLE_ELM_TO_CSHARP="true"
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --framework <net8.0|net10.0>    Target framework"
+            echo "  --configuration <Debug|Release>  Build configuration (default: Debug)"
+            echo "  --enable-cql-to-elm              Enable CqlToElm conversion"
+            echo "  --enable-elm-to-csharp           Enable ElmToCSharp conversion"
+            echo "  --help                           Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}==========================================================================="
+echo "Firely CQL SDK Build Script"
+echo -e "===========================================================================${RESET}"
+echo ""
+
+# Interactive prompts if parameters not provided
+if [ -z "$FRAMEWORK" ]; then
+    echo -e "${YELLOW}Select target framework and configuration:${RESET}"
+    echo "  1. .NET 8 / Debug"
+    echo "  2. .NET 8 / Release"
+    echo "  3. .NET 10 / Debug"
+    echo "  4. .NET 10 / Release"
+    echo ""
+    read -p "Enter choice (1-4): " choice
+
+    case $choice in
+        1)
+            FRAMEWORK="net8.0"
+            CONFIGURATION="Debug"
+            ;;
+        2)
+            FRAMEWORK="net8.0"
+            CONFIGURATION="Release"
+            ;;
+        3)
+            FRAMEWORK="net10.0"
+            CONFIGURATION="Debug"
+            ;;
+        4)
+            FRAMEWORK="net10.0"
+            CONFIGURATION="Release"
+            ;;
+        *)
+            echo -e "${RED}Invalid choice. Defaulting to .NET 8 / Debug${RESET}"
+            FRAMEWORK="net8.0"
+            CONFIGURATION="Debug"
+            ;;
+    esac
+fi
+
+if [ -z "$ENABLE_CQL_TO_ELM" ] && [ -z "$ENABLE_ELM_TO_CSHARP" ]; then
+    echo ""
+    echo -e "${YELLOW}Select code generation options:${RESET}"
+    echo "  1. None (both disabled)"
+    echo "  2. CqlToElm only (converts CQL files to ELM JSON)"
+    echo "  3. ElmToCSharp only (generates C# code from ELM)"
+    echo "  4. Both enabled (CqlToElm + ElmToCSharp)"
+    echo ""
+    read -p "Enter choice (1-4, default: 1): " codegen_choice
+
+    case $codegen_choice in
+        1)
+            ENABLE_CQL_TO_ELM="false"
+            ENABLE_ELM_TO_CSHARP="false"
+            ;;
+        2)
+            ENABLE_CQL_TO_ELM="true"
+            ENABLE_ELM_TO_CSHARP="false"
+            ;;
+        3)
+            ENABLE_CQL_TO_ELM="false"
+            ENABLE_ELM_TO_CSHARP="true"
+            ;;
+        4)
+            ENABLE_CQL_TO_ELM="true"
+            ENABLE_ELM_TO_CSHARP="true"
+            ;;
+        *)
+            ENABLE_CQL_TO_ELM="false"
+            ENABLE_ELM_TO_CSHARP="false"
+            ;;
+    esac
+fi
+
+echo ""
+echo -e "${GREEN}==========================================================================="
+echo "Build Configuration:"
+echo -e "===========================================================================${RESET}"
+echo "  Framework:        ${FRAMEWORK}"
+echo "  Configuration:    ${CONFIGURATION}"
+echo "  CqlToElm:         $([ "$ENABLE_CQL_TO_ELM" = "true" ] && echo "Enabled" || echo "Disabled")"
+echo "  ElmToCSharp:      $([ "$ENABLE_ELM_TO_CSHARP" = "true" ] && echo "Enabled" || echo "Disabled")"
+echo ""
+
+# Build MSBuild properties
+PROPERTIES=(
+    "/p:Configuration=$CONFIGURATION"
+    "/p:TargetFramework=$FRAMEWORK"
+)
+
+if [ "$ENABLE_CQL_TO_ELM" = "true" ]; then
+    PROPERTIES+=("/p:CqlToElmEnabled=true")
+fi
+
+if [ "$ENABLE_ELM_TO_CSHARP" = "true" ]; then
+    PROPERTIES+=("/p:ElmToCSharpEnabled=true")
+fi
+
+# Execute build
+echo -e "${BLUE}Building solution...${RESET}"
+echo ""
+
+SOLUTION_FILE="Cql-Sdk-All.sln"
+
+echo -e "\033[90mCommand: dotnet build \"$SOLUTION_FILE\" ${PROPERTIES[*]}${RESET}"
+echo ""
+
+dotnet build "$SOLUTION_FILE" "${PROPERTIES[@]}"
+
+if [ $? -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}==========================================================================="
+    echo "Build completed successfully!"
+    echo -e "===========================================================================${RESET}"
+else
+    echo ""
+    echo -e "${RED}==========================================================================="
+    echo "Build failed!"
+    echo -e "===========================================================================${RESET}"
+    exit 1
+fi


### PR DESCRIPTION
Regen C# - mostly just qualifying `default` or `null` values with its type when passing to a method. Changes is a result of previous PR #1209 

Also merge the submodules:
- https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/pull/92
- https://github.com/FirelyTeam/Ncqa.DQIC/pull/45