### PR TITLE
Release 2.8.1 → start 2.8.2 dev cycle

### DIFF
--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -6,7 +6,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 			-->
-		<VersionPrefix>2.7.0</VersionPrefix>
+		<VersionPrefix>2.8.2</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<!--

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The SDK targets **.NET 8 (LTS)** and **.NET 10 (LTS)** to provide optimal perfor
 
 ## Release Notes
 
-This is release version 2.7.0 of the engine.
+This is release version 2.8.1 of the engine.
 
 The release notes at [firely-cql-sdk/releases](https://github.com/FirelyTeam/firely-cql-sdk/releases) for each major version document changes and known issues.
 

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -23,7 +23,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 		-->
-		<VersionPrefix>2.8.0</VersionPrefix>
+		<VersionPrefix>2.8.1</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -23,7 +23,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 		-->
-		<VersionPrefix>2.8.1</VersionPrefix>
+		<VersionPrefix>2.8.2</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>

--- a/docs/releases/release-notes-2.8.1.md
+++ b/docs/releases/release-notes-2.8.1.md
@@ -1,0 +1,67 @@
+## Firely CQL SDK 2.8.1
+
+### tl;dr
+
+> **Upgrading?** Here is the short version:
+>
+> - **Breaking changes:** None.
+> - **Required migrations:** None.
+> - **Highlights:** Fixed a bug in tuple-to-tuple implicit conversion compatibility checking that caused non-first field incompatibilities to be silently ignored.
+
+---
+
+### CQL SDK
+
+#### New Public API
+
+- None. All changes in this release are to internal behavior.
+
+#### Improvements
+
+- **Tuple-to-tuple implicit conversion fix** — `CoercionProvider.HasImplicitConversion` now correctly evaluates all tuple elements when checking whether one tuple type can be implicitly converted to another. Previously, the inner per-element loop contained early `return true` statements that exited the entire method on the first compatible element match, causing incompatibilities in any non-first field to be silently ignored. The fix accumulates the per-element result into a `found` flag, breaks out of the inner loop only, and returns `true` only after all elements have been verified compatible.
+
+#### Dependency Updates
+
+- None.
+
+#### Potentially Breaking
+
+- None.
+
+---
+
+### CQL Packager
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- None.
+
+---
+
+### Demo Projects and Build Tooling
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- None.
+
+---
+
+### Upgrade Checklist
+
+1. No migration steps required.
+
+---
+
+### Pull Requests
+
+| PR | Title |
+| --- | --- |
+| [#1291](https://github.com/FirelyTeam/firely-cql-sdk/pull/1291) | Fix tuple-to-tuple implicit conversion compatibility check |


### PR DESCRIPTION
## Summary

- Bumps `VersionPrefix` to `2.8.1` in `cql-sdk.props`
- Adds release notes for v2.8.1 (`docs/releases/release-notes-2.8.1.md`)
- Updates README release version line to 2.8.1
- Bumps `VersionPrefix` to `2.8.2` to start the next development cycle

## Test plan

- [ ] Verify `cql-sdk.props` has `VersionPrefix` set to `2.8.2` after merge
- [ ] Verify `docs/releases/release-notes-2.8.1.md` is present
- [ ] Verify `README.md` reflects version 2.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)