### PR TITLE
refactor: consolidate Coalesce binding and deprecate CoalesceValueTypes (#1313)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # 1. Copilot Instructions for Firely CQL SDK
 
-**Version:** 3.2.0
+**Version:** 3.3.0
 
 This file is the decision-tree entry point. Route tasks here first, then open the focused sub-document before choosing tools.
 
@@ -97,6 +97,8 @@ This file is the decision-tree entry point. Route tasks here first, then open th
 
 ## 6.0. Appendix: Version History
 
+- 3.3.0
+  - Expanded code generation version management guidance: clarified that binder/compiler changes which alter generated C# (not only CodeGeneration.NET changes) require a `GeneratorToolVersion` bump, fixed the stale invoker reference, and added the requirement to regenerate checked-in `*.g.cs` files in the same pull request.
 - 3.2.0
   - Added a durable documentation rule for copilot instruction docs: cap heading numbering at three segments and keep deeper numbering in body text instead of deeper headings.
 - 3.1.0

--- a/.github/copilot-instructions/05-build-and-test.md
+++ b/.github/copilot-instructions/05-build-and-test.md
@@ -57,26 +57,37 @@ Parent document: [../copilot-instructions.md](../copilot-instructions.md)
 
 ## 5.3. Code Generation Version Management
 
-5.3.1 **When modifying C# code generation logic, always update the `LibrarySetCSharpCodeGenerator.GeneratorToolVersion`**:
-5.3.1.1 **Locate the version**: The version is hardcoded in `CodeGeneration.NET/_CODE GENERATOR VERSION_.cs` as `GeneratorToolVersion`
+5.3.1 **What counts as a code generation change**: Any change that alters the C# emitted for CQL libraries requires a `GeneratorToolVersion` update, regardless of which project the change lives in. This includes:
+5.3.1.1 Changes in `CodeGeneration.NET` (the C# writer itself)
 
-5.3.1.2 **Apply semantic versioning**:
-5.3.1.2.1 **Major version** (x.0.0.0): Breaking changes to generated code that require new `LibraryInstanceInvoker` support
+5.3.1.2 Changes in `Cql.Compiler` that affect the expression trees being emitted — for example, `CqlOperatorsBinder` selecting a different `ICqlOperators` method or overload (e.g., binding `Coalesce<T>` instead of `CoalesceValueTypes<T>`), changed generic type arguments, or changed conversions
 
-      5.3.1.2.2 **Minor version** (x.y.0.0): Non-breaking additions like new attributes or functionality
+5.3.1.3 Changes to `ICqlOperators` signatures or constraints that flow into generated call sites
 
-      5.3.1.2.3 **Patch version** (x.y.z.0): Bug fixes that don't change the generated API
+5.3.2 **When modifying C# code generation logic, always update the `LibrarySetCSharpCodeGenerator.GeneratorToolVersion`**:
+5.3.2.1 **Locate the version**: The version is hardcoded in `CodeGeneration.NET/_CODE GENERATOR VERSION_.cs` as `GeneratorToolVersion`
 
-5.3.1.3 **Check compatibility**: Ensure `LibraryInstanceInvoker_3_0.SupportsVersion` covers the new version range
+5.3.2.2 **Apply semantic versioning**:
+5.3.2.2.1 **Major version** (x.0.0.0): Breaking changes to generated code that require new `LibraryInstanceInvoker` support
 
-5.3.1.4 **Create new invoker if needed**: For major version changes, a new `LibraryInstanceInvoker_X_Y` may be required
+      5.3.2.2.2 **Minor version** (x.y.0.0): Non-breaking additions like new attributes or functionality
 
-5.3.1.5 **Examples**:
-5.3.1.5.1 Adding `CqlFunctionParameterAttribute` → Minor version increment (3.0.0.0 → 3.1.0.0)
+      5.3.2.2.3 **Patch version** (x.y.z.0): Bug fixes that don't change the generated API
 
-      5.3.1.5.2 Changing method signatures → Major version increment (3.0.0.0 → 4.0.0.0)
+5.3.2.3 **Check compatibility**: Ensure the current `LibraryInstanceInvoker_X_Y.SupportsVersion` covers the new version (check `MinSupportedGeneratorToolVersion` and `FirstUnsupportedGeneratorToolVersion` in `Cql.Invocation/Toolkit/Internal/LibraryInvoker.X.Y.cs`)
 
-      5.3.1.5.3 Fixing identifier normalization → Patch version increment (3.0.0.0 → 3.0.1.0)
+5.3.2.4 **Create new invoker if needed**: For major version changes, a new `LibraryInstanceInvoker_X_Y` may be required
+
+5.3.2.5 **Regenerate checked-in generated code**: The version is embedded in every checked-in `*.g.cs` file via `GeneratedCodeAttribute` (e.g., `CoreTests/CSharp`, Demo library sets). Regenerate these libraries as part of the same pull request so the embedded version matches
+
+5.3.2.6 **Examples**:
+5.3.2.6.1 Adding `CqlFunctionParameterAttribute` → Minor version increment (3.0.0.0 → 3.1.0.0)
+
+      5.3.2.6.2 Changing method signatures → Major version increment (3.0.0.0 → 4.0.0.0)
+
+      5.3.2.6.3 Fixing identifier normalization → Patch version increment (3.0.0.0 → 3.0.1.0)
+
+      5.3.2.6.4 Binder emits a different `ICqlOperators` method for the same CQL (e.g., `CoalesceValueTypes<T>` → `Coalesce<T>`) → Patch version increment (5.1.0.0 → 5.1.1.0)
 
 ## 5.4. Generating ELM Files from CQL
 

--- a/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
+++ b/Cql/CodeGeneration.NET/_CODE GENERATOR VERSION_.cs
@@ -22,5 +22,5 @@ internal partial class LibrarySetCSharpCodeGenerator
     /// Also, it is important to ensure the library invoker toolkit is updated to support the new version,
     /// for this you need to update the LibraryInvoker.SupportsVersion method, or create a new version of the LibraryInvoker.
     /// </remarks>
-    internal const string GeneratorToolVersion = "5.1.0.0";
+    internal const string GeneratorToolVersion = "5.1.1.0";
 }

--- a/Cql/CoreTests/CSharp/ConceptDefTest-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/ConceptDefTest-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("ConceptDefTest", "1.0.0")]
 public partial class ConceptDefTest_1_0_0 : ILibrary, ISingleton<ConceptDefTest_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
+++ b/Cql/CoreTests/CSharp/CqlBooleanTest-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CqlBooleanTest", "1.0.000")]
 public partial class CqlBooleanTest_1_0_000 : ILibrary, ISingleton<CqlBooleanTest_1_0_000>
 {

--- a/Cql/CoreTests/CSharp/CqlNestedTupleTest-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/CqlNestedTupleTest-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CqlNestedTupleTest", "1.0.0")]
 public partial class CqlNestedTupleTest_1_0_0 : ILibrary, ISingleton<CqlNestedTupleTest_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRConversionTest-2023.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIRConversionTest", "2023.0.0")]
 public partial class FHIRConversionTest_2023_0_0 : ILibrary, ISingleton<FHIRConversionTest_2023_0_0>
 {

--- a/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/FHIRHelpers-4.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIRHelpers", "4.0.1")]
 public partial class FHIRHelpers_4_0_1 : ILibrary, ISingleton<FHIRHelpers_4_0_1>
 {

--- a/Cql/CoreTests/CSharp/ParameterNameTest-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/ParameterNameTest-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("ParameterNameTest", "1.0.0")]
 public partial class ParameterNameTest_1_0_0 : ILibrary, ISingleton<ParameterNameTest_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/RR23-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("RR23", "1.0.0")]
 public partial class RR23_1_0_0 : ILibrary, ISingleton<RR23_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/TestCodeSystemInclude-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/TestCodeSystemInclude-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("TestCodeSystemInclude", "1.0.0")]
 public partial class TestCodeSystemInclude_1_0_0 : ILibrary, ISingleton<TestCodeSystemInclude_1_0_0>
 {

--- a/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieve-1.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("TestRetrieve", "1.0.1")]
 public partial class TestRetrieve_1_0_1 : ILibrary, ISingleton<TestRetrieve_1_0_1>
 {

--- a/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
+++ b/Cql/CoreTests/CSharp/TestRetrieveInclude-1.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("TestRetrieveInclude", "1.0.1")]
 public partial class TestRetrieveInclude_1_0_1 : ILibrary, ISingleton<TestRetrieveInclude_1_0_1>
 {

--- a/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
+++ b/Cql/CoreTests/CSharp/ValueSetExprExample-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("ValueSetExprExample", "1.0.0")]
 public partial class ValueSetExprExample_1_0_0 : ILibrary, ISingleton<ValueSetExprExample_1_0_0>
 {

--- a/Cql/CoreTests/LibraryPreprocessorTest.cs
+++ b/Cql/CoreTests/LibraryPreprocessorTest.cs
@@ -11,6 +11,7 @@ using Hl7.Cql.Compiler.Preprocessing;
 using Hl7.Cql.Elm;
 using Hl7.Cql.Conversion;
 using Hl7.Cql.Operators;
+using Hl7.Cql.Primitives;
 using Hl7.Cql.Runtime;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Linq.Expressions;
@@ -100,23 +101,22 @@ namespace CoreTests
         }
 
         [TestMethod]
-        public void CoalesceOnNullableValueTupleList_UsesValueTypeOverload()
+        public void CoalesceOnStringList_UsesCoalesce()
         {
+            // After consolidation: all Coalesce calls route to Coalesce<T> (no reference vs value type distinction)
             var binder = new CqlOperatorsBinder(
                 NullLogger<CqlOperatorsBinder>.Instance,
                 new TestTypeResolver(),
                 Hl7.Cql.Conversion.TypeConverter.Create());
 
-            var operand = System.Linq.Expressions.Expression.Constant(new (int? isHighRisk, int? isInconclusive, DateOnly? eventDate)?[]
-            {
-                ((int?)1, null, new DateOnly(2026, 6, 11)),
-                null
-            });
+            var operand = System.Linq.Expressions.Expression.Constant(
+                new string?[] { "hello", null, "world" },
+                typeof(IEnumerable<string?>));
 
             var call = (MethodCallExpression)binder.BindToMethod(nameof(ICqlOperators.Coalesce), [operand], []);
 
-            call.Method.Name.Should().Be(nameof(ICqlOperators.CoalesceValueTypes));
-            call.Method.GetGenericArguments().Single().Should().Be(typeof((int?, int?, DateOnly?)));
+            call.Method.Name.Should().Be(nameof(ICqlOperators.Coalesce));
+            call.Method.GetGenericArguments().Single().Should().Be(typeof(string));
         }
 
     }

--- a/Cql/CoreTests/LibraryPreprocessorTest.cs
+++ b/Cql/CoreTests/LibraryPreprocessorTest.cs
@@ -166,6 +166,23 @@ namespace CoreTests
             call.Method.GetGenericArguments().Single().Should().Be(typeof((CqlTupleMetadata, bool?, bool?, CqlInterval<CqlDate>, CqlDate, CqlDate)?));
         }
 
+        [TestMethod]
+        public void CoalesceOnNonNullableValueTypeList_Throws()
+        {
+            var binder = new CqlOperatorsBinder(
+                NullLogger<CqlOperatorsBinder>.Instance,
+                new TestTypeResolver(),
+                Hl7.Cql.Conversion.TypeConverter.Create());
+
+            var operand = System.Linq.Expressions.Expression.Constant(
+                new[] { 1, 2, 3 },
+                typeof(IEnumerable<int>));
+
+            var act = () => binder.BindToMethod(nameof(ICqlOperators.Coalesce), [operand], []);
+
+            act.Should().Throw<ArgumentException>().WithMessage("*reference type or Nullable<U>*");
+        }
+
     }
 
     internal class TestTypeResolver : BaseTypeResolver

--- a/Cql/CoreTests/LibraryPreprocessorTest.cs
+++ b/Cql/CoreTests/LibraryPreprocessorTest.cs
@@ -119,6 +119,53 @@ namespace CoreTests
             call.Method.GetGenericArguments().Single().Should().Be(typeof(string));
         }
 
+        [TestMethod]
+        public void CoalesceOnNullableValueTupleList_UsesCoalesceWithNullableElementType()
+        {
+            // Regression test (#1307/#1313): Coalesce over a list of nullable value tuples must bind to
+            // the unconstrained Coalesce<T> with T = the nullable tuple type, so the no-match result is null.
+            var binder = new CqlOperatorsBinder(
+                NullLogger<CqlOperatorsBinder>.Instance,
+                new TestTypeResolver(),
+                Hl7.Cql.Conversion.TypeConverter.Create());
+
+            var operand = System.Linq.Expressions.Expression.Constant(new (int? isHighRisk, int? isInconclusive, DateOnly? eventDate)?[]
+            {
+                ((int?)1, null, new DateOnly(2026, 6, 11)),
+                null
+            });
+
+            var call = (MethodCallExpression)binder.BindToMethod(nameof(ICqlOperators.Coalesce), [operand], []);
+
+            call.Method.Name.Should().Be(nameof(ICqlOperators.Coalesce));
+            call.Method.GetGenericArguments().Single().Should().Be(typeof((int?, int?, DateOnly?)?));
+        }
+
+        [TestMethod]
+        public void CoalesceOnHedisNullableTupleList_UsesCoalesceWithNullableElementType()
+        {
+            // Regression test (#1307/#1313): exact HEDIS 2025 shape that previously failed with CS0452.
+            var binder = new CqlOperatorsBinder(
+                NullLogger<CqlOperatorsBinder>.Instance,
+                new TestTypeResolver(),
+                Hl7.Cql.Conversion.TypeConverter.Create());
+
+            IEnumerable<(CqlTupleMetadata, bool? isInpatient, bool? isEdVisit, CqlInterval<CqlDate> inpatientPeriod, CqlDate historyReferenceDate, CqlDate episodeDate)?> source =
+            [
+                (new CqlTupleMetadata(), true, false, null, new CqlDate(2026, 6, 11), new CqlDate(2026, 6, 12)),
+                null
+            ];
+
+            var operand = System.Linq.Expressions.Expression.Constant(
+                source,
+                typeof(IEnumerable<(CqlTupleMetadata, bool? isInpatient, bool? isEdVisit, CqlInterval<CqlDate> inpatientPeriod, CqlDate historyReferenceDate, CqlDate episodeDate)?>));
+
+            var call = (MethodCallExpression)binder.BindToMethod(nameof(ICqlOperators.Coalesce), [operand], []);
+
+            call.Method.Name.Should().Be(nameof(ICqlOperators.Coalesce));
+            call.Method.GetGenericArguments().Single().Should().Be(typeof((CqlTupleMetadata, bool?, bool?, CqlInterval<CqlDate>, CqlDate, CqlDate)?));
+        }
+
     }
 
     internal class TestTypeResolver : BaseTypeResolver

--- a/Cql/CoreTests/ModelTest.cs
+++ b/Cql/CoreTests/ModelTest.cs
@@ -55,6 +55,28 @@ namespace CoreTests
             Assert.AreEqual(age, 29);
         }
 
+        [TestMethod]
+        public void Coalesce_NonNullableValueType_Throws()
+        {
+            // Coalesce<T> requires T to be a reference type or Nullable<U> (#1313);
+            // non-nullable value types cannot represent null and must throw.
+            var ops = CqlOperators.Create(new UnitTestTypeResolver());
+
+            var act = () => ops.Coalesce<int>([1, 2]);
+
+            act.Should().Throw<ArgumentException>().WithMessage("*non-nullable value type*");
+        }
+
+        [TestMethod]
+        public void Coalesce_NullableValueType_ReturnsFirstNonNullOrNull()
+        {
+            var ops = CqlOperators.Create(new UnitTestTypeResolver());
+
+            ops.Coalesce<int?>([null, 42, 7]).Should().Be(42);
+            ops.Coalesce<int?>([null, null]).Should().BeNull();
+            ops.Coalesce<int?>(null).Should().BeNull();
+        }
+
         private class UnitTestPatient
         {
             public DateIso8601 birthDate { get; set; }

--- a/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
@@ -109,20 +109,15 @@ partial class CqlOperatorsBinder
                 "Operands to this method must be list-like with a single element type, e.g. IEnumerable<T>",
                 nameof(operand));
 
-        if (elementType.IsValueType)
+        // For Nullable<T>, extract the underlying type T so Coalesce<T> receives the base type
+        if (elementType.IsValueType && elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>))
         {
-
-            if (elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                var underlying = Nullable.GetUnderlyingType(elementType)!;
-                return BindToBestMethodOverload(nameof(ICqlOperators.CoalesceValueTypes), [operand], [underlying])!;
-            }
-
-            return BindToBestMethodOverload(nameof(ICqlOperators.CoalesceValueTypes), [operand], [elementType])!;
+            var underlying = Nullable.GetUnderlyingType(elementType)!;
+            return BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [underlying])!;
         }
 
-        var call = BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [elementType])!;
-        return call;
+        // Always use Coalesce<T> (now unconstrained to handle value types, reference types, and tuples)
+        return BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [elementType])!;
 
     }
 

--- a/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
@@ -109,16 +109,9 @@ partial class CqlOperatorsBinder
                 "Operands to this method must be list-like with a single element type, e.g. IEnumerable<T>",
                 nameof(operand));
 
-        // For Nullable<T>, extract the underlying type T so Coalesce<T> receives the base type
-        if (elementType.IsValueType && elementType.IsGenericType && elementType.GetGenericTypeDefinition() == typeof(Nullable<>))
-        {
-            var underlying = Nullable.GetUnderlyingType(elementType)!;
-            return BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [underlying])!;
-        }
-
-        // Always use Coalesce<T> (now unconstrained to handle value types, reference types, and tuples)
+        // Always use Coalesce<T>, which is unconstrained and handles reference types,
+        // nullable value types (T = Nullable<U> returns null when no match), and tuples alike.
         return BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [elementType])!;
-
     }
 
     private Expression Flatten(Expression operand)

--- a/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
+++ b/Cql/Cql.Compiler/CqlOperatorsBinder.Specific.cs
@@ -109,6 +109,11 @@ partial class CqlOperatorsBinder
                 "Operands to this method must be list-like with a single element type, e.g. IEnumerable<T>",
                 nameof(operand));
 
+        if (elementType.IsValueType && Nullable.GetUnderlyingType(elementType) is null)
+            throw new ArgumentException(
+                $"Coalesce<T> requires T to be a reference type or Nullable<U>, but found non-nullable value type '{elementType}'.",
+                nameof(operand));
+
         // Always use Coalesce<T>, which is unconstrained and handles reference types,
         // nullable value types (T = Nullable<U> returns null when no match), and tuples alike.
         return BindToBestMethodOverload(nameof(ICqlOperators.Coalesce), [operand], [elementType])!;

--- a/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
@@ -15,15 +15,15 @@ namespace Hl7.Cql.Operators
 
         /// <inheritdoc />
         public T? Coalesce<T>(IEnumerable<T>? source)
-            where T : class
         {
             if (source == null)
-                return null!;
+                return default!;
             var t = source.FirstOrDefault(t => t != null);
             return t;
         }
 
         /// <inheritdoc />
+        [Obsolete("Use Coalesce<T> instead. This method is retained for backward compatibility with external implementations.", false)]
         public T? CoalesceValueTypes<T>(IEnumerable<T?>? source)
             where T : struct
         {

--- a/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
@@ -23,7 +23,7 @@ namespace Hl7.Cql.Operators
         }
 
         /// <inheritdoc />
-        [Obsolete("Use Coalesce<T> instead. This method is retained for backward compatibility with external implementations.", false)]
+        [Obsolete("Use Coalesce<T> with T = Nullable<U> instead. The class constraint on Coalesce<T> has been removed.", false)]
         public T? CoalesceValueTypes<T>(IEnumerable<T?>? source)
             where T : struct
         {

--- a/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
+++ b/Cql/Cql.Runtime/Operators/CqlOperators.NullologicalOperators.cs
@@ -16,8 +16,14 @@ namespace Hl7.Cql.Operators
         /// <inheritdoc />
         public T? Coalesce<T>(IEnumerable<T>? source)
         {
+            // Non-nullable value types cannot represent null, so they cannot satisfy CQL null semantics.
+            // The JIT specializes generic value-type instantiations, eliminating this check for valid T.
+            if (default(T) is not null)
+                throw new ArgumentException(
+                    $"Coalesce<T> requires T to be a reference type or Nullable<U>, but was instantiated with non-nullable value type {typeof(T)}.");
+
             if (source == null)
-                return default!;
+                return default;
             var t = source.FirstOrDefault(t => t != null);
             return t;
         }

--- a/Cql/Cql.Runtime/Operators/ICqlOperators.cs
+++ b/Cql/Cql.Runtime/Operators/ICqlOperators.cs
@@ -127,7 +127,7 @@ namespace Hl7.Cql.Operators
         /// <para>CQL Specification: §9.B Appendix B – CQL Reference, Nullological Operators: Coalesce</para>
         /// <para>Signature: <c>Coalesce&lt;T&gt;(arguments List&lt;T&gt;) T</c></para>
         /// <para>If all arguments evaluate to null, the result is null.</para>
-        /// <para><strong>Note:</strong> For non-nullable value types (e.g., <c>int</c>, <c>float</c>), a no-match result returns <c>default</c> (e.g., <c>0</c>) rather than null. This method is intended for use with nullable reference types and nullable value types; consider using <see cref="CoalesceValueTypes{T}"/> explicitly for nullable value types to make the intent clear.</para>
+        /// <para><strong>Note:</strong> For nullable value types use <c>T = Nullable&lt;U&gt;</c> (e.g., <c>Coalesce&lt;int?&gt;</c>), which returns null when no non-null element is found. Instantiating with a non-nullable value type (e.g., <c>Coalesce&lt;int&gt;</c>) returns <c>default</c> (e.g., <c>0</c>) in that case, which does not match CQL null semantics.</para>
         /// </remarks>
         /// <seealso href="https://cql.hl7.org/09-b-cqlreference.html#coalesce">CQL Specification §9.B - Coalesce</seealso>
         T?                                       Coalesce<T>(IEnumerable<T>? source);
@@ -143,8 +143,10 @@ namespace Hl7.Cql.Operators
         /// <para>CQL Specification: §9.B Appendix B – CQL Reference, Nullological Operators: Coalesce</para>
         /// <para>Signature: <c>Coalesce&lt;T&gt;(arguments List&lt;T&gt;) T</c></para>
         /// <para>If all arguments evaluate to null, the result is null.</para>
+        /// <para><strong>Deprecated:</strong> Use <see cref="Coalesce{T}"/> with <c>T = Nullable&lt;U&gt;</c> instead; it is no longer constrained to reference types.</para>
         /// </remarks>
         /// <seealso href="https://cql.hl7.org/09-b-cqlreference.html#coalesce">CQL Specification §9.B - Coalesce</seealso>
+        [Obsolete("Use Coalesce<T> with T = Nullable<U> instead. The class constraint on Coalesce<T> has been removed.", false)]
         T?                                       CoalesceValueTypes<T>(IEnumerable<T?>? source) where T : struct;
         bool?                                    CodeInList(CqlCode? element, IEnumerable<CqlCode>? argument);
         bool?                                    CodeInValueSet(CqlCode? code, CqlValueSet? valueSet);

--- a/Cql/Cql.Runtime/Operators/ICqlOperators.cs
+++ b/Cql/Cql.Runtime/Operators/ICqlOperators.cs
@@ -127,9 +127,10 @@ namespace Hl7.Cql.Operators
         /// <para>CQL Specification: §9.B Appendix B – CQL Reference, Nullological Operators: Coalesce</para>
         /// <para>Signature: <c>Coalesce&lt;T&gt;(arguments List&lt;T&gt;) T</c></para>
         /// <para>If all arguments evaluate to null, the result is null.</para>
+        /// <para><strong>Note:</strong> For non-nullable value types (e.g., <c>int</c>, <c>float</c>), a no-match result returns <c>default</c> (e.g., <c>0</c>) rather than null. This method is intended for use with nullable reference types and nullable value types; consider using <see cref="CoalesceValueTypes{T}"/> explicitly for nullable value types to make the intent clear.</para>
         /// </remarks>
         /// <seealso href="https://cql.hl7.org/09-b-cqlreference.html#coalesce">CQL Specification §9.B - Coalesce</seealso>
-        T?                                       Coalesce<T>(IEnumerable<T>? source) where T : class;
+        T?                                       Coalesce<T>(IEnumerable<T>? source);
 
         /// <summary>
         /// Returns the first non-null result in a list of nullable value type arguments.

--- a/Cql/Cql.Runtime/Operators/ICqlOperators.cs
+++ b/Cql/Cql.Runtime/Operators/ICqlOperators.cs
@@ -122,12 +122,13 @@ namespace Hl7.Cql.Operators
         /// <typeparam name="T">The type of the elements in the source collection.</typeparam>
         /// <param name="source">A collection of values to check for non-null elements.</param>
         /// <returns>The first non-null element in the collection, or null if all elements are null or the source is null.</returns>
+        /// <exception cref="ArgumentException">When <typeparamref name="T"/> is a non-nullable value type, which cannot represent null and therefore cannot satisfy CQL null semantics.</exception>
         /// <remarks>
         /// <para>Implements the CQL Coalesce operator.</para>
         /// <para>CQL Specification: §9.B Appendix B – CQL Reference, Nullological Operators: Coalesce</para>
         /// <para>Signature: <c>Coalesce&lt;T&gt;(arguments List&lt;T&gt;) T</c></para>
         /// <para>If all arguments evaluate to null, the result is null.</para>
-        /// <para><strong>Note:</strong> For nullable value types use <c>T = Nullable&lt;U&gt;</c> (e.g., <c>Coalesce&lt;int?&gt;</c>), which returns null when no non-null element is found. Instantiating with a non-nullable value type (e.g., <c>Coalesce&lt;int&gt;</c>) returns <c>default</c> (e.g., <c>0</c>) in that case, which does not match CQL null semantics.</para>
+        /// <para><strong>Note:</strong> <typeparamref name="T"/> must be a reference type or <c>Nullable&lt;U&gt;</c> (e.g., <c>Coalesce&lt;int?&gt;</c>). Instantiating with a non-nullable value type (e.g., <c>Coalesce&lt;int&gt;</c>) throws <see cref="ArgumentException"/>.</para>
         /// </remarks>
         /// <seealso href="https://cql.hl7.org/09-b-cqlreference.html#coalesce">CQL Specification §9.B - Coalesce</seealso>
         T?                                       Coalesce<T>(IEnumerable<T>? source);

--- a/Cql/Cql.Runtime/PublicAPI.Shipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Shipped.txt
@@ -102,7 +102,7 @@ Hl7.Cql.Operators.ICqlOperators.Ceiling(decimal? argument) -> int?
 Hl7.Cql.Operators.ICqlOperators.Ceiling(int? argument) -> int?
 Hl7.Cql.Operators.ICqlOperators.Ceiling(long? argument) -> long?
 Hl7.Cql.Operators.ICqlOperators.Children(object! o) -> System.Collections.Generic.IEnumerable<object!>!
-Hl7.Cql.Operators.ICqlOperators.Coalesce<T>(System.Collections.Generic.IEnumerable<T!>? source) -> T?
+Hl7.Cql.Operators.ICqlOperators.Coalesce<T>(System.Collections.Generic.IEnumerable<T>? source) -> T?
 Hl7.Cql.Operators.ICqlOperators.CoalesceValueTypes<T>(System.Collections.Generic.IEnumerable<T?>? source) -> T?
 Hl7.Cql.Operators.ICqlOperators.CodeInList(Hl7.Cql.Primitives.CqlCode? element, System.Collections.Generic.IEnumerable<Hl7.Cql.Primitives.CqlCode!>? argument) -> bool?
 Hl7.Cql.Operators.ICqlOperators.CodeInValueSet(Hl7.Cql.Primitives.CqlCode? code, Hl7.Cql.Primitives.CqlValueSet? valueSet) -> bool?

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -135,7 +135,7 @@
     },
     "PackageCLI elm (Ticket 1305 HEDIS 2025 ELM->FHIR)": {
       "commandName": "Project",
-      "commandLineArgs": "elm --elm \"$(Hedis2025StagingDir)/elm\" --cql \"$(Hedis2025StagingDir)/cql\" --libraries \"$(Hedis2025StagingDir)/resources/libraries\" --measures \"$(Hedis2025StagingDir)/resources/measures\" --cs \"$(Hedis2025StagingDir)/csharp\" --dll \"$(Hedis2025StagingDir)/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log --file-log-level Debug --console-log-level Warning",
+      "commandLineArgs": "elm --elm \"$(Hedis2025StagingDir)/elm\" --cql \"$(Hedis2025StagingDir)/cql\" --libraries \"$(Hedis2025StagingDir)/resources/libraries\" --measures \"$(Hedis2025StagingDir)/resources/measures\" --cs \"$(Hedis2025StagingDir)/csharp\" --dll \"$(Hedis2025StagingDir)/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log",
       "environmentVariables": {
         "CQLPACKAGE_PROFILE": "Demo"
       }

--- a/Cql/PackagerCLI/Properties/launchSettings.json
+++ b/Cql/PackagerCLI/Properties/launchSettings.json
@@ -135,7 +135,7 @@
     },
     "PackageCLI elm (Ticket 1305 HEDIS 2025 ELM->FHIR)": {
       "commandName": "Project",
-      "commandLineArgs": "elm --elm \"$(Hedis2025StagingDir)/elm\" --cql \"$(Hedis2025StagingDir)/cql\" --libraries \"$(Hedis2025StagingDir)/resources/libraries\" --measures \"$(Hedis2025StagingDir)/resources/measures\" --cs \"$(Hedis2025StagingDir)/csharp\" --dll \"$(Hedis2025StagingDir)/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log",
+      "commandLineArgs": "elm --elm \"$(Hedis2025StagingDir)/elm\" --cql \"$(Hedis2025StagingDir)/cql\" --libraries \"$(Hedis2025StagingDir)/resources/libraries\" --measures \"$(Hedis2025StagingDir)/resources/measures\" --cs \"$(Hedis2025StagingDir)/csharp\" --dll \"$(Hedis2025StagingDir)/dll\" --debug-symbols Embedded --json-pretty --log-file packager.log --file-log-level Debug --console-log-level Warning",
       "environmentVariables": {
         "CQLPACKAGE_PROFILE": "Demo"
       }

--- a/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/DocumentationofCurrentMedicationsFHIR-0.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("DocumentationofCurrentMedicationsFHIR", "0.2.000")]
 public partial class DocumentationofCurrentMedicationsFHIR_0_2_000 : ILibrary, ISingleton<DocumentationofCurrentMedicationsFHIR_0_2_000>
 {

--- a/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/FHIRHelpers-4.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIRHelpers", "4.3.000")]
 public partial class FHIRHelpers_4_3_000 : ILibrary, ISingleton<FHIRHelpers_4_3_000>
 {

--- a/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/MultipleResourcesExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("MultipleResourcesExample", "0.0.1")]
 public partial class MultipleResourcesExample_0_0_1 : ILibrary, ISingleton<MultipleResourcesExample_0_0_1>
 {

--- a/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
+++ b/Demo/Measures.Authoring/CSharp/ParametersExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("ParametersExample", "0.0.1")]
 public partial class ParametersExample_0_0_1 : ILibrary, ISingleton<ParametersExample_0_0_1>
 {

--- a/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/QICoreCommon-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("QICoreCommon", "2.0.000")]
 public partial class QICoreCommon_2_0_000 : ILibrary, ISingleton<QICoreCommon_2_0_000>
 {

--- a/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/Status-1.6.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Status", "1.6.000")]
 public partial class Status_1_6_000 : ILibrary, ISingleton<Status_1_6_000>
 {

--- a/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
+++ b/Demo/Measures.Authoring/CSharp/SupplementalDataElements-3.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("SupplementalDataElements", "3.4.000")]
 public partial class SupplementalDataElements_3_4_000 : ILibrary, ISingleton<SupplementalDataElements_3_4_000>
 {

--- a/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdultOutpatientEncountersFHIR4-2.2.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AdultOutpatientEncountersFHIR4", "2.2.000")]
 public partial class AdultOutpatientEncountersFHIR4_2_2_000 : ILibrary, ISingleton<AdultOutpatientEncountersFHIR4_2_2_000>
 {

--- a/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/AdvancedIllnessandFrailtyExclusionECQMFHIR4-5.17.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AdvancedIllnessandFrailtyExclusionECQMFHIR4", "5.17.000")]
 public partial class AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000 : ILibrary, ISingleton<AdvancedIllnessandFrailtyExclusionECQMFHIR4_5_17_000>
 {

--- a/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/BCSEHEDISMY2022-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("BCSEHEDISMY2022", "1.0.0")]
 public partial class BCSEHEDISMY2022_1_0_0 : ILibrary, ISingleton<BCSEHEDISMY2022_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/BreastCancerScreeningsFHIR-0.0.009.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("BreastCancerScreeningsFHIR", "0.0.009")]
 public partial class BreastCancerScreeningsFHIR_0_0_009 : ILibrary, ISingleton<BreastCancerScreeningsFHIR_0_0_009>
 {

--- a/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/CervicalCancerScreeningFHIR-0.0.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CervicalCancerScreeningFHIR", "0.0.005")]
 public partial class CervicalCancerScreeningFHIR_0_0_005 : ILibrary, ISingleton<CervicalCancerScreeningFHIR_0_0_005>
 {

--- a/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/ColorectalCancerScreeningsFHIR-0.0.003.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("ColorectalCancerScreeningsFHIR", "0.0.003")]
 public partial class ColorectalCancerScreeningsFHIR_0_0_003 : ILibrary, ISingleton<ColorectalCancerScreeningsFHIR_0_0_003>
 {

--- a/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/CumulativeMedicationDurationFHIR4-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CumulativeMedicationDurationFHIR4", "1.0.000")]
 public partial class CumulativeMedicationDurationFHIR4_1_0_000 : ILibrary, ISingleton<CumulativeMedicationDurationFHIR4_1_0_000>
 {

--- a/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
+++ b/Demo/Measures.Demo/CSharp/DRCommunicationWithPhysicianManagingDiabetesFHIR-0.0.004.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("DRCommunicationWithPhysicianManagingDiabetesFHIR", "0.0.004")]
 public partial class DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004 : ILibrary, ISingleton<DRCommunicationWithPhysicianManagingDiabetesFHIR_0_0_004>
 {

--- a/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/DevDays-2023.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("DevDays", "2023.0.0")]
 public partial class DevDays_2023_0_0 : ILibrary, ISingleton<DevDays_2023_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
+++ b/Demo/Measures.Demo/CSharp/DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-0.0.015.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("DiabetesHemoglobinA1cHbA1cPoorControl9FHIR", "0.0.015")]
 public partial class DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015 : ILibrary, ISingleton<DiabetesHemoglobinA1cHbA1cPoorControl9FHIR_0_0_015>
 {

--- a/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
+++ b/Demo/Measures.Demo/CSharp/DischargedonAntithromboticTherapyFHIR-0.0.010.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("DischargedonAntithromboticTherapyFHIR", "0.0.010")]
 public partial class DischargedonAntithromboticTherapyFHIR_0_0_010 : ILibrary, ISingleton<DischargedonAntithromboticTherapyFHIR_0_0_010>
 {

--- a/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam125FHIR-0.0.009.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Exam125FHIR", "0.0.009")]
 public partial class Exam125FHIR_0_0_009 : ILibrary, ISingleton<Exam125FHIR_0_0_009>
 {

--- a/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
+++ b/Demo/Measures.Demo/CSharp/Exam130FHIR-0.0.003.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Exam130FHIR", "0.0.003")]
 public partial class Exam130FHIR_0_0_003 : ILibrary, ISingleton<Exam130FHIR_0_0_003>
 {

--- a/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIR347-0.1.021.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIR347", "0.1.021")]
 public partial class FHIR347_0_1_021 : ILibrary, ISingleton<FHIR347_0_1_021>
 {

--- a/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
+++ b/Demo/Measures.Demo/CSharp/FHIRHelpers-4.0.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIRHelpers", "4.0.001")]
 public partial class FHIRHelpers_4_0_001 : ILibrary, ISingleton<FHIRHelpers_4_0_001>
 {

--- a/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospiceFHIR4-2.3.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("HospiceFHIR4", "2.3.000")]
 public partial class HospiceFHIR4_2_3_000 : ILibrary, ISingleton<HospiceFHIR4_2_3_000>
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmHyperglycemiainHospitalizedPatientsFHIR-0.0.006.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("HospitalHarmHyperglycemiainHospitalizedPatientsFHIR", "0.0.006")]
 public partial class HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006 : ILibrary, ISingleton<HospitalHarmHyperglycemiainHospitalizedPatientsFHIR_0_0_006>
 {

--- a/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/HospitalHarmSevereHypoglycemiaFHIR-0.0.012.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("HospitalHarmSevereHypoglycemiaFHIR", "0.0.012")]
 public partial class HospitalHarmSevereHypoglycemiaFHIR_0_0_012 : ILibrary, ISingleton<HospitalHarmSevereHypoglycemiaFHIR_0_0_012>
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWMFHIR-0.102.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("HybridHWMFHIR", "0.102.005")]
 public partial class HybridHWMFHIR_0_102_005 : ILibrary, ISingleton<HybridHWMFHIR_0_102_005>
 {

--- a/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
+++ b/Demo/Measures.Demo/CSharp/HybridHWRFHIR-1.3.005.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("HybridHWRFHIR", "1.3.005")]
 public partial class HybridHWRFHIR_1_3_005 : ILibrary, ISingleton<HybridHWRFHIR_1_3_005>
 {

--- a/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/MATGlobalCommonFunctionsFHIR4-6.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("MATGlobalCommonFunctionsFHIR4", "6.1.000")]
 public partial class MATGlobalCommonFunctionsFHIR4_6_1_000 : ILibrary, ISingleton<MATGlobalCommonFunctionsFHIR4_6_1_000>
 {

--- a/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
+++ b/Demo/Measures.Demo/CSharp/MeasureExample-0.0.1.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("MeasureExample", "0.0.1")]
 public partial class MeasureExample_0_0_1 : ILibrary, ISingleton<MeasureExample_0_0_1>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAAdvancedIllnessandFrailty-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAAdvancedIllnessandFrailty", "1.0.0")]
 public partial class NCQAAdvancedIllnessandFrailty_1_0_0 : ILibrary, ISingleton<NCQAAdvancedIllnessandFrailty_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQACQLBase-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQACQLBase", "1.0.0")]
 public partial class NCQACQLBase_1_0_0 : ILibrary, ISingleton<NCQACQLBase_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAClaims-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAClaims", "1.0.0")]
 public partial class NCQAClaims_1_0_0 : ILibrary, ISingleton<NCQAClaims_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAEncounter-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAEncounter", "1.0.0")]
 public partial class NCQAEncounter_1_0_0 : ILibrary, ISingleton<NCQAEncounter_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAFHIRBase-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAFHIRBase", "1.0.0")]
 public partial class NCQAFHIRBase_1_0_0 : ILibrary, ISingleton<NCQAFHIRBase_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHealthPlanEnrollment-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAHealthPlanEnrollment", "1.0.0")]
 public partial class NCQAHealthPlanEnrollment_1_0_0 : ILibrary, ISingleton<NCQAHealthPlanEnrollment_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAHospice-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAHospice", "1.0.0")]
 public partial class NCQAHospice_1_0_0 : ILibrary, ISingleton<NCQAHospice_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAPalliativeCare-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAPalliativeCare", "1.0.0")]
 public partial class NCQAPalliativeCare_1_0_0 : ILibrary, ISingleton<NCQAPalliativeCare_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQAStatus-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQAStatus", "1.0.0")]
 public partial class NCQAStatus_1_0_0 : ILibrary, ISingleton<NCQAStatus_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
+++ b/Demo/Measures.Demo/CSharp/NCQATerminology-1.0.0.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NCQATerminology", "1.0.0")]
 public partial class NCQATerminology_1_0_0 : ILibrary, ISingleton<NCQATerminology_1_0_0>
 {

--- a/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/PalliativeCareFHIR-0.6.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("PalliativeCareFHIR", "0.6.000")]
 public partial class PalliativeCareFHIR_0_6_000 : ILibrary, ISingleton<PalliativeCareFHIR_0_6_000>
 {

--- a/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
+++ b/Demo/Measures.Demo/CSharp/PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR-0.0.008.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR", "0.0.008")]
 public partial class PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008 : ILibrary, ISingleton<PrimaryCariesPreventionasOfferedbyPCPsincludingDentistsFHIR_0_0_008>
 {

--- a/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
+++ b/Demo/Measures.Demo/CSharp/SafeUseofOpioidsConcurrentPrescribingFHIR-0.0.012.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("SafeUseofOpioidsConcurrentPrescribingFHIR", "0.0.012")]
 public partial class SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012 : ILibrary, ISingleton<SafeUseofOpioidsConcurrentPrescribingFHIR_0_0_012>
 {

--- a/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/SupplementalDataElementsFHIR4-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("SupplementalDataElementsFHIR4", "2.0.000")]
 public partial class SupplementalDataElementsFHIR4_2_0_000 : ILibrary, ISingleton<SupplementalDataElementsFHIR4_2_0_000>
 {

--- a/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/TJCOverallFHIR-1.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("TJCOverallFHIR", "1.8.000")]
 public partial class TJCOverallFHIR_1_8_000 : ILibrary, ISingleton<TJCOverallFHIR_1_8_000>
 {

--- a/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
+++ b/Demo/Measures.Demo/CSharp/VTEFHIR4-4.8.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("VTEFHIR4", "4.8.000")]
 public partial class VTEFHIR4_4_8_000 : ILibrary, ISingleton<VTEFHIR4_4_8_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AHAOverall-4.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AHAOverall", "4.1.000")]
 public partial class AHAOverall_4_1_000 : ILibrary, ISingleton<AHAOverall_4_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdultOutpatientEncounters-4.19.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AdultOutpatientEncounters", "4.19.000")]
 public partial class AdultOutpatientEncounters_4_19_000 : ILibrary, ISingleton<AdultOutpatientEncounters_4_19_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AdvancedIllnessandFrailty-1.27.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AdvancedIllnessandFrailty", "1.27.000")]
 public partial class AdvancedIllnessandFrailty_1_27_000 : ILibrary, ISingleton<AdvancedIllnessandFrailty_1_27_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/AlaraCommonFunctions-1.10.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("AlaraCommonFunctions", "1.10.000")]
 public partial class AlaraCommonFunctions_1_10_000 : ILibrary, ISingleton<AlaraCommonFunctions_1_10_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Antibiotic-1.11.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Antibiotic", "1.11.000")]
 public partial class Antibiotic_1_11_000 : ILibrary, ISingleton<Antibiotic_1_11_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/CumulativeMedicationDuration-6.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CumulativeMedicationDuration", "6.0.000")]
 public partial class CumulativeMedicationDuration_6_0_000 : ILibrary, ISingleton<CumulativeMedicationDuration_6_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Hospice-6.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Hospice", "6.18.000")]
 public partial class Hospice_6_18_000 : ILibrary, ISingleton<Hospice_6_18_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/NHSNHelpers-0.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("NHSNHelpers", "0.1.000")]
 public partial class NHSNHelpers_0_1_000 : ILibrary, ISingleton<NHSNHelpers_0_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PCMaternal-5.25.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("PCMaternal", "5.25.000")]
 public partial class PCMaternal_5_25_000 : ILibrary, ISingleton<PCMaternal_5_25_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/PalliativeCare-1.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("PalliativeCare", "1.18.000")]
 public partial class PalliativeCare_1_18_000 : ILibrary, ISingleton<PalliativeCare_1_18_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/Status-1.15.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("Status", "1.15.000")]
 public partial class Status_1_15_000 : ILibrary, ISingleton<Status_1_15_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/SupplementalDataElements-5.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("SupplementalDataElements", "5.1.000")]
 public partial class SupplementalDataElements_5_1_000 : ILibrary, ISingleton<SupplementalDataElements_5_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/TJCOverall-8.25.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("TJCOverall", "8.25.000")]
 public partial class TJCOverall_8_25_000 : ILibrary, ISingleton<TJCOverall_8_25_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/VTE-8.18.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("VTE", "8.18.000")]
 public partial class VTE_8_18_000 : ILibrary, ISingleton<VTE_8_18_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS0334FHIRPCCesareanBirth-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS0334FHIRPCCesareanBirth", "1.0.000")]
 public partial class CMS0334FHIRPCCesareanBirth_1_0_000 : ILibrary, ISingleton<CMS0334FHIRPCCesareanBirth_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1017FHIRHHFI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1017FHIRHHFI", "1.0.000")]
 public partial class CMS1017FHIRHHFI_1_0_000 : ILibrary, ISingleton<CMS1017FHIRHHFI_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1028FHIRPCSevereOBComps-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1028FHIRPCSevereOBComps", "1.0.000")]
 public partial class CMS1028FHIRPCSevereOBComps_1_0_000 : ILibrary, ISingleton<CMS1028FHIRPCSevereOBComps_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS104FHIRSTKDCAntithrombotic-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS104FHIRSTKDCAntithrombotic", "1.0.000")]
 public partial class CMS104FHIRSTKDCAntithrombotic_1_0_000 : ILibrary, ISingleton<CMS104FHIRSTKDCAntithrombotic_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1056FHIRCTClinical-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1056FHIRCTClinical-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1056FHIRCTClinical", "1.0.000")]
 public partial class CMS1056FHIRCTClinical_1_0_000 : ILibrary, ISingleton<CMS1056FHIRCTClinical_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1074FHIRCTIQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1074FHIRCTIQR", "1.0.000")]
 public partial class CMS1074FHIRCTIQR_1_0_000 : ILibrary, ISingleton<CMS1074FHIRCTIQR_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS108FHIRVTEProphylaxis-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS108FHIRVTEProphylaxis", "1.0.000")]
 public partial class CMS108FHIRVTEProphylaxis_1_0_000 : ILibrary, ISingleton<CMS108FHIRVTEProphylaxis_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1154ScreeningPrediabetesFHIR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1154ScreeningPrediabetesFHIR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1154ScreeningPrediabetesFHIR", "1.0.000")]
 public partial class CMS1154ScreeningPrediabetesFHIR_1_0_000 : ILibrary, ISingleton<CMS1154ScreeningPrediabetesFHIR_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1157FHIRHIVRetention-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1157FHIRHIVRetention", "1.0.000")]
 public partial class CMS1157FHIRHIVRetention_1_0_000 : ILibrary, ISingleton<CMS1157FHIRHIVRetention_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1173FHIRDiagnosticDelayVTE-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1173FHIRDiagnosticDelayVTE", "1.0.000")]
 public partial class CMS1173FHIRDiagnosticDelayVTE_1_0_000 : ILibrary, ISingleton<CMS1173FHIRDiagnosticDelayVTE_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS117FHIRChildImmunStatus-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS117FHIRChildImmunStatus", "1.0.000")]
 public partial class CMS117FHIRChildImmunStatus_1_0_000 : ILibrary, ISingleton<CMS117FHIRChildImmunStatus_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1188FHIRHIVSTITesting-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1188FHIRHIVSTITesting-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1188FHIRHIVSTITesting", "1.0.000")]
 public partial class CMS1188FHIRHIVSTITesting_1_0_000 : ILibrary, ISingleton<CMS1188FHIRHIVSTITesting_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1206FHIRCTOQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1206FHIRCTOQR", "1.0.000")]
 public partial class CMS1206FHIRCTOQR_1_0_000 : ILibrary, ISingleton<CMS1206FHIRCTOQR_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1218FHIRHHRF-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1218FHIRHHRF", "1.0.000")]
 public partial class CMS1218FHIRHHRF_1_0_000 : ILibrary, ISingleton<CMS1218FHIRHHRF_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS122FHIRDiabetesAssessGT9Pct-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS122FHIRDiabetesAssessGT9Pct", "1.0.000")]
 public partial class CMS122FHIRDiabetesAssessGT9Pct_1_0_000 : ILibrary, ISingleton<CMS122FHIRDiabetesAssessGT9Pct_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1244FHIRECATHOQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1244FHIRECATHOQR", "1.0.000")]
 public partial class CMS1244FHIRECATHOQR_1_0_000 : ILibrary, ISingleton<CMS1244FHIRECATHOQR_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS124FHIRCervicalCancerScreen-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS124FHIRCervicalCancerScreen", "1.0.000")]
 public partial class CMS124FHIRCervicalCancerScreen_1_0_000 : ILibrary, ISingleton<CMS124FHIRCervicalCancerScreen_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS125FHIRBreastCancerScreen-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS125FHIRBreastCancerScreen", "1.0.000")]
 public partial class CMS125FHIRBreastCancerScreen_1_0_000 : ILibrary, ISingleton<CMS125FHIRBreastCancerScreen_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS1264FHIRECATREHQR-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS1264FHIRECATREHQR", "1.0.000")]
 public partial class CMS1264FHIRECATREHQR_1_0_000 : ILibrary, ISingleton<CMS1264FHIRECATREHQR_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS128FHIRAntidepressantMgmt-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS128FHIRAntidepressantMgmt", "1.0.000")]
 public partial class CMS128FHIRAntidepressantMgmt_1_0_000 : ILibrary, ISingleton<CMS128FHIRAntidepressantMgmt_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS129FHIRProstCaBoneScanUse-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS129FHIRProstCaBoneScanUse", "1.0.000")]
 public partial class CMS129FHIRProstCaBoneScanUse_1_0_000 : ILibrary, ISingleton<CMS129FHIRProstCaBoneScanUse_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS130FHIRColorectalCancerScrn-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS130FHIRColorectalCancerScrn", "1.0.000")]
 public partial class CMS130FHIRColorectalCancerScrn_1_0_000 : ILibrary, ISingleton<CMS130FHIRColorectalCancerScrn_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS131FHIRDiabetesEyeExam-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS131FHIRDiabetesEyeExam", "1.0.000")]
 public partial class CMS131FHIRDiabetesEyeExam_1_0_000 : ILibrary, ISingleton<CMS131FHIRDiabetesEyeExam_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS133FHIRCataracts2040BCVA90Days-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS133FHIRCataracts2040BCVA90Days", "1.0.000")]
 public partial class CMS133FHIRCataracts2040BCVA90Days_1_0_000 : ILibrary, ISingleton<CMS133FHIRCataracts2040BCVA90Days_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS135FHIRACEIorARBorARNIforHF-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS135FHIRACEIorARBorARNIforHF", "1.0.000")]
 public partial class CMS135FHIRACEIorARBorARNIforHF_1_0_000 : ILibrary, ISingleton<CMS135FHIRACEIorARBorARNIforHF_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS136FHIRChildADHDMedFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS136FHIRChildADHDMedFollowUp", "1.0.000")]
 public partial class CMS136FHIRChildADHDMedFollowUp_1_0_000 : ILibrary, ISingleton<CMS136FHIRChildADHDMedFollowUp_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS137FHIRSUDTxInitEngagement-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS137FHIRSUDTxInitEngagement", "1.0.000")]
 public partial class CMS137FHIRSUDTxInitEngagement_1_0_000 : ILibrary, ISingleton<CMS137FHIRSUDTxInitEngagement_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS138FHIRTobaccoScrnCessation-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS138FHIRTobaccoScrnCessation", "1.0.000")]
 public partial class CMS138FHIRTobaccoScrnCessation_1_0_000 : ILibrary, ISingleton<CMS138FHIRTobaccoScrnCessation_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS139FHIRFallRiskScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS139FHIRFallRiskScreening-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS139FHIRFallRiskScreening", "1.0.000")]
 public partial class CMS139FHIRFallRiskScreening_1_0_000 : ILibrary, ISingleton<CMS139FHIRFallRiskScreening_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS142FHIRCommWithDrManagingDiab-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS142FHIRCommWithDrManagingDiab", "1.0.000")]
 public partial class CMS142FHIRCommWithDrManagingDiab_1_0_000 : ILibrary, ISingleton<CMS142FHIRCommWithDrManagingDiab_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS143FHIRPOAGOpticNerveEval-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS143FHIRPOAGOpticNerveEval", "1.0.000")]
 public partial class CMS143FHIRPOAGOpticNerveEval_1_0_000 : ILibrary, ISingleton<CMS143FHIRPOAGOpticNerveEval_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS144FHIRHFBetaBlockerForLVSD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS144FHIRHFBetaBlockerForLVSD", "1.0.000")]
 public partial class CMS144FHIRHFBetaBlockerForLVSD_1_0_000 : ILibrary, ISingleton<CMS144FHIRHFBetaBlockerForLVSD_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS145FHIRCADBBlockerTPMIorLVSD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS145FHIRCADBBlockerTPMIorLVSD", "1.0.000")]
 public partial class CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000 : ILibrary, ISingleton<CMS145FHIRCADBBlockerTPMIorLVSD_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS146FHIRApproTestPharyngitis-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS146FHIRApproTestPharyngitis", "1.0.000")]
 public partial class CMS146FHIRApproTestPharyngitis_1_0_000 : ILibrary, ISingleton<CMS146FHIRApproTestPharyngitis_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS149FHIRDementiaCognitiveAssess-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS149FHIRDementiaCognitiveAssess", "1.0.000")]
 public partial class CMS149FHIRDementiaCognitiveAssess_1_0_000 : ILibrary, ISingleton<CMS149FHIRDementiaCognitiveAssess_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS153FHIRChlamydiaScreening-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS153FHIRChlamydiaScreening", "1.0.000")]
 public partial class CMS153FHIRChlamydiaScreening_1_0_000 : ILibrary, ISingleton<CMS153FHIRChlamydiaScreening_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS154FHIRAppropriateTxforURI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS154FHIRAppropriateTxforURI", "1.0.000")]
 public partial class CMS154FHIRAppropriateTxforURI_1_0_000 : ILibrary, ISingleton<CMS154FHIRAppropriateTxforURI_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS155FHIRWgtAssessCounseling-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS155FHIRWgtAssessCounseling", "1.0.000")]
 public partial class CMS155FHIRWgtAssessCounseling_1_0_000 : ILibrary, ISingleton<CMS155FHIRWgtAssessCounseling_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS156FHIRHighRiskMedsElderly-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS156FHIRHighRiskMedsElderly", "1.0.000")]
 public partial class CMS156FHIRHighRiskMedsElderly_1_0_000 : ILibrary, ISingleton<CMS156FHIRHighRiskMedsElderly_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS157FHIRPainIntensityQuantified-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS157FHIRPainIntensityQuantified", "1.0.000")]
 public partial class CMS157FHIRPainIntensityQuantified_1_0_000 : ILibrary, ISingleton<CMS157FHIRPainIntensityQuantified_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS159FHIRDepRemissionat12Months-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS159FHIRDepRemissionat12Months", "1.0.000")]
 public partial class CMS159FHIRDepRemissionat12Months_1_0_000 : ILibrary, ISingleton<CMS159FHIRDepRemissionat12Months_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS165FHIRControllingHighBP-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS165FHIRControllingHighBP", "1.0.000")]
 public partial class CMS165FHIRControllingHighBP_1_0_000 : ILibrary, ISingleton<CMS165FHIRControllingHighBP_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS177FHIRChildMDDSuicideAssmt-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS177FHIRChildMDDSuicideAssmt", "1.0.000")]
 public partial class CMS177FHIRChildMDDSuicideAssmt_1_0_000 : ILibrary, ISingleton<CMS177FHIRChildMDDSuicideAssmt_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS190FHIRVTEProphylaxisICU-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS190FHIRVTEProphylaxisICU", "1.0.000")]
 public partial class CMS190FHIRVTEProphylaxisICU_1_0_000 : ILibrary, ISingleton<CMS190FHIRVTEProphylaxisICU_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS22FHIRPCSBPScreeningFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS22FHIRPCSBPScreeningFollowUp", "1.0.000")]
 public partial class CMS22FHIRPCSBPScreeningFollowUp_1_0_000 : ILibrary, ISingleton<CMS22FHIRPCSBPScreeningFollowUp_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS2FHIRPCSDepScreenAndFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS2FHIRPCSDepScreenAndFollowUp", "1.0.000")]
 public partial class CMS2FHIRPCSDepScreenAndFollowUp_1_0_000 : ILibrary, ISingleton<CMS2FHIRPCSDepScreenAndFollowUp_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS314FHIRHIVViralSuppression-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS314FHIRHIVViralSuppression-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS314FHIRHIVViralSuppression", "1.0.000")]
 public partial class CMS314FHIRHIVViralSuppression_1_0_000 : ILibrary, ISingleton<CMS314FHIRHIVViralSuppression_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS347FHIRStatinPreventionTxCVD-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS347FHIRStatinPreventionTxCVD", "1.0.000")]
 public partial class CMS347FHIRStatinPreventionTxCVD_1_0_000 : ILibrary, ISingleton<CMS347FHIRStatinPreventionTxCVD_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS349FHIRHIVScreening-1.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS349FHIRHIVScreening", "1.1.000")]
 public partial class CMS349FHIRHIVScreening_1_1_000 : ILibrary, ISingleton<CMS349FHIRHIVScreening_1_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS506FHIRSafeUseofOpioids-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS506FHIRSafeUseofOpioids", "1.0.000")]
 public partial class CMS506FHIRSafeUseofOpioids_1_0_000 : ILibrary, ISingleton<CMS506FHIRSafeUseofOpioids_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS50FHIRReceiptofSpecialistReport-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS50FHIRReceiptofSpecialistReport", "1.0.000")]
 public partial class CMS50FHIRReceiptofSpecialistReport_1_0_000 : ILibrary, ISingleton<CMS50FHIRReceiptofSpecialistReport_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS56FHIRFuncStatHipReplacement-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS56FHIRFuncStatHipReplacement", "1.0.000")]
 public partial class CMS56FHIRFuncStatHipReplacement_1_0_000 : ILibrary, ISingleton<CMS56FHIRFuncStatHipReplacement_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS645FHIRBoneDensityPCADTherapy-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS645FHIRBoneDensityPCADTherapy", "1.0.000")]
 public partial class CMS645FHIRBoneDensityPCADTherapy_1_0_000 : ILibrary, ISingleton<CMS645FHIRBoneDensityPCADTherapy_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS646FHIRIntravesicalBCGTherapy-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS646FHIRIntravesicalBCGTherapy", "1.0.000")]
 public partial class CMS646FHIRIntravesicalBCGTherapy_1_0_000 : ILibrary, ISingleton<CMS646FHIRIntravesicalBCGTherapy_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS68FHIRDocumentationCurrentMeds-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS68FHIRDocumentationCurrentMeds", "1.0.000")]
 public partial class CMS68FHIRDocumentationCurrentMeds_1_0_000 : ILibrary, ISingleton<CMS68FHIRDocumentationCurrentMeds_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS69FHIRPCSBMIScreenAndFollowUp-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS69FHIRPCSBMIScreenAndFollowUp", "1.0.000")]
 public partial class CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000 : ILibrary, ISingleton<CMS69FHIRPCSBMIScreenAndFollowUp_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS71FHIRSTKAnticoagAFFlutter-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS71FHIRSTKAnticoagAFFlutter", "1.0.000")]
 public partial class CMS71FHIRSTKAnticoagAFFlutter_1_0_000 : ILibrary, ISingleton<CMS71FHIRSTKAnticoagAFFlutter_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS72FHIRSTKAntithromboticDay2-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS72FHIRSTKAntithromboticDay2", "1.0.000")]
 public partial class CMS72FHIRSTKAntithromboticDay2_1_0_000 : ILibrary, ISingleton<CMS72FHIRSTKAntithromboticDay2_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS74FHIRDentalCariesPrevention-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS74FHIRDentalCariesPrevention", "1.0.000")]
 public partial class CMS74FHIRDentalCariesPrevention_1_0_000 : ILibrary, ISingleton<CMS74FHIRDentalCariesPrevention_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS75FHIRChildrenDentalDecay-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS75FHIRChildrenDentalDecay", "1.0.000")]
 public partial class CMS75FHIRChildrenDentalDecay_1_0_000 : ILibrary, ISingleton<CMS75FHIRChildrenDentalDecay_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS771FHIRUrinarySymptomScoreBPH-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS771FHIRUrinarySymptomScoreBPH", "1.0.000")]
 public partial class CMS771FHIRUrinarySymptomScoreBPH_1_0_000 : ILibrary, ISingleton<CMS771FHIRUrinarySymptomScoreBPH_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS816FHIRHHHypo-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS816FHIRHHHypo", "1.0.000")]
 public partial class CMS816FHIRHHHypo_1_0_000 : ILibrary, ISingleton<CMS816FHIRHHHypo_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS819FHIRHHORAE-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS819FHIRHHORAE", "1.0.000")]
 public partial class CMS819FHIRHHORAE_1_0_000 : ILibrary, ISingleton<CMS819FHIRHHORAE_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS826FHIRHHPI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS826FHIRHHPI", "1.0.000")]
 public partial class CMS826FHIRHHPI_1_0_000 : ILibrary, ISingleton<CMS826FHIRHHPI_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS832FHIRHHAKI-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS832FHIRHHAKI", "1.0.000")]
 public partial class CMS832FHIRHHAKI_1_0_000 : ILibrary, ISingleton<CMS832FHIRHHAKI_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS871FHIRHHHyper-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS871FHIRHHHyper", "1.0.000")]
 public partial class CMS871FHIRHHHyper_1_0_000 : ILibrary, ISingleton<CMS871FHIRHHHyper_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS90FHIRFSAforHeartFailure-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS90FHIRFSAforHeartFailure", "1.0.000")]
 public partial class CMS90FHIRFSAforHeartFailure_1_0_000 : ILibrary, ISingleton<CMS90FHIRFSAforHeartFailure_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS951FHIRKidneyHealthEval-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS951FHIRKidneyHealthEval", "1.0.000")]
 public partial class CMS951FHIRKidneyHealthEval_1_0_000 : ILibrary, ISingleton<CMS951FHIRKidneyHealthEval_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS986FHIRMalnutritionScore-1.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS986FHIRMalnutritionScore", "1.0.000")]
 public partial class CMS986FHIRMalnutritionScore_1_0_000 : ILibrary, ISingleton<CMS986FHIRMalnutritionScore_1_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMS996FHIRAptTxforSTEMI-2.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMS996FHIRAptTxforSTEMI", "2.0.000")]
 public partial class CMS996FHIRAptTxforSTEMI_2_0_000 : ILibrary, ISingleton<CMS996FHIRAptTxforSTEMI_2_0_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR529HybridHospitalWideReadmission-0.5.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMSFHIR529HybridHospitalWideReadmission", "0.5.001")]
 public partial class CMSFHIR529HybridHospitalWideReadmission_0_5_001 : ILibrary, ISingleton<CMSFHIR529HybridHospitalWideReadmission_0_5_001>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/cms/CMSFHIR844HybridHospitalWideMortality-0.5.001.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CMSFHIR844HybridHospitalWideMortality", "0.5.001")]
 public partial class CMSFHIR844HybridHospitalWideMortality_0_5_001 : ILibrary, ISingleton<CMSFHIR844HybridHospitalWideMortality_0_5_001>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/CQMCommon-4.1.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("CQMCommon", "4.1.000")]
 public partial class CQMCommon_4_1_000 : ILibrary, ISingleton<CQMCommon_4_1_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/FHIRHelpers-4.4.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("FHIRHelpers", "4.4.000")]
 public partial class FHIRHelpers_4_4_000 : ILibrary, ISingleton<FHIRHelpers_4_4_000>
 {

--- a/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
+++ b/Demo/Measures.dqm-content-qicore-2025/CSharp/lib/QICoreCommon-4.0.000.g.cs
@@ -12,7 +12,7 @@ using Hl7.Fhir.Model;
 using Range = Hl7.Fhir.Model.Range;
 using Task = Hl7.Fhir.Model.Task;
 
-[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.0.0")]
+[System.CodeDom.Compiler.GeneratedCode(".NET Code Generation", "5.1.1.0")]
 [CqlLibrary("QICoreCommon", "4.0.000")]
 public partial class QICoreCommon_4_0_000 : ILibrary, ISingleton<QICoreCommon_4_0_000>
 {

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -2,9 +2,11 @@
 
 ## Breaking Changes
 
+- **#1313** — Removed the `where T : class` constraint from `ICqlOperators.Coalesce<T>`. External implementations of `ICqlOperators` must remove the constraint from their `Coalesce<T>` implementation. `ICqlOperators.CoalesceValueTypes<T>` is now deprecated (`[Obsolete]`); use `Coalesce<T>` with `T = Nullable<U>` (e.g. `Coalesce<int?>`) instead.
+
 ## Features
 
 ## Fixes
 
 - **#1305** — Added `PowerResultTypeCorrector` to the ELM library preprocessor pipeline. This corrects a compatibility issue with externally-provided ELM produced by the Java `cql2elm` translator, which incorrectly stamps `Power` nodes with an `Integer` or `Long` result type when both operands are integer-typed. The preprocessor now normalizes all `Power` node result types to `Decimal` before expression binding, matching the CQL specification. Our own `CqlToElm` translator was already correct and is unaffected.
-- **#1307** — Fixed `CS0452` compilation failures in generated C# when coalescing lists of nullable value tuples. The operator binder now resolves the actual list element type via the type resolver (instead of naively taking the first generic type argument), so value-type elements — including nullable value tuples — bind to `ICqlOperators.CoalesceValueTypes<T>` rather than the class-constrained `Coalesce<T>` overload.
+- **#1307 / #1313** — Fixed `CS0452` compilation failures in generated C# when coalescing lists of nullable value tuples. The `where T : class` constraint on `ICqlOperators.Coalesce<T>` was removed and the operator binder now always binds `Coalesce<T>` using the actual list element type resolved via the type resolver (for nullable value types, `T` is the nullable type itself, e.g. `Coalesce<int?>`, preserving CQL null semantics). `CoalesceValueTypes<T>` is deprecated and no longer emitted by the binder.


### PR DESCRIPTION
Fixes #1313

## Summary

Consolidates CQL `Coalesce` binding onto a single unconstrained `ICqlOperators.Coalesce<T>` operator and deprecates `CoalesceValueTypes<T>`. This eliminates the CS0452 compile errors that occurred when packaging HEDIS 2025 content (coalesce over lists of nullable value tuples) and removes the dual-overload split that caused them.

## Changes

### Runtime (`Cql.Runtime`)
- Removed the `where T : class` constraint from `ICqlOperators.Coalesce<T>`; nullable value types now bind with `T = Nullable<U>`, preserving CQL null semantics (`source.FirstOrDefault(t => t != null)`).
- Marked `CoalesceValueTypes<T>` as `[Obsolete]` on both the interface and the `CqlOperators` implementation. It is retained (non-error) for backward compatibility with previously generated assemblies.
- Corrected XML docs on `Coalesce<T>` to document the `T = Nullable<U>` convention.

### Compiler (`Cql.Compiler`)
- `CqlOperatorsBinder.Coalesce` no longer extracts the underlying type from `Nullable<T>` element types and no longer routes value types to `CoalesceValueTypes`. It always binds `Coalesce<T>` with the list's element type as-is.

### Code generation versioning
- Bumped `GeneratorToolVersion` from `5.1.0.0` to `5.1.1.0`, since the binder change alters emitted C# (`Coalesce<T>` instead of `CoalesceValueTypes<T>`).
- `LibraryInstanceInvoker_5_0` supports `[5.1.0.0, 5.2.0.0)`, so no invoker change is required.
- Regenerated all checked-in `*.g.cs` files (145 files now carry `5.1.1.0`; zero remaining references to `CoalesceValueTypes`).

### Tests (`CoreTests`)
- Added/restored binder regression tests:
  - `CoalesceOnStringList_UsesCoalesce` — reference types still bind `Coalesce<T>`.
  - `CoalesceOnNullableValueTupleList_UsesCoalesceWithNullableElementType` — `(int?, int?, DateOnly?)?` binds `Coalesce<T>` with the nullable tuple type.
  - `CoalesceOnHedisNullableTupleList_UsesCoalesceWithNullableElementType` — HEDIS-shaped tuple (`CqlTupleMetadata`-tagged) binds correctly.

### Docs & process
- Release notes: breaking-change entry for external `ICqlOperators` implementers (constraint removal + `CoalesceValueTypes` deprecation) and fix entry for #1307 / #1313.
- Copilot instructions: binder/compiler changes that alter generated C# now require a `GeneratorToolVersion` bump and regeneration of checked-in `*.g.cs` in the same PR.

## Breaking change

External implementers of `ICqlOperators` must remove the `where T : class` constraint from their `Coalesce<T>` implementation. `CoalesceValueTypes<T>` is deprecated but still present, so previously generated assemblies continue to run.

## Validation

- **CoreTests**: 708 passed on both `net8.0` and `net10.0`, 0 failures.
- **HEDIS 2025 packaging** (real-world repro from #1313): 382 libraries, 160 measures, 382 generated C# files, 382 DLLs — zero CS0452, zero compilation errors.
- **Full regeneration build**: `Cql-Sdk-All.sln` Release with `ElmToolingEnabled=true` succeeded (0 errors); all regenerated output verified at generator version `5.1.1.0`.
