### PR TITLE
fix: normalize legacy ELM Power result type to Decimal in preprocessor (#1305)

### DIFF
--- a/Cql/CoreTests/LibraryPreprocessorTest.cs
+++ b/Cql/CoreTests/LibraryPreprocessorTest.cs
@@ -42,6 +42,57 @@ namespace CoreTests
             rtsChecker.Nodes.Should().BeEmpty();
         }
 
+        [TestMethod]
+        public void LegacyPowerIntegerResultType_IsNormalizedToDecimal()
+        {
+            var power = new Power
+            {
+                locator = "1:1-1:16",
+                operand =
+                [
+                    new Literal
+                    {
+                        value = "10",
+                        valueType = SystemTypes.IntegerType.name,
+                        resultTypeSpecifier = SystemTypes.IntegerType,
+                        resultTypeName = SystemTypes.IntegerType.name
+                    },
+                    new Literal
+                    {
+                        value = "2",
+                        valueType = SystemTypes.IntegerType.name,
+                        resultTypeSpecifier = SystemTypes.IntegerType,
+                        resultTypeName = SystemTypes.IntegerType.name
+                    }
+                ],
+                resultTypeSpecifier = SystemTypes.IntegerType,
+                resultTypeName = SystemTypes.IntegerType.name
+            };
+
+            var lib = new Library
+            {
+                identifier = new VersionedIdentifier { id = "LegacyPowerTest", version = "1.0.0" },
+                schemaIdentifier = new VersionedIdentifier { id = "urn:hl7-org:elm", version = "r1" },
+                statements =
+                [
+                    new ExpressionDef
+                    {
+                        name = "PowExpr",
+                        context = "Patient",
+                        expression = power,
+                        resultTypeSpecifier = SystemTypes.IntegerType,
+                        resultTypeName = SystemTypes.IntegerType.name
+                    }
+                ]
+            };
+
+            var corrector = new PowerResultTypeCorrector(NullLogger<PowerResultTypeCorrector>.Instance);
+            corrector.Fix(lib);
+
+            power.resultTypeSpecifier.Should().BeEquivalentTo(SystemTypes.DecimalType);
+            power.resultTypeName.Should().Be(SystemTypes.DecimalType.name);
+        }
+
     }
 
     class ResultTypeSpecifierChecker : BaseElmTreeWalker

--- a/Cql/CoreTests/LibraryPreprocessorTest.cs
+++ b/Cql/CoreTests/LibraryPreprocessorTest.cs
@@ -86,8 +86,9 @@ namespace CoreTests
                 ]
             };
 
-            var corrector = new PowerResultTypeCorrector(NullLogger<PowerResultTypeCorrector>.Instance);
-            corrector.Fix(lib);
+            var ls = new LibrarySet("", lib);
+            var pp = new LibraryPreprocessor(ls, NullLoggerFactory.Instance);
+            pp.PreprocessLibrary(lib);
 
             power.resultTypeSpecifier.Should().BeEquivalentTo(SystemTypes.DecimalType);
             power.resultTypeName.Should().Be(SystemTypes.DecimalType.name);

--- a/Cql/Cql.Compiler/Preprocessing/LibraryPreprocessor.cs
+++ b/Cql/Cql.Compiler/Preprocessing/LibraryPreprocessor.cs
@@ -21,6 +21,7 @@ internal class LibraryPreprocessor(
     private readonly AmbiguousOverloadCorrector _ambiguousOverloadCorrector = new(loggerFactory.CreateLogger<AmbiguousOverloadCorrector>());
     private readonly ExpressionRefCorrector _expressionRefCorrector = new(loggerFactory.CreateLogger<ExpressionRefCorrector>(), librarySet);
     private readonly MissingResultTypeSpecifierCorrector _missingResultTypeSpecifierCorrector = new(loggerFactory.CreateLogger<MissingResultTypeSpecifierCorrector>());
+    private readonly PowerResultTypeCorrector _powerResultTypeCorrector = new(loggerFactory.CreateLogger<PowerResultTypeCorrector>());
     private readonly ProfiledValueSetPropertyCorrector _profiledValueSetPropertyCorrector = new(loggerFactory.CreateLogger<ProfiledValueSetPropertyCorrector>());
 
     public void PreprocessLibrary(Library library)
@@ -28,6 +29,7 @@ internal class LibraryPreprocessor(
         _ambiguousOverloadCorrector.Fix(library);
         _expressionRefCorrector.Fix(library);
         _missingResultTypeSpecifierCorrector.Fix(library);
+        _powerResultTypeCorrector.Fix(library);
         _profiledValueSetPropertyCorrector.Fix(library);
     }
 }

--- a/Cql/Cql.Compiler/Preprocessing/PowerResultTypeCorrector.cs
+++ b/Cql/Cql.Compiler/Preprocessing/PowerResultTypeCorrector.cs
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Elm;
+
+namespace Hl7.Cql.Compiler.Preprocessing;
+
+/// <summary>
+/// Corrects legacy Java-generated ELM where Power is declared as Integer/Long.
+/// The CQL spec defines Power as returning Decimal.
+/// </summary>
+internal class PowerResultTypeCorrector(ILogger<PowerResultTypeCorrector> logger)
+{
+    private readonly ElmTreeWalker _walker = ElmTreeWalker.Create((self, node) =>
+    {
+        if (node is Power power)
+        {
+            logger.LogDebug(
+                "Correcting Power result type from '{fromType}' to '{toType}' @ {locator}.\n{expressionKey}",
+                power.resultTypeName,
+                SystemTypes.DecimalType,
+                power.locator,
+                self.ContextStackString);
+            power.WithResultType(SystemTypes.DecimalType);
+        }
+
+        return false;
+    });
+
+    public void Fix(Library library)
+    {
+        logger.LogDebug("Preprocessing library '{library}'", library.VersionedLibraryIdentifier);
+        _walker.Start(library);
+    }
+
+}

--- a/Cql/PackagerCLI/PackagerCLI.csproj
+++ b/Cql/PackagerCLI/PackagerCLI.csproj
@@ -8,6 +8,7 @@
 		<RR23LibrarySetDir>$(CqlSolutionDir)/LibrarySets/RR23/</RR23LibrarySetDir>
 		<DemoLibrarySetDir>$(CqlSolutionDir)/LibrarySets/Demo/</DemoLibrarySetDir>
 		<NcqaBuildArtifactsDir>$(CqlSolutionDir)/submodules/Ncqa.DQIC/BuildArtifacts/</NcqaBuildArtifactsDir>
+		<Hedis2025StagingDir>D:/firely-dqm-libraries/workspace/HEDIS/2025/staging</Hedis2025StagingDir>
 		<MeasuresAuthoringDemoDir>$(CqlSolutionDir)/Demo/Measures.Authoring/</MeasuresAuthoringDemoDir>
 		<MeasuresDemoDir>$(CqlSolutionDir)/Demo/Measures.Demo/</MeasuresDemoDir>
 		<MeasuresDqmContentQiCoreDemoDir>$(CqlSolutionDir)/Demo/Measures.dqm-content-qicore-2025/</MeasuresDqmContentQiCoreDemoDir>

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -135,7 +135,7 @@
     },
     "PackageCLI elm (Ticket 1305 HEDIS 2025 ELM->FHIR)": {
       "commandName": "Project",
-      "commandLineArgs": "elm --elm \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/elm\" --cql \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/cql\" --libraries \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/resources/libraries\" --measures \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/resources/measures\" --cs \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/csharp\" --dll \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log",
+      "commandLineArgs": "elm --elm \"$(Hedis2025StagingDir)/elm\" --cql \"$(Hedis2025StagingDir)/cql\" --libraries \"$(Hedis2025StagingDir)/resources/libraries\" --measures \"$(Hedis2025StagingDir)/resources/measures\" --cs \"$(Hedis2025StagingDir)/csharp\" --dll \"$(Hedis2025StagingDir)/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log",
       "environmentVariables": {
         "CQLPACKAGE_PROFILE": "Demo"
       }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -133,6 +133,13 @@
         "CQLPACKAGE_PROFILE": "dqm-content-qicore-2025"
       }
     },
+    "PackageCLI elm (Ticket 1305 HEDIS 2025 ELM->FHIR)": {
+      "commandName": "Project",
+      "commandLineArgs": "elm --elm \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/elm\" --cql \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/cql\" --libraries \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/resources/libraries\" --measures \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/resources/measures\" --cs \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/csharp\" --dll \"D:/firely-dqm-libraries/workspace/HEDIS/2025/staging/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log",
+      "environmentVariables": {
+        "CQLPACKAGE_PROFILE": "Demo"
+      }
+    },
     "PackageCLI extract-library-attachments (dqm-content-qicore-2025 | All Attachments for CMS56FHIRFuncStatHipReplacement)": {
       "commandName": "Project",
       "commandLineArgs": "extract-library-attachments --library-file \"$(DqmContentQiCoreLibrarySetDir)/Replaced/Library-CMS56FHIRFuncStatHipReplacement-1.0.000.json\" --cql-dir \"$(DqmContentQiCoreLibrarySetDir)/Extracted/Cql\" --elm-dir \"$(DqmContentQiCoreLibrarySetDir)/Extracted/Elm\" --csharp-dir \"$(DqmContentQiCoreLibrarySetDir)/Extracted/CSharp\" --dll-dir \"$(DqmContentQiCoreLibrarySetDir)/Extracted/Assemblies\" --pdb-dir \"$(DqmContentQiCoreLibrarySetDir)/Extracted/DebugSymbols\" --log-file packager.log",

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -5,3 +5,5 @@
 ## Features
 
 ## Fixes
+
+- **#1305** — Added `PowerResultTypeCorrector` to the ELM library preprocessor pipeline. This corrects a compatibility issue with externally-provided ELM produced by the Java `cql2elm` translator, which incorrectly stamps `Power` nodes with an `Integer` or `Long` result type when both operands are integer-typed. The preprocessor now normalizes all `Power` node result types to `Decimal` before expression binding, matching the CQL specification. Our own `CqlToElm` translator was already correct and is unaffected.


### PR DESCRIPTION
Closes #1305

## Primary Work

**Fix: normalize legacy Java-generated ELM `Power` result type to `Decimal`**

The Java `cql2elm` translator incorrectly stamps `Power` ELM nodes with an `Integer` or `Long` result type when both operands are integer-typed (e.g. `Power(10, 2)`). The CQL specification defines `Power` as always returning `Decimal`. When the Packager ingests such externally-provided ELM and the compiler calls `ChangeType` to match the declared node type, it throws:

```
Cannot convert Nullable<Decimal> to Nullable<Int32>
```

The root cause was traced to `FHIR_Common-2025.2.1.cql` line 527:

```cql
Truncate(value * Power(10, places)) / Power(10, places)
```

Both `Power` calls have integer operands. The Java translator (pre-fix) annotated these nodes as `Integer` result type, while our runtime resolved the overload to return `Decimal`, causing the cast mismatch at expression build time.

### Changes

- **`Cql/Cql.Compiler/Preprocessing/PowerResultTypeCorrector.cs`** — New `ElmTreeWalker`-based preprocessor that unconditionally overwrites every `Power` node's result type to `Decimal` (`System.Decimal` / `urn:hl7-org:elm-types:r1`), matching the CQL spec.
- **`Cql/Cql.Compiler/Preprocessing/LibraryPreprocessor.cs`** — Wired `PowerResultTypeCorrector` into the existing preprocessing pipeline alongside the other compatibility correctors.
- **`Cql/CoreTests/LibraryPreprocessorTest.cs`** — Regression test: constructs a minimal in-memory ELM library with an integer-typed `Power` node, runs the corrector, and asserts the result type is normalized to `Decimal`.

### Notes

- Our own `CqlToElm` translator was already correct: `SystemLibrary.Power` declares `DecimalType` as the return type for all overloads. This fix only targets externally-provided ELM.
- The preprocessor change is consistent with the existing pattern for Java translator compatibility bugs (`AmbiguousOverloadCorrector`, `ProfiledValueSetPropertyCorrector`, etc.).

---

## Auxiliary Work

- **`Cql/PackagerCLI/Properties/launchSettings.json`** — Added `PackageCLI elm (Ticket 1305 HEDIS 2025 ELM->FHIR)` launch profile for local repro of the HEDIS 2025 staging path.
- **`docs/releases/vnext-release-notes.md`** — Added fix entry for #1305.
