### PR TITLE
Spec report refresh for 2026 conformance re-verification (#1264)

### DIFF
--- a/spec/report/cql-spec-deviations-report.md
+++ b/spec/report/cql-spec-deviations-report.md
@@ -20,11 +20,13 @@
 ## Deviation #1: Power Operator Returns Wrong Type
 
 ### CQL Specification Reference
+
 - **Section:** [Power](https://cql.hl7.org/09-b-cqlreference.html#power)
 - **Key Quote:** "The Power operator raises the first argument to the power given by the second argument. If either argument is null, the result is null. If the result of the operation cannot be represented, the result is null."
 - **Expected Type Behavior:** The CQL specification indicates that Power should return the same type as the first operand when both operands are of the same type. However, for operations resulting in fractional values (e.g., negative exponents), the result should be a decimal to preserve precision.
 
 ### Current Implementation
+
 **Location:** [`Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs:683-699`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs#L683-L699)
 
 ```csharp
@@ -48,16 +50,18 @@ public decimal? Power(decimal? argument, decimal? exponent)
 ```
 
 ### The Problem
+
 When `Power(2, -2)` is evaluated, `Math.Pow(2, -2)` returns `0.25` (a double). When this is cast to `int?`, it becomes `0`, losing the fractional part. This violates the CQL specification's intent that operations should preserve precision.
 
 ### Affected Tests
-**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:63-74`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L63-L74)
+
+**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:63-74`](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L63-L74>)
 
 All marked with reason: `"Power returns integers, not decimals"`
 
 1. `Power2ToNeg2` - Expected: `0.25`, Current: `0` (as int)
 2. `DecimalOneStep` - Expected: `Power(10,-8)` as decimal, Current: integer
-3. `DecimalPosOneStep` - Expected: `+Power(10,-8)` as decimal, Current: integer  
+3. `DecimalPosOneStep` - Expected: `+Power(10,-8)` as decimal, Current: integer
 4. `DecimalNegOneStep` - Expected: `-Power(10,-8)` as decimal, Current: integer
 5. `DecimalTwoStep` - Expected: `2.0*Power(10,-8)` as decimal, Current: integer
 6. `DecimalPosTwoStep` - Expected: `+2.0*Power(10,-8)` as decimal, Current: integer
@@ -67,9 +71,11 @@ All marked with reason: `"Power returns integers, not decimals"`
 10. `DecimalNegTenStep` - Expected: `-Power(10,-7)` as decimal, Current: integer
 
 ### Test Example: Power2ToNeg2
+
 **Location:** [`Cql/CqlToElmTests/Input/DQIC/CqlArithmeticFunctionsTest.xml`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/Input/DQIC/CqlArithmeticFunctionsTest.xml)
 
 **Current Test (Skipped):**
+
 ```xml
 <test name="Power2ToNeg2">
     <expression>Power(2, -2)</expression>
@@ -83,6 +89,7 @@ All marked with reason: `"Power returns integers, not decimals"`
 ### Proposed Fix
 
 **Option 1: Return Decimal for All Power Operations**
+
 ```csharp
 public decimal? Power(int? argument, int? exponent)
 {
@@ -104,21 +111,22 @@ public decimal? Power(decimal? argument, decimal? exponent)
 ```
 
 **Option 2: Conditional Return Based on Exponent**
+
 ```csharp
 public decimal? Power(int? argument, int? exponent)
 {
     if (argument == null || exponent == null) return null;
-    
+
     var result = Math.Pow((double)argument, (double)exponent);
-    
+
     // If exponent is negative or result has fractional part, return decimal
     if (exponent < 0 || result != Math.Floor(result))
         return (decimal)result;
-    
+
     // Try to return as int if it fits
     if (result >= int.MinValue && result <= int.MaxValue)
         return (int)result;
-    
+
     // Otherwise return as decimal
     return (decimal)result;
 }
@@ -129,6 +137,7 @@ public decimal? Power(int? argument, int? exponent)
 ### Test Changes Required
 
 **Before (Currently Skipped):**
+
 ```csharp
 // In SkippedTests.cs - DoesNotMatchExpectation
 { "Power2ToNeg2", "Power returns integers, not decimals" },
@@ -140,6 +149,7 @@ public decimal? Power(int? argument, int? exponent)
 Remove these entries from `SkippedTests.DoesNotMatchExpectation` and verify all Power-related tests pass with decimal return type.
 
 ### Impact Analysis
+
 - **Breaking Change:** Yes - existing code expecting `int?` or `long?` from Power will need updating
 - **Affected Overloads:** 3 (int, long, decimal)
 - **Tests Fixed:** 10 currently skipped tests
@@ -150,11 +160,13 @@ Remove these entries from `SkippedTests.DoesNotMatchExpectation` and verify all 
 ## Deviation #2: ProperContains/ProperIn Null Handling
 
 ### CQL Specification Reference
+
 - **Section:** [ProperContains](https://cql.hl7.org/09-b-cqlreference.html#propercontains) / [ProperIn](https://cql.hl7.org/09-b-cqlreference.html#properin)
 - **Key Quote:** "The operator is defined for lists and intervals. For lists, a list properly contains another list if it contains every element of the argument, and there is at least one additional element. For intervals, an interval properly contains another interval if it contains every point in the argument interval, and there is at least one additional point."
 - **Null Semantics:** The specification does not explicitly state that `ProperContains` should return null when comparing elements at different precisions. The general CQL principle is that comparisons involving incompatible or uncertain values should follow the three-valued logic (true/false/null).
 
 ### Current Implementation
+
 **Location:** [`Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs:2065-2088`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/Cql.Runtime/Operators/CqlOperators.IntervalOperators.cs#L2065-L2088)
 
 ```csharp
@@ -185,18 +197,22 @@ public bool? ElementProperlyIncludedInInterval(CqlTime left, CqlInterval<CqlTime
 ```
 
 ### The Problem
+
 The SkippedTests comment states: `"There is no spec language justifying null instead of false"`. When comparing a time value `@T15:59:59` (second precision) against a list containing times with millisecond precision like `@T15:59:59.999`, the implementation returns `null` due to precision mismatch. However, it may be more appropriate to return `false` since we can definitively determine that the element is not properly included (it equals one of the endpoints at the specified precision).
 
 ### Affected Tests
-**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:75-76`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L75-L76)
 
-1. `ProperContainsTimeNull` - Expected behavior unclear  
+**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:75-76`](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L75-L76>)
+
+1. `ProperContainsTimeNull` - Expected behavior unclear
 2. `ProperInTimeNull` - Expected behavior unclear
 
 ### Test Example: ProperContainsTimeNull
+
 **Location:** [`Cql/CqlToElmTests/Input/DQIC/CqlListOperatorsTest.xml`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/Input/DQIC/CqlListOperatorsTest.xml)
 
 **Current Test (Skipped):**
+
 ```xml
 <test name="ProperContainsTimeNull">
     <expression>{ @T15:59:59.999, @T20:59:59.999, @T20:59:49.999 } properly includes @T15:59:59</expression>
@@ -207,6 +223,7 @@ The SkippedTests comment states: `"There is no spec language justifying null ins
 **Issue:** The test expects `null`, but the comment suggests this may not be correct per the spec.
 
 ### Analysis Required
+
 This deviation requires **further investigation** to determine:
 
 1. What does the reference CQL implementation return for this case?
@@ -222,6 +239,7 @@ This deviation requires **further investigation** to determine:
 ### Potential Fix (Pending Investigation)
 
 **If the spec requires `false`:**
+
 ```csharp
 public bool? ElementProperlyIncludedInInterval(CqlTime left, CqlInterval<CqlTime>? right, string precision)
 {
@@ -230,7 +248,7 @@ public bool? ElementProperlyIncludedInInterval(CqlTime left, CqlInterval<CqlTime
 
     // Determine comparison precision
     var effectivePrecision = precision ?? GetCommonPrecision(left, right.low, right.high);
-    
+
     if (effectivePrecision == null)
         return false;  // Changed from null - cannot determine proper inclusion with incompatible precision
 
@@ -255,6 +273,7 @@ public bool? ElementProperlyIncludedInInterval(CqlTime left, CqlInterval<CqlTime
 Update expected output from `null` to `false` (or remove from skipped tests if `null` is confirmed correct).
 
 ### Impact Analysis
+
 - **Breaking Change:** Potentially - depends on spec clarification
 - **Affected Methods:** `ElementProperlyIncludedInInterval` overloads for CqlTime, possibly CqlDate and CqlDateTime
 - **Tests Fixed:** 2 currently skipped tests (or confirmed as correct)
@@ -265,6 +284,7 @@ Update expected output from `null` to `false` (or remove from skipped tests if `
 ## Deviation #3: Round Negative Midpoint Behavior
 
 ### CQL Specification Reference
+
 - **Section:** [Round](https://cql.hl7.org/09-b-cqlreference.html#round)
 - **Key Quote:** "The Round operator returns the nearest integer to its argument. The semantics of round are defined as a traditional mathematical round, meaning that a decimal value of 0.5 or higher will round to 1."
 - **Rounding Mode:** The specification indicates "round half away from zero" behavior, which means:
@@ -274,6 +294,7 @@ Update expected output from `null` to `false` (or remove from skipped tests if `
   - `Round(-1.5)` → `-2` (away from zero)
 
 ### Current Implementation
+
 **Location:** [`Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs:705-709`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs#L705-L709)
 
 ```csharp
@@ -285,10 +306,12 @@ public decimal? Round(decimal? argument, int? precision)
 ```
 
 ### The Problem
+
 The implementation uses `MidpointRounding.AwayFromZero`, which should produce the correct behavior. However, the tests indicate there may be an issue with specific edge cases.
 
 ### Affected Tests
-**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:77-78`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L77-L78)
+
+**Location:** [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:77-78`](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L77-L78>)
 
 1. `RoundNeg0D5` - "This rounding test doesn't behave like the others"
 2. `RoundNeg1D5` - "This rounding test doesn't behave like the others"
@@ -298,6 +321,7 @@ The implementation uses `MidpointRounding.AwayFromZero`, which should produce th
 **Location:** [`Cql/CqlToElmTests/Input/DQIC/CqlArithmeticFunctionsTest.xml`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/Input/DQIC/CqlArithmeticFunctionsTest.xml)
 
 **Test 1: RoundNeg0D5**
+
 ```xml
 <test name="RoundNeg0D5">
     <expression>Round(-0.5)</expression>
@@ -306,6 +330,7 @@ The implementation uses `MidpointRounding.AwayFromZero`, which should produce th
 ```
 
 **Test 2: RoundNeg1D5**
+
 ```xml
 <test name="RoundNeg1D5">
     <expression>Round(-1.5)</expression>
@@ -314,20 +339,26 @@ The implementation uses `MidpointRounding.AwayFromZero`, which should produce th
 ```
 
 ### Analysis
+
 The test expectations appear inconsistent:
+
 - `Round(-0.5)` expects `0.0` (rounds toward zero, not away)
 - `Round(-1.5)` expects `-1.0` (rounds toward zero, not away)
 
 However, the CQL spec says "round half away from zero":
+
 - `Round(-0.5)` should be `-1.0` (away from zero)
 - `Round(-1.5)` should be `-2.0` (away from zero)
 
 ### The Issue
+
 **Either:**
+
 1. The test expectations in the XML are wrong (should expect -1.0 and -2.0)
 2. The CQL specification uses a different rounding mode than stated (possibly "round half up" which would give -0.0 and -1.0)
 
 ### Investigation Required
+
 1. **Check CQL Reference Implementation:** Verify what the official Java implementation returns
 2. **Verify Spec Interpretation:** Confirm whether "round half away from zero" or "round half up" is intended
 3. **Check Test Suite Origin:** These may be from the official CQL test suite - verify expectations
@@ -335,6 +366,7 @@ However, the CQL spec says "round half away from zero":
 ### Potential Fix Options
 
 **Option 1: Tests Are Wrong (Spec Says "Away from Zero")**
+
 ```xml
 <!-- Update test expectations -->
 <test name="RoundNeg0D5">
@@ -349,11 +381,12 @@ However, the CQL spec says "round half away from zero":
 ```
 
 **Option 2: Implementation Is Wrong (Spec Says "Round Half Up")**
+
 ```csharp
 public decimal? Round(decimal? argument, int? precision)
 {
     if (argument == null) return null;
-    
+
     // Use "Round Half Up" / "Bankers Rounding" / "Round to Even"
     return Math.Round(argument.Value, precision ?? 0, MidpointRounding.ToEven);
 }
@@ -363,11 +396,13 @@ public decimal? Round(decimal? argument, int? precision)
 Implement custom rounding logic based on spec clarification.
 
 ### Recommendation
+
 **Investigation needed.** Most likely the test expectations are wrong based on the spec's clear statement of "round half away from zero." However, this should be verified against the reference implementation.
 
 ### Test Changes Required
 
 **Before (Currently Skipped):**
+
 ```csharp
 // In SkippedTests.cs - DoesNotMatchExpectation
 { "RoundNeg0D5", "This rounding test doesn't behave like the others" },
@@ -378,6 +413,7 @@ Implement custom rounding logic based on spec clarification.
 Remove from skipped tests once correct behavior is confirmed and either tests or implementation updated.
 
 ### Impact Analysis
+
 - **Breaking Change:** Depends on resolution - if implementation changes, yes
 - **Affected Methods:** 1 (Round)
 - **Tests Fixed:** 2 currently skipped tests
@@ -388,12 +424,14 @@ Remove from skipped tests once correct behavior is confirmed and either tests or
 ## Deviation #4: Expand Function Integer Output
 
 ### CQL Specification Reference
+
 - **Section:** [Expand](https://cql.hl7.org/09-b-cqlreference.html#expand-1)
 - **Key Quote:** "The Expand operator returns the set of intervals of size per that cover the given interval. For example, `expand { Interval[0, 10] } per 1` returns a list of intervals: `{ Interval[0, 0], Interval[1, 1], ..., Interval[10, 10] }`"
 - **Type Preservation:** The spec indicates that the intervals should preserve the type of the input interval
 
 ### Current Issue
-**Location:** Referenced in [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:72-73`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L72-L73)
+
+**Location:** Referenced in [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:72-73`](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L72-L73>)
 
 ```csharp
 { "ExpandPer1", "The expectation should have decimal values, not integers; the test does not compile in reference cql-to-elm" },
@@ -401,9 +439,11 @@ Remove from skipped tests once correct behavior is confirmed and either tests or
 ```
 
 ### Test Example: ExpandPer1
+
 **Location:** [`Cql/CqlToElmTests/Input/DQIC/CqlIntervalOperatorsTest.xml`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/Input/DQIC/CqlIntervalOperatorsTest.xml)
 
 **Current Test (Skipped):**
+
 ```xml
 <test name="ExpandPer1">
     <expression>expand { Interval[10.0, 12.5] } per 1</expression>
@@ -413,16 +453,20 @@ Remove from skipped tests once correct behavior is confirmed and either tests or
 ```
 
 ### The Problem
+
 The test shows:
+
 1. **Input:** `Interval[10.0, 12.5]` - decimal interval
 2. **Expected Output:** `{ Interval[10, 10], Interval[11, 11], Interval[12, 12] }` - integer intervals
 3. **Actual:** Compilation error - no matching signature
 
 The test expectation appears wrong because:
+
 - Input is decimal, so output should preserve decimal type: `{ Interval[10.0, 10.0], Interval[11.0, 11.0], Interval[12.0, 12.0] }`
 - The comment even states: "The expectation should have decimal values, not integers"
 
 ### Test Example: ExpandPerHour
+
 ```xml
 <test name="ExpandPerHour">
     <expression>expand { Interval[@T10:00, @T12:30] } per hour</expression>
@@ -433,6 +477,7 @@ The test expectation appears wrong because:
 **Issue:** Comment states "The expectation does not match the same example as published in the specification"
 
 ### Analysis
+
 These test cases appear to have incorrect expectations rather than implementation bugs. The issues are:
 
 1. **ExpandPer1:** Test expects integer output from decimal input (type mismatch)
@@ -441,6 +486,7 @@ These test cases appear to have incorrect expectations rather than implementatio
 ### Proposed Fix
 
 **Fix Test ExpandPer1:**
+
 ```xml
 <test name="ExpandPer1">
     <expression>expand { Interval[10.0, 12.5] } per 1.0</expression>
@@ -452,6 +498,7 @@ These test cases appear to have incorrect expectations rather than implementatio
 Consult the CQL specification example and update the test to match. Need to verify what the correct output should be.
 
 ### Investigation Required
+
 1. **Review CQL Spec Example:** Find the exact example for time interval expansion in the spec
 2. **Verify Expand Implementation:** Check if the implementation correctly preserves types
 3. **Test Signature Resolution:** Ensure proper overload exists for `expand(list<interval<decimal>>, decimal)`
@@ -459,6 +506,7 @@ Consult the CQL specification example and update the test to match. Need to veri
 ### Test Changes Required
 
 **Before (Currently Skipped):**
+
 ```csharp
 // In SkippedTests.cs - DoesNotMatchExpectation
 { "ExpandPer1", "The expectation should have decimal values, not integers; the test does not compile in reference cql-to-elm" },
@@ -469,6 +517,7 @@ Consult the CQL specification example and update the test to match. Need to veri
 Update test expectations to match spec, remove from skipped tests.
 
 ### Impact Analysis
+
 - **Breaking Change:** No - likely just test fixes
 - **Implementation Changes:** May need to add overload or fix type preservation
 - **Tests Fixed:** 2 currently skipped tests
@@ -479,26 +528,31 @@ Update test expectations to match spec, remove from skipped tests.
 ## Deviation #5: List Equality Null Handling
 
 ### CQL Specification Reference
+
 - **Section:** [Equal](https://cql.hl7.org/09-b-cqlreference.html#equal)
 - **Key Quote:** "For list values, equality returns true if and only if the lists have the same element type, have the same number of elements, and for each element in the lists, in order, the elements are equal."
 - **Null Elements:** The specification states: "For the purposes of comparison, null elements are considered equal to other null elements."
 
 ### Current Issue
-**Location:** Referenced in [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:43`](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L43)
+
+**Location:** Referenced in [`Cql/CqlToElmTests/(tests)/SkippedTests.cs:43`](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs#L43>)
 
 ```csharp
 { "EqualNullNull", "The spec states that null elements are considered equal for list equality." },
 ```
 
 ### The Problem
+
 The comment indicates that the implementation does not correctly handle null elements in list equality comparisons. According to the CQL spec, `{null, 1} = {null, 1}` should return `true`, not `null`.
 
 ### Investigation Required
+
 1. **Find Test Case:** Locate the `EqualNullNull` test to see exact expression and expectation
 2. **Check Implementation:** Review list equality implementation in `CqlOperators.EqualityAndEquivalence.cs`
 3. **Verify Behavior:** Confirm current implementation returns `null` or `false` when it should return `true`
 
 ### Potential Fix Location
+
 **Expected Location:** `Cql/Cql.Runtime/Operators/CqlOperators.EqualityAndEquivalence.cs`
 
 The list equality implementation needs to treat `null` elements as equal to each other.
@@ -506,6 +560,7 @@ The list equality implementation needs to treat `null` elements as equal to each
 ### Test Changes Required
 
 **Before (Currently Skipped):**
+
 ```csharp
 // In SkippedTests.cs - DoesNotCompile
 { "EqualNullNull", "The spec states that null elements are considered equal for list equality." },
@@ -515,6 +570,7 @@ The list equality implementation needs to treat `null` elements as equal to each
 Remove from skipped tests once implementation correctly handles null element equality.
 
 ### Impact Analysis
+
 - **Breaking Change:** Yes - changes equality semantics
 - **Affected Methods:** List equality comparison
 - **Tests Fixed:** 1 currently skipped test
@@ -579,11 +635,9 @@ These represent missing features or test issues rather than spec violations.
 1. **Phase 1: Low Risk, High Value**
    - Fix Expand test expectations
    - Update Round tests (after verification)
-   
 2. **Phase 2: Investigation**
    - Research ProperContains behavior
    - Consult CQL reference implementation
-   
 3. **Phase 3: Breaking Changes**
    - Implement Power operator fix with decimal return
    - Implement List equality null handling
@@ -599,6 +653,7 @@ These represent missing features or test issues rather than spec violations.
 ## Testing Strategy
 
 ### Before Changes
+
 ```bash
 # Run current test suite to establish baseline
 dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --logger "console;verbosity=normal"
@@ -606,6 +661,7 @@ dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --logger "console;verbosity=n
 ```
 
 ### After Each Fix
+
 ```bash
 # Run specific test category
 dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --filter "FullyQualifiedName~Power"
@@ -614,6 +670,7 @@ dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --filter "FullyQualifiedName~
 ```
 
 ### Final Verification
+
 ```bash
 # Full test suite should show fewer skipped tests
 dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --logger "console;verbosity=normal"
@@ -627,7 +684,7 @@ dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --logger "console;verbosity=n
 - [CQL Specification 1.5](https://cql.hl7.org/)
 - [CQL Operators Reference](https://cql.hl7.org/09-b-cqlreference.html)
 - [Repository Issue Tracker](https://github.com/FirelyTeam/firely-cql-sdk/issues)
-- [SkippedTests.cs](https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs)
+- [SkippedTests.cs](<https://github.com/FirelyTeam/firely-cql-sdk/blob/main/Cql/CqlToElmTests/(tests)/SkippedTests.cs>)
 
 ---
 
@@ -641,29 +698,33 @@ dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj --logger "console;verbosity=n
 
 Based on analysis of the DQIC (Data Quality Improvement Committee) test suite in `Cql/CqlToElmTests/Input/DQIC/`:
 
-| Test Category | Test Count | Spec Reference | Status |
-|--------------|------------|----------------|---------|
-| Age Operators | 8 | [Age](https://cql.hl7.org/09-b-cqlreference.html#age) | ✓ |
-| Aggregate Functions | 40 | [Aggregate](https://cql.hl7.org/09-b-cqlreference.html#aggregate-functions) | ✓ |
-| Arithmetic Functions | 193 | [Arithmetic](https://cql.hl7.org/09-b-cqlreference.html#arithmetic-operators-4) | ⚠️ Power issues |
-| Comparison Operators | 191 | [Comparison](https://cql.hl7.org/09-b-cqlreference.html#comparison-operators-4) | ✓ |
-| Conditional Operators | 10 | [Conditional](https://cql.hl7.org/03-developersguide.html#conditional-expressions) | ✓ |
-| DateTime Operators | 294 | [DateTime](https://cql.hl7.org/09-b-cqlreference.html#datetime-operators-2) | ⚠️ Precision |
-| Error/Messaging | 5 | [Errors](https://cql.hl7.org/09-b-cqlreference.html#errors-and-messaging) | ✓ |
-| Interval Operators | 361 | [Intervals](https://cql.hl7.org/09-b-cqlreference.html#interval-operators-3) | ⚠️ Expand, ProperContains |
-| List Operators | 209 | [Lists](https://cql.hl7.org/09-b-cqlreference.html#list-operators-2) | ⚠️ Equality nulls |
-| Logical Operators | 40 | [Logical](https://cql.hl7.org/09-b-cqlreference.html#logical-operators-3) | ✓ |
-| Nullological Operators | 23 | [Nullological](https://cql.hl7.org/09-b-cqlreference.html#nullological-operators-3) | ✓ |
-| String Operators | 82 | [Strings](https://cql.hl7.org/09-b-cqlreference.html#string-operators-3) | ✓ |
-| Type Operators | 33 | [Types](https://cql.hl7.org/09-b-cqlreference.html#type-operators-1) | ✓ |
-| CQL Types | 39 | [Types](https://cql.hl7.org/09-b-cqlreference.html#types-2) | ✓ |
-| Literals/Selectors | 67 | [Literals](https://cql.hl7.org/03-developersguide.html#literals) | ⚠️ Decimal step |
-| **TOTAL** | **1,595** | | **59 skipped** |
+| Test Category          | Test Count | Spec Reference                                                                      | Status                    |
+| ---------------------- | ---------- | ----------------------------------------------------------------------------------- | ------------------------- |
+| Age Operators          | 8          | [Age](https://cql.hl7.org/09-b-cqlreference.html#age)                               | ✓                         |
+| Aggregate Functions    | 40         | [Aggregate](https://cql.hl7.org/09-b-cqlreference.html#aggregate-functions)         | ✓                         |
+| Arithmetic Functions   | 193        | [Arithmetic](https://cql.hl7.org/09-b-cqlreference.html#arithmetic-operators-4)     | ⚠️ Power issues           |
+| Comparison Operators   | 191        | [Comparison](https://cql.hl7.org/09-b-cqlreference.html#comparison-operators-4)     | ✓                         |
+| Conditional Operators  | 10         | [Conditional](https://cql.hl7.org/03-developersguide.html#conditional-expressions)  | ✓                         |
+| DateTime Operators     | 294        | [DateTime](https://cql.hl7.org/09-b-cqlreference.html#datetime-operators-2)         | ⚠️ Precision              |
+| Error/Messaging        | 5          | [Errors](https://cql.hl7.org/09-b-cqlreference.html#errors-and-messaging)           | ✓                         |
+| Interval Operators     | 361        | [Intervals](https://cql.hl7.org/09-b-cqlreference.html#interval-operators-3)        | ⚠️ Expand, ProperContains |
+| List Operators         | 209        | [Lists](https://cql.hl7.org/09-b-cqlreference.html#list-operators-2)                | ⚠️ Equality nulls         |
+| Logical Operators      | 40         | [Logical](https://cql.hl7.org/09-b-cqlreference.html#logical-operators-3)           | ✓                         |
+| Nullological Operators | 23         | [Nullological](https://cql.hl7.org/09-b-cqlreference.html#nullological-operators-3) | ✓                         |
+| String Operators       | 82         | [Strings](https://cql.hl7.org/09-b-cqlreference.html#string-operators-3)            | ✓                         |
+| Type Operators         | 33         | [Types](https://cql.hl7.org/09-b-cqlreference.html#type-operators-1)                | ✓                         |
+| CQL Types              | 39         | [Types](https://cql.hl7.org/09-b-cqlreference.html#types-2)                         | ✓                         |
+| Literals/Selectors     | 67         | [Literals](https://cql.hl7.org/03-developersguide.html#literals)                    | ⚠️ Decimal step           |
+| **TOTAL**              | **1,595**  |                                                                                     | **59 skipped**            |
 
 ### Key Findings from Test Analysis
 
-#### 1. **String Operators - Full Conformance**
-All 82 string operator tests pass, indicating good spec compliance for:
+#### 1. **String Operators - High Coverage with Open Gaps**
+
+String operator coverage is broad, but conformance is not fully closed. In particular, `Split` separator semantics require re-validation against spec expectations (full string separator semantics).
+
+Covered operators include:
+
 - Combine, Concatenate
 - StartsWith, EndsWith
 - Indexer, PositionOf, LastPositionOf
@@ -671,31 +732,39 @@ All 82 string operator tests pass, indicating good spec compliance for:
 - Split, SplitOnMatches
 - Substring, Upper, Lower
 
-**Implementation Quality:** ✅ Good - uses proper null handling and CultureInfo.InvariantCulture
+**Implementation Quality:** ⚠️ Mixed - mostly strong null/culture handling, with open behavior gaps tracked in report issues.
 
 #### 2. **Logical/Nullological Operators - Full Conformance**
+
 All 63 tests pass for:
+
 - And, Or, Xor, Not, Implies
 - Coalesce, IsNull, IsTrue, IsFalse
 
 **Implementation Quality:** ✅ Good - correctly implements three-valued logic
 
 #### 3. **Aggregate Functions - Mostly Conformant**
+
 40 tests covering AllTrue, AnyTrue, Avg, Count, Max, Min, Sum show good conformance.
 
 **Potential Issue Identified:**
 The test suite includes edge cases for null handling in aggregates. Need to verify:
+
 - `AllTrue({null, true, true})` - should return null per three-valued logic
 - Empty list behavior for all aggregates
 
 #### 4. **DateTime Operators - Precision Challenges**
+
 294 tests reveal precision handling is complex. Known issues:
+
 - Uncertainty support not implemented (9 skipped tests)
 - Duration calculations follow spec correctly (verified in DurationTest.cs)
 - Precision mismatch handling needs clarification
 
 #### 5. **Comparison Operators - Spec Conformant**
+
 191 tests pass, indicating correct implementation of:
+
 - Equal, NotEqual
 - Greater, GreaterOrEqual, Less, LessOrEqual
 - Equivalent, NotEquivalent
@@ -704,9 +773,11 @@ The test suite includes edge cases for null handling in aggregates. Need to veri
 **Good Implementation:** Uses CqlComparers for type-specific comparison logic
 
 #### 6. **Invalid Expression Handling**
+
 Tests marked `invalid="true"` verify error handling:
+
 - `Exp(1000)` - results in positive infinity
-- `Ln(0)` - results in negative infinity  
+- `Ln(0)` - results in negative infinity
 - `predecessor of DateTime(0001,1,1,0,0,0,0)` - underflow
 - `successor of DateTime(9999,12,31,23,59,59,999)` - overflow
 
@@ -718,30 +789,30 @@ Tests marked `invalid="true"` verify error handling:
 
 ### Key CQL Specification Sections and Implementation
 
-| Spec Section | Implementation | Notes |
-|--------------|----------------|-------|
-| [02-authorsguide.html](https://cql.hl7.org/02-authorsguide.html) | Multiple | Author-facing semantics |
+| Spec Section                                                           | Implementation                   | Notes                    |
+| ---------------------------------------------------------------------- | -------------------------------- | ------------------------ |
+| [02-authorsguide.html](https://cql.hl7.org/02-authorsguide.html)       | Multiple                         | Author-facing semantics  |
 | [03-developersguide.html](https://cql.hl7.org/03-developersguide.html) | `Cql.Compiler/`, `Cql.CqlToElm/` | Type system, conversions |
-| [09-b-cqlreference.html](https://cql.hl7.org/09-b-cqlreference.html) | `Cql.Runtime/Operators/` | All operators |
-| [elm.html](https://cql.hl7.org/elm.html) | `Cql/Elm/` | ELM object model |
-| [examples.html](https://cql.hl7.org/examples.html) | `Examples/` | Usage examples |
-| [tests.html](https://cql.hl7.org/tests.html) | `Cql/CqlToElmTests/Input/DQIC/` | Official test suite |
+| [09-b-cqlreference.html](https://cql.hl7.org/09-b-cqlreference.html)   | `Cql.Runtime/Operators/`         | All operators            |
+| [elm.html](https://cql.hl7.org/elm.html)                               | `Cql/Elm/`                       | ELM object model         |
+| [examples.html](https://cql.hl7.org/examples.html)                     | `Examples/`                      | Usage examples           |
+| [tests.html](https://cql.hl7.org/tests.html)                           | `Cql/CqlToElmTests/Input/DQIC/`  | Official test suite      |
 
 ### Operator Implementation Files
 
-| Operator Category | File | Lines | Spec Section |
-|------------------|------|-------|--------------|
-| Arithmetic | `CqlOperators.ArithmeticOperators.cs` | ~750 | [§9.2](https://cql.hl7.org/09-b-cqlreference.html#arithmetic-operators-4) |
-| Comparison | `CqlOperators.ComparisonOperators.cs` | ~800 | [§9.4](https://cql.hl7.org/09-b-cqlreference.html#comparison-operators-4) |
-| Equality | `CqlOperators.EqualityAndEquivalence.cs` | ~600 | [§9.4](https://cql.hl7.org/09-b-cqlreference.html#equal) |
-| Logical | `CqlOperators.LogicalOperators.cs` | ~200 | [§9.15](https://cql.hl7.org/09-b-cqlreference.html#logical-operators-3) |
-| String | `CqlOperators.StringOperators.cs` | ~170 | [§9.22](https://cql.hl7.org/09-b-cqlreference.html#string-operators-3) |
-| DateTime | `CqlOperators.DateTimeOperators.cs` | ~1200 | [§9.6](https://cql.hl7.org/09-b-cqlreference.html#datetime-operators-2) |
-| Interval | `CqlOperators.IntervalOperators.cs` | ~2100 | [§9.11](https://cql.hl7.org/09-b-cqlreference.html#interval-operators-3) |
-| List | `CqlOperators.ListOperators.cs` | ~900 | [§9.14](https://cql.hl7.org/09-b-cqlreference.html#list-operators-2) |
-| Type | `CqlOperators.TypeOperators.cs` | ~400 | [§9.25](https://cql.hl7.org/09-b-cqlreference.html#type-operators-1) |
-| Aggregate | `CqlOperators.AggregateFunctions.cs` | ~300 | [§9.1](https://cql.hl7.org/09-b-cqlreference.html#aggregate-functions) |
-| Clinical | `CqlOperators.ClinicalOperators2.cs` | ~150 | [§9.5](https://cql.hl7.org/09-b-cqlreference.html#clinical-operators-2) |
+| Operator Category | File                                     | Lines | Spec Section                                                              |
+| ----------------- | ---------------------------------------- | ----- | ------------------------------------------------------------------------- |
+| Arithmetic        | `CqlOperators.ArithmeticOperators.cs`    | ~750  | [§9.2](https://cql.hl7.org/09-b-cqlreference.html#arithmetic-operators-4) |
+| Comparison        | `CqlOperators.ComparisonOperators.cs`    | ~800  | [§9.4](https://cql.hl7.org/09-b-cqlreference.html#comparison-operators-4) |
+| Equality          | `CqlOperators.EqualityAndEquivalence.cs` | ~600  | [§9.4](https://cql.hl7.org/09-b-cqlreference.html#equal)                  |
+| Logical           | `CqlOperators.LogicalOperators.cs`       | ~200  | [§9.15](https://cql.hl7.org/09-b-cqlreference.html#logical-operators-3)   |
+| String            | `CqlOperators.StringOperators.cs`        | ~170  | [§9.22](https://cql.hl7.org/09-b-cqlreference.html#string-operators-3)    |
+| DateTime          | `CqlOperators.DateTimeOperators.cs`      | ~1200 | [§9.6](https://cql.hl7.org/09-b-cqlreference.html#datetime-operators-2)   |
+| Interval          | `CqlOperators.IntervalOperators.cs`      | ~2100 | [§9.11](https://cql.hl7.org/09-b-cqlreference.html#interval-operators-3)  |
+| List              | `CqlOperators.ListOperators.cs`          | ~900  | [§9.14](https://cql.hl7.org/09-b-cqlreference.html#list-operators-2)      |
+| Type              | `CqlOperators.TypeOperators.cs`          | ~400  | [§9.25](https://cql.hl7.org/09-b-cqlreference.html#type-operators-1)      |
+| Aggregate         | `CqlOperators.AggregateFunctions.cs`     | ~300  | [§9.1](https://cql.hl7.org/09-b-cqlreference.html#aggregate-functions)    |
+| Clinical          | `CqlOperators.ClinicalOperators2.cs`     | ~150  | [§9.5](https://cql.hl7.org/09-b-cqlreference.html#clinical-operators-2)   |
 
 ---
 
@@ -766,6 +837,7 @@ public bool? EndsWith(string argument, string suffix)
 **CQL Spec:** Should return `false` when suffix is longer than argument.
 
 **Recommended Fix:**
+
 ```csharp
 public bool? EndsWith(string argument, string suffix)
 {
@@ -800,6 +872,7 @@ public bool? Matches(string source, string pattern)
 ```
 
 **Potential Issues:**
+
 1. Character comparison `pattern[0].Equals("^")` is wrong - should be `pattern[0] == '^'`
 2. Automatically adding anchors may not match CQL spec behavior
 3. Returns `false` for multiple matches - spec may expect `true` if pattern matches
@@ -841,6 +914,7 @@ public string? Substring(string source, int? startIndex, int? length = null)
 Should be: `var subLength = Math.Min(length.Value, source.Length - startIndex.Value);`
 
 **Example:**
+
 - `Substring("abcdef", 3, 5)` should return `"def"` (3 chars from index 3)
 - Current: Tries to get min(5, 6) = 5 chars, throws exception
 - Should: Get min(5, 6-3) = 3 chars = `"def"`
@@ -895,16 +969,19 @@ Cql/
 ### Test Execution Strategy
 
 **Unit Tests (CoreTests):**
+
 ```bash
 dotnet test Cql/CoreTests/CoreTests.csproj --filter "Category=UnitTest"
 ```
 
 **CQL Compilation Tests:**
+
 ```bash
 dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj
 ```
 
 **Specific Operator Tests:**
+
 ```bash
 dotnet test --filter "FullyQualifiedName~PowerTest"
 dotnet test --filter "FullyQualifiedName~ProperContains"
@@ -930,38 +1007,46 @@ For creating individual tracking issues for each deviation:
 
 ```markdown
 ## Description
+
 [Brief description of the deviation]
 
 ## CQL Specification
+
 - **Section:** [Link to spec section]
 - **Quote:** [Relevant spec text]
 - **Expected Behavior:** [What spec requires]
 
 ## Current Implementation
+
 - **File:** [Link to file on GitHub]
 - **Lines:** [Line numbers]
 - **Current Behavior:** [What currently happens]
 
 ## Example
+
 **Input:** `[example expression]`
 **Expected:** `[expected result]`
 **Actual:** `[actual result]`
 
 ## Proposed Fix
+
 [Code snippet or description]
 
 ## Impact
+
 - **Breaking Change:** [Yes/No]
 - **Risk Level:** [High/Medium/Low]
 - **Tests Affected:** [Number and names]
 - **Priority:** [High/Medium/Low]
 
 ## Related
+
 - **Skipped Tests:** [List test names]
 - **Related Issues:** [Link to related issues]
 - **Spec Deviation Report:** Section [X]
 
 ## Checklist
+
 - [ ] Verify spec interpretation
 - [ ] Implement fix
 - [ ] Add/update tests

--- a/spec/report/issue-10-high-power-decimal-overload-regression.md
+++ b/spec/report/issue-10-high-power-decimal-overload-regression.md
@@ -1,0 +1,92 @@
+# [HIGH] Re-open Power conformance: decimal overload non-representable handling and active regression
+
+**Labels:** `bug`, `spec-conformance`, `high`, `arithmetic-operators`, `power`  
+**Priority:** HIGH  
+**Spec Reference:** CQL 1.5.3, Power operator (`spec/condensed/09-b-cqlreference.md`, section `#### Power`)
+
+## Description
+
+Power conformance should be re-opened. There are two concrete issues:
+
+1. **Implementation inconsistency in `Power(decimal?, decimal?)`:** non-representable results are not handled defensively (unlike integer/long overloads).
+2. **Active failing conformance test:** `PowerIntegerByDecimalSmall` is currently failing in `CqlToElmTests` with a large numeric mismatch (`Expected 8.0`, `Actual 1.00000002302585`).
+
+Even though the conformance status file marks Power as resolved, current test evidence shows this area is still unstable.
+
+## CQL Specification Basis
+
+From `spec/condensed/09-b-cqlreference.md` under **Power**:
+
+- If either argument is `null`, result is `null`.
+- **If the result cannot be represented, the result is `null`.**
+
+## Evidence
+
+### 1) Decimal overload lacks non-representable guards
+
+**File:** `Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs`
+
+- `Power(int?, int?)` and `Power(long?, long?)` guard `NaN`, `Infinity`, and `OverflowException`, returning `null`.
+- `Power(decimal?, decimal?)` currently does:
+
+```csharp
+public decimal? Power(decimal? argument, decimal? exponent)
+{
+    if (argument == null || exponent == null) return null;
+    else return (decimal)Math.Pow((double)argument, (double)exponent);
+}
+```
+
+This path does not explicitly guard non-representable values consistently with the other overloads and spec intent.
+
+### 2) Active failing test
+
+**Command executed:**
+
+```bash
+dotnet test Cql/CqlToElmTests/CqlToElmTests.csproj -c Release --no-build --filter FullyQualifiedName~PowerIntegerByDecimalSmall
+```
+
+**Observed failure (both net8.0 and net10.0):**
+
+- Test: `PowerIntegerByDecimalSmall`
+- File/line: `Cql/CqlToElmTests/(tests)/PowerTest.cs:239`
+- Message: `Assert.AreEqual failed. Expected:<8.0>. Actual:<1.00000002302585>.`
+
+## Impact
+
+- **Spec conformance risk:** High (Power semantics and representability behavior).
+- **Runtime correctness risk:** High (unexpected numeric result in targeted conformance test).
+- **Process risk:** High (status docs currently report Power as resolved).
+
+## Proposed Fix Plan
+
+1. **Harden `Power(decimal?, decimal?)`:**
+   - Add explicit handling for `NaN`/`Infinity`.
+   - Catch `OverflowException` and return `null`.
+   - Keep behavior consistent across all Power overloads.
+2. **Investigate `PowerIntegerByDecimalSmall` regression path:**
+   - Validate expression translation/typing pipeline for this specific test.
+   - Confirm whether failure originates in runtime operator evaluation, conversion path, or generated invocation.
+3. **Unblock and restore conformance coverage:**
+   - Reconcile stale skip metadata for old Power rationale in `SkippedTests.cs`.
+4. **Update report status once fixed and verified with targeted tests.**
+
+## Acceptance Criteria
+
+- [ ] `Power(decimal?, decimal?)` returns `null` for non-representable results (spec compliant)
+- [ ] `PowerIntegerByDecimalSmall` passes on net8.0 and net10.0
+- [ ] No regressions in existing Power tests
+- [ ] Conformance report files updated to reflect final verified status
+
+## Related Files
+
+- Implementation: `Cql/Cql.Runtime/Operators/CqlOperators.ArithmeticOperators.cs`
+- Interface: `Cql/Cql.Runtime/Operators/ICqlOperators.cs`
+- Tests: `Cql/CqlToElmTests/(tests)/PowerTest.cs`
+- Skip metadata: `Cql/CqlToElmTests/(tests)/SkippedTests.cs`
+- Spec: `spec/condensed/09-b-cqlreference.md`
+
+## Notes
+
+Previous issue #1198 was closed as resolved. This issue tracks newly observed evidence that Power conformance is not fully stable and needs re-validation/fix.

--- a/spec/report/issue-11-high-split-string-separator-semantics.md
+++ b/spec/report/issue-11-high-split-string-separator-semantics.md
@@ -1,0 +1,89 @@
+# [HIGH] Fix Split separator semantics to use full string separator
+
+**Labels:** `bug`, `spec-conformance`, `high`, `string-operators`, `split`  
+**Priority:** HIGH  
+**Spec Reference:** CQL 1.5.3, String operators (`spec/condensed/09-b-cqlreference.md`, section `#### Split`)
+
+## Description
+
+`Split(stringToSplit, separator)` currently treats the separator as a **set of delimiter characters** by calling:
+
+```csharp
+stringToSplit.Split(separator.ToCharArray())
+```
+
+This is not equivalent to CQL's `Split(..., separator String)` semantics, where `separator` is a string token/pattern literal (non-regex), not a character bag.
+
+## CQL Specification Basis
+
+From `spec/condensed/09-b-cqlreference.md` under **Split**:
+
+- Signature: `Split(stringToSplit String, separator String) List<String>`
+- If `stringToSplit` is null, result is null.
+- If `stringToSplit` does not contain any appearance of `separator`, result is `{ stringToSplit }`.
+
+The operator definition implies matching on occurrences of the separator string, not any character contained in separator.
+
+## Current Implementation
+
+**File:** `Cql/Cql.Runtime/Operators/CqlOperators.StringOperators.cs`
+
+```csharp
+public IEnumerable<string>? Split(string stringToSplit, string separator)
+{
+    if (stringToSplit == null)
+        return null;
+    if (separator == null)
+        return new[] { stringToSplit };
+    else return stringToSplit.Split(separator.ToCharArray());
+}
+```
+
+## Why This Is Incorrect
+
+Using `separator.ToCharArray()` changes semantics:
+
+- `Split("A--B--C", "--")` should split by `"--"` token.
+- Current logic splits on `'-'` characters individually.
+
+This can produce different tokenization and empty segments than string-separator semantics.
+
+## Impact
+
+- **Spec conformance risk:** High in string operator behavior.
+- **Behavioral risk:** High for multi-character separators.
+- **Confidence risk:** Existing report text claims full string conformance while this mismatch exists.
+
+## Proposed Fix
+
+Use a true string-separator split overload, e.g.:
+
+```csharp
+stringToSplit.Split(new[] { separator }, StringSplitOptions.None)
+```
+
+Maintain current null semantics.
+
+## Acceptance Criteria
+
+- [ ] `Split` uses full string separator semantics (not char-array splitting)
+- [ ] Existing Split tests still pass
+- [ ] Add/adjust tests for multi-character separators
+- [ ] Verify no regressions in `SplitOnMatches` (regex variant)
+- [ ] Update conformance report status accordingly
+
+## Suggested Test Additions
+
+- [ ] `Split('A--B--C', '--')` -> `{ 'A', 'B', 'C' }`
+- [ ] `Split('A::B:C', '::')` -> `{ 'A', 'B:C' }`
+- [ ] `Split('abc', 'xyz')` -> `{ 'abc' }`
+
+## Related Files
+
+- Implementation: `Cql/Cql.Runtime/Operators/CqlOperators.StringOperators.cs`
+- Existing XML tests: `Cql/CqlToElmTests/Input/DQIC/CqlStringOperatorsTest.xml`
+- Spec: `spec/condensed/09-b-cqlreference.md`
+
+## Notes
+
+This issue is distinct from `Matches` anchoring behavior (#1199). It specifically targets `Split` token semantics and should be addressed independently.

--- a/spec/report/issues-readme.md
+++ b/spec/report/issues-readme.md
@@ -18,6 +18,8 @@ Remaining open issue documents:
 - `issue-04-high-round-test-expectations.md`
 - `issue-06-medium-matches-operator-anchoring.md`
 - `issue-07-low-unskip-expand-tests.md`
+- `issue-10-high-power-decimal-overload-regression.md`
+- `issue-11-high-split-string-separator-semantics.md`
 
 ## Open Issues List
 
@@ -32,6 +34,16 @@ Remaining open issue documents:
   - **Test Issue:** Runtime behavior is correct, test expectations are not
   - **Impact:** Valid spec behavior remains skipped
   - **Fix:** Update `RoundNeg0D5` and `RoundNeg1D5` expected outputs and unskip
+
+- **[issue-10-high-power-decimal-overload-regression.md](issue-10-high-power-decimal-overload-regression.md)** - [HIGH]
+  - **Bug:** Power conformance re-opened: `Power(decimal?, decimal?)` representability handling inconsistency + active failing `PowerIntegerByDecimalSmall`
+  - **Impact:** High conformance risk in arithmetic behavior and unstable test evidence
+  - **Fix:** Align decimal overload non-representable handling with spec and investigate/fix failing conformance path
+
+- **[issue-11-high-split-string-separator-semantics.md](issue-11-high-split-string-separator-semantics.md)** - [HIGH]
+  - **Bug:** `Split` uses character-set splitting via `separator.ToCharArray()` instead of full string separator semantics
+  - **Impact:** Multi-character separator behavior diverges from CQL spec intent
+  - **Fix:** Use string-separator split semantics and add regression tests
 
 ### Medium Priority
 
@@ -49,10 +61,10 @@ Remaining open issue documents:
 
 ## Summary Statistics
 
-- **Open Issues:** 4
+- **Open Issues:** 6
 - **Resolved/Removed in this pass:** 3
 - **Critical:** 0
-- **High:** 2
+- **High:** 4
 - **Medium:** 1
 - **Low:** 1
 
@@ -65,12 +77,14 @@ Remaining open issue documents:
 ## Recommended Next Implementation Order
 
 1. **Issue #02** (HIGH) - `EndsWith` bounds and empty-suffix handling
-2. **Issue #04** (HIGH) - Round test expectation corrections
-3. **Issue #06** (MEDIUM) - `Matches` partial-matching conformance
-4. **Issue #07** (LOW) - Unskip and validate Expand tests
+2. **Issue #10** (HIGH) - Re-open Power conformance and fix active regression
+3. **Issue #11** (HIGH) - Correct `Split` string-separator semantics
+4. **Issue #04** (HIGH) - Round test expectation corrections
+5. **Issue #06** (MEDIUM) - `Matches` partial-matching conformance
+6. **Issue #07** (LOW) - Unskip and validate Expand tests
 
 ---
 
-**Last Re-evaluated:** 2026-05-16  
+**Last Re-evaluated:** 2026-05-17  
 **CQL Version:** 1.5.3 Release 1 Errata 2  
 **Spec Location:** `spec/condensed/`

--- a/spec/report/spec-verified-findings.md
+++ b/spec/report/spec-verified-findings.md
@@ -1,6 +1,6 @@
 # CQL Specification Verified Findings
 
-**Last Re-evaluated:** 2026-05-16  
+**Last Re-evaluated:** 2026-05-17  
 **CQL Version:** 1.5.3 Release 1 Errata 2  
 **Source:** Local spec files in `spec/condensed/`
 
@@ -27,9 +27,9 @@ This document captures the current verification status of previously reported co
 ### 3) Power typing/null handling alignment
 
 - **Spec basis:** Non-representable results should return `null`; behavior should preserve numeric semantics.
-- **Current status:** **Resolved**.
-- **Verification note:** `Power(int?, int?)` and `Power(long?, long?)` now return `decimal?`, runtime handles overflow/non-representable outcomes as `null`, and CQL-to-ELM typing is aligned to decimal.
-- **Issue doc removed:** `issue-05-high-power-operator-null-return.md`
+- **Current status:** **Re-opened**.
+- **Verification note:** `Power(decimal?, decimal?)` still lacks non-representable defensive handling consistency compared to integer/long overloads, and `PowerIntegerByDecimalSmall` currently fails in conformance tests.
+- **Tracking doc:** [issue-10-high-power-decimal-overload-regression.md](issue-10-high-power-decimal-overload-regression.md)
 
 ---
 
@@ -59,25 +59,34 @@ This document captures the current verification status of previously reported co
 - **Why still open:** `ExpandPer1` and `ExpandPerHour` remain in skipped test metadata and are not yet verified as active passing coverage.
 - **Tracking doc:** [issue-07-low-unskip-expand-tests.md](issue-07-low-unskip-expand-tests.md)
 
+### 8) Split separator semantics use character-set splitting
+
+- **Current status:** **Open**.
+- **Why still open:** `Split` currently uses `separator.ToCharArray()` and splits by delimiter characters, not by full string separator token semantics.
+- **Tracking doc:** [issue-11-high-split-string-separator-semantics.md](issue-11-high-split-string-separator-semantics.md)
+
 ---
 
 ## Current Summary Matrix
 
-| Item                          | Status   | Priority              | Notes                                  |
-| ----------------------------- | -------- | --------------------- | -------------------------------------- |
-| Substring length              | RESOLVED | Critical (historical) | Issue doc removed                      |
-| List equality nulls           | RESOLVED | High (historical)     | Issue doc removed                      |
-| Power behavior/typing         | RESOLVED | High (historical)     | Issue doc removed                      |
-| EndsWith bounds/empty suffix  | OPEN     | High                  | Runtime change needed                  |
-| Round negative midpoint tests | OPEN     | High                  | Test expectation + skip cleanup needed |
-| Matches anchoring             | OPEN     | Medium                | Runtime semantics change needed        |
-| Expand skipped tests          | OPEN     | Low                   | Enable and validate test coverage      |
+| Item                          | Status   | Priority              | Notes                                                      |
+| ----------------------------- | -------- | --------------------- | ---------------------------------------------------------- |
+| Substring length              | RESOLVED | Critical (historical) | Issue doc removed                                          |
+| List equality nulls           | RESOLVED | High (historical)     | Issue doc removed                                          |
+| Power behavior/typing         | OPEN     | High                  | Re-opened based on current test evidence                   |
+| EndsWith bounds/empty suffix  | OPEN     | High                  | Runtime change needed                                      |
+| Round negative midpoint tests | OPEN     | High                  | Test expectation + skip cleanup needed                     |
+| Matches anchoring             | OPEN     | Medium                | Runtime semantics change needed                            |
+| Expand skipped tests          | OPEN     | Low                   | Enable and validate test coverage                          |
+| Split separator semantics     | OPEN     | High                  | Runtime behavior does not match string separator semantics |
 
 ---
 
 ## Next Focus
 
 1. Complete `EndsWith` spec-edge handling.
-2. Correct and unskip Round negative midpoint tests.
-3. Update `Matches` to spec-aligned matching behavior.
-4. Unskip and validate Expand coverage.
+2. Re-open and stabilize `Power` behavior (`PowerIntegerByDecimalSmall` + decimal overload representability handling).
+3. Correct `Split` to use full string separator semantics.
+4. Correct and unskip Round negative midpoint tests.
+5. Update `Matches` to spec-aligned matching behavior.
+6. Unskip and validate Expand coverage.


### PR DESCRIPTION
## Summary
This PR commits the current spec-conformance reporting updates prepared while picking up #1264.

### Included changes
- Add new report issue document for re-opened Power conformance regression:
  - `spec/report/issue-10-high-power-decimal-overload-regression.md`
- Add new report issue document for Split separator semantics gap:
  - `spec/report/issue-11-high-split-string-separator-semantics.md`
- Update report status/index docs to reflect current open findings:
  - `spec/report/spec-verified-findings.md`
  - `spec/report/issues-readme.md`
  - `spec/report/cql-spec-deviations-report.md`

## Related issues
- Primary: #1264
- Umbrella tracking: #1193

## Notes
This PR is focused on report and issue-tracking synchronization (no runtime code changes).