### PR TITLE
Fix typo in Java-Dependencies-Vars.sh

### DIFF
--- a/Demo/Cql/Build/Java-Dependencies-Vars.sh
+++ b/Demo/Cql/Build/Java-Dependencies-Vars.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # * Java-Dependencies-Vars.ps1
 # * Java-Dependencies-Vars.sh
 # * The Hl7.Cql.Packager.Program.JavaToolVersion for the Packager CLI
-: "${CqlToElmCliVersion:=3.29.0}"}"
+: "${CqlToElmCliVersion:=3.29.0}"
 
 : "${TargetDependencies:=$SCRIPT_DIR/target/dependency}"
 


### PR DESCRIPTION
## Description
Fixes a syntax typo in Demo/Cql/Build/Java-Dependencies-Vars.sh where an
extra `}"` breaks the default assignment of CqlToElmCliVersion.

This causes the demo CQL-to-ELM build setup to fail in a clean environment.

## Related issues


## Testing
Ran the script locally and confirmed it executes correctly.

## FirelyTeam Checklist
- [X] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes