### PR TITLE
Set next release version to 2.9.2

### DIFF
--- a/Demo/cql-demo.props
+++ b/Demo/cql-demo.props
@@ -6,7 +6,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 			-->
-		<VersionPrefix>2.9.1</VersionPrefix>
+		<VersionPrefix>2.9.2</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<!--

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The SDK targets **.NET 8 (LTS)** and **.NET 10 (LTS)** to provide optimal perfor
 
 ## Release Notes
 
-This is release version 2.9.1 of the engine.
+This is release version 2.9.2 of the engine.
 
 The release notes at [firely-cql-sdk/releases](https://github.com/FirelyTeam/firely-cql-sdk/releases) for each major version document changes and known issues.
 

--- a/cql-sdk.props
+++ b/cql-sdk.props
@@ -23,7 +23,7 @@
 			## Instructions when updating VersionPrefix/VersionSuffix : https://github.com/FirelyTeam/firely-cql-sdk/wiki/Creating-Tags-and-Releases
 			Keep this in sync between cql-sdk.props and cql-demo.props
 		-->
-		<VersionPrefix>2.9.1</VersionPrefix>
+		<VersionPrefix>2.9.2</VersionPrefix>
 		<!-- <VersionSuffix>rc.1</VersionSuffix> -->
 
 		<Authors>NCQA, Firely (info@fire.ly) and contributors</Authors>

--- a/docs/releases/release-notes-2.9.2.md
+++ b/docs/releases/release-notes-2.9.2.md
@@ -66,3 +66,4 @@
 | ---------------------------------------------------------------- | --------------------------------------------------------------------- |
 | [#1335](https://github.com/FirelyTeam/firely-cql-sdk/pull/1335) | Upgrade cql-to-elm tooling: Java 3.29.0 -> Kotlin-based org.cqframework 4.0.0 |
 | [#1336](https://github.com/FirelyTeam/firely-cql-sdk/pull/1336) | Update Firely .NET SDK to 6.3.0                                        |
+| [#1338](https://github.com/FirelyTeam/firely-cql-sdk/pull/1338) | Set next release version to 2.9.2 (#1337)                              |

--- a/docs/releases/release-notes-2.9.2.md
+++ b/docs/releases/release-notes-2.9.2.md
@@ -1,0 +1,68 @@
+## Firely CQL SDK 2.9.2
+
+### tl;dr
+
+> **Upgrading?** Here is the short version:
+>
+> - **Breaking changes:** None.
+> - **Required migrations:** None.
+> - **Highlights:** Upgraded the Demo build pipeline's CQL-to-ELM tooling to the new Kotlin-based translator release, and bumped the Firely .NET SDK dependency to 6.3.0. No CQL-observable behavior changes.
+
+---
+
+### CQL SDK
+
+#### New Public API
+
+- None.
+
+#### Improvements
+
+- None.
+
+#### Dependency Updates
+
+- Bumped the Firely .NET SDK (`Hl7.Fhir.Base`/`Hl7.Fhir.R4`) dependency from 6.2.1 to 6.3.0 (#1336).
+
+#### Potentially Breaking
+
+- None.
+
+---
+
+### CQL Packager
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- None.
+
+---
+
+### Demo Projects and Build Tooling
+
+#### Breaking
+
+- None.
+
+#### Improvements
+
+- Upgraded the Maven-fetched CQL-to-ELM tooling used by the Demo build pipeline (`Demo/Cql/Build/pom.xml`, `Java-Dependencies-Vars.ps1`/`.sh`, `Hl7.Cql.Packager.Program.JavaToolVersion`) from `info.cqframework:cql-to-elm-cli`/`elm-fhir` `3.29.0` to `org.cqframework:cql-to-elm-cli`/`elm-fhir` `4.0.0`. The Maven groupId changed because upstream ([cqframework/clinical_quality_language](https://github.com/cqframework/clinical_quality_language)) rewrote its CQL-to-ELM translator from Java to Kotlin internally and renamed the groupId as part of that migration; the CLI is still a JVM application invoked the same way (`java -classpath ...`), so this is a version/groupId bump only. The generated ELM output is unchanged: regenerating every checked-in ELM fixture in this repo with the new tooling and diffing against the pre-upgrade output showed no differences beyond the `translatorVersion` annotation field and a couple of inconsequential JSON key reorderings. `CqlTooling.Targets.xml` also gained a small inline MSBuild task to re-indent the ELM JSON the new tooling produces, since the Kotlin-based CLI only emits compact (non-indented) JSON with no pretty-print option (#1333, #1335).
+
+---
+
+### Upgrade Checklist
+
+- No action required. This release is fully backward compatible with 2.9.1.
+
+---
+
+### Pull Requests
+
+| PR                                                              | Title                                                                    |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------- |
+| [#1335](https://github.com/FirelyTeam/firely-cql-sdk/pull/1335) | Upgrade cql-to-elm tooling: Java 3.29.0 -> Kotlin-based org.cqframework 4.0.0 |
+| [#1336](https://github.com/FirelyTeam/firely-cql-sdk/pull/1336) | Update Firely .NET SDK to 6.3.0                                        |

--- a/docs/releases/vnext-release-notes.md
+++ b/docs/releases/vnext-release-notes.md
@@ -4,8 +4,4 @@
 
 ## Features
 
-- Upgraded the Maven-fetched CQL-to-ELM tooling used by the Demo build pipeline (`Demo/Cql/Build/pom.xml`, `Java-Dependencies-Vars.ps1`/`.sh`, `Hl7.Cql.Packager.Program.JavaToolVersion`) from `info.cqframework:cql-to-elm-cli`/`elm-fhir` `3.29.0` to `org.cqframework:cql-to-elm-cli`/`elm-fhir` `4.0.0`. The Maven groupId changed because upstream ([cqframework/clinical_quality_language](https://github.com/cqframework/clinical_quality_language)) rewrote its CQL-to-ELM translator from Java to Kotlin (Kotlin Multiplatform) internally and renamed the groupId as part of that migration; the CLI is still a JVM application invoked the same way (`java -classpath ...`), so this is a version/groupId bump only, not a change to how we invoke it. **The generated ELM output is unchanged**: regenerating every checked-in ELM fixture in this repo with the new tooling and diffing against the pre-upgrade output showed no differences beyond the `translatorVersion` annotation field and a couple of inconsequential JSON key reorderings. `CqlTooling.Targets.xml` also gained a small inline MSBuild task to re-indent the ELM JSON the new tooling produces, since the Kotlin-based CLI only emits compact (non-indented) JSON with no pretty-print option.
-
 ## Fixes
-
-- Bumped the Firely .NET SDK (`Hl7.Fhir.Base`/`Hl7.Fhir.R4`) dependency from 6.2.1 to 6.3.0.


### PR DESCRIPTION
## Primary Work
- Updated the next release package version from 2.9.1 to 2.9.2.
- Kept solution packaging configuration in sync by updating both shared props files:
  - cql-sdk.props
  - Demo/cql-demo.props
- Updated the README release-version reference to 2.9.2.
- Added `docs/releases/release-notes-2.9.2.md`, summarizing the work merged since 2.9.1: the CQL-to-ELM tooling upgrade to the Kotlin-based `org.cqframework` 4.0.0 release (#1333/#1335) and the Firely .NET SDK bump to 6.3.0 (#1336).
- Drained the corresponding entries out of `docs/releases/vnext-release-notes.md`.
- This aligns repository version metadata with issue #1337.

---

## Auxiliary Work
- No functional code changes.
- No new public API surface.
- No behavior changes; packaging/version metadata and release notes only.

Closes #1337
