### PR TITLE
feat: Expose Generator Tool Version

### DIFF
--- a/Cql/CodeGeneration.NET/PublicAPI.Shipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Shipped.txt
@@ -70,6 +70,7 @@ override Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig.Equals(object? obj)
 override Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig.GetHashCode() -> int
 override Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig.ToString() -> string!
 override Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitResultArtifacts.GetHashCode() -> int
+static readonly Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkit.GeneratorToolVersion -> System.Version!
 static Hl7.Cql.CodeGeneration.NET.AssemblyBinary.Default.get -> Hl7.Cql.CodeGeneration.NET.AssemblyBinary!
 static Hl7.Cql.CodeGeneration.NET.AssemblyBinary.operator !=(Hl7.Cql.CodeGeneration.NET.AssemblyBinary? left, Hl7.Cql.CodeGeneration.NET.AssemblyBinary? right) -> bool
 static Hl7.Cql.CodeGeneration.NET.AssemblyBinary.operator ==(Hl7.Cql.CodeGeneration.NET.AssemblyBinary? left, Hl7.Cql.CodeGeneration.NET.AssemblyBinary? right) -> bool

--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
@@ -42,6 +42,9 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
         _services = ElmToolkitServices.Create(loggerFactory, config);
     }
 
+    /// <summary>
+    /// Gets the version of the .NET code generator tool used by this toolkit.
+    /// </summary>
     public static readonly Version GeneratorToolVersion = new(LibrarySetCSharpCodeGenerator.GeneratorToolVersion);
 
     private ElmToolkitArtifactsById _artifactsById;

--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
@@ -42,6 +42,8 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
         _services = ElmToolkitServices.Create(loggerFactory, config);
     }
 
+    public static readonly Version GeneratorToolVersion = new(LibrarySetCSharpCodeGenerator.GeneratorToolVersion);
+
     private ElmToolkitArtifactsById _artifactsById;
     private readonly ElmToolkitServices _services;
 

--- a/Cql/Cql.Invocation/PublicAPI.Shipped.txt
+++ b/Cql/Cql.Invocation/PublicAPI.Shipped.txt
@@ -81,6 +81,8 @@ override Hl7.Cql.Invocation.Toolkit.LibraryInstanceInvoker.DependencyLibraryIden
 override Hl7.Cql.Invocation.Toolkit.LibraryInstanceInvoker.LibraryIdentifier.get -> Hl7.Cql.Runtime.CqlVersionedLibraryIdentifier
 override Hl7.Cql.Invocation.Toolkit.LibraryInvoker.ToString() -> string!
 override Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.ToString() -> string?
+static readonly Hl7.Cql.Invocation.Toolkit.InvocationToolkit.FirstUnsupportedGeneratorToolVersion -> System.Version!
+static readonly Hl7.Cql.Invocation.Toolkit.InvocationToolkit.MinSupportedGeneratorToolVersion -> System.Version!
 static Hl7.Cql.Invocation.Toolkit.CqlParameterInfo.operator !=(Hl7.Cql.Invocation.Toolkit.CqlParameterInfo left, Hl7.Cql.Invocation.Toolkit.CqlParameterInfo right) -> bool
 static Hl7.Cql.Invocation.Toolkit.CqlParameterInfo.operator ==(Hl7.Cql.Invocation.Toolkit.CqlParameterInfo left, Hl7.Cql.Invocation.Toolkit.CqlParameterInfo right) -> bool
 static Hl7.Cql.Invocation.Toolkit.Extensions.CqlToolkitInvocationExtensions.CreateLibrarySetInvoker(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit, Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig? elmToolkitConfig = null, string! name = "") -> Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!

--- a/Cql/Cql.Invocation/PublicAPI.Shipped.txt
+++ b/Cql/Cql.Invocation/PublicAPI.Shipped.txt
@@ -83,6 +83,8 @@ override Hl7.Cql.Invocation.Toolkit.LibraryInvoker.ToString() -> string!
 override Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.ToString() -> string?
 static readonly Hl7.Cql.Invocation.Toolkit.InvocationToolkit.FirstUnsupportedGeneratorToolVersion -> System.Version!
 static readonly Hl7.Cql.Invocation.Toolkit.InvocationToolkit.MinSupportedGeneratorToolVersion -> System.Version!
+static readonly Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.FirstUnsupportedGeneratorToolVersion -> System.Version!
+static readonly Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker.MinSupportedGeneratorToolVersion -> System.Version!
 static Hl7.Cql.Invocation.Toolkit.CqlParameterInfo.operator !=(Hl7.Cql.Invocation.Toolkit.CqlParameterInfo left, Hl7.Cql.Invocation.Toolkit.CqlParameterInfo right) -> bool
 static Hl7.Cql.Invocation.Toolkit.CqlParameterInfo.operator ==(Hl7.Cql.Invocation.Toolkit.CqlParameterInfo left, Hl7.Cql.Invocation.Toolkit.CqlParameterInfo right) -> bool
 static Hl7.Cql.Invocation.Toolkit.Extensions.CqlToolkitInvocationExtensions.CreateLibrarySetInvoker(this Hl7.Cql.CqlToElm.Toolkit.CqlToolkit! cqlToolkit, Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig? elmToolkitConfig = null, string! name = "") -> Hl7.Cql.Invocation.Toolkit.LibrarySetInvoker!

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
@@ -28,6 +28,9 @@ internal sealed class LibraryInstanceInvoker_5_0 : LibraryInstanceInvoker
                       .AsReadOnly();
     }
 
+    public static readonly Version MinSupportedGeneratorToolVersion = new(5,0,0,0);
+    public static readonly Version FirstUnsupportedGeneratorToolVersion = new(5,1,0,0);
+
     public override IReadOnlyDictionary<DefinitionSignature, DefinitionInvoker> Definitions { get; }
 
     private static object GetLibraryFromStaticInstanceProperty(Type libraryType) =>
@@ -57,8 +60,8 @@ internal sealed class LibraryInstanceInvoker_5_0 : LibraryInstanceInvoker
     /// The current CQL tool version can be referenced by <see cref="LibrarySetCSharpCodeGenerator.GeneratorToolVersion"/>.
     /// </summary>
     public static bool SupportsVersion(Version cqlToolVersion) =>
-        cqlToolVersion >= new Version(5, 0, 0, 0)
-        && cqlToolVersion < new Version(5, 1, 0, 0);
+        cqlToolVersion >= MinSupportedGeneratorToolVersion
+        && cqlToolVersion < FirstUnsupportedGeneratorToolVersion;
 }
 
 file sealed class DefinitionInvoker_5_0(

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
@@ -28,7 +28,14 @@ internal sealed class LibraryInstanceInvoker_5_0 : LibraryInstanceInvoker
                       .AsReadOnly();
     }
 
+    /// <summary>
+    /// The minimum (inclusive) CQL code generator tool version this invoker supports.
+    /// </summary>
     public static readonly Version MinSupportedGeneratorToolVersion = new(5,0,0,0);
+
+    /// <summary>
+    /// The first (exclusive) CQL code generator tool version this invoker does not support.
+    /// </summary>
     public static readonly Version FirstUnsupportedGeneratorToolVersion = new(5,1,0,0);
 
     public override IReadOnlyDictionary<DefinitionSignature, DefinitionInvoker> Definitions { get; }

--- a/Cql/Cql.Invocation/Toolkit/InvocationToolkit.cs
+++ b/Cql/Cql.Invocation/Toolkit/InvocationToolkit.cs
@@ -36,6 +36,9 @@ public sealed class InvocationToolkit : IToolkit<InvocationToolkit>
         _services = LibrarySetInvokerBuilderServices.Create(loggerFactory);
     }
 
+    public static readonly Version MinSupportedGeneratorToolVersion = LibrarySetInvoker.MinSupportedGeneratorToolVersion;
+    public static readonly Version FirstUnsupportedGeneratorToolVersion = LibrarySetInvoker.FirstUnsupportedGeneratorToolVersion;
+
     /// <inheritdoc />
     [EditorBrowsable(EditorBrowsableState.Advanced)]
     public ILoggerFactory LoggerFactory { get; }

--- a/Cql/Cql.Invocation/Toolkit/InvocationToolkit.cs
+++ b/Cql/Cql.Invocation/Toolkit/InvocationToolkit.cs
@@ -36,7 +36,20 @@ public sealed class InvocationToolkit : IToolkit<InvocationToolkit>
         _services = LibrarySetInvokerBuilderServices.Create(loggerFactory);
     }
 
+    /// <summary>
+    /// Gets the minimum generator tool version supported by this invocation toolkit.
+    /// </summary>
+    /// <remarks>
+    /// This value mirrors <see cref="LibrarySetInvoker.MinSupportedGeneratorToolVersion"/>.
+    /// </remarks>
     public static readonly Version MinSupportedGeneratorToolVersion = LibrarySetInvoker.MinSupportedGeneratorToolVersion;
+
+    /// <summary>
+    /// Gets the first generator tool version that this invocation toolkit does not support for executing generated code.
+    /// </summary>
+    /// <remarks>
+    /// This value mirrors <see cref="LibrarySetInvoker.FirstUnsupportedGeneratorToolVersion"/>.
+    /// </remarks>
     public static readonly Version FirstUnsupportedGeneratorToolVersion = LibrarySetInvoker.FirstUnsupportedGeneratorToolVersion;
 
     /// <inheritdoc />

--- a/Cql/Cql.Invocation/Toolkit/LibraryInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/LibraryInvoker.cs
@@ -149,18 +149,16 @@ public abstract class LibraryInvoker
             return false;
         }
 
-        if (LibraryInstanceInvoker_5_0.SupportsVersion(cqlToolVersion))
+        if (!LibraryInstanceInvoker_5_0.SupportsVersion(cqlToolVersion))
         {
-            if (LibraryInstanceInvoker_5_0.TryCreate(librarySetInvoker, libraryType, out libraryInvoker))
-                return true;
+            logger?.LogWarning(
+                "Skipping type {type} because it was generated with an unsupported version {ver} of the CQL tool.",
+                libraryType.FullName,
+                cqlToolVersion);
+            return false;
         }
 
-        logger?.LogWarning(
-            "Skipping type {type} because it was generated with an unsupported version {ver} of the CQL tool.",
-            libraryType.FullName,
-            cqlToolVersion);
-
-        return false;
+        return LibraryInstanceInvoker_5_0.TryCreate(librarySetInvoker, libraryType, out libraryInvoker);
     }
 
 

--- a/Cql/Cql.Invocation/Toolkit/LibrarySetInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/LibrarySetInvoker.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Invocation.Toolkit.Internal;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.Toolkit;
 using static Hl7.Cql.Invocation.Toolkit.StringBuilderExtensions;
@@ -20,6 +21,9 @@ namespace Hl7.Cql.Invocation.Toolkit;
 public sealed class LibrarySetInvoker : IDisposable, IToolkit<LibrarySetInvoker>
 {
     private readonly AssemblyLoadContext _alc;
+
+    public static readonly Version MinSupportedGeneratorToolVersion = LibraryInstanceInvoker_5_0.MinSupportedGeneratorToolVersion;
+    public static readonly Version FirstUnsupportedGeneratorToolVersion = LibraryInstanceInvoker_5_0.FirstUnsupportedGeneratorToolVersion;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LibrarySetInvoker"/> class.

--- a/Cql/Cql.Invocation/Toolkit/LibrarySetInvoker.cs
+++ b/Cql/Cql.Invocation/Toolkit/LibrarySetInvoker.cs
@@ -22,7 +22,14 @@ public sealed class LibrarySetInvoker : IDisposable, IToolkit<LibrarySetInvoker>
 {
     private readonly AssemblyLoadContext _alc;
 
+    /// <summary>
+    /// Gets the minimum generator tool version that this invoker supports for executing generated code.
+    /// </summary>
     public static readonly Version MinSupportedGeneratorToolVersion = LibraryInstanceInvoker_5_0.MinSupportedGeneratorToolVersion;
+
+    /// <summary>
+    /// Gets the first generator tool version that this invoker does not support for executing generated code.
+    /// </summary>
     public static readonly Version FirstUnsupportedGeneratorToolVersion = LibraryInstanceInvoker_5_0.FirstUnsupportedGeneratorToolVersion;
 
     /// <summary>

--- a/Cql/Cql.Packaging/FhirLibraryExtensions.cs
+++ b/Cql/Cql.Packaging/FhirLibraryExtensions.cs
@@ -1,3 +1,4 @@
+using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Iso8601;
 using Hl7.Cql.Primitives;
@@ -100,8 +101,10 @@ internal static class FhirLibraryExtensions
                 fhirLibrary.Content.Add(CreateCqlAttachment(elmLibrary!.VersionedLibraryIdentifier, cqlBytes));
 
             if (assemblyBytes is { Length: > 0 } dll)
+            {
                 fhirLibrary.Content.Add(CreateDllAttachment(elmLibrary!.VersionedLibraryIdentifier, dll));
-
+                fhirLibrary.AddGeneratorToolVersionToParameters();
+            }
             if (debugSymbols is { Length: > 0 } pdb)
                 fhirLibrary.Content.Add(CreatePdbAttachment(elmLibrary!.VersionedLibraryIdentifier, pdb));
 
@@ -172,6 +175,18 @@ internal static class FhirLibraryExtensions
                 Value = new ResourceReference { Reference = "#options" },
             };
             fhirLibrary.Extension.Add(optionsExtension);
+        }
+
+        public void AddGeneratorToolVersionToParameters()
+        {
+            if (fhirLibrary.Contained.OfType<Parameters>().FirstOrDefault(p => p.Id == "options") is { } parametersResource)
+            {
+                parametersResource.Parameter.Add(new Parameters.ParameterComponent
+                {
+                    Name = ".NETGeneratorToolVersion",
+                    Value = new FhirString(LibrarySetCSharpCodeGenerator.GeneratorToolVersion)
+                });
+            }
         }
 
         private void AddDataRequirements(

--- a/Cql/Cql.Packaging/FhirLibraryExtensions.cs
+++ b/Cql/Cql.Packaging/FhirLibraryExtensions.cs
@@ -146,47 +146,28 @@ internal static class FhirLibraryExtensions
                 fhirLibrary.Contained.Remove(existingParameter);
             }
 
-            // Now add new options parameter
-            var optionsParameter = new Parameters();
-            optionsParameter.Id = "options";
+            var optionsParameter = fhirLibrary.AddNewOptionsParameterResource();
             optionsParameter.Parameter.AddRange(fhirParameters);
-            fhirLibrary.Contained.Add(optionsParameter);
 
-            // Add and replace existing CQL options extension, or add new one
-
-            // See requirement for Contained resources: https://build.fhir.org/domainresource.html#invs
-            // dom-3: If the resource is contained in another resource,
-            //        it SHALL be referred to from elsewhere in the resource
-            //        or SHALL refer to the containing resource
-            //
-            // This is done by adding an extension. (Example: https://build.fhir.org/ig/HL7/cql-ig/Library-CQLExample.json.html)
-
-            // Find and remove existing options extension
-            var existingExtension = fhirLibrary.Extension.FirstOrDefault(e => e.Url == Constants.Hl7FhirStructureDefinitionCqlOptions);
-            if (existingExtension != null)
-            {
-                fhirLibrary.Extension.Remove(existingExtension);
-            }
-
-            // Now add new options extensions
-            var optionsExtension = new Extension
-            {
-                Url = Constants.Hl7FhirStructureDefinitionCqlOptions,
-                Value = new ResourceReference { Reference = "#options" },
-            };
-            fhirLibrary.Extension.Add(optionsExtension);
+            fhirLibrary.EnsureCqlOptionsExtension();
         }
 
         public void AddGeneratorToolVersionToParameters()
         {
-            if (fhirLibrary.Contained.OfType<Parameters>().FirstOrDefault(p => p.Id == "options") is { } parametersResource)
+            fhirLibrary.Contained ??= [];
+
+            // Get or create the options parameters resource (preserving existing parameters)
+            var existingParameter =
+                fhirLibrary.Contained.OfType<Parameters>().FirstOrDefault(p => p.Id == "options");
+            var optionsParameter = existingParameter ?? fhirLibrary.AddNewOptionsParameterResource();
+
+            optionsParameter.Parameter.Add(new Parameters.ParameterComponent
             {
-                parametersResource.Parameter.Add(new Parameters.ParameterComponent
-                {
-                    Name = ".NETGeneratorToolVersion",
-                    Value = new FhirString(LibrarySetCSharpCodeGenerator.GeneratorToolVersion)
-                });
-            }
+                Name = "CSharpGeneratorVersion",
+                Value = new FhirString(LibrarySetCSharpCodeGenerator.GeneratorToolVersion)
+            });
+
+            fhirLibrary.EnsureCqlOptionsExtension();
         }
 
         private void AddDataRequirements(
@@ -279,6 +260,39 @@ internal static class FhirLibraryExtensions
                 fhirLibrary.Content.Add(newAttachment);
             }
         }
+    }
+
+    private static void EnsureCqlOptionsExtension(this FhirLibrary fhirLibrary)
+    {
+        // Ensure the required extension reference exists
+        // See requirement for Contained resources: https://build.fhir.org/domainresource.html#invs
+        // dom-3: If the resource is contained in another resource,
+        //        it SHALL be referred to from elsewhere in the resource
+        //        or SHALL refer to the containing resource
+        //
+        // This is done by adding an extension. (Example: https://build.fhir.org/ig/HL7/cql-ig/Library-CQLExample.json.html)
+
+        // Find and remove existing options extension
+        var existingExtension = fhirLibrary.Extension.FirstOrDefault(e => e.Url == Constants.Hl7FhirStructureDefinitionCqlOptions);
+        if (existingExtension != null)
+        {
+            fhirLibrary.Extension.Remove(existingExtension);
+        }
+
+        // Now add new options extensions
+        var optionsExtension = new Extension
+        {
+            Url = Constants.Hl7FhirStructureDefinitionCqlOptions,
+            Value = new ResourceReference { Reference = "#options" },
+        };
+        fhirLibrary.Extension.Add(optionsExtension);
+    }
+
+    private static Parameters AddNewOptionsParameterResource(this FhirLibrary fhirLibrary)
+    {
+        var newOptionsParameter = new Parameters { Id = "options" };
+        fhirLibrary.Contained.Add(newOptionsParameter);
+        return newOptionsParameter;
     }
 
     private static void AddOutParameters(


### PR DESCRIPTION
Proposed implementation of PR #1219 

- Exposing Generator Tool version on ElmToolkit as `ElmToolkit.GeneratorToolVersion`
- Exposing supported tool range for execution as `MinSupportedGeneratorToolVersion` and `FirstUnsupportedGeneratorToolVersion` on `LibrarySetInvoker` and `InvocationToolkit` (maybe it's sufficient to expose on `InvocationToolkit`only ...)
- Adding Generator Tool Version as ".NETGeneratorToolVersion" to parameters section in FHIR Library Resource
- Small boyscout-rule-refactoring in `LibraryInvoker.cs` - this should not change the logic, but might be more readable ;-)
