### PR TITLE
Only sign NuGet packages on v* tag releases

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -93,14 +93,14 @@ stages:
       useVersionSuffix: true
     ${{ else }}: # release mode
       useVersionSuffix: false
-    # Only sign on release tags or develop branch (not PRs)
-    ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+    # Only sign on release tags (v* tag)
+    ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
       shouldSign: true
       azureServiceConnectionForSigning: 'AzureTrustedSigningPrincipal'
       trustedSigningAccountEndpoint: 'https://weu.codesigning.azure.net/'
       trustedSigningAccountName: 'FirelyCodeSigning'
       certificateProfileName: 'FirelyCodeSigning'
-    ${{ else }}:
+    ${{ else }}: # non-tag builds: skip signing
       shouldSign: false
       azureServiceConnectionForSigning: ''
       trustedSigningAccountEndpoint: ''

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -10,7 +10,7 @@
 # - Build once, sign and pack on same agent (no artifact download overhead)
 # - Tests run in parallel after build
 # - Java dependencies are cached across builds
-# - Signing only happens on release tags or develop branch
+# - Signing only happens on v* tag releases (controlled via shouldSign parameter)
 # - .NET SDKs are only installed where needed (test jobs only install what they need)
 #
 # Usage: Include this template in azure-pipelines.yml for complete build/test/sign pipeline
@@ -152,8 +152,8 @@ stages:
               includesymbols: true
               includesource: true
 
-          # Sign NuGet packages with Azure Trusted Signing (only on v* tag releases)
-          - ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+          # Sign NuGet packages with Azure Trusted Signing (controlled by shouldSign parameter)
+          - ${{ if eq(parameters.shouldSign, true) }}:
             - template: codesign-nuget-package-using-trusted-signing.yml@templates
               parameters:
                 azureServiceConnection: '${{ parameters.azureServiceConnectionForSigning }}'

--- a/build/build-test-sign.yml
+++ b/build/build-test-sign.yml
@@ -152,8 +152,8 @@ stages:
               includesymbols: true
               includesource: true
 
-          # Sign NuGet packages with Azure Trusted Signing (skip for PRs)
-          - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+          # Sign NuGet packages with Azure Trusted Signing (only on v* tag releases)
+          - ${{ if startswith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
             - template: codesign-nuget-package-using-trusted-signing.yml@templates
               parameters:
                 azureServiceConnection: '${{ parameters.azureServiceConnectionForSigning }}'


### PR DESCRIPTION
Signing with Azure Trusted Signing is only needed when publishing to NuGet. This change ensures the signing step is skipped on regular branch builds and only runs when triggered by a `v*` release tag.