### PR TITLE
Fixed library filter.

### DIFF
--- a/Demo/CLI/LibraryRunner.cs
+++ b/Demo/CLI/LibraryRunner.cs
@@ -153,7 +153,8 @@ namespace CLI
             Dictionary<string, Exception> errors = new Dictionary<string, Exception>();
 
             // Get expressions from the library set (excluding functions for simplicity in demo)
-            var expressions = librarySetInvoker.SelectExpressions().ToList();
+            librarySetInvoker.LibraryInvokers.TryGetValue(_opts.LibraryIdentifier, out var libraryInvoker);
+            var expressions = libraryInvoker!.SelectExpressions().ToList();
 
             // Invoke all expressions and collect results
             var results = expressions.SelectResults(setup, new SelectResultsOptions(

--- a/Demo/CLI/LibraryRunner.cs
+++ b/Demo/CLI/LibraryRunner.cs
@@ -153,8 +153,13 @@ namespace CLI
             Dictionary<string, Exception> errors = new Dictionary<string, Exception>();
 
             // Get expressions from the library set (excluding functions for simplicity in demo)
-            librarySetInvoker.LibraryInvokers.TryGetValue(_opts.LibraryIdentifier, out var libraryInvoker);
-            var expressions = libraryInvoker!.SelectExpressions().ToList();
+            var expressions = librarySetInvoker.SelectExpressionsForLibrary(_opts.LibraryIdentifier).ToList();
+            if (expressions.Count == 0)
+            {
+                Console.Error.WriteLine($"No expressions found for library identifier '{_opts.LibraryIdentifier}'.");
+                Console.Error.WriteLine($"Available libraries: {string.Join(", ", librarySetInvoker.LibraryInvokers.Keys)}");
+                throw new InvalidOperationException($"No expressions available for library identifier '{_opts.LibraryIdentifier}'.");
+            }
 
             // Invoke all expressions and collect results
             var results = expressions.SelectResults(setup, new SelectResultsOptions(


### PR DESCRIPTION
## Description
Working with @richfirely last week we noticed that this section of the code was running all measures instead of just a single one. This change fixed the issue.

## Related issues


## Testing
Tested running measures locally.

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes

