### PR TITLE
Optimize RunLibrary/SelectResults hot path: value set fast path, direct-delegate invoker, cache tuning (-40%)

### DIFF
--- a/Cql/CoreTests/CacheTest.cs
+++ b/Cql/CoreTests/CacheTest.cs
@@ -294,4 +294,53 @@ public class CacheTest
         Assert.AreEqual(3, ((ICqlContextInternals)ctx).CacheMisses, "All calls should be misses without cache");
         Assert.AreEqual(0, ((ICqlContextInternals)ctx).CacheHits, "Should have no hits without cache");
     }
+
+    [TestMethod]
+    public void Cache_UseNewCacheWithCustomCapacity_ShouldCacheResults()
+    {
+        // Arrange
+        var ctx = FhirCqlContext.ForBundle();
+        ctx.UseNewCache(initialCapacity: 64);
+        var lib = CqlNestedTupleTest_1_0_0.Instance;
+
+        // Act - Call the same expression twice
+        var result1 = lib.Result(ctx);
+        var result2 = lib.Result(ctx);
+
+        // Assert - Caching still works with a non-default capacity
+        Assert.IsNotNull(result1);
+        Assert.IsNotNull(result2);
+        Assert.AreEqual(result1, result2);
+    }
+
+    [TestMethod]
+    public void Cache_UseNewCacheWithMinimumCapacity_ShouldSucceed()
+    {
+        // Arrange
+        var ctx = FhirCqlContext.ForBundle();
+
+        // Act - The minimum accepted capacity should not throw
+        ctx.UseNewCache(initialCapacity: CqlContext.MinimumCacheInitialCapacity);
+        var lib = CqlNestedTupleTest_1_0_0.Instance;
+        var result1 = lib.Result(ctx);
+        var result2 = lib.Result(ctx);
+
+        // Assert
+        Assert.AreEqual(result1, result2);
+    }
+
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void Cache_UseNewCacheWithTooSmallCapacity_ShouldThrow(int initialCapacity)
+    {
+        // Arrange
+        var ctx = FhirCqlContext.ForBundle();
+
+        // Act & Assert
+        var ex = Assert.ThrowsException<ArgumentOutOfRangeException>(() => ctx.UseNewCache(initialCapacity));
+        Assert.AreEqual("initialCapacity", ex.ParamName);
+    }
 }

--- a/Cql/Cql.Firely/ValueSetSource.cs
+++ b/Cql/Cql.Firely/ValueSetSource.cs
@@ -151,7 +151,15 @@ public class ValueSetSource : IValueSetDictionary
         Predicate<IValueSetFacade> @internal,
         Action<ValidateCodeParameters> external)
     {
-        if (TaskHelper.Await(() => Load(valueSetUri)) is { } vs && @internal(vs)) return true;
+        // Fast path: a warm cache hit does not need the sync-over-async machinery in Load.
+        if (_valueSets.TryGetValue(valueSetUri, out var cached))
+        {
+            if (@internal(cached)) return true;
+        }
+        else if (TaskHelper.Await(() => Load(valueSetUri)) is { } vs && @internal(vs))
+        {
+            return true;
+        }
 
         if (_termService is null) return false;
 
@@ -166,6 +174,13 @@ public class ValueSetSource : IValueSetDictionary
     /// <inheritdoc />
     public bool TryGetCodesInValueSet(string valueSetUri, out IEnumerable<CqlCode>? codes)
     {
+        // Fast path: a warm cache hit does not need the sync-over-async machinery in Load.
+        if (_valueSets.TryGetValue(valueSetUri, out var cachedValueSet))
+        {
+            codes = cachedValueSet;
+            return true;
+        }
+
         codes = TaskHelper.Await(() => Load(valueSetUri));
         if (codes is not null) return true;
 

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
@@ -88,6 +88,8 @@ file sealed class DefinitionInvoker_5_0(
     methodInfo.GetCustomAttributes<CqlTagAttribute>()
               .ToArray())
 {
+    private readonly Func<CqlContext, object?[], object?> _compiledInvoker = CreateInvoker(library, methodInfo);
+
     public static (bool success, DefinitionInvoker definitionInvoker) TryCreate(
         ILibrary library,
         LibraryInvoker libraryInvoker,
@@ -101,16 +103,101 @@ file sealed class DefinitionInvoker_5_0(
         return (true, definitionInvoker);
     }
 
-    public override object? Invoke(CqlContext cqlContext, params object?[] args)
+    public override object? Invoke(CqlContext cqlContext, params object?[] args) =>
+        _compiledInvoker(cqlContext, args);
+
+    /// <summary>
+    /// Creates a delegate that directly calls the definition method on the library instance,
+    /// avoiding the per-invocation overhead of <see cref="MethodBase.Invoke(object?, object?[])"/>.
+    /// For common arities a strongly-typed delegate is bound via <see cref="MethodInfo.CreateDelegate{T}(object?)"/>
+    /// (a direct call, no IL generation); other shapes fall back to a compiled expression tree.
+    /// The delegate is created once per definition when the invoker is constructed.
+    /// Exceptions thrown by the definition propagate unwrapped, matching the previous
+    /// <see cref="BindingFlags.DoNotWrapExceptions"/> behavior.
+    /// </summary>
+    private static Func<CqlContext, object?[], object?> CreateInvoker(ILibrary library, MethodInfo methodInfo)
     {
-        object?[] methodArgs = args is { Length: > 0 }
-                             ? [cqlContext, ..args]
-                             : [cqlContext];
-        return methodInfo.Invoke(
-            library,
-            BindingFlags.DoNotWrapExceptions,
-            null,
-            methodArgs,
-            CultureInfo.InvariantCulture);
+        var parameters = methodInfo.GetParameters();
+        if (methodInfo.ReturnType != typeof(void)
+            && parameters.Length is >= 1 and <= 5
+            && parameters[0].ParameterType == typeof(CqlContext))
+        {
+            var wrapperName = parameters.Length switch
+            {
+                1 => nameof(WrapArity0),
+                2 => nameof(WrapArity1),
+                3 => nameof(WrapArity2),
+                4 => nameof(WrapArity3),
+                _ => nameof(WrapArity4),
+            };
+            Type[] typeArguments = [.. parameters.Skip(1).Select(p => p.ParameterType), methodInfo.ReturnType];
+            var wrapper = typeof(DefinitionInvoker_5_0)
+                          .GetMethod(wrapperName, BindingFlags.NonPublic | BindingFlags.Static)!
+                          .MakeGenericMethod(typeArguments);
+            return (Func<CqlContext, object?[], object?>)wrapper.Invoke(null, [library, methodInfo])!;
+        }
+
+        return CompileInvoker(library, methodInfo);
+    }
+
+    private static Func<CqlContext, object?[], object?> WrapArity0<TResult>(ILibrary library, MethodInfo methodInfo)
+    {
+        var invoke = methodInfo.CreateDelegate<Func<CqlContext, TResult>>(library);
+        return (cqlContext, _) => invoke(cqlContext);
+    }
+
+    private static Func<CqlContext, object?[], object?> WrapArity1<T1, TResult>(ILibrary library, MethodInfo methodInfo)
+    {
+        var invoke = methodInfo.CreateDelegate<Func<CqlContext, T1, TResult>>(library);
+        return (cqlContext, args) => invoke(cqlContext, (T1)args[0]!);
+    }
+
+    private static Func<CqlContext, object?[], object?> WrapArity2<T1, T2, TResult>(ILibrary library, MethodInfo methodInfo)
+    {
+        var invoke = methodInfo.CreateDelegate<Func<CqlContext, T1, T2, TResult>>(library);
+        return (cqlContext, args) => invoke(cqlContext, (T1)args[0]!, (T2)args[1]!);
+    }
+
+    private static Func<CqlContext, object?[], object?> WrapArity3<T1, T2, T3, TResult>(ILibrary library, MethodInfo methodInfo)
+    {
+        var invoke = methodInfo.CreateDelegate<Func<CqlContext, T1, T2, T3, TResult>>(library);
+        return (cqlContext, args) => invoke(cqlContext, (T1)args[0]!, (T2)args[1]!, (T3)args[2]!);
+    }
+
+    private static Func<CqlContext, object?[], object?> WrapArity4<T1, T2, T3, T4, TResult>(ILibrary library, MethodInfo methodInfo)
+    {
+        var invoke = methodInfo.CreateDelegate<Func<CqlContext, T1, T2, T3, T4, TResult>>(library);
+        return (cqlContext, args) => invoke(cqlContext, (T1)args[0]!, (T2)args[1]!, (T3)args[2]!, (T4)args[3]!);
+    }
+
+    /// <summary>
+    /// Fallback for definition shapes not covered by the typed <c>WrapArityN</c> adapters:
+    /// compiles an expression tree that calls the definition directly.
+    /// </summary>
+    private static Func<CqlContext, object?[], object?> CompileInvoker(ILibrary library, MethodInfo methodInfo)
+    {
+        var parameters = methodInfo.GetParameters();
+        var cqlContextParameter = Expression.Parameter(typeof(CqlContext), "cqlContext");
+        var argsParameter = Expression.Parameter(typeof(object?[]), "args");
+
+        var callArguments = new Expression[parameters.Length];
+        callArguments[0] = parameters[0].ParameterType == typeof(CqlContext)
+            ? cqlContextParameter
+            : Expression.Convert(cqlContextParameter, parameters[0].ParameterType);
+        for (var i = 1; i < parameters.Length; i++)
+        {
+            callArguments[i] = Expression.Convert(
+                Expression.ArrayIndex(argsParameter, Expression.Constant(i - 1)),
+                parameters[i].ParameterType);
+        }
+
+        var call = Expression.Call(Expression.Constant(library), methodInfo, callArguments);
+        var body = methodInfo.ReturnType == typeof(void)
+            ? (Expression)Expression.Block(call, Expression.Constant(null, typeof(object)))
+            : Expression.Convert(call, typeof(object));
+
+        return Expression
+               .Lambda<Func<CqlContext, object?[], object?>>(body, cqlContextParameter, argsParameter)
+               .Compile();
     }
 }

--- a/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
+++ b/Cql/Cql.Invocation/Toolkit/Internal/LibraryInvoker.5.0.cs
@@ -134,7 +134,12 @@ file sealed class DefinitionInvoker_5_0(
             var wrapper = typeof(DefinitionInvoker_5_0)
                           .GetMethod(wrapperName, BindingFlags.NonPublic | BindingFlags.Static)!
                           .MakeGenericMethod(typeArguments);
-            return (Func<CqlContext, object?[], object?>)wrapper.Invoke(null, [library, methodInfo])!;
+            return (Func<CqlContext, object?[], object?>)wrapper.Invoke(
+                null,
+                BindingFlags.DoNotWrapExceptions,
+                binder: null,
+                parameters: [library, methodInfo],
+                culture: null)!;
         }
 
         return CompileInvoker(library, methodInfo);

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+*REMOVED*Hl7.Cql.Runtime.CqlContext.UseNewCache() -> void
+Hl7.Cql.Runtime.CqlContext.UseNewCache(int initialCapacity = 1024) -> void
+Hl7.Cql.Runtime.CqlContext.CacheInitialCapacity = 1024 -> int
+Hl7.Cql.Runtime.CqlContext.MinimumCacheInitialCapacity = 16 -> int

--- a/Cql/Cql.Runtime/Runtime/CqlContext.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlContext.cs
@@ -99,25 +99,44 @@ namespace Hl7.Cql.Runtime
         /// <summary>
         /// Invalidates the current cache, forcing subsequent operations to use fresh data.
         /// </summary>
+        /// <param name="initialCapacity">The initial capacity of the definition/expression memoization cache.
+        /// Sizing this to (an upper bound of) the number of definitions/expressions expected to be cached during
+        /// the evaluation avoids internal resizing of the cache. Must be at least <see cref="MinimumCacheInitialCapacity"/>.
+        /// Defaults to <see cref="CacheInitialCapacity"/>.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="initialCapacity"/> is less than
+        /// <see cref="MinimumCacheInitialCapacity"/>.</exception>
         /// <remarks>Call this method to clear any cached data and ensure that future operations do not use stale
         /// information. This is useful when the underlying data source has changed and the cache needs to be
         /// refreshed.</remarks>
-        public void UseNewCache()
+        public void UseNewCache(int initialCapacity = CacheInitialCapacity)
         {
+            if (initialCapacity < MinimumCacheInitialCapacity)
+                throw new ArgumentOutOfRangeException(
+                    nameof(initialCapacity),
+                    initialCapacity,
+                    $"The initial cache capacity must be at least {MinimumCacheInitialCapacity}.");
+
             // A fresh cache is populated by mostly-sequential definition evaluation, so use a single
             // lock (concurrencyLevel: 1) and pre-size it to avoid repeated resizes, which acquire
             // all internal locks and dominated the write cost with the default settings.
-            _cache = new ConcurrentDictionary<long, object?>(concurrencyLevel: 1, capacity: CacheInitialCapacity);
+            _cache = new ConcurrentDictionary<long, object?>(concurrencyLevel: 1, capacity: initialCapacity);
             _cacheCallCount = 0;
             _cacheFactoryInvocations = 0;
         }
 
         /// <summary>
-        /// The initial capacity of the definition/expression memoization cache. Sized to hold the
+        /// The default initial capacity of the definition/expression memoization cache. Sized to hold the
         /// cached results of a typical measure evaluation (all definitions across all libraries in
         /// a library set) without internal resizing.
         /// </summary>
-        private const int CacheInitialCapacity = 1024;
+        public const int CacheInitialCapacity = 1024;
+
+        /// <summary>
+        /// The smallest initial capacity accepted by <see cref="UseNewCache(int)"/>. Values below this are
+        /// rejected because they defeat the purpose of pre-sizing the cache: it would immediately need to be
+        /// resized as definitions/expressions are evaluated.
+        /// </summary>
+        public const int MinimumCacheInitialCapacity = 16;
 
         /// <summary>
         /// Disables caching for subsequent operations by resetting the cache state.

--- a/Cql/Cql.Runtime/Runtime/CqlContext.cs
+++ b/Cql/Cql.Runtime/Runtime/CqlContext.cs
@@ -104,10 +104,20 @@ namespace Hl7.Cql.Runtime
         /// refreshed.</remarks>
         public void UseNewCache()
         {
-            _cache = new ConcurrentDictionary<long, object?>();
+            // A fresh cache is populated by mostly-sequential definition evaluation, so use a single
+            // lock (concurrencyLevel: 1) and pre-size it to avoid repeated resizes, which acquire
+            // all internal locks and dominated the write cost with the default settings.
+            _cache = new ConcurrentDictionary<long, object?>(concurrencyLevel: 1, capacity: CacheInitialCapacity);
             _cacheCallCount = 0;
             _cacheFactoryInvocations = 0;
         }
+
+        /// <summary>
+        /// The initial capacity of the definition/expression memoization cache. Sized to hold the
+        /// cached results of a typical measure evaluation (all definitions across all libraries in
+        /// a library set) without internal resizing.
+        /// </summary>
+        private const int CacheInitialCapacity = 1024;
 
         /// <summary>
         /// Disables caching for subsequent operations by resetting the cache state.


### PR DESCRIPTION
Addresses #1322 — implements the top-ranked fixes from the RunLibrary/SelectResults hot-path profiling investigation.
Related IntegrationRunner PR https://github.com/FirelyTeam/Firely.Cql.Sdk.Integration.Runner/pull/99

## Primary Work

### Issue item 1 — `ValueSetSource` synchronous fast path (~48% of evaluation CPU removed)

`CheckInternalAndExternalTs` called `TaskHelper.Await(() => Load(valueSetUri))` for **every code-membership check**. `TaskHelper.Await` wraps the call in `Task.Run(...)` and blocks, so even a 100% warm cache hit paid for a lambda allocation, a thread-pool dispatch, `Task.InternalWait`, and spin/lock waits — all to perform what is ultimately a `ConcurrentDictionary.TryGetValue`.

`CheckInternalAndExternalTs` and `TryGetCodesInValueSet` now check `_valueSets.TryGetValue` synchronously before falling back to the async `Load` path. The external terminology service fallback and resolver semantics are unchanged.

### Issue item 3 — Direct-delegate definition invocation (Option B2, ~30% reflection overhead removed)

`DefinitionInvoker_5_0.Invoke` dispatched through `MethodInfo.Invoke` (reflection) for every definition invocation, including an args-array copy per call.

It now binds a strongly-typed delegate once per definition at invoker construction:

- For the common shapes (`CqlContext` + 0–4 typed arguments, non-void return) it uses `MethodInfo.CreateDelegate` through small generic `WrapArityN` adapters — a direct call, no IL generation, AOT/trimming friendly.
- Other shapes fall back to a compiled expression tree.
- Exceptions still propagate unwrapped, matching the previous `BindingFlags.DoNotWrapExceptions` behavior — including during adapter construction itself, where the `WrapArityN` binder is invoked via the `MethodBase.Invoke` overload with `BindingFlags.DoNotWrapExceptions` so a `CreateDelegate` failure for an unexpected method shape isn't masked by a `TargetInvocationException`.

Design decision (documented in #1322, item 3): a generated `InvokeDefinition` switch per library (Option A) was considered but rejected — it requires a `GeneratorToolVersion` bump and cannot dispatch overloaded CQL functions by name alone. A generated signature-keyed dispatch table (Option C) is the planned follow-up when a generator version bump is warranted.

### Issue item 4 — Memoization cache tuning (~2%)

`CqlContext.UseNewCache()` created a `ConcurrentDictionary<long, object?>` with default settings (lock per CPU, capacity 31). A fresh cache is created per evaluation, so every definition is a cache write, and growth resizes acquire all internal locks. The cache is now created with `concurrencyLevel: 1` and pre-sized to 1024 entries by default. The thread-safety contract is unchanged.

`UseNewCache` now also accepts an optional `initialCapacity` parameter so callers with library sets that are much larger or smaller than the default assumption can tune the pre-sizing themselves, with a public `MinimumCacheInitialCapacity` (16) enforced to guard against values too small to benefit from pre-sizing at all.

## Performance Results

Benchmark: `IntegrationRunner.Benchmarks --direct-runlibrary 8b33d091 <N>` (CMS156FHIRHighRiskMedsElderly, slowest warm case), Release, net10.0, same machine/session. Each iteration = `FhirCqlContext.ForBundle` + `CqlLibraryRunner.RunLibrary` with the bundle preloaded outside the loop. Comparisons use equal iteration counts.

### 30,000 iterations (steady state)

| Step | Change | Total | ms/iter | vs baseline |
|---|---|---|---|---|
| 0 | Baseline (develop) | 8.054 s | 0.268 | — |
| 1 | ValueSetSource fast path + CreateDelegate invoker | 4.898 s | 0.163 | **-39.2% (1.64×)** |
| 2 | + cache tuning | 4.790 s | 0.160 | **-40.3% (1.68×)** |

### 10,000 iterations (includes proportionally more JIT warmup)

| Step | Change | Total | ms/iter | vs baseline |
|---|---|---|---|---|
| 0 | Baseline | 4.367 s | 0.437 | — |
| 1 | ValueSetSource fast path + CreateDelegate invoker | 2.515 s | 0.251 | **-42.6% (1.74×)** |
| 2 | + cache tuning | 2.560 s | 0.256 | -41.4% (within noise of step 1) |

### Profile before/after (CPU samples under `CqlLibraryRunner.RunLibrary`, 30k-iteration traces)

| Cost | Baseline share | After |
|---|---|---|
| `ValueSetSource.CheckInternalAndExternalTs` (sync-over-async) | ~48% | not visible |
| Reflection `MethodBase.Invoke` dispatch | ~30% | near-zero (adapter frames only) |
| `IndexedBundle.FilterByType` + `ToCodings` | ~54% incl. (mostly the value set checks) | ~12% |
| `ConcurrentDictionary` cache writes + `Monitor` | ~22% | reduced (residual overlaps GC poll) |

After these changes the profile is dominated by genuine CQL semantic work (`SelectResults` enumeration/`ToList`, `CqlOperators.Where`/`Union`, generated definition bodies) rather than infrastructure overhead.

## Validation

- IntegrationRunner: **2369 passed, 0 failed** (1488 skipped = not in passes file) — identical to baseline.
- CoreTests: **715 passed, 0 failed, 9 skipped** — identical to baseline; added coverage in `CacheTest.cs` for the new `UseNewCache(initialCapacity)` parameter (default/custom/minimum-boundary/too-small cases).
- Profiling methodology: `dotnet-trace` (`Microsoft-DotNETCore-SampleProfiler`) + speedscope subtree analysis rooted at `CqlLibraryRunner.RunLibrary`.

## Not implemented in this PR (tracked in #1322)

- **Issue item 2** — `IndexedBundle` coding caching / per-retrieve value set facade resolution: not implemented here; residual ~12% after the item 1 fast path landed (down from ~54% inclusive, most of which was item 1's overhead flowing through this path). Confirmed with a fresh, independent re-profile on the current branch state (30k-iteration `--direct-runlibrary` trace, same CMS156 case): total sampled CPU under `RunLibrary` dropped from 5.0 s (baseline) to 3.0 s, of which `IndexedBundle.FilterByType`'s enumeration (inclusive of `ICoded.ToCodings()`) accounts for ~13% (0.4 s) — consistent with the original ~12% estimate and not affected by the item 3/4 changes. `ValueSetSource.CheckInternalAndExternalTs` no longer registers in the profile at all, confirming the item 1 fast path holds up. Deferred pending a dedicated implementation pass.
- **Issue item 3, Option C** — generated signature-keyed dispatch table on library classes: not implemented here (Option B2 was implemented instead, see above). Deferred until a `GeneratorToolVersion` bump is warranted.
- **Issue item 5** — `CqlOperators.Union` cost (~36% of baseline samples): not implemented; the issue marks this as largely inherent CQL semantic work, not overhead, and recommends no action unless it remains a top cost after items 1–4 are re-profiled.

---

## Auxiliary Work

- Updated the `Firely.Cql.Sdk.Integration.Runner` submodule pointer to include the `--direct-runlibrary` profiling harness used to produce the measurements above (FirelyTeam/Firely.Cql.Sdk.Integration.Runner#99).

## Review Feedback Addressed

- **Copilot**: adapter construction (`CreateInvoker`'s `WrapArityN` binder call) could mask exceptions in a `TargetInvocationException`. Fixed by invoking the binder via the `MethodBase.Invoke` overload with `BindingFlags.DoNotWrapExceptions`.
- **@alexzautke**: requested the memoization cache's initial capacity be configurable rather than a fixed constant. Added an optional `initialCapacity` parameter to `UseNewCache` (default unchanged) plus a validated `MinimumCacheInitialCapacity` floor, with unit test coverage.
