### PR TITLE
Fix tuple implicit conversion checks

### DIFF
--- a/Cql/Cql.CqlToElm/CoercionProvider.cs
+++ b/Cql/Cql.CqlToElm/CoercionProvider.cs
@@ -363,18 +363,25 @@ namespace Hl7.Cql.CqlToElm
                         {
                             // written for easier debugging
                             if (IsExactMatch(fromElementType, toElementType))
-                                return true;
+                                found = true;
                             else if (IsSubtype(fromElementType, toElementType))
-                                return true;
+                                found = true;
                             else if (CanBeCast(fromElementType, toElementType))
-                                return true;
+                                found = true;
                             else if (HasImplicitConversion(fromElementType, toElementType))
-                                return true;
+                                found = true;
+                            break;
                         }
                     }
+                    // The from element either has no same-named to element, or the
+                    // matched element is not convertible: the tuples are incompatible.
                     if (!found)
                         return false;
                 }
+                // Every from element was matched and is convertible. Because the
+                // element counts are equal and element names are unique within a
+                // tuple, this also guarantees every to element is covered.
+                return true;
             }
             else if (from == SystemTypes.IntegerType
                 && (to == SystemTypes.LongType || to == SystemTypes.DecimalType || to == SystemTypes.QuantityType))

--- a/Cql/CqlToElmTests/(tests)/CoercionTest.cs
+++ b/Cql/CqlToElmTests/(tests)/CoercionTest.cs
@@ -95,6 +95,46 @@ namespace Hl7.Cql.CqlToElm.Test
         }
 
         [TestMethod]
+        public void TupleHasImplicitConversionToIdenticalTuple()
+        {
+            var from = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.IntegerType));
+            var to = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.IntegerType));
+            Assert.IsTrue(CoercionProvider.HasImplicitConversion(from, to));
+        }
+
+        [TestMethod]
+        public void TupleHasImplicitConversionWhenFieldsReordered()
+        {
+            var from = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.StringType));
+            var to = TupleType(("y", SystemTypes.StringType), ("x", SystemTypes.IntegerType));
+            Assert.IsTrue(CoercionProvider.HasImplicitConversion(from, to));
+        }
+
+        [TestMethod]
+        public void TupleHasNoImplicitConversionWhenNonFirstFieldIncompatible()
+        {
+            var from = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.StringType));
+            var to = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.CodeType));
+            Assert.IsFalse(CoercionProvider.HasImplicitConversion(from, to));
+        }
+
+        [TestMethod]
+        public void TupleHasNoImplicitConversionWhenFieldNameMissing()
+        {
+            var from = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.IntegerType));
+            var to = TupleType(("x", SystemTypes.IntegerType), ("z", SystemTypes.IntegerType));
+            Assert.IsFalse(CoercionProvider.HasImplicitConversion(from, to));
+        }
+
+        [TestMethod]
+        public void TupleHasImplicitConversionWhenFieldConvertible()
+        {
+            var from = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.IntegerType));
+            var to = TupleType(("x", SystemTypes.IntegerType), ("y", SystemTypes.DecimalType));
+            Assert.IsTrue(CoercionProvider.HasImplicitConversion(from, to));
+        }
+
+        [TestMethod]
         public void IntegerIsSubtypeOfAny()
         {
             var expression = Integer();

--- a/Cql/CqlToElmTests/(tests)/EquivalentTest.cs
+++ b/Cql/CqlToElmTests/(tests)/EquivalentTest.cs
@@ -1552,6 +1552,45 @@ namespace Hl7.Cql.CqlToElm.Test
         }
 
         [TestMethod]
+        public void FhirCodeableConcept_EquivalentTo_Concept_ResolvesToEquivalent()
+        {
+            var cqlToolkit = CreateCqlToolkit().AddFHIRHelpers();
+            var library = cqlToolkit.MakeLibrary("""
+                 library EqualsTest version '1.0.0'
+                 using FHIR version '4.0.1'
+
+                 include FHIRHelpers version '4.0.1'
+
+                 define "Fhir Codeable Concept":
+                    FHIR.CodeableConcept {
+                        coding: {
+                            FHIR.Coding {
+                                system: FHIR.uri {value: 'http://loinc.org'},
+                                code: FHIR.code {value: '8480-6'},
+                                display: FHIR.string { value: 'Systolic blood pressure'}
+                            }
+                        },
+                        text: FHIR.string{value: 'FhirCodeableConcept'}
+                    }
+
+                 define "Concept1":
+                     Concept {
+                         codes: {
+                            Code { system: 'http://loinc.org', code: '8480-6', display: 'Systolic blood pressure' }
+                         },
+                         display: 'Concept1'
+                     }
+
+                 define "AreEquivalent": "Fhir Codeable Concept" ~ "Concept1"
+                 """);
+            // MakeLibrary already asserts the translation reported no errors. Verify
+            // the FHIR.CodeableConcept vs Concept type mismatch resolved to Equivalent
+            // rather than producing an unresolved-operator error.
+            var areEquivalent = library.ShouldDefine<ExpressionDef>("AreEquivalent");
+            areEquivalent.expression.Should().BeOfType<Equivalent>();
+        }
+
+        [TestMethod]
         public void FhirCode_EquivalentTo_CqlCode_String()
         {
             var cqlToolkit = CreateCqlToolkit();


### PR DESCRIPTION
## Description
This PR fixes tuple-to-tuple implicit conversion compatibility checks in CQL-to-ELM coercion so conversion only succeeds when all required tuple elements are name-matched and implicitly convertible.

It also adds focused regression coverage for:
- tuple conversion compatibility (identical shape, reordered fields, missing fields, incompatible fields),
- operator resolution for `FHIR.CodeableConcept ~ Concept`, ensuring translation resolves to an `Equivalent` expression.

## Related issues
Handled automatically by the system.

## Testing
- Added/updated unit tests in `Cql/CqlToElmTests/(tests)/CoercionTest.cs`
- Added regression test in `Cql/CqlToElmTests/(tests)/EquivalentTest.cs`

## FirelyTeam Checklist
- [x] **Update the title** of the PR to be succinct and less than 50 characters
- [ ] Mark the PR with the label **breaking change** when this PR introduces breaking changes