### PR TITLE
Update the next release package version from 2.9.0 to 2.9.1

### DIFF
--- a/Cql/Cql.Runtime/PublicAPI.Shipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Shipped.txt
@@ -712,7 +712,6 @@ virtual Hl7.Cql.Runtime.Parsing.CqlParseErrorHandler.Invoke(Hl7.Cql.Runtime.Pars
 ~override Hl7.Cql.Runtime.DefinitionSignature.Equals(object obj) -> bool
 ~override Hl7.Cql.Runtime.Parsing.CqlParseError.Equals(object obj) -> bool
 Hl7.Cql.Runtime.CqlContext.DontUseCaching() -> void
-Hl7.Cql.Runtime.CqlContext.UseNewCache() -> void
 Hl7.Cql.Runtime.Defaults
 static Hl7.Cql.Runtime.Defaults.EnumerationOptionsRecurseSubdirectories.get -> System.IO.EnumerationOptions!
 Hl7.Cql.Runtime.IO.DirectoryPostProcessingStrategy
@@ -722,3 +721,6 @@ Hl7.Cql.Toolkit.SubdirectoryPreserver.SubdirectoryPreserver() -> void
 
 
 Hl7.Cql.Runtime.CqlContext.GetOrCompute<T>(long cacheKey, System.Func<Hl7.Cql.Runtime.CqlContext!, T>! factory) -> T
+Hl7.Cql.Runtime.CqlContext.UseNewCache(int initialCapacity = 1024) -> void
+const Hl7.Cql.Runtime.CqlContext.CacheInitialCapacity = 1024 -> int
+const Hl7.Cql.Runtime.CqlContext.MinimumCacheInitialCapacity = 16 -> int

--- a/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
+++ b/Cql/Cql.Runtime/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-*REMOVED*Hl7.Cql.Runtime.CqlContext.UseNewCache() -> void
-Hl7.Cql.Runtime.CqlContext.UseNewCache(int initialCapacity = 1024) -> void
-Hl7.Cql.Runtime.CqlContext.CacheInitialCapacity = 1024 -> int
-Hl7.Cql.Runtime.CqlContext.MinimumCacheInitialCapacity = 16 -> int

--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -6,7 +6,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 			-->
-		<VersionPrefix>2.9.0</VersionPrefix>
+		<VersionPrefix>2.9.1</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<!--

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The SDK targets **.NET 8 (LTS)** and **.NET 10 (LTS)** to provide optimal perfor
 
 ## Release Notes
 
-This is release version 2.9.0 of the engine.
+This is release version 2.9.1 of the engine.
 
 The release notes at [firely-cql-sdk/releases](https://github.com/FirelyTeam/firely-cql-sdk/releases) for each major version document changes and known issues.
 

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -23,7 +23,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 		-->
-		<VersionPrefix>2.9.0</VersionPrefix>
+		<VersionPrefix>2.9.1</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>

--- a/docs/releases/release-notes-2.9.1.md
+++ b/docs/releases/release-notes-2.9.1.md
@@ -69,3 +69,4 @@
 | [#1317](https://github.com/FirelyTeam/firely-cql-sdk/pull/1317) | Collapse single-type ELM choice types to concrete type                                    |
 | [#1323](https://github.com/FirelyTeam/firely-cql-sdk/pull/1323) | Optimize RunLibrary/SelectResults hot path: value set fast path, direct-delegate invoker, cache tuning (-40%) |
 | [#1327](https://github.com/FirelyTeam/firely-cql-sdk/pull/1327) | Fix O(n²) Distinct and comparer dispatch hot paths (#1324)                                |
+| [#1330](https://github.com/FirelyTeam/firely-cql-sdk/pull/1330) | Update the next release package version from 2.9.0 to 2.9.1 (#1329)                       |

--- a/docs/releases/release-notes-2.9.1.md
+++ b/docs/releases/release-notes-2.9.1.md
@@ -1,0 +1,71 @@
+## Firely CQL SDK 2.9.1
+
+### tl;dr
+
+> **Upgrading?** Here is the short version:
+>
+> - **Breaking changes:** None.
+> - **Required migrations:** None.
+> - **Highlights:** Significant runtime performance improvements to `RunLibrary`/`SelectResults` and to `CqlComparers`/`CqlOperators` (notably `Distinct`), plus a fix for ELM choice-type handling in generated code. This release contains no correctness or behavior changes to CQL evaluation results.
+
+---
+
+### CQL SDK
+
+#### New Public API
+
+- None.
+
+#### Improvements
+
+- Optimized the `RunLibrary`/`SelectResults` hot path with a value-set fast path, a direct-delegate invoker, and cache tuning, reducing evaluation overhead by roughly 40% in benchmarks (#1322, #1323).
+- Fixed O(n²) hot paths in `CqlComparers`/`CqlOperators`: `Distinct` now uses a `HashSet`-based O(n) algorithm instead of repeated `List.Contains` scans, comparer type-resolution is memoized instead of re-walking base types on every call, boxing was removed from equality fast paths, and `CqlConcept` comparisons cache their sorted code arrays instead of re-sorting on every `Compare` (#1324, #1327).
+- The C# compiler now collapses ELM choice types whose alternatives all map to the same .NET type (e.g. `Choice<Condition, Condition>` produced for unions of QiCore Condition profiles) to that single type instead of `object`. Generated code stays strongly typed and no longer falls back to late-bound property access (seen in e.g. CMS125 "Right Mastectomy Diagnosis"). The generator tool version was bumped to 5.1.2.0 and the checked-in generated libraries were regenerated (#1317).
+
+#### Dependency Updates
+
+- None.
+
+#### Potentially Breaking
+
+- None.
+
+---
+
+### CQL Packager
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- None.
+
+---
+
+### Demo Projects and Build Tooling
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- None.
+
+---
+
+### Upgrade Checklist
+
+- No action required. This release is fully backward compatible with 2.9.0.
+
+---
+
+### Pull Requests
+
+| PR                                                              | Title                                                                                    |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [#1317](https://github.com/FirelyTeam/firely-cql-sdk/pull/1317) | Collapse single-type ELM choice types to concrete type                                    |
+| [#1323](https://github.com/FirelyTeam/firely-cql-sdk/pull/1323) | Optimize RunLibrary/SelectResults hot path: value set fast path, direct-delegate invoker, cache tuning (-40%) |
+| [#1327](https://github.com/FirelyTeam/firely-cql-sdk/pull/1327) | Fix O(n²) Distinct and comparer dispatch hot paths (#1324)                                |

--- a/docs/releases/release-notes-2.9.1.md
+++ b/docs/releases/release-notes-2.9.1.md
@@ -6,7 +6,7 @@
 >
 > - **Breaking changes:** The CQL Packager's default fixed canonical URL for `FHIRHelpers` changed from `https://fhir.org/guides/cqf/common/Library/FHIRHelpers` to `http://hl7.org/fhir/uv/cql/Library/FHIRHelpers`.
 > - **Required migrations:** If you rely on the Packager's previous default `FHIRHelpers` canonical, set it explicitly via `FixedLibraryCanonicals` in your Packager configuration.
-> - **Highlights:** Significant runtime performance improvements to `RunLibrary`/`SelectResults` and to `CqlComparers`/`CqlOperators` (notably `Distinct`), plus a fix for ELM choice-type handling in generated code. Aside from the `FHIRHelpers` canonical default noted above, this release contains no correctness or behavior changes to CQL evaluation results.
+> - **Highlights:** Significant runtime performance improvements to `RunLibrary`/`SelectResults` and to `CqlComparers`/`CqlOperators` (notably `Distinct`), a fix for ELM choice-type handling in generated code, and an update of the Firely .NET SDK dependency to 6.2.1. Aside from the `FHIRHelpers` canonical default noted above, this release contains no correctness or behavior changes to CQL evaluation results.
 
 ---
 
@@ -24,7 +24,7 @@
 
 #### Dependency Updates
 
-- None.
+- Bumped the Firely .NET SDK (`Hl7.Fhir.Base`/`Hl7.Fhir.R4`) dependency from 6.2.0 to 6.2.1 (#1320).
 
 #### Potentially Breaking
 
@@ -68,6 +68,7 @@
 | PR                                                              | Title                                                                                    |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | [#1312](https://github.com/FirelyTeam/firely-cql-sdk/pull/1312) | Update default FHIRHelpers canonical URL to hl7.org/fhir/uv/cql                            |
+| [#1320](https://github.com/FirelyTeam/firely-cql-sdk/pull/1320) | Update Firely .NET SDK to v6.2.1                                                           |
 | [#1317](https://github.com/FirelyTeam/firely-cql-sdk/pull/1317) | Collapse single-type ELM choice types to concrete type                                    |
 | [#1323](https://github.com/FirelyTeam/firely-cql-sdk/pull/1323) | Optimize RunLibrary/SelectResults hot path: value set fast path, direct-delegate invoker, cache tuning (-40%) |
 | [#1327](https://github.com/FirelyTeam/firely-cql-sdk/pull/1327) | Fix O(n²) Distinct and comparer dispatch hot paths (#1324)                                |

--- a/docs/releases/release-notes-2.9.1.md
+++ b/docs/releases/release-notes-2.9.1.md
@@ -4,9 +4,9 @@
 
 > **Upgrading?** Here is the short version:
 >
-> - **Breaking changes:** None.
-> - **Required migrations:** None.
-> - **Highlights:** Significant runtime performance improvements to `RunLibrary`/`SelectResults` and to `CqlComparers`/`CqlOperators` (notably `Distinct`), plus a fix for ELM choice-type handling in generated code. This release contains no correctness or behavior changes to CQL evaluation results.
+> - **Breaking changes:** The CQL Packager's default fixed canonical URL for `FHIRHelpers` changed from `https://fhir.org/guides/cqf/common/Library/FHIRHelpers` to `http://hl7.org/fhir/uv/cql/Library/FHIRHelpers`.
+> - **Required migrations:** If you rely on the Packager's previous default `FHIRHelpers` canonical, set it explicitly via `FixedLibraryCanonicals` in your Packager configuration.
+> - **Highlights:** Significant runtime performance improvements to `RunLibrary`/`SelectResults` and to `CqlComparers`/`CqlOperators` (notably `Distinct`), plus a fix for ELM choice-type handling in generated code. Aside from the `FHIRHelpers` canonical default noted above, this release contains no correctness or behavior changes to CQL evaluation results.
 
 ---
 
@@ -36,7 +36,7 @@
 
 #### Breaking
 
-- None.
+- Changed the default fixed canonical URL for `FHIRHelpers` from `https://fhir.org/guides/cqf/common/Library/FHIRHelpers` to `http://hl7.org/fhir/uv/cql/Library/FHIRHelpers` (the CQL IG canonical) in `PackagingToolkitConfig.CreateDefaultFixedLibraryCanonicals()`. The matching example in `Hl7.Cql.Packager.appsettings.json` was updated to stay consistent. If you depend on the previous default, override it explicitly via `FixedLibraryCanonicals` (#1312).
 
 #### Improvements
 
@@ -58,7 +58,8 @@
 
 ### Upgrade Checklist
 
-- No action required. This release is fully backward compatible with 2.9.0.
+1. If your build relies on the Packager's previous default `FHIRHelpers` fixed canonical (`https://fhir.org/guides/cqf/common/Library/FHIRHelpers`), set it explicitly via `FixedLibraryCanonicals` in your Packager configuration — the default is now `http://hl7.org/fhir/uv/cql/Library/FHIRHelpers`.
+2. No other action required.
 
 ---
 
@@ -66,6 +67,7 @@
 
 | PR                                                              | Title                                                                                    |
 | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| [#1312](https://github.com/FirelyTeam/firely-cql-sdk/pull/1312) | Update default FHIRHelpers canonical URL to hl7.org/fhir/uv/cql                            |
 | [#1317](https://github.com/FirelyTeam/firely-cql-sdk/pull/1317) | Collapse single-type ELM choice types to concrete type                                    |
 | [#1323](https://github.com/FirelyTeam/firely-cql-sdk/pull/1323) | Optimize RunLibrary/SelectResults hot path: value set fast path, direct-delegate invoker, cache tuning (-40%) |
 | [#1327](https://github.com/FirelyTeam/firely-cql-sdk/pull/1327) | Fix O(n²) Distinct and comparer dispatch hot paths (#1324)                                |

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -4,11 +4,4 @@
 
 ## Features
 
-## Improvements
-
-- Optimized the `RunLibrary`/`SelectResults` hot path: replaced repeated dictionary/reflection lookups with cached delegates and reduced allocations on the definition-evaluation path (#1322, #1323).
-- Reduced allocations and removed several O(n²) patterns in `CqlComparers`/`CqlOperators`: `Distinct` now uses a `HashSet`-based O(n) algorithm instead of `List.Contains`, comparer type-resolution is memoized, boxing was removed from equality fast paths, and `CqlConcept` comparisons cache their sorted code arrays instead of re-sorting on every call (#1324, #1327).
-
 ## Fixes
-
-- The C# compiler now collapses ELM choice types whose alternatives all map to the same .NET type (e.g. `Choice<Condition, Condition>` produced for unions of QiCore Condition profiles) to that single type instead of `object`. Generated code stays strongly typed and no longer falls back to late-bound property access (seen in e.g. CMS125 "Right Mastectomy Diagnosis"). The generator tool version was bumped to 5.1.2.0 and the checked-in generated libraries were regenerated.

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -4,6 +4,11 @@
 
 ## Features
 
+## Improvements
+
+- Optimized the `RunLibrary`/`SelectResults` hot path: replaced repeated dictionary/reflection lookups with cached delegates and reduced allocations on the definition-evaluation path (#1322, #1323).
+- Reduced allocations and removed several O(n²) patterns in `CqlComparers`/`CqlOperators`: `Distinct` now uses a `HashSet`-based O(n) algorithm instead of `List.Contains`, comparer type-resolution is memoized, boxing was removed from equality fast paths, and `CqlConcept` comparisons cache their sorted code arrays instead of re-sorting on every call (#1324, #1327).
+
 ## Fixes
 
 - The C# compiler now collapses ELM choice types whose alternatives all map to the same .NET type (e.g. `Choice<Condition, Condition>` produced for unions of QiCore Condition profiles) to that single type instead of `object`. Generated code stays strongly typed and no longer falls back to late-bound property access (seen in e.g. CMS125 "Right Mastectomy Diagnosis"). The generator tool version was bumped to 5.1.2.0 and the checked-in generated libraries were regenerated.


### PR DESCRIPTION
## Primary Work
- Updated the next release package version from 2.9.0 to 2.9.1.
- Kept solution packaging configuration in sync by updating both shared props files:
  - cql-sdk.props
  - Demo/cql-demo.props
- Updated the README release-version reference to 2.9.1.
- Shipped the pending `Cql.Runtime` `PublicAPI.Unshipped.txt` entries (`CqlContext.UseNewCache(int)`, `CqlContext.CacheInitialCapacity`, `CqlContext.MinimumCacheInitialCapacity`) into `PublicAPI.Shipped.txt`.
- Added `docs/releases/release-notes-2.9.1.md`, summarizing the work merged since 2.9.0: the ELM choice-type collapse fix (#1317), the `RunLibrary`/`SelectResults` hot-path optimization (#1322/#1323), and the `CqlComparers`/`CqlOperators` O(n²) fixes (#1324/#1327).
- Drained the corresponding entries out of `docs/releases/vnext-release-notes.md`.
- This aligns repository version metadata with issue #1329.

---

## Auxiliary Work
- No functional code changes.
- No new public API surface (only shipping already-introduced API from Unshipped to Shipped).
- No behavior changes; packaging/version metadata and release notes only.

Closes #1329
