### PR TITLE
Fix AllowInvalidCSharp regression: save C# files even when assembly compilation fails

### DIFF
--- a/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirProgram.cs
+++ b/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirProgram.cs
@@ -226,15 +226,24 @@ public class CqlToFhirProgram
                         subdirectoryPreserver: subdirectoryPreserver);
 
                 // Update status to "saved" for .NET
-                var extensions = opt.PdbOutDir is not null ? new[] { ".dll", ".pdb" } : new[] { ".dll" };
+                var librariesWithDebugSymbols = elmToAssemblyResults
+                    .Where(result => result.debugSymbolsBinary is { Length: > 0 })
+                    .Select(result => result.libraryIdentifier)
+                    .ToHashSet();
                 foreach (var libraryId in successfulCompilations)
                 {
+                    var extensions = opt.PdbOutDir is not null && librariesWithDebugSymbols.Contains(libraryId)
+                        ? new[] { ".dll", ".pdb" }
+                        : new[] { ".dll" };
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Saved(extensions));
                 }
 
                 sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
                 if (opt.PdbOutDir is not null)
-                    sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                {
+                    var debugSymbolsCount = elmToAssemblyResults.Count(result => result.debugSymbolsBinary is { Length: > 0 });
+                    sbSummary.AppendLine(Invariant($"* Saved {debugSymbolsCount} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                }
             }
 
             if (opt.FhirOutDir is not null || opt.LibrariesOutDir is not null || opt.MeasuresOutDir is not null)

--- a/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirProgram.cs
+++ b/Cql/PackagerCLI/Commands.CqlToFhir/CqlToFhirProgram.cs
@@ -80,8 +80,8 @@ public class CqlToFhirProgram
             }
 
             // Create subdirectory preserver if not flattening hierarchy
-            SubdirectoryPreserver? subdirectoryPreserver = opt.FlattenDirHierarchy 
-                ? null 
+            SubdirectoryPreserver? subdirectoryPreserver = opt.FlattenDirHierarchy
+                ? null
                 : new SubdirectoryPreserver();
 
             CqlToolkit cqlToolkit = new CqlToolkit(loggerFactory, cqlOpt);
@@ -156,24 +156,30 @@ public class CqlToFhirProgram
 
             ElmToolkit elmToolkit = cqlToolkit.CreateElmToolkit(elmOpt);
 
-            var elmToolkitResults = elmToolkit
-                                    .CompileToAssemblies()
-                                    .GetElmToAssemblyResults()
-                                    .ToList();
-            if (elmToolkitResults.Count == 0)
+            elmToolkit.CompileToAssemblies();
+
+            // Libraries that generated C# (includes invalid C# when AllowInvalidCSharp is enabled)
+            var elmToCSharpResults = elmToolkit.GetElmToCSharpResults().ToList();
+            // Libraries that also compiled into a .NET assembly
+            var elmToAssemblyResults = elmToolkit.GetElmToAssemblyResults().ToList();
+            if (elmToCSharpResults.Count == 0)
             {
                 logger.LogError(ExitCodes.NoElmLibsCompiled.ExitingMessage);
                 return ExitCodes.NoElmLibsCompiled.Code;
             }
 
             // Track C# and .NET results
-            var successfulCompilations = new HashSet<CqlVersionedLibraryIdentifier>(elmToolkitResults.Select(r => r.libraryIdentifier));
+            var cSharpLibraries = new HashSet<CqlVersionedLibraryIdentifier>(elmToCSharpResults.Select(r => r.libraryIdentifier));
+            var successfulCompilations = new HashSet<CqlVersionedLibraryIdentifier>(elmToAssemblyResults.Select(r => r.libraryIdentifier));
             foreach (var libraryId in successfulElmLibraries)
             {
-                if (successfulCompilations.Contains(libraryId))
+                if (cSharpLibraries.Contains(libraryId))
                 {
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.CSharp, LibraryStageStatus.Ok());
-                    tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Ok());
+                    tracker.RecordStatus(
+                        libraryId,
+                        LibraryProcessingStage.DotNet,
+                        successfulCompilations.Contains(libraryId) ? LibraryStageStatus.Ok() : LibraryStageStatus.Failed());
                 }
                 else
                 {
@@ -190,12 +196,22 @@ public class CqlToFhirProgram
                         subdirectoryPreserver: subdirectoryPreserver);
 
                 // Update status to "saved" for C#
-                foreach (var libraryId in successfulCompilations)
+                foreach (var libraryId in cSharpLibraries)
                 {
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.CSharp, LibraryStageStatus.Saved(".g.cs"));
                 }
 
-                sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} C# files (*.g.cs) to directory {opt.CSharpOutDir}."));
+                sbSummary.AppendLine(Invariant($"* Saved {elmToCSharpResults.Count} C# files (*.g.cs) to directory {opt.CSharpOutDir}."));
+            }
+
+            // Outputs beyond C# require at least one library compiled into a .NET assembly
+            if (elmToAssemblyResults.Count == 0)
+            {
+                if ((opt.DllOutDir, opt.FhirOutDir ?? opt.LibrariesOutDir ?? opt.MeasuresOutDir) is (null, null))
+                    return ExitCodes.Success.Code;
+
+                logger.LogError(ExitCodes.NoElmLibsCompiled.ExitingMessage);
+                return ExitCodes.NoElmLibsCompiled.Code;
             }
 
             if (opt.DllOutDir is not null)
@@ -216,9 +232,9 @@ public class CqlToFhirProgram
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Saved(extensions));
                 }
 
-                sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
+                sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
                 if (opt.PdbOutDir is not null)
-                    sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                    sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
             }
 
             if (opt.FhirOutDir is not null || opt.LibrariesOutDir is not null || opt.MeasuresOutDir is not null)

--- a/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirProgram.cs
+++ b/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirProgram.cs
@@ -100,29 +100,35 @@ internal sealed class ElmToFhirProgram
 
             sbSummary.AppendLine(Invariant($"* Loaded {elmToolkit.ArtifactsById.Count} ELM libraries from directory {opt.ElmInDir}."));
 
-            var elmToolkitResults = elmToolkit
-                                    .CompileToAssemblies()
-                                    .GetElmToAssemblyResults()
-                                    .ToList();
-            if (elmToolkitResults.Count == 0)
+            elmToolkit.CompileToAssemblies();
+
+            // Libraries that generated C# (includes invalid C# when AllowInvalidCSharp is enabled)
+            var elmToCSharpResults = elmToolkit.GetElmToCSharpResults().ToList();
+            // Libraries that also compiled into a .NET assembly
+            var elmToAssemblyResults = elmToolkit.GetElmToAssemblyResults().ToList();
+            if (elmToCSharpResults.Count == 0)
             {
                 logger.LogError(ExitCodes.NoElmLibsCompiled.ExitingMessage);
                 return ExitCodes.NoElmLibsCompiled.Code;
             }
 
             // Track C# and .NET results - check which libraries have successful results
-            var successfulLibraries = new HashSet<CqlVersionedLibraryIdentifier>(elmToolkitResults.Select(r => r.libraryIdentifier));
+            var cSharpLibraries = new HashSet<CqlVersionedLibraryIdentifier>(elmToCSharpResults.Select(r => r.libraryIdentifier));
+            var successfulLibraries = new HashSet<CqlVersionedLibraryIdentifier>(elmToAssemblyResults.Select(r => r.libraryIdentifier));
             foreach (var (libraryId, artifacts) in elmToolkit.ArtifactsById)
             {
-                if (successfulLibraries.Contains(libraryId))
+                if (cSharpLibraries.Contains(libraryId))
                 {
-                    // Successfully compiled to C# and assemblies
+                    // Successfully generated C#
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.CSharp, LibraryStageStatus.Ok());
-                    tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Ok());
+                    tracker.RecordStatus(
+                        libraryId,
+                        LibraryProcessingStage.DotNet,
+                        successfulLibraries.Contains(libraryId) ? LibraryStageStatus.Ok() : LibraryStageStatus.Failed());
                 }
                 else
                 {
-                    // Failed to compile
+                    // Failed to generate C#
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.CSharp, LibraryStageStatus.Failed());
                 }
             }
@@ -136,12 +142,22 @@ internal sealed class ElmToFhirProgram
                         subdirectoryPreserver: subdirectoryPreserver);
 
                 // Update status to "saved" for C#
-                foreach (var libraryId in successfulLibraries)
+                foreach (var libraryId in cSharpLibraries)
                 {
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.CSharp, LibraryStageStatus.Saved(".g.cs"));
                 }
 
-                sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} C# files (*.g.cs) to directory {opt.CSharpOutDir}."));
+                sbSummary.AppendLine(Invariant($"* Saved {elmToCSharpResults.Count} C# files (*.g.cs) to directory {opt.CSharpOutDir}."));
+            }
+
+            // Outputs beyond C# require at least one library compiled into a .NET assembly
+            if (elmToAssemblyResults.Count == 0)
+            {
+                if ((opt.DllOutDir, opt.FhirOutDir ?? opt.LibrariesOutDir ?? opt.MeasuresOutDir) is (null, null))
+                    return ExitCodes.Success.Code;
+
+                logger.LogError(ExitCodes.NoElmLibsCompiled.ExitingMessage);
+                return ExitCodes.NoElmLibsCompiled.Code;
             }
 
             if (opt.DllOutDir is not null)
@@ -161,9 +177,9 @@ internal sealed class ElmToFhirProgram
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Saved(extensions));
                 }
 
-                sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
+                sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
                 if (opt.PdbOutDir is not null)
-                    sbSummary.AppendLine(Invariant($"* Saved {elmToolkitResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                    sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
             }
 
             if ((opt.CqlInDir, opt.FhirOutDir ?? opt.LibrariesOutDir ?? opt.MeasuresOutDir) is (not null, not null))

--- a/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirProgram.cs
+++ b/Cql/PackagerCLI/Commands.ElmToFhir/ElmToFhirProgram.cs
@@ -171,15 +171,24 @@ internal sealed class ElmToFhirProgram
                         subdirectoryPreserver: subdirectoryPreserver);
 
                 // Update status to "saved" for .NET
-                var extensions = opt.PdbOutDir is not null ? new[] { ".dll", ".pdb" } : new[] { ".dll" };
+                var librariesWithDebugSymbols = elmToAssemblyResults
+                    .Where(result => result.debugSymbolsBinary is { Length: > 0 })
+                    .Select(result => result.libraryIdentifier)
+                    .ToHashSet();
                 foreach (var libraryId in successfulLibraries)
                 {
+                    var extensions = opt.PdbOutDir is not null && librariesWithDebugSymbols.Contains(libraryId)
+                        ? new[] { ".dll", ".pdb" }
+                        : new[] { ".dll" };
                     tracker.RecordStatus(libraryId, LibraryProcessingStage.DotNet, LibraryStageStatus.Saved(extensions));
                 }
 
                 sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} .NET Assembly files (*.dll) to directory {opt.DllOutDir}."));
                 if (opt.PdbOutDir is not null)
-                    sbSummary.AppendLine(Invariant($"* Saved {elmToAssemblyResults.Count} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                {
+                    var debugSymbolsCount = elmToAssemblyResults.Count(result => result.debugSymbolsBinary is { Length: > 0 });
+                    sbSummary.AppendLine(Invariant($"* Saved {debugSymbolsCount} Debug Symbol files (*.pdb) to directory {opt.PdbOutDir}."));
+                }
             }
 
             if ((opt.CqlInDir, opt.FhirOutDir ?? opt.LibrariesOutDir ?? opt.MeasuresOutDir) is (not null, not null))


### PR DESCRIPTION
Fixes #1304

## Primary Work

### Problem

With `Elm:AllowInvalidCSharp = true`, the PackagerCLI no longer wrote `.g.cs` files when the generated C# failed Roslyn compilation — the regression reported in #1304 (original feature: #871).

Root cause: both `ElmToFhirProgram` and `CqlToFhirProgram` gated the whole run on `GetElmToAssemblyResults()`, which only yields artifacts with a non-null `AssemblyBinary`. Libraries kept via `AllowInvalidCSharp` are yielded *without* an assembly binary, so they were excluded from that count. Because failures cascade (a library whose C# fails to compile breaks the metadata references of all its dependents), a single invalid common library could drive the assembly-result count to zero, triggering the `NoElmLibsCompiled` early exit **before** `SaveCSharpFilesToDirectory` ever ran.

### Fix (applied to both `elm` and `cql` commands)

- Gate the run on `GetElmToCSharpResults()` (generated C#, including invalid C#) instead of assembly results, so the C# save step always runs when `--cs` is requested.
- Move the `NoElmLibsCompiled` failure **after** the C# save: it now only fires when outputs beyond C# (`--dll`/FHIR) were requested and zero assemblies compiled. A `--cs`-only run with invalid C# now succeeds.
- Track the C# and .NET stages independently in the `LibraryProcessingTracker`: a library whose C# was generated but failed Roslyn compilation now reports `CSharp = Ok/Saved` and `DotNet = Failed` (previously it incorrectly reported `CSharp = Failed` even though the file was written in partial-failure scenarios).
- Summary lines now report the actual count of `.g.cs` files written instead of the assembly-success count.

### Validation

Manually verified with the CLI:

| Scenario | Before | After |
|---|---|---|
| `elm --cs` on demo ELM (38 libs, all valid) | 38 `.g.cs`, exit 0 | 38 `.g.cs`, exit 0 |
| `cql`/`elm` `--cs` with CQL producing invalid C# (CS0542: member named like enclosing type) | nothing written, error exit | invalid `.g.cs` written, exit 0 |
| `--cs --dll` with invalid C# | nothing written, error exit | `.g.cs` written, exit 3 (`NoElmLibsCompiled`) |

Build is clean (0 warnings, 0 errors).

---

## Auxiliary Work

None.
