### PR TITLE
Replace inline skip-stage with shared template (DEVOPS-706, DEVOPS-708)

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -26,63 +26,16 @@ trigger:
     - spike*
 
 stages:
-- stage: checkForDocChangesStage
-  displayName: 'Check for changes in docs folder'
-  jobs:
-    - job: CheckDocChangesJob
-      displayName: 'Check for changes in docs folder'
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - checkout: self
-          fetchDepth: 0
-        - script: |
-            echo "##vso[task.setvariable variable=SOURCE_BRANCH]$(Build.SourceBranch)"
-            echo "##vso[task.setvariable variable=TARGET_BRANCH]$(System.PullRequest.TargetBranch)"
-        - powershell: |
-            echo "##[group]Checking for changes outside docs folder"
-            # Check if we are in a PR build or normal branch build
-            if ($env:BUILD_REASON -eq "PullRequest") {
-                echo "PR build detected"
-                # PR build: compare source branch with target branch (e.g., main)
-                $CHANGED_FILES = git diff --name-only origin/$env:TARGET_BRANCH
-                echo "Checking changes between $env:TARGET_BRANCH and $env:SOURCE_BRANCH results in the following files: $CHANGED_FILES"
-            } else {
-                echo "Branch build detected"
-                # Branch build: compare current commit with previous commit
-                git fetch origin $env:Build_SourceBranch --depth=2
-                $CHANGED_FILES = git diff --name-only HEAD~1 HEAD
-                echo "Checking results in the following files: $CHANGED_FILES"
-            }
-
-            $skipBuildStage = 'true'
-
-            foreach ($file in $CHANGED_FILES) {
-                if ($file -match '^docs\/.+$' -eq $false) {
-                    $skipBuildStage = 'false'
-                    echo "File $file is not /docs/ folder"
-                    break
-                }
-                echo "File $file is in /docs/ folder"
-            }
-
-
-            if ( $skipBuildStage -eq 'true') {
-              Write-Host "Only /docs/ files changed, skipping build."
-            }
-            else {
-              Write-Host "Changes outside /docs/ detected, proceeding with build."
-            }
-            echo "##vso[task.setvariable variable=skipBuild;isOutput=true]$skipBuildStage"
-
-          displayName: 'Check for changes outside docs folder'
-          name: checkForDocChanges
+- template: check-skip-stage.yml@templates
+  parameters:
+    ignorePatterns:
+      - '^docs/.+'
 
 # Include the build-test-sign template which defines Build, Test, and Package stages
 - template: build-test-sign.yml
   parameters:
-    buildStageDependsOn: checkForDocChangesStage
-    buildStageCondition: and(succeeded(), not(eq(dependencies.checkForDocChangesStage.outputs['CheckDocChangesJob.checkForDocChanges.skipBuild'], 'true')))
+    buildStageDependsOn: checkSkipStage
+    buildStageCondition: and(succeeded(), ne(dependencies.checkSkipStage.outputs['checkChanges.evaluateIgnorePatterns.skip'], 'true'))
     dotNetCoreVersion: $(DOTNET_CORE_SDK)
     multiTargetTestProjects: $(multiTargetTestProjects)
     net10IntegrationTestProjects: $(net10IntegrationTestProjects)


### PR DESCRIPTION
Fixes: https://firely.atlassian.net/browse/DEVOPS-708

## Summary

This pipeline already had a hand-rolled `checkForDocChangesStage` that detected docs-only commits. Replace it with the shared `check-skip-stage.yml@templates` so this repo stays in sync with the pattern just rolled out across Vonk (FirelyTeam/Vonk#3075), Firely.Auth (FirelyTeam/Firely.Auth#1889), firely-net-sdk (FirelyTeam/firely-net-sdk#3496), Firely.Validator (FirelyTeam/Firely.Validator#27) and firely-car (FirelyTeam/firely-car#388).

Net effect: -53 lines of inline PowerShell, +6 lines of template invocation.

## Behaviour

Scope is unchanged — still only `^docs/.+` matches; root-level markdown (`.github/copilot-instructions.md`, `build/README.md`) does **not** trigger a skip, just like before.

The hand-rolled version had a latent bug in the PR-build path: it used `System.PullRequest.TargetBranch` (which contains `refs/heads/<name>`) directly with `origin/`, yielding an invalid `origin/refs/heads/<name>` ref for `git diff`. The shared template uses `System.PullRequest.TargetBranchName` (the bare branch name), so PR builds now diff against a valid ref.

The `build-test-sign.yml` template's `buildStageDependsOn` and `buildStageCondition` parameters are simply repointed at the new stage and output variable.

## Test plan

- [ ] Verify a docs-only commit on this branch correctly skips the build.
- [ ] Verify a code commit on this branch runs the full pipeline.
- [ ] Verify a PR build (which previously had the latent ref bug) now correctly evaluates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)