### PR TITLE
Port ExpressionBuilderContext onto the typed IR (phase 4)

### DIFF
--- a/Cql/Cql.Compiler/Ir/IrDefinition.cs
+++ b/Cql/Cql.Compiler/Ir/IrDefinition.cs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Abstractions.CqlDefinition"/>: the base class for the
+/// definitions the expression builder produces for a library (expressions, functions,
+/// parameters, codes, code systems, concepts and value sets).
+///
+/// <para>This is a mechanical port onto the typed IR (phase 4 of the Linq.Expressions removal,
+/// see <c>docs/linq-expression-removal-plan.md</c>). Unlike the old <c>CqlDefinition</c>, this
+/// class does <b>not</b> derive from <c>System.Linq.Expressions.Expression</c> — that base was
+/// only needed to host definitions inside expression trees, which the IR pipeline never does.
+/// Only the surface the builder actually writes/reads is mirrored.</para>
+/// </summary>
+internal abstract class IrDefinition(string name)
+{
+    public string Name { get; } = name;
+
+    public abstract Type ReturnType { get; }
+}
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Abstractions.CqlLambdaDefinition"/>: a definition whose
+/// body is a lambda (expression definitions, functions and parameters).
+/// </summary>
+internal abstract class IrLambdaDefinition(
+    IrLambda lambda,
+    string name) : IrDefinition(name)
+{
+    public IrLambda Lambda { get; } = lambda;
+
+    /// <summary>The <c>Func&lt;…&gt;</c> delegate type of <see cref="Lambda"/>, mirroring
+    /// <c>CqlLambdaDefinition.Type</c> (note: the IR lambda does not carry the implicit
+    /// <c>CqlContext</c> parameter the old <c>LambdaExpression</c> was prefixed with).</summary>
+    public Type Type => Lambda.Type;
+
+    public override Type ReturnType => Lambda.Body.Type;
+}
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.CqlExpressionDefinition"/>.
+/// </summary>
+internal class IrExpressionDefinition(
+    IrLambda lambda,
+    string name,
+    (string tagName, string[] tagValues)[]? tags = null)
+    : IrLambdaDefinition(lambda, name)
+{
+    public (string Name, string[] Values)[] Tags { get; } = tags ?? [];
+}
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.CqlFunctionDefinition"/>.
+/// </summary>
+internal class IrFunctionDefinition(
+    IrLambda lambda,
+    string name,
+    IReadOnlyDictionary<string, string>? originalParameterNames = null,
+    params (string tagName, string[] tagValues)[] tags) : IrExpressionDefinition(lambda, name, tags)
+{
+    /// <summary>
+    /// Gets a dictionary mapping normalized C# parameter names to their original CQL parameter names.
+    /// Only contains entries where the normalized name differs from the original name.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> OriginalParameterNames { get; } = originalParameterNames ?? ReadOnlyDictionary<string, string>.Empty;
+}
+
+/// <summary>
+/// IR counterpart of <see cref="CqlParameterDefinition"/>.
+/// </summary>
+internal class IrParameterDefinition(
+    IrLambda lambda,
+    string name)
+    : IrLambdaDefinition(lambda, name);
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.CqlCodeSystemDefinition"/>.
+/// </summary>
+internal class IrCodeSystemDefinition(
+    string name,
+    CqlCodeSystem codeSystem)
+    : IrDefinition(name)
+{
+    public CqlCodeSystem CodeSystem { get; } = codeSystem;
+    public override Type ReturnType => typeof(CqlCodeSystem);
+}
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.CqlConceptDefinition"/>.
+/// </summary>
+internal class IrConceptDefinition(
+    string name,
+    string? display,
+    IReadOnlyList<CqlCode> codes)
+    : IrDefinition(name)
+{
+    public string? Display { get; } = display;
+    public IReadOnlyList<CqlCode> Codes { get; } = codes;
+    public override Type ReturnType => typeof(CqlConcept);
+}
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.CqlCodeDefinition"/>.
+/// </summary>
+internal class IrCodeDefinition(
+    string name,
+    CqlCode code)
+    : IrDefinition(name)
+{
+    public CqlCode Code { get; } = code;
+
+    // NOTE(phase4): faithful to CqlCodeDefinition.ReturnType, which (likely unintentionally)
+    // returns the old definition class itself rather than typeof(CqlCode). The same value is
+    // returned here to guarantee parity. FIXME(phase6): revisit when the old class is deleted.
+    public override Type ReturnType => typeof(Hl7.Cql.Compiler.Expressions.CqlCodeDefinition);
+}
+
+/// <summary>
+/// IR counterpart of <see cref="CqlValueSetDefinition"/>.
+/// </summary>
+internal class IrValueSetDefinition(
+    string name,
+    string valueSetId,
+    string? valueSetVersion)
+    : IrDefinition(name)
+{
+    public string ValueSetId { get; } = valueSetId;
+    public string? ValueSetVersion { get; } = valueSetVersion;
+    public override Type ReturnType => typeof(CqlValueSet);
+}
+
+/// <summary>
+/// IR counterpart of <c>CqlDefinitionDictionary</c> (the
+/// <c>DefinitionDictionary&lt;CqlDefinition&gt;</c> global-using alias): the definitions
+/// dictionary the IR library contexts read and write. <see cref="DefinitionDictionary{T}"/>
+/// itself is Expression-free, so it is reused directly; this subclass only exists to give the
+/// closed generic a name usable across the IR pipeline without touching the (old-pipeline)
+/// global usings.
+/// </summary>
+internal sealed class IrDefinitionDictionary : DefinitionDictionary<IrDefinition>;

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilder.cs
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Elm;
+using TypeConverter = Hl7.Cql.Conversion.TypeConverter;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="ExpressionBuilder"/>. This is a mechanical port; see the
+/// remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+internal class IrExpressionBuilder(
+    ILogger<IrExpressionBuilder> logger,
+    ExpressionBuilderSettings expressionBuilderSettings,
+    IrCqlOperatorsBinder cqlOperatorsBinder,
+    TupleBuilderCache tupleBuilderCache,
+    TypeResolver typeResolver,
+    TypeConverter typeConverter,
+    IrCqlContextBinder cqlContextBinder)
+{
+    private readonly ILogger<IrExpressionBuilder> _logger = logger;
+    private readonly ExpressionBuilderSettings _expressionBuilderSettings = expressionBuilderSettings;
+    private readonly IrCqlOperatorsBinder _cqlOperatorsBinder = cqlOperatorsBinder;
+    private readonly TupleBuilderCache _tupleBuilderCache = tupleBuilderCache;
+    private readonly TypeResolver _typeResolver = typeResolver;
+    private readonly TypeConverter _typeConverter = typeConverter;
+    private readonly IrCqlContextBinder _cqlContextBinder = cqlContextBinder;
+
+    /*
+     * The IrExpressionBuilderContext is created anew for each of the ProcessXXX methods.
+     * This works, because all but the ProcessExpressionDef methods only change state
+     * on the IrLibraryExpressionBuilderContext.
+     *
+     * Only ProcessExpressionDef changes state on the IrExpressionBuilderContext.
+     */
+
+    public void ProcessIncludes(IrLibraryExpressionBuilderContext libCtx, IncludeDef includeDef) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessIncludes(includeDef);
+
+    internal IrExpressionBuilderContext NewExpressionBuilderContext(
+        IrLibraryExpressionBuilderContext libCtx,
+        Dictionary<string, IrLocal>? operands = null) =>
+        new(_logger, _expressionBuilderSettings, _cqlOperatorsBinder, _tupleBuilderCache, _typeResolver, _typeConverter, _cqlContextBinder, libCtx, operands);
+
+    public void ProcessValueSetDef(IrLibraryExpressionBuilderContext libCtx, ValueSetDef valueSetDef) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessValueSetDef(valueSetDef);
+
+    public void ProcessCodeDef(
+        IrLibraryExpressionBuilderContext libCtx,
+        CodeDef codeDef,
+        HashSet<(string codeName, string codeSystemUrl)> foundCodeNameCodeSystemUrls) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessCodeDef(codeDef, foundCodeNameCodeSystemUrls);
+
+    public void ProcessCodeSystemDef(IrLibraryExpressionBuilderContext libCtx, CodeSystemDef codeSystemDef) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessCodeSystemDef(codeSystemDef);
+
+    public void ProcessConceptDef(IrLibraryExpressionBuilderContext libCtx, ConceptDef conceptDef) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessConceptDef(conceptDef);
+
+    public void ProcessParameterDef(IrLibraryExpressionBuilderContext libCtx, ParameterDef parameterDef) =>
+        NewExpressionBuilderContext(libCtx)
+            .ProcessParameterDef(parameterDef);
+
+    public void ProcessExpressionDef(IrLibraryExpressionBuilderContext libCtx, ExpressionDef expressionDef) =>
+        NewExpressionBuilderContext(libCtx, new Dictionary<string, IrLocal>())
+            .ProcessExpressionDef(expressionDef);
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.DebuggerView.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.DebuggerView.cs
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Abstractions.Infrastructure;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <c>ExpressionBuilderContext.DebuggerView.cs</c>: the
+/// <see cref="IBuilderContext"/> implementation (element stack, <c>PushElement</c>, debugger
+/// views) that the shared <c>NewExpressionBuildingException</c> /
+/// <c>CatchRethrowExpressionBuildingException</c> extensions build their ELM context from.
+/// <see cref="IBuilderContext"/> and those extensions are Expression-free, so they are reused
+/// directly rather than ported.
+/// </summary>
+[DebuggerDisplay("{DebuggerView}")]
+partial class IrExpressionBuilderContext : IBuilderContext
+{
+    private IBuilderContext CreateBuilderNode() => new ExpressionBuilderNode()
+    {
+        LibraryExpressionBuilder = _libraryContext,
+        ElementStackList = [.. _elementStack],
+        ElementStackPosition = 0,
+    };
+
+    IBuilderContext? IBuilderContext.OuterBuilderContext =>
+        CreateBuilderNode().OuterBuilderContext;
+
+    BuilderContextDebuggerInfo? IBuilderContext.DebuggerInfo =>
+        CreateBuilderNode().DebuggerInfo;
+
+    private string FormatMessage(string message, Elm.Element? element = null)
+    {
+        var locator = element?.locator;
+
+        return string.IsNullOrWhiteSpace(locator)
+            ? $"{_libraryContext.LibraryVersionedIdentifier}: {message}"
+            : $"{_libraryContext.LibraryVersionedIdentifier} line {locator}: {message}";
+    }
+
+    public string DebuggerView => this.GetDebuggerView();
+
+    [DebuggerStepThrough]
+    private IPopToken PushElement(Elm.Element element)
+    {
+        _elementStack.TryPeek(out var previous);
+        if (previous == element) return EmptyDisposable.Instance;
+
+        _elementStack = _elementStack.Push(element);
+        return new PopElementToken(this, previous);
+    }
+
+    private readonly record struct ExpressionBuilderNode : IBuilderContext
+    {
+        public IrLibraryExpressionBuilderContext LibraryExpressionBuilder { get; init; }
+        public IReadOnlyList<Elm.Element> ElementStackList { get; init; }
+        public int ElementStackPosition { get; init; }
+
+        public IBuilderContext? OuterBuilderContext => ElementStackPosition < ElementStackList.Count - 1
+            ? this with { ElementStackPosition = ElementStackPosition + 1 }
+            : LibraryExpressionBuilder;
+
+        public BuilderContextDebuggerInfo? DebuggerInfo => ElementStackPosition >= 0 && ElementStackPosition < ElementStackList.Count
+            ? BuilderContextDebuggerInfo.FromElement(ElementStackList[ElementStackPosition])
+            : null!;
+    }
+
+    private readonly record struct PopElementToken : IPopToken
+    {
+        private readonly IrExpressionBuilderContext _owner;
+        private readonly Elm.Element? _previousElement;
+
+        [DebuggerStepThrough]
+        public PopElementToken(IrExpressionBuilderContext owner, Elm.Element? previousElement)
+        {
+            _owner = owner;
+            _previousElement = previousElement;
+        }
+
+        void IDisposable.Dispose() => Pop();
+
+        public void Pop()
+        {
+            var expectedPreviousElement = _owner._elementStack.ElementAtOrDefault(1);
+
+            if (_previousElement != expectedPreviousElement)
+                throw new InvalidOperationException("Popping should be called in the correct reverse order.");
+
+            _owner._elementStack = _owner._elementStack.Pop();
+        }
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.LibraryDefs.cs
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <c>ExpressionBuilderContext.LibraryDefs.cs</c>: processing the library's
+/// top-level definitions (codes, code systems, concepts, includes, parameters, value sets and
+/// expression/function definitions) into <see cref="IrDefinition"/>s on the library context.
+/// Mechanical port; see the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    public void ProcessCodeSystemDef(
+        CodeSystemDef codeSystem) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(codeSystem))
+            {
+                if (!_libraryContext.TryGetCodesByCodeSystemName(codeSystem.name, out var codes))
+                    codes = [];
+
+                var cqlCodeSystem = new CqlCodeSystem(codeSystem.id, codeSystem.version, codes);
+                var cqlCodeSystemDefinition = new IrCodeSystemDefinition(codeSystem.name!, cqlCodeSystem);
+                _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, codeSystem.name!, cqlCodeSystemDefinition);
+            }
+        });
+
+
+    public void ProcessConceptDef(
+        ConceptDef conceptDef) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(conceptDef))
+            {
+                var conceptDefName = conceptDef.name!;
+                CqlCode[] cqlCodes = [];
+                if (conceptDef.code is { Length: > 0 } codeRefs)
+                {
+                    cqlCodes = codeRefs.SelectToArray(codeRef =>
+                    {
+                        if (!_libraryContext.TryGetCode(codeRef, out var systemCode))
+                            throw this.NewExpressionBuildingException(
+                                $"Code {codeRef.name} in concept {conceptDefName} is not defined.", null);
+                        return new CqlCode(systemCode.code, systemCode.system /*, systemCode.version, systemCode.display*/);
+                    });
+                }
+                var cqlConceptDefinition = new IrConceptDefinition(conceptDefName, conceptDef.display, cqlCodes);
+                _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, conceptDefName, cqlConceptDefinition);
+            }
+        });
+
+    public void ProcessCodeDef(
+        CodeDef codeDef,
+        ISet<(string codeName, string codeSystemUrl)> codeNameCodeSystemUrlsSet) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(codeDef))
+            {
+                if (codeDef.codeSystem == null)
+                    throw this.NewExpressionBuildingException("Code definition has a null codeSystem node.", null);
+
+                if (!_libraryContext.TryGetCodeSystemName(codeDef.codeSystem, out string? csUrl))
+                    throw this.NewExpressionBuildingException($"Undefined code system {codeDef.codeSystem.name!}",
+                                                              null);
+
+                if (!codeNameCodeSystemUrlsSet.Add((codeDef.name!, csUrl!)))
+                    throw this.NewExpressionBuildingException(
+                        $"Duplicate code name detected: {codeDef.name} from {codeDef.codeSystem.name} ({csUrl})", null);
+
+                var cqlCode = new CqlCode(codeDef.id, csUrl);
+                _libraryContext.AddCode(codeDef, cqlCode);
+                var cqlCodeDefinition = new IrCodeDefinition(codeDef.name, cqlCode);
+                _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, codeDef.name, cqlCodeDefinition);
+            }
+        });
+
+    public void ProcessExpressionDef(
+        ExpressionDef expressionDef)
+    {
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(expressionDef))
+            {
+                if (_operands is null)
+                    throw new InvalidOperationException("Operands dictionary is null.");
+
+                var expressionDefName = expressionDef.name;
+                if (string.IsNullOrWhiteSpace(expressionDefName))
+                {
+                    throw this.NewExpressionBuildingException(
+                        $"Definition with local ID {expressionDef.localId} does not have a name.  This is not allowed.",
+                        null);
+                }
+
+                var expressionKey = $"{_libraryContext.LibraryVersionedIdentifier}.{expressionDefName}";
+                Type[] parameterTypes = [];
+
+                // NOTE(phase4): unlike the old CqlLambdaDefinition, the IR lambda for a definition
+                // does not carry the CqlContext parameter (see IrLambdaDefinition remarks) — this
+                // array holds only the CQL operand locals, so it starts empty instead of
+                // `[CqlExpressions.ParameterExpression]`.
+                IrLocal[] parameters = [];
+                IReadOnlyDictionary<string, string> originalParameterNames = new Dictionary<string, string>();
+
+                // Handle function definitions
+                if (expressionDef is FunctionDef { operand: { } operands, external: var isExternalFunction } functionDef)
+                {
+                    (parameterTypes, originalParameterNames) = BuildParameterTypes(operands, expressionDefName);
+                    parameters = [.. _operands.Values];
+
+                    if (isExternalFunction)
+                    {
+                        HandleExternalFunction(expressionKey, functionDef, parameterTypes, expressionDefName);
+                        return;
+                    }
+
+                    // Check for duplicate function signatures
+                    var isDuplicate = _libraryContext.LibraryDefinitions.ContainsDefinition(_libraryContext.LibraryVersionedIdentifier, new(expressionDefName, parameterTypes));
+                    if (isDuplicate)
+                    {
+                        if (_logger.IsEnabled(LogLevel.Warning))
+                        {
+                            IEnumerable<string> ops = operands
+                                                      .Where(op => op.operandTypeSpecifier != null && op.operandTypeSpecifier.resultTypeName != null)
+                                                      .Select(op => $"{op.name} {op.operandTypeSpecifier!.resultTypeName!}");
+                            _logger.LogWarning(
+                                FormatMessage($"Function {expressionDefName}({string.Join(", ", ops)}) skipped; another function matching this signature already exists."));
+                        }
+                        return;
+                    }
+                }
+
+                if (expressionDef.expression is { } expressionDefExpression)
+                {
+                    var bodyExpression = TranslateArg(expressionDefExpression);
+                    var lambda = new IrLambda(parameters, bodyExpression);
+                    var tags = BuildTags();
+                    var def = expressionDef is FunctionDef
+                                  ? new IrFunctionDefinition(lambda, expressionDefName, originalParameterNames, tags)
+                                  : (IrDefinition)new IrExpressionDefinition(lambda, expressionDefName, tags);
+                    _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, new(expressionDefName, parameterTypes), def);
+                }
+            }
+        });
+
+        (string name, string[] values)[] BuildTags()
+        {
+            (string name, string[] values)[] valueTuples = [];
+            if (expressionDef.annotation is { Length: > 0 } annotations)
+            {
+                valueTuples = annotations
+                              .OfType<Annotation>()
+                              .SelectMany(a => a.t ?? [])
+                              .SelectWhere(tag => string.IsNullOrWhiteSpace(tag?.name)
+                                                      ? default
+                                                      : (true, (name: tag.name!, values: (string[])[tag.value ?? ""])))
+                              .ToArray();
+            }
+            return valueTuples;
+        }
+
+        void HandleExternalFunction(
+            string expressionKey,
+            FunctionDef function,
+            Type[] parameterTypes,
+            string expressionDefName)
+        {
+            if (!_expressionBuilderSettings.AllowUnresolvedExternals)
+                throw this.NewExpressionBuildingException(
+                    $"{expressionKey} is declared external, but it was not defined in the expression scope.");
+
+            var returnType = TypeFor(expressionDef)!;
+            var operands = function.operand ?? [];
+
+            // NOTE(phase4): ported as-is. The old builder prefixed this signature with a synthetic
+            // "context" entry (CqlExpressions.ParameterExpression.Type there, typeof(CqlContext)
+            // here) because CqlFunctionDefinition's LambdaExpression always carried the context
+            // parameter first; the resulting DefinitionSignature below therefore includes the
+            // context type even though non-external definitions register their signature with only
+            // the CQL operand types (see the isDuplicate check above). This looks like a latent bug
+            // (a CQL-argument-only lookup could never match this signature), but it's preserved here
+            // for parity. The IR lambda passed to NotImplemented, however, only ever carries the CQL
+            // operand parameters (see IrLambdaDefinition remarks), so the synthetic entry is sliced
+            // off before it gets there.
+            (string name, Type type)[] paramNamesAndTypes = new (string name, Type type)[operands.Length + 1];
+            paramNamesAndTypes[0] = ("context", typeof(CqlContext));
+            for (int o = 0; o < operands.Length; o++)
+                paramNamesAndTypes[o + 1] = (operands[o].name, parameterTypes[o]);
+            var notImplemented = NotImplemented(expressionKey, paramNamesAndTypes[1..], returnType);
+            var paramTypes = paramNamesAndTypes.Select(p => p.type).ToArray();
+            var definition = new IrFunctionDefinition(notImplemented, expressionDefName);
+            var definitionSignature = new DefinitionSignature(expressionDefName, paramTypes);
+            _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, definitionSignature, definition);
+
+            if (_logger.IsEnabled(LogLevel.Warning))
+                _logger.LogWarning(
+                    FormatMessage(
+                        $"Function '{expressionDefName}' is declared external, but it was not defined in the expression scope. " +
+                        "A stub has been created that throws a NotImplemented exception."), expressionDef);
+        }
+
+        (Type[] parameterTypes, IReadOnlyDictionary<string, string> originalParameterNames) BuildParameterTypes(OperandDef[] operandDefs, string expressionDefName)
+        {
+            var parameterTypes = new Type[operandDefs.Length];
+            var originalNames = new Dictionary<string, string>();
+            int i = 0;
+            foreach (var operandDef in operandDefs)
+            {
+                if (operandDef.operandTypeSpecifier is null)
+                    throw this.NewExpressionBuildingException(
+                        $"Operand for function {expressionDefName} is missing its {nameof(operandDef.operandTypeSpecifier)} property",
+                        null);
+
+                var operandType = TypeFor(operandDef.operandTypeSpecifier)!;
+                var normalizedName = IdentifierNormalizer.Normalize(operandDef.name);
+                var parameter = new IrLocal(operandType, normalizedName);
+                _operands.Add(operandDef.name, parameter);
+                parameterTypes[i++] = parameter.Type;
+
+                // Store original name if it differs from the normalized name.
+                var isSameCSharpAndCqlName = (normalizedName.StartsWith('@') ? normalizedName[1..] : normalizedName) == operandDef.name;
+                if (!isSameCSharpAndCqlName)
+                    originalNames[normalizedName] = operandDef.name;
+            }
+
+            return (parameterTypes, originalNames);
+        }
+    }
+
+    public void ProcessIncludes(
+        IncludeDef includeDef) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(includeDef))
+            {
+                var alias = includeDef.libraryName
+                            ?? throw this.NewExpressionBuildingException(
+                                $"Include {includeDef.localId} does not have a alias.");
+
+                var libNav = includeDef.GetVersionedLibraryIdentifierString() ??
+                             throw this.NewExpressionBuildingException(
+                                 $"Include {includeDef.localId} does not have a well-formed name and version");
+                _libraryContext.AddAliasLibraryVersionedIdentifier(alias, libNav);
+            }
+        });
+
+    public void ProcessParameterDef(
+        ParameterDef parameter) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(parameter))
+            {
+                var parameterName = parameter.name!;
+                if (_libraryContext.LibraryDefinitions.ContainsDefinition(_libraryContext.LibraryVersionedIdentifier, parameterName))
+                    throw this.NewExpressionBuildingException($"There is already a definition named {parameterName}",
+                                                              null);
+
+                var defaultValue =
+                    parameter.@default != null
+                        ? TranslateArg(parameter.@default).NewTypeAsExpression<object>()
+                        : new IrConstant(null, typeof(object));
+                var resolveParam = _cqlContextBinder.ResolveParameter(_libraryContext.LibraryVersionedIdentifier, parameterName, defaultValue);
+
+                var parameterType = TypeFor(parameter.parameterTypeSpecifier)!;
+                var cast = _cqlOperatorsBinder.CastToType(resolveParam, parameterType);
+                // e.g. (bundle, context) => context.Parameters["Measurement Period"]
+                // NOTE(phase4): the IR lambda for a parameter definition has no parameters at all,
+                // not even the context (see IrLambdaDefinition remarks) — the body references
+                // IrContextParameter.Instance directly (see IrCqlContextBinder.ResolveParameter).
+                var lambda = new IrLambda([], cast);
+                var paramDef = new IrParameterDefinition(lambda, parameterName);
+                _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, parameterName, paramDef);
+            }
+        });
+
+    public void ProcessValueSetDef(
+        ValueSetDef valueSetDef) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(valueSetDef))
+            {
+                var def = new IrValueSetDefinition(valueSetDef.name!, valueSetDef.id, valueSetDef.version);
+                _libraryContext.LibraryDefinitions.AddDefinition(_libraryContext.LibraryVersionedIdentifier, valueSetDef.name!, def);
+            }
+        });
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Operators.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Operators.cs
@@ -1,0 +1,837 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Operators;
+using Hl7.Cql.Primitives;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using Convert = System.Convert;
+using TypeSpecifier = Hl7.Cql.Elm.TypeSpecifier;
+
+/// <summary>
+/// IR counterpart of the operator regions of <c>ExpressionBuilderContext.cs</c> (arithmetic,
+/// comparison, messaging, interval, nullological and type operators, plus the ChangeType
+/// helpers). Mechanical port of the old per-node methods; see the remarks on
+/// <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    #region ArithmeticOperators
+
+    private const string Int32MaxPlusOneAsString = "2147483648";
+
+    private IrExpression NegateLiteral(Negate e, Literal literal)
+    {
+        // handle things like -2147483648 which gets translated to Negate(2147483648)
+        // since int.MaxValue is 2147483647, we have to handle this specially
+        var literalType = TypeFor(literal);
+        if (literalType == typeof(int?) && literal.value == Int32MaxPlusOneAsString)
+            return new IrConstant(int.MinValue, typeof(int));
+
+        if (literalType == typeof(long?)
+            && literal.value == long.MinValue.ToString(CultureInfo.InvariantCulture))
+            return new IrConstant(long.MinValue, typeof(long));
+
+        return BindCqlOperator(nameof(ICqlOperators.Negate), e.operand);
+    }
+
+    private IrExpression Negate(Negate e)
+    {
+        if (e.operand is Literal literal)
+            return NegateLiteral(e, literal);
+
+        return BindCqlOperator(nameof(ICqlOperators.Negate), e.operand);
+    }
+
+    #endregion
+
+    #region ComparisonOperators
+
+    protected IrExpression Equivalent(Equivalent eqv)
+    {
+        if (TranslateArgs(eqv.operand) is [{ } left, { } right]
+            && _typeResolver.GetListElementType(left.Type, throwError: false) is { } leftType
+            && _typeResolver.GetListElementType(right.Type, throwError: false) is { } rightType
+            && leftType != rightType)
+        {
+            // This appears in the CQL tests:
+            //  { 'a', 'b', 'c' } ~ { 1, 2, 3 } = false
+            return new IrConstant(false, typeof(bool?));
+        }
+
+        return BindCqlOperator(nameof(ICqlOperators.Equivalent), GetBindArgs(eqv));
+    }
+
+    #endregion
+
+    #region ErrorsAndMessaging
+
+    private IrExpression Message(Message e)
+    {
+        var condition = TranslateArg(e.condition!);
+
+        var source = TranslateArg(e.source!);
+        var code = TranslateArg(e.code!);
+        var severity = TranslateArg(e.severity!);
+        var message = TranslateArg(e.message!);
+
+        if (source is IrConstant { Value: null } constant)
+        {
+            // create an explicit "null as object" so the generic type can be inferred in source code.
+            // NOTE(phase4): ported as-is — constant.Type == constant.Type trivially, so
+            // NewAssignToTypeExpression short-circuits on the exact-type check and this is a
+            // no-op (source is reassigned to the same instance). Kept faithful to the old code.
+            source = constant.NewAssignToTypeExpression(constant.Type);
+        }
+
+        var call = BindCqlOperator(nameof(ICqlOperators.Message), source, code, severity, message);
+        if (condition.Type.IsNullableValueType(out _))
+        {
+            condition = condition.Coalesce();
+        }
+
+        return new IrConditional(condition, call, source, call.Type);
+    }
+
+    #endregion
+
+    #region IntervalOperators
+
+    protected IrExpression? Includes(Includes e)
+    {
+        var left = TranslateArg(e.operand![0]);
+        var right = TranslateArg(e.operand![1]);
+        if (_typeResolver.IsListType(left.Type))
+        {
+            var leftElementType = _typeResolver.GetListElementType(left.Type);
+            if (_typeResolver.IsListType(right.Type))
+            {
+                // NOTE(phase4): ported as-is — this reads left.Type where right.Type looks
+                // intended, so leftElementType != rightElementType can never be true and the
+                // element-type check below is dead. Preserved verbatim from the old pipeline.
+                var rightElementType = _typeResolver.GetListElementType(left.Type);
+                if (leftElementType != rightElementType)
+                    throw this.NewExpressionBuildingException();
+                return BindCqlOperator(nameof(ICqlOperators.ListIncludesList), left, right);
+            }
+
+            if (leftElementType != right.Type)
+                throw this.NewExpressionBuildingException();
+            return BindCqlOperator(nameof(ICqlOperators.ListIncludesElement), left, right);
+        }
+
+        if (left.Type.IsCqlInterval(out var leftPointType))
+        {
+            if (right.Type.IsCqlInterval(out var pointType))
+            {
+                var precision = ((IGetPrecision)e).GetPrecision();
+                return BindCqlOperator(nameof(ICqlOperators.IntervalIncludesInterval), left, right, precision);
+            }
+            else
+            {
+                var precision = ((IGetPrecision)e).GetPrecision();
+                return BindCqlOperator(nameof(ICqlOperators.IntervalIncludesElement), left, right, precision);
+            }
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    protected IrExpression IncludedIn(IncludedIn e)
+    {
+        var left = TranslateArg(e.operand![0]);
+        var right = TranslateArg(e.operand![1]);
+        if (_typeResolver.IsListType(left.Type))
+        {
+            var leftElementType = _typeResolver.GetListElementType(left.Type);
+            if (_typeResolver.IsListType(right.Type))
+            {
+                // NOTE(phase4): ported as-is — same left.Type/right.Type mixup as in Includes()
+                // above; leftElementType != rightElementType can never be true here.
+                var rightElementType = _typeResolver.GetListElementType(left.Type);
+                if (leftElementType != rightElementType)
+                    throw this.NewExpressionBuildingException();
+                return BindCqlOperator(nameof(ICqlOperators.ListIncludesList), right, left);
+            }
+
+            if (leftElementType != right.Type)
+                throw this.NewExpressionBuildingException();
+            return BindCqlOperator(nameof(ICqlOperators.ListIncludesElement), right, left);
+        }
+
+        if (left.Type.IsCqlInterval(out var leftPointType) && right.Type.IsCqlInterval(out var rightPointType))
+        {
+            var precision = ((IGetPrecision)e).GetPrecision();
+            return BindCqlOperator(nameof(ICqlOperators.IntervalIncludesInterval), right, left, precision);
+        }
+
+        if (right.Type.IsCqlInterval(out var pointType))
+        {
+            var precision = ((IGetPrecision)e).GetPrecision();
+            if (left.Type != pointType)
+                throw this.NewExpressionBuildingException();
+            return BindCqlOperator(nameof(ICqlOperators.IntervalIncludesElement), right, left, precision);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    protected IrExpression? ProperIncludes(ProperIncludes e)
+    {
+        var left = TranslateArg(e.operand![0]);
+        var right = TranslateArg(e.operand![1]);
+        if (left.Type.IsCqlInterval(out var leftPointType))
+        {
+            var precision = ((IGetPrecision)e).GetPrecision();
+            if (right.Type.IsCqlInterval(out var rightPointType))
+            {
+                return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesInterval), left, right, precision);
+            }
+
+            return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesElement), left, right, precision);
+        }
+
+        if (_typeResolver.IsListType(left.Type))
+        {
+            // var leftElementType = _typeResolver.GetListElementType(left.Type);
+            if (_typeResolver.IsListType(right.Type))
+            {
+                // var rightElementType = _typeResolver.GetListElementType(right.Type);
+                return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesList), left, right);
+            }
+
+            return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesElement), left, right);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+
+    protected IrExpression? ProperIncludedIn(ProperIncludedIn e)
+    {
+        var left = TranslateArg(e.operand![0]);
+        var right = TranslateArg(e.operand![1]);
+        if (left.Type.IsCqlInterval(out var leftPointType))
+        {
+            if (right.Type.IsCqlInterval(out var rightPointType))
+            {
+                var precision = ((IGetPrecision)e).GetPrecision();
+                return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesInterval), right, left, precision);
+            }
+        }
+        else if (_typeResolver.IsListType(left.Type))
+        {
+            var leftElementType = _typeResolver.GetListElementType(left.Type);
+            if (_typeResolver.IsListType(right.Type))
+            {
+                var rightElementType = _typeResolver.GetListElementType(right.Type);
+                if (leftElementType != rightElementType)
+                    throw this.NewExpressionBuildingException();
+                return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesList), right, left);
+            }
+        }
+        else if (right.Type.IsCqlInterval(out var rightPointType))
+        {
+            var precision = ((IGetPrecision)e).GetPrecision();
+            return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesElement), right, left, precision);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    private IrExpression? ProperIn(ProperIn e)
+    {
+        var element = TranslateArg(e.operand![0]);
+        var intervalOrList = TranslateArg(e.operand![1]);
+        if (intervalOrList.Type.IsCqlInterval(out var pointType))
+        {
+            var precision = ((IGetPrecision)e).GetPrecision();
+            return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesElement), intervalOrList, element, precision);
+        }
+
+        if (_typeResolver.IsListType(intervalOrList.Type))
+        {
+            return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesElement), intervalOrList, element);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    protected IrExpression? ProperContains(ProperContains e)
+    {
+        var left = TranslateArg(e.operand![0]);
+        var right = TranslateArg(e.operand![1]);
+        if (_typeResolver.IsListType(left.Type))
+        {
+            var leftElementType = _typeResolver.GetListElementType(left.Type);
+            if (_typeResolver.IsListType(right.Type))
+            {
+                var rightElementType = _typeResolver.GetListElementType(right.Type);
+                if (leftElementType != rightElementType)
+                    throw this.NewExpressionBuildingException();
+                return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesList), left, right);
+            }
+
+            if (leftElementType != right.Type)
+                throw this.NewExpressionBuildingException();
+            return BindCqlOperator(nameof(ICqlOperators.ListProperlyIncludesElement), left, right);
+        }
+
+        if (left.Type.IsCqlInterval(out var leftPointType))
+        {
+            if (leftPointType != right.Type)
+                throw this.NewExpressionBuildingException();
+            var precision = ((IGetPrecision)e).GetPrecision();
+            return BindCqlOperator(nameof(ICqlOperators.IntervalProperlyIncludesElement), left, right, precision);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    #endregion
+
+    #region NullologicalOperators
+
+    protected IrExpression Coalesce(Coalesce ce)
+    {
+        var operands = TranslateArgs(ce.operand);
+
+        if (operands.Length == 1 && _typeResolver.IsListType(operands[0].Type))
+            return BindCqlOperator(nameof(ICqlOperators.Coalesce), operands[0]);
+
+        var distinctOperandTypes = operands
+                                   .Select(op => op.Type)
+                                   .Distinct()
+                                   .ToArray();
+        if (distinctOperandTypes.Length != 1)
+            throw this.NewExpressionBuildingException("All operand types should match when using Coalesce");
+
+        var type = operands[0].Type;
+        if (type.IsValueType && !type.IsNullableValueType(out _))
+            throw new NotSupportedException("Coalesce on value types is not defined.");
+
+        if (operands.Length == 1)
+            return operands[0];
+
+        IrExpression coalesce = new IrBinary(IrBinaryOp.Coalesce, operands[0], operands[1]);
+        for (int i = 2; i < operands.Length; i++)
+        {
+            coalesce = new IrBinary(IrBinaryOp.Coalesce, coalesce, operands[i]);
+        }
+
+        return coalesce;
+    }
+
+    protected IrExpression IsNull(IsNull isn)
+    {
+        var operand = TranslateArg(isn.operand!);
+        while (true)
+        {
+            // NOTE(phase4): the old code unwrapped two distinct node shapes that both represent
+            // a cast to object — the custom ElmAsExpression node and a raw
+            // UnaryExpression(Convert/ConvertChecked/TypeAs). The IR collapses both into IrCast
+            // (see its doc comment), so a single check here covers what used to be two separate
+            // loop iterations in the Expression-based pipeline.
+            if (operand is IrCast { Type: var asType } cast && asType == typeof(object))
+            {
+                operand = cast.Operand;
+                continue;
+            }
+
+            break;
+        }
+
+        if (operand.Type.IsValueType && operand.Type.IsNullableValueType(out _) == false)
+            return new IrConstant(false, typeof(bool?));
+
+
+        var compare = new IrBinary(IrBinaryOp.Equal, operand, new IrConstant(null, operand.Type));
+        return compare;
+        //var asNullableBool = compare.NewAssignToTypeExpression<bool?>();
+        //return asNullableBool;
+    }
+
+    #endregion
+
+    #region Type Operators
+
+    protected IrExpression As(As @as) //@ TODO: Cast - As
+    {
+        var castKind = @as.strict ? IrCastKind.Cast : IrCastKind.As;
+
+        if (@as.operand is List list)
+        {
+            using (PushElement(list))
+            {
+                // create new ListType[0]; instead of new object[0] as IEnumerable<object> as IEnumerable<ListType>;
+                if ((list.element?.Length ?? 0) == 0)
+                {
+                    var type = TypeFor(@as.asTypeSpecifier!)!;
+                    if (_typeResolver.IsListType(type))
+                    {
+                        var listElementType = _typeResolver.GetListElementType(type) ??
+                                              throw this.NewExpressionBuildingException(
+                                                  $"{type} was expected to be a list type.");
+                        var newArray = new IrNewArrayBounds(listElementType, new IrConstant(0, typeof(int)));
+                        var elmAs = new IrCast(newArray, type, castKind);
+                        return elmAs;
+                    }
+                    else if (type == _typeResolver.AnyType) // handles untyped empty lists whose type is Any
+                    {
+                        var newArray = new IrNewArrayBounds(_typeResolver.AnyType, new IrConstant(0, typeof(int)));
+                        var elmAs = new IrCast(newArray, type, castKind);
+                        return elmAs;
+                    }
+
+                    throw this.NewExpressionBuildingException(
+                        "Cannot use as operator on a list if the as type is not also a list type.");
+                }
+            }
+        }
+
+        // asTypeSpecifier is an expression with its own resulttypespecifier that actually contains the real type
+        if (@as.asTypeSpecifier != null)
+        {
+            using (PushElement(@as.asTypeSpecifier))
+            {
+                if (@as.operand is Null)
+                {
+                    var type = TypeFor(@as.asTypeSpecifier!)!;
+                    var defaultExpression = new IrDefault(type);
+                    return new IrCast(defaultExpression, type, castKind);
+                }
+                else
+                {
+                    var type = TypeFor(@as.asTypeSpecifier!)!;
+                    var operand = TranslateArg(@as.operand!);
+                    var converted = ChangeType(operand, type, out var typeConversion, considerSafeUpcast: true);
+                    switch (typeConversion)
+                    {
+                        case TypeConversion.NoMatch:
+                            // log an unsafe cast
+                            _logger.LogWarning(
+                                FormatMessage(
+                                    $"{operand.Type.ToCSharpString(Defaults.TypeCSharpFormat)} as {type.ToCSharpString(Defaults.TypeCSharpFormat)} will always result in null.",
+                                    @as.operand));
+                            return new IrDefault(type);
+
+                        case TypeConversion.OperatorConvert:
+                            return converted;
+
+                        case TypeConversion.ExpressionTypeAs:
+                        default:
+                            // NOTE(phase4): ported as-is — even when typeConversion came back as
+                            // ExactType (equal types; there is no case label for it above), this
+                            // falls into the default arm and still wraps in a cast/as node built
+                            // from the original operand, rather than returning operand or
+                            // converted directly.
+                            return new IrCast(operand, type, castKind);
+                    }
+                }
+            }
+        }
+
+        {
+            if (string.IsNullOrWhiteSpace(@as.asType.Name))
+                throw this.NewExpressionBuildingException("The 'as' operator has no type name.");
+
+            if (@as.operand is null)
+                throw this.NewExpressionBuildingException("Operand cannot be null");
+
+            var type = _typeResolver.ResolveType(@as.asType.Name!)
+                       ?? throw this.NewExpressionBuildingException($"Cannot resolve type {@as.asType.Name}");
+
+            var operand = TranslateArg(@as.operand);
+            if (!type.IsAssignableTo(operand.Type))
+            {
+                _logger.LogWarning(FormatMessage(
+                                       $"Potentially unsafe cast from {operand.Type.ToCSharpString(Defaults.TypeCSharpFormat)} to type {type.ToCSharpString(Defaults.TypeCSharpFormat)}",
+                                       @as.operand));
+            }
+
+            return new IrCast(operand, type, castKind);
+        }
+    }
+
+    protected IrExpression Is(Is @is) // @TODO: Cast - Is
+    {
+        var op = TranslateArg(@is.operand!);
+        Type? type = null;
+        if (@is.isTypeSpecifier != null)
+        {
+            if (@is.isTypeSpecifier is ChoiceTypeSpecifier choice)
+            {
+                var firstChoiceType = TypeFor(choice.choice[0], false) ??
+                                      throw this.NewExpressionBuildingException("Could not resolve type for Is expression");
+
+                IrExpression result = op.NewTypeIsExpression(firstChoiceType);
+                for (int i = 1; i < choice.choice.Length; i++)
+                {
+                    var cti = TypeFor(choice.choice[i], false) ??
+                              throw this.NewExpressionBuildingException("Could not resolve type for Is expression");
+
+                    var ie = op.NewTypeIsExpression(cti);
+                    // NOTE(phase4): the old code used Expression.Or (a non-short-circuiting
+                    // logical OR). The IR only models the short-circuiting form (OrElse); since
+                    // both operands are pure IrTypeIs checks with no side effects, OrElse is
+                    // observably identical here.
+                    result = new IrBinary(IrBinaryOp.OrElse, result, ie);
+                }
+
+                var ta = result.NewTypeAsExpression<bool?>();
+                return ta;
+            }
+
+            type = TypeFor(@is.isTypeSpecifier, false) ??
+                   throw this.NewExpressionBuildingException($"Could not resolve type for Is expression");
+        }
+        else if (!string.IsNullOrWhiteSpace(@is.isType?.Name))
+        {
+            type = _typeResolver.ResolveType(@is.isType.Name) ??
+                   throw this.NewExpressionBuildingException($"Could not resolve type {@is.isType.Name}");
+        }
+
+        if (type == null)
+            throw this.NewExpressionBuildingException(
+                $"Could not identify Is type specifer via {nameof(@is.isTypeSpecifier)} or {nameof(@is.isType)}.");
+
+        var isExpression = op.NewTypeIsExpression(type);
+        var nullable = isExpression.NewTypeAsExpression<bool?>();
+        return nullable;
+    }
+
+    #endregion
+
+    #region Conditionals and literals
+
+    protected IrExpression Case(Case ce)
+    {
+        //[{ when1, then1 }, { when2, then2}, { when3, then3 }]
+        // when1 ? then 1 : (when2 ? then 2 : (when3 ? then 3 : else }
+        if (ce.caseItem?.Length > 0 && ce.@else != null)
+        {
+            var elseThen = TranslateArg(ce.@else!);
+            var cases = new List<(IrExpression When, IrExpression Then)>();
+
+            if (ce.comparand != null)
+            {
+                var comparand = TranslateArg(ce.comparand);
+
+                foreach (var caseItem in ce.caseItem)
+                {
+                    var caseWhen = TranslateArg(caseItem.when!);
+                    var caseWhenEquality = BindCqlOperator(nameof(ICqlOperators.Equal), [comparand, caseWhen]).Coalesce();
+                    var caseThen = TranslateArg(caseItem.then!);
+
+                    if (caseThen.Type != elseThen.Type)
+                        caseThen = caseThen.NewAssignToTypeExpression(elseThen.Type);
+
+                    cases.Add((caseWhenEquality, caseThen));
+                }
+            }
+            else
+            {
+                foreach (var caseItem in ce.caseItem)
+                {
+                    var caseWhen = TranslateArg(caseItem.when!);
+                    var caseThen = TranslateArg(caseItem.then!);
+
+                    if (caseThen.Type != elseThen.Type)
+                        caseThen = caseThen.NewAssignToTypeExpression(elseThen.Type);
+
+                    if (caseWhen.Type.IsNullableValueType(out _))
+                    {
+                        caseWhen = caseWhen.Coalesce();
+                    }
+
+                    cases.Add((caseWhen, caseThen));
+                }
+            }
+
+            return new IrIfChain(cases, elseThen, elseThen.Type);
+        }
+
+        throw this.NewExpressionBuildingException("Invalid case expression.  At least 1 case and an else must be present.");
+    }
+
+    protected IrExpression If(If @if)
+    {
+        var rc = TranslateArg(@if.condition!);
+        var condition = rc.Coalesce();
+        var then = TranslateArg(@if.then!);
+        if (@if.@else != null)
+        {
+            var @else = TranslateArg(@if.@else!);
+            if (then.Type.IsValueType)
+            {
+                @else = HandleNullable(@else, then.Type);
+            }
+
+            if (then.Type != @else.Type)
+            {
+                // In fact, this is allowed, but since this would be handled using type "object" at runtime
+                // (since the CLR does not support discriminated unions), we will throw an exception here.
+                // We could also optimize by first trying whether the arguments are convertible to each other,
+                // since that would catch quite a few cases (mostly the if .... then X else List<X> cases),
+                // which are common.
+                throw this.NewExpressionBuildingException(
+                    $"The If expression at {@if.locator} produces two branches with different types.");
+                // then = Expression.Convert(then, typeof(object));
+                // @else = Expression.Convert(@else, typeof(object));
+            }
+
+            var ifThenElse = new IrConditional(condition, then, @else, then.Type);
+
+            return ifThenElse;
+        }
+
+        var @false = new IrConstant(null, typeof(object)).NewAssignToTypeExpression(then.Type);
+        var ifThen = new IrConditional(condition, then, @false, then.Type);
+        return ifThen;
+    }
+
+    protected IrExpression List(List list)
+    {
+        if (list.resultTypeSpecifier == null)
+            throw this.NewExpressionBuildingException($"List is missing a result type specifier.");
+        if (list.resultTypeSpecifier is ListTypeSpecifier listTypeSpecifier)
+        {
+            var elementType = TypeFor(listTypeSpecifier.elementType)!;
+            var elements = TranslateArgs(list.element);
+            if (!elementType.IsNullableValueType(out _) && elements.Any(exp => exp.Type.IsNullableValueType(out _)))
+            {
+                for (int i = 0; i < elements.Length; i++)
+                {
+                    elements[i] = HandleNullable(elements[i], elementType);
+                }
+            }
+
+            for (int i = 0; i < elements.Length; i++)
+            {
+                if (elements[i].Type != elementType)
+                {
+                    elements[i] = elements[i].NewTypeAsExpression(elementType);
+                }
+            }
+
+            // NOTE(phase4): ported as-is — TranslateArgs never returns null, so the null-check
+            // below (and the NewArrayBounds fallback it guards) is dead code in both the old and
+            // new pipelines.
+            IrExpression array;
+            if (elements != null)
+            {
+                array = new IrNewArray(elementType, elements);
+            }
+            else
+            {
+                array = new IrNewArrayBounds(elementType, new IrConstant(0, typeof(int)));
+            }
+
+            return array;
+        }
+
+        throw this.NewExpressionBuildingException($"List is the wrong type");
+    }
+
+    protected IrExpression Literal(Literal lit)
+    {
+        var type = _typeResolver.ResolveType(lit.valueType.Name) ?? throw this.NewExpressionBuildingException($"Cannot resolve type for {lit.valueType}");
+
+
+        var (value, convertedType) = ConvertLiteral(lit, type);
+
+        // var result = _operatorBinding.ConvertToType(Expression.Constant(value), convertedType);
+        // return result;
+
+        if (type.IsNullableValueType(out _))
+        {
+            var changed = new IrConstant(value!, convertedType);
+            var asNullable = changed.NewAssignToTypeExpression(type);
+            return asNullable;
+        }
+
+        return new IrConstant(value, convertedType);
+    }
+
+    protected (object?, Type) ConvertLiteral(Literal lit, Type? type) //@ TODO: Cast - ConvertLiteral
+    {
+        if (type == null)
+            throw new NotImplementedException().WithContext(this);
+
+        if (type.IsNullableValueType(out var underlyingType))
+        {
+            if (string.IsNullOrWhiteSpace(lit.value))
+                return (null, type);
+
+            if (!typeof(IConvertible).IsAssignableFrom(underlyingType))
+                throw new NotSupportedException("Only convertible types can be used for literals.");
+
+            try
+            {
+                var converted = Convert.ChangeType(lit.value, underlyingType, CultureInfo.InvariantCulture); //@ TODO: Cast - ConvertLiteral
+                return (converted, underlyingType);
+            }
+            catch (OverflowException)
+            {
+                return (null, type);
+            }
+        }
+
+        if (type == typeof(string))
+            return (lit.value, type);
+
+        if (typeof(IConvertible).IsAssignableFrom(type))
+        {
+            var converted = Convert.ChangeType(lit.value, type, CultureInfo.InvariantCulture); //@ TODO: Cast - ConvertLiteral
+            return (converted, type);
+        }
+
+        throw new NotSupportedException("Only convertible types can be used for literals.");
+    }
+
+    #endregion
+
+    #region ChangeType
+
+    private IrExpression ChangeType(
+        IrExpression expr,
+        TypeSpecifier? typeSpecifier,
+        bool throwOnError = false,
+        bool considerSafeUpcast = false) // @TODO: Cast - ChangeType
+    {
+        if (typeSpecifier is not null)
+        {
+            if (TypeFor(typeSpecifier, throwOnError) is { } resultType)
+            {
+                if (resultType != expr.Type)
+                {
+                    var typeAs = ChangeType(expr, resultType, out _, throwOnError, considerSafeUpcast);
+                    return typeAs;
+                }
+            }
+        }
+
+        return expr;
+    }
+
+
+    private IrExpression ChangeType(
+        Element element,
+        Type outputType,
+        bool throwOnError = false,
+        bool considerSafeUpcast = false)
+        => ChangeType(
+            TranslateArg(element),
+            outputType,
+            throwOnError,
+            considerSafeUpcast); // @TODO: Cast - ChangeType
+
+    private IrExpression ChangeType(
+        IrExpression input,
+        Type outputType,
+        bool throwOnError = false,
+        bool considerSafeUpcast = false) =>
+        ChangeType(input, outputType, out _, throwOnError, considerSafeUpcast); // @TODO: Cast - ChangeType
+
+
+    private IrExpression ChangeType(
+        IrExpression input,
+        Type outputType,
+        out TypeConversion typeConversion,
+        bool throwOnError = false,
+        bool considerSafeUpcast = false) // @TODO: Cast - ChangeType
+    {
+        var (expression, tc) = input.TryNewAssignToTypeExpression(outputType, false, considerSafeUpcast);
+        if (tc != TypeConversion.NoMatch)
+        {
+            typeConversion = tc;
+            return expression!;
+        }
+
+        // tuples are not convertible.
+        if (input.Type.IsAssignableTo(typeof(TupleBaseType)) || outputType.IsAssignableTo(typeof(TupleBaseType)))
+        {
+            // unless they're the same type.
+            if (input.Type == outputType)
+            {
+                typeConversion = TypeConversion.ExactType;
+                return input;
+            }
+
+            // Handle conversion between compatible TupleBaseType types that differ only in element types
+            // (e.g. when an As expression converts {Id:Integer, Name:String} to {Id:Integer, Name:Any}).
+            if (input.Type.IsAssignableTo(typeof(TupleBaseType)) && outputType.IsAssignableTo(typeof(TupleBaseType)))
+            {
+                var inputProps = input.Type.GetProperties();
+                var outputProps = outputType.GetProperties();
+                if (inputProps.Length == outputProps.Length)
+                {
+                    var bindings = new List<(MemberInfo Member, IrExpression Value)>();
+                    bool allMatched = true;
+                    foreach (var outputProp in outputProps)
+                    {
+                        var inputProp = Array.Find(inputProps, p => p.Name == outputProp.Name);
+                        if (inputProp is null)
+                        {
+                            allMatched = false;
+                            break;
+                        }
+
+                        var inputAccess = new IrProperty(input, inputProp);
+                        var convertedValue = inputProp.PropertyType != outputProp.PropertyType
+                            ? ChangeType(inputAccess, outputProp.PropertyType, considerSafeUpcast: true)
+                            : (IrExpression)inputAccess;
+                        bindings.Add((outputProp, convertedValue));
+                    }
+
+                    if (allMatched)
+                    {
+                        typeConversion = TypeConversion.OperatorConvert;
+                        var ctor = outputType.GetConstructor(Type.EmptyTypes)
+                                   ?? throw this.NewExpressionBuildingException($"Tuple type {outputType} has no accessible parameterless constructor.");
+                        return new IrMemberInit(new IrNew(ctor), bindings);
+                    }
+                }
+            }
+
+            typeConversion = TypeConversion.NoMatch;
+            throwCannotCastIfNoMatch(typeConversion);
+            return input;
+        }
+
+        if (_typeResolver.IsListType(input.Type)
+            && _typeResolver.IsListType(outputType))
+        {
+            var inputElementType = _typeResolver.GetListElementType(input.Type, true)!;
+            var outputElementType = _typeResolver.GetListElementType(outputType, true)!;
+            var lambdaParameter = new IrLocal(inputElementType, TypeNameToIdentifier(inputElementType, this));
+            var lambdaBody = ChangeType(lambdaParameter, outputElementType, out typeConversion, throwOnError: true);
+            var lambda = new IrLambda([lambdaParameter], lambdaBody);
+            return BindCqlOperator(nameof(ICqlOperators.Select), input, lambda);
+        }
+
+        Type toType = TryCorrectQiCoreBindingError(input.Type, outputType, out var correctedTo)
+                          ? correctedTo!
+                          : outputType;
+        _cqlOperatorsBinder.TryConvert(input, toType, out (IrExpression arg, TypeConversion conversion) tryConvert);
+        typeConversion = tryConvert.conversion;
+        throwCannotCastIfNoMatch(tryConvert.conversion);
+        return tryConvert.arg;
+
+        void throwCannotCastIfNoMatch(TypeConversion result)
+        {
+            if (result == TypeConversion.NoMatch && throwOnError)
+                throw this.NewExpressionBuildingException($"Cannot convert {input.Type} to {outputType}.");
+        }
+    }
+
+    #endregion
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Query.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Query.cs
@@ -451,7 +451,7 @@ partial class IrExpressionBuilderContext
             var whereLambda = new IrLambda([whereLambdaParameter], suchThatBody);
             var callWhereOnSource = BindCqlOperator(nameof(ICqlOperators.Where), source, whereLambda);
 
-            // NOTE(phase4): ported as-is — this second parameter shares the alias name with
+            // NOTE(phase4): ported as-is (#1343) — this second parameter shares the alias name with
             // whereLambdaParameter but is a distinct IrLocal instance, exactly as the old builder
             // called Expression.Parameter(...) a second time here. It is never referenced in the
             // lambda body below (selectBody is rootScopeParameter, ignoring the parameter), so its

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Query.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Query.cs
@@ -1,0 +1,976 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Compiler.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Operators;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using Tuple = Hl7.Cql.Elm.Tuple;
+using IrExpressionElementPairForIdentifier = System.Collections.Generic.KeyValuePair<string, (Hl7.Cql.Compiler.Ir.IrExpression, Hl7.Cql.Elm.Element)>;
+
+/// <summary>
+/// IR counterpart of the query region of <c>ExpressionBuilderContext.cs</c> (query sources,
+/// where/return/aggregate/sort clauses, relationship clauses) plus the property/instance/tuple
+/// construction machinery. Mechanical port of the old per-node methods; see the remarks on
+/// <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    #region Query
+
+    protected IrExpression Query(Query query)
+    {
+        QueryDumpDebugInfoToLog(query);
+
+        Action popTokens = null!;
+
+        void PushScopes(
+            string? alias = null,
+            params IrExpressionElementPairForIdentifier[] kvps)
+        {
+            var popToken = this.PushScopes(alias, kvps);
+            popTokens = (() => popToken.Pop()) + popTokens;
+        }
+
+        try
+        {
+            var sources = query.source;
+            if (sources.Length == 0)
+                throw this.NewExpressionBuildingException("Queries must define at least 1 source");
+
+            var (@return, sourcesPreviouslySingletons) = ProcessQuerySources(query);
+            var returnElementType = _typeResolver.GetListElementType(@return.Type, true)!;
+
+            IrLocal scopeParameter;
+            if (sources.Length == 1)
+            {
+                var source0 = sources[0];
+                var sourceParameterName = IdentifierNormalizer.Normalize(source0.alias);
+                scopeParameter = new IrLocal(returnElementType, sourceParameterName);
+                PushScopes(ImpliedAlias, new IrExpressionElementPairForIdentifier(source0.alias, ((IrExpression)scopeParameter, (Elm.Element)source0.expression)));
+            }
+            else
+            {
+                var sourceParameterName = TypeNameToIdentifier(returnElementType, this);
+                scopeParameter = new IrLocal(returnElementType, sourceParameterName);
+                var scopes =
+                    (
+                        from property in returnElementType!.GetProperties()
+                        let propertyAccess = new IrProperty(scopeParameter, property)
+                        select new IrExpressionElementPairForIdentifier(property.Name, (propertyAccess, (Elm.Element)query))
+                    )
+                    .ToArray();
+                PushScopes(ImpliedAlias, scopes);
+            }
+
+            if (query.let != null)
+            {
+                foreach (var let in query.let)
+                {
+                    var expression = TranslateArg(let.expression!);
+                    PushScopes(ImpliedAlias, new IrExpressionElementPairForIdentifier(let.identifier!, (expression, (Elm.Element)let.expression!)));
+                }
+            }
+
+            // handle with/such-that
+            if (query.relationship is not null)
+            {
+                foreach (var relationship in query.relationship)
+                {
+                    using (PushElement(relationship))
+                    {
+                        var selectManyLambda = WithToSelectManyBody(scopeParameter, relationship);
+
+                        var selectManyCall = BindCqlOperator(nameof(ICqlOperators.SelectMany), @return, selectManyLambda);
+                        if (relationship is Without)
+                        {
+                            var callExcept = BindCqlOperator(nameof(ICqlOperators.Except), @return, selectManyCall);
+                            @return = callExcept;
+                        }
+                        else
+                        {
+                            @return = selectManyCall;
+                        }
+                    }
+                }
+            }
+
+            // 20240312 EK: refactoring made this redundant, but I am not sure it really is, so I am keeping
+            // it around. It was used to redefine the type for the "rootScopeParameter", which used to be defined
+            // inside every if statement here (so for where, return, etc).
+            // -----
+            // The element type may have changed
+            // elementType = TypeResolver.GetListElementType(@return.Type, @throw: true)!;
+            if (query.where is { } queryWhere)
+            {
+                @return = Where(queryWhere, scopeParameter, @return);
+            }
+
+            if (query.@return != null)
+            {
+                using (PushElement(query.@return))
+                {
+                    var selectBody = TranslateArg(query.@return.expression!);
+                    var selectLambda = new IrLambda([scopeParameter], selectBody);
+                    var callSelect = BindCqlOperator(nameof(ICqlOperators.Select), @return, selectLambda);
+                    @return = callSelect;
+                    if (query.@return.distinct)
+                    {
+                        // NOTE(phase4): ported as-is — `qt`/`t` are computed but never used, matching
+                        // the old ExpressionBuilderContext.Query's dead code.
+                        var qt = query.GetTypeSpecifier();
+                        var t = TypeFor(qt, false);
+                        @return = BindCqlOperator(nameof(ICqlOperators.Distinct), [@return]);
+                    }
+                }
+            }
+
+            if (query.aggregate is { } queryAggregate)
+            {
+                @return = AggregateClause(query, queryAggregate, scopeParameter, @return);
+            }
+
+            if (query.sort is { by.Length: > 0 })
+            {
+                @return = SortClause(query, @return);
+            }
+
+            // Because we promoted the source to a list, we now have to demote the result again.
+            var wereAllSourcesPreviouslySingletons = sourcesPreviouslySingletons.All(b => b);
+            if (wereAllSourcesPreviouslySingletons)
+            {
+                @return = DemoteSourceListToSingleton(@return);
+            }
+
+            if (query.resultTypeSpecifier is ListTypeSpecifier && !_typeResolver.IsListType(@return.Type))
+            {
+                @return = new IrNewArray(@return.Type, @return);
+            }
+
+            return @return;
+        }
+        finally
+        {
+            popTokens?.Invoke();
+        }
+    }
+
+    private IrExpression DemoteSourceListToSingleton(IrExpression source)
+    {
+        // Do not inline this method, so that we can clearly see the pairing with the call to PromoteSourceSingletonToList
+        var typeArg = _typeResolver.GetListElementType(source.Type, true);
+        return BindCqlOperator(nameof(ICqlOperators.SingletonFrom), [source], [typeArg!]);
+    }
+
+    private (IrExpression source, bool sourceOriginallyASingleton) PromoteSourceSingletonToList(IrExpression source)
+    {
+        if (_typeResolver.IsListType(source.Type))
+            return (source, false);
+
+        source = new IrNewArray(source.Type, source);
+        return (source, true);
+    }
+
+    [Conditional("DEBUG")]
+    private void QueryDumpDebugInfoToLog(Query query)
+    {
+        var sourceLength = query.source?.Length ?? 0;
+        var lines = ReadCqlLines(query);
+        var sources = ReadSources();
+
+        (string alias, Type sourceType, bool isEnumerationType)[] ReadSources() => query.source!
+                                                                                        .SelectToArray(s =>
+                                                                                        {
+                                                                                            var sourceType = TranslateArg(s.expression).Type;
+                                                                                            var isEnumerationType = _typeResolver.IsListType(sourceType);
+                                                                                            if (isEnumerationType)
+                                                                                                sourceType = _typeResolver
+                                                                                                    .GetListElementType(sourceType, true)!;
+                                                                                            return (
+                                                                                                       s.alias,
+                                                                                                       sourceType,
+                                                                                                       isEnumerationType
+                                                                                                   );
+                                                                                        });
+
+        string[]? ReadCqlLines(Element element)
+        {
+            if (element.locator?.Split([":", "-"], 4, StringSplitOptions.TrimEntries) is not [{ } r0, { } c0, { } r1, { } c1]) return null;
+
+            static int ParseInt32(string s) => int.Parse(s, CultureInfo.InvariantCulture);
+
+            var (row0, col0, row1, col1) = (ParseInt32(r0), ParseInt32(c0), ParseInt32(r1), ParseInt32(c1));
+
+            var elmFilePath = _libraryContext.Library.OriginalFilePath;
+            if (elmFilePath is null)
+                return null;
+
+            var fiElm = new FileInfo(elmFilePath);
+            var fiCql = new FileInfo(Path.Combine(fiElm.Directory!.Parent!.FullName, "CQL", fiElm.Name[..^4] + "cql"));
+            if (!fiCql.Exists)
+                return null;
+
+            var lines =
+                File.ReadLines(fiCql.FullName)
+                    .Select((lineText, i) => (lineText, lineNum: i + 1))
+                    .Where(t => t.lineNum >= row0 && t.lineNum <= row1)
+                    .Select(t =>
+                    {
+                        var lineText = t.lineText;
+                        Debug.Assert(row0 != row1 || col1 > col0);
+                        if (t.lineNum == row1)
+                        {
+                            // Cannot trust the locator data in elm files to be within the bounds of the current line
+                            col1 = Math.Clamp(col1, 0, lineText.Length);
+                            lineText = lineText[..col1] + "<<<" + lineText[col1..];
+                        }
+
+                        if (t.lineNum == row0)
+                        {
+                            // Cannot trust the locator data in elm files to be within the bounds of the current line
+                            col0 = Math.Clamp(col0, 0, lineText.Length);
+                            lineText = lineText[..col0] + ">>>" + lineText[col0..];
+                        }
+
+                        return lineText;
+                    })
+                    .ToArray();
+            return lines;
+        }
+
+        _logger.LogDebug(
+            """
+            Found {queryType} Query with {sourceCount} source(s) at: {at}
+            Sources:{sources}
+            CQL: {lines}
+            """,
+            ((ReadOnlySpan<string>) ["Empty", "Single", "Multi"])[Math.Clamp(sourceLength, 0, 2)],
+            sourceLength,
+            DebuggerView,
+            $"{string.Concat(from s in sources select $"\n\t{s.alias}: {(s.isEnumerationType ? "Enumeration" : "Singleton")} of {s.sourceType}")}",
+            lines is not null ? $"{string.Concat(from l in lines select $"\n\t{l}")}" : "");
+    }
+
+    private (IrExpression sourceExpression, bool[] sourcesPreviouslySingletons) ProcessQuerySources(Query query)
+    {
+        AliasedQuerySource[] sources = query.source;
+
+        if (sources.Length is 0)
+            throw this.NewExpressionBuildingException("A query must have at least one source.");
+
+        var aliases = sources.SelectToArray(s => s.alias);
+        if (aliases.Any(alias => string.IsNullOrEmpty(alias)))
+            throw this.NewExpressionBuildingException("Query sources must have aliases.");
+
+        var sourceExpressions = TranslateArgs(sources.SelectToArray(source => source.expression));
+
+        // Returns a CrossJoin between IEnumerable<> of T1, T2, T3, etc and return into IEnumerable<(T1, T2, T3, etc)>
+        // a) If a source is not of a list-type (ie, a singleton), it needs to be promoted to a list type.
+        // b) Cross-Join
+        //    IEnumerable<A> a = ...;
+        //    IEnumerable<B> b = ...;
+        //    IEnumerable<c> c = ...;
+        //    IEnumerable<(A, B, C)> crossJoinedValueTupleResults = CrossJoin<A, B, C>(a, b, c);
+
+        var temp = sourceExpressions.SelectToArray(expr => PromoteSourceSingletonToList(expr));
+        var promotedSourceExpressions = temp.SelectToArray(s => s.source);
+        var sourcesPreviouslySingletons = temp.SelectToArray(s => s.sourceOriginallyASingleton);
+
+        // Only one source, so no need for cross-joining. Return as-is.
+        if (sources.Length == 1)
+            return (promotedSourceExpressions[0], sourcesPreviouslySingletons);
+
+        var crossJoinedValueTupleResultsExpression = BindCqlOperator(nameof(ICqlOperators.CrossJoin), promotedSourceExpressions);
+
+        // Select the IEnumerable<> of value-tuples above into IEnumerable<> of our custom tuple
+        // a) Create the custom tuple
+        // b) Select
+        //    IEnumerable<Tuple_ABC> crossJoinedCqlTupleResults = Select(
+        //        crossJoinedValueTupleResults,
+        //        valueTuple => {
+        //            var abc = new Tuple_ABC();
+        //            abc.A = t.Item1;
+        //            abc.B = t.Item2;
+        //            abc.C = t.Item3;
+        //            return abc;
+        //        });
+
+        Type[] sourceListElementTypes = promotedSourceExpressions
+            .SelectToArray(pse => _typeResolver.GetListElementType(pse.Type, true)!);
+
+        // IEnumerable<(A,B,C)
+        var funcResultType = crossJoinedValueTupleResultsExpression.Type;
+
+        // (A,B,C)
+        const BindingFlags bfPublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+        Type valueTupleType = _typeResolver.GetListElementType(funcResultType, true)!;
+        FieldInfo[] valueTupleFields = valueTupleType.GetFields(bfPublicInstance | BindingFlags.GetField);
+
+        Type cqlTupleType = _tupleBuilderCache.CreateOrGetTupleTypeFor(sourceListElementTypes.Zip(aliases).ToList());
+        PropertyInfo[] cqlTupleProperties = cqlTupleType.GetProperties(bfPublicInstance | BindingFlags.SetProperty);
+
+        Debug.Assert(valueTupleFields.Length > 0);
+        Debug.Assert(valueTupleFields.Length == cqlTupleProperties.Length);
+
+        var valueTupleTypeParam = new IrLocal(valueTupleType, "_valueTuple");
+        var selectExpression =
+            new IrLambda(
+                [valueTupleTypeParam],
+                CopyValueTupleIntoCqlTuple());
+
+        IrExpression CopyValueTupleIntoCqlTuple()
+        {
+            // NOTE(phase4): the reflection-emitted CQL tuple type is constructed via IrTupleInit
+            // (matching every element to its property by name) rather than IrNew + IrMemberInit,
+            // per the phase-4 node-type mapping for CQL tuple types.
+            var elements = valueTupleFields
+                          .Zip(cqlTupleProperties, (valueTupleField, cqlTupleProp) => (valueTupleField, cqlTupleProp))
+                          .SelectToArray(
+                              valueTupleFields.Length,
+                              t => (t.cqlTupleProp.Name, (IrExpression)new IrProperty(valueTupleTypeParam, t.valueTupleField)));
+
+            var copyProps = new IrTupleInit(cqlTupleType, elements);
+            return copyProps;
+        }
+
+        var crossJoinedCqlTupleResultsExpression = BindCqlOperator(nameof(ICqlOperators.Select), crossJoinedValueTupleResultsExpression, selectExpression);
+
+        return (crossJoinedCqlTupleResultsExpression, sourcesPreviouslySingletons)!;
+    }
+
+    protected IrExpression SortClause(
+        Query query,
+        IrExpression @return)
+    {
+        //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByExpression))]
+        //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByColumn))]
+        //[System.Xml.Serialization.XmlIncludeAttribute(typeof(ByDirection))]
+        using (PushElement(query.sort))
+        {
+            foreach (var by in query.sort.by)
+            {
+                using (PushElement(by))
+                {
+                    ListSortDirection order = by.direction.ListSortOrder();
+                    switch (by)
+                    {
+                        case ByExpression byExpression:
+                        {
+                            var parameterName = "@this";
+                            var returnElementType = _typeResolver.GetListElementType(@return.Type, true)!;
+                            var sortMemberParameter = new IrLocal(returnElementType, parameterName);
+                            using (PushScopes(parameterName,
+                                              new IrExpressionElementPairForIdentifier(parameterName, (sortMemberParameter, (Elm.Element)byExpression.expression))))
+                            {
+                                var sortMemberExpression = TranslateArg(byExpression.expression);
+                                var lambdaBody = _cqlOperatorsBinder.ConvertToType(sortMemberExpression, typeof(object));
+                                var sortLambda = new IrLambda([sortMemberParameter], lambdaBody);
+                                return BindCqlOperator(nameof(ICqlOperators.SortBy), @return, sortLambda,
+                                                       new IrConstant(order, typeof(ListSortDirection)));
+                            }
+                        }
+                        case ByColumn byColumn:
+                        {
+                            var parameterName = "@this";
+                            var returnElementType = _typeResolver.GetListElementType(@return.Type, true)!;
+                            var sortMemberParameter = new IrLocal(returnElementType, parameterName);
+                            var pathMemberType = TypeFor(byColumn);
+                            if (pathMemberType == null)
+                            {
+                                throw this.NewExpressionBuildingException(
+                                    $"Type specifier {by.resultTypeName} at {by.locator ?? "unknown"} could not be resolved.");
+                            }
+
+                            var pathExpression = PropertyHelper(sortMemberParameter, byColumn.path, pathMemberType!);
+                            var lambdaBody = _cqlOperatorsBinder.ConvertToType(pathExpression, typeof(object));
+                            var sortLambda = new IrLambda([sortMemberParameter], lambdaBody);
+                            return BindCqlOperator(nameof(ICqlOperators.SortBy), @return, sortLambda, new IrConstant(order, typeof(ListSortDirection)));
+                        }
+                        default:
+                        {
+                            return BindCqlOperator(nameof(ICqlOperators.ListSort), @return, new IrConstant(order, typeof(ListSortDirection)));
+                        }
+                    }
+                }
+            }
+        }
+
+        return @return;
+    }
+
+    protected IrLambda WithToSelectManyBody(
+        IrLocal rootScopeParameter,
+        RelationshipClause with)
+    {
+        if (with.expression == null)
+            throw this.NewExpressionBuildingException("With must have a 'source' expression.");
+
+        if (with.suchThat == null)
+            throw this.NewExpressionBuildingException("With must have a 'such that' expression.");
+
+        //define "With Such That":
+        //[Encounter] E
+        //  with[Condition] P
+        //   such that P.onset during E.period
+        //     and P.abatement after end of E.period
+
+        //Func<Bundle, Context, IEnumerable<Encounter>> x = (bundle, ctx) =>
+        //    bundle.Entry.ByResourceType<Encounter>()
+        //    .SelectMany(E =>
+        //        bundle.Entry.ByResourceType<Condition>() // <--
+        //            .Where(P => true) // such that goes here
+        //            .Select(P => E));
+        var source = TranslateArg(with.expression);
+        if (!_typeResolver.IsListType(source.Type))
+        {
+            // e.g.:
+            // with "Index Prescription Start Date" IPSD
+            // where IPSD is a Date
+            // Promote to an array for consistency.
+            var newArray = new IrNewArray(source.Type, source);
+            source = newArray;
+        }
+
+        var sourceElementType = _typeResolver.GetListElementType(source.Type)!;
+
+        var whereLambdaParameter = new IrLocal(sourceElementType, with.alias);
+        using (PushScopes(ImpliedAlias, new IrExpressionElementPairForIdentifier(with.alias!, (whereLambdaParameter, (Elm.Element)with))))
+        {
+            var suchThatBody = TranslateArg(with.suchThat);
+
+            var whereLambda = new IrLambda([whereLambdaParameter], suchThatBody);
+            var callWhereOnSource = BindCqlOperator(nameof(ICqlOperators.Where), source, whereLambda);
+
+            // NOTE(phase4): ported as-is — this second parameter shares the alias name with
+            // whereLambdaParameter but is a distinct IrLocal instance, exactly as the old builder
+            // called Expression.Parameter(...) a second time here. It is never referenced in the
+            // lambda body below (selectBody is rootScopeParameter, ignoring the parameter), so its
+            // identity doesn't matter beyond giving the Select lambda a correctly-typed parameter slot.
+            var selectLambdaParameter = new IrLocal(sourceElementType, with.alias);
+            IrExpression selectBody = rootScopeParameter; // P => E
+            var selectLambda = new IrLambda([selectLambdaParameter], selectBody);
+            var callSelectOnWhere = BindCqlOperator(nameof(ICqlOperators.Select), callWhereOnSource, selectLambda);
+            var selectManyLambda = new IrLambda([rootScopeParameter], callSelectOnWhere);
+            return selectManyLambda;
+        }
+    }
+
+
+    protected IrExpression Where(
+        Elm.Expression queryWhere,
+        IrLocal sourceParameter,
+        IrExpression @return)
+    {
+        using (PushElement(queryWhere))
+        {
+            var whereBody = TranslateArg(queryWhere);
+            var whereLambda = new IrLambda([sourceParameter], whereBody);
+            return BindCqlOperator(nameof(ICqlOperators.Where), @return, whereLambda);
+        }
+    }
+
+    protected IrExpression AggregateClause(
+        Query query,
+        AggregateClause queryAggregate,
+        IrLocal sourceParameter,
+        IrExpression @return)
+    {
+        using (PushElement(queryAggregate))
+        {
+            var resultAlias = queryAggregate.identifier!;
+            Type? resultType = null;
+            if (queryAggregate.resultTypeSpecifier is { } typeSpecifier)
+            {
+                resultType = TypeFor(typeSpecifier)!;
+            }
+            else if (!string.IsNullOrWhiteSpace(queryAggregate.resultTypeName.Name!))
+            {
+                resultType = _typeResolver.ResolveType(queryAggregate.resultTypeName.Name!);
+            }
+
+            if (resultType is null)
+                throw this.NewExpressionBuildingException(
+                    $"Could not resolve aggregate query result type for query {query.localId} at {query.locator}");
+
+            var resultParameter = new IrLocal(resultType, resultAlias);
+            using (PushScopes(ImpliedAlias, new IrExpressionElementPairForIdentifier(resultAlias!, (resultParameter, (Elm.Element)queryAggregate))))
+            {
+                var lambdaBody = TranslateArg(queryAggregate.expression!);
+                // when starting is not present, it is a null literal typed as Any (object).
+                // cast the null to the expression type.
+                var starting = TranslateArg(queryAggregate.starting!);
+                var startingValue = ChangeType(starting, lambdaBody.Type, throwOnError: true);
+                if (queryAggregate.distinct)
+                    @return = _cqlOperatorsBinder.BindToMethod(nameof(ICqlOperators.Distinct), [@return], [resultType]);
+                var lambda = new IrLambda([resultParameter, sourceParameter], lambdaBody);
+
+                return BindCqlOperator(nameof(ICqlOperators.Aggregate), @return, lambda, startingValue);
+            }
+        }
+    }
+
+    #endregion
+
+    #region Properties, instances and tuples
+
+    protected IrExpression? IdentifierRef(IdentifierRef ire)
+    {
+        if (string.Equals("$this", ire.name) && ImpliedAlias != null)
+        {
+            var scopeExpression = GetScopeExpression(ImpliedAlias!);
+            return scopeExpression;
+        }
+
+        var pe = new Property
+        {
+            resultTypeSpecifier = ire.resultTypeSpecifier,
+            resultTypeName = ire.resultTypeName,
+            localId = ire.localId,
+            locator = ire.locator,
+            path = ire.name,
+            scope = ImpliedAlias!,
+        };
+        var prop = Property(pe);
+        return prop;
+    }
+
+    protected IrExpression OperandRef(OperandRef ore)
+    {
+        if (_operands?.TryGetValue(ore.name!, out var expression) == true)
+            return expression;
+        throw this.NewExpressionBuildingException($"Operand reference to {ore.name} not found in definition operands.");
+    }
+
+    protected IrExpression Property(Property op)
+    {
+        using (PushElement(op))
+        {
+            if (string.IsNullOrWhiteSpace(op.path))
+                throw this.NewExpressionBuildingException("Property expression cannot have null or empty path");
+            var path = op.path;
+
+            Type? expectedType;
+
+            if (!string.IsNullOrWhiteSpace(op.scope))
+            {
+                var scopeExpression = GetScopeExpression(op.scope!);
+                expectedType = TypeFor(op) ?? typeof(object);
+                var pathMemberInfo = _typeResolver.GetProperty(scopeExpression.Type, path!) ??
+                                     _typeResolver.GetProperty(scopeExpression.Type, op.path);
+                if (pathMemberInfo == null)
+                {
+                    _logger.LogWarning(
+                        FormatMessage(
+                            $"Property {op.path} can't be known at design time, and will be late-bound, slowing performance.  Consider casting the source first so that this property can be definitely bound.",
+                            op));
+                    return BindCqlOperator(nameof(ICqlOperators.LateBoundProperty), scopeExpression, new IrConstant(op.path, typeof(string)),
+                                           new IrConstant(expectedType, typeof(Type)));
+                }
+
+                var propogate = PropagateNull(scopeExpression, pathMemberInfo);
+                string message = $"TupleBuilderCache failed to resolve type.";
+                var resultType = TypeFor(op) ?? throw this.NewExpressionBuildingException(message);
+                if (resultType != propogate.Type)
+                {
+                    propogate = ChangeType(propogate, resultType, throwOnError: true);
+                }
+
+                return propogate;
+            }
+
+            if (op.source == null)
+                throw this.NewExpressionBuildingException("Property expression cannot have an empty source when scope is empty");
+
+            var source = TranslateArg(op.source);
+            var parts = path.Split('.');
+            if (parts.Length > 1)
+            {
+                // support paths like birthDate.value on Patient
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    var pathPart = parts[i];
+                    var pathMemberInfo = _typeResolver.GetProperty(source.Type, pathPart);
+                    if (pathMemberInfo != null)
+                    {
+                        var propertyAccess = PropagateNull(source, pathMemberInfo);
+                        source = propertyAccess;
+                    }
+                }
+
+                return source;
+            }
+
+            // If we cannot determine the type from the ELM, let's try
+            // if the POCO model can help us.
+            expectedType = TypeFor(op, throwIfNotFound: false)
+                           ?? _typeResolver.GetProperty(source.Type, path)?.PropertyType
+                           ?? throw this.NewExpressionBuildingException("Cannot resolve type for expression");
+
+            var result = PropertyHelper(source, path, expectedType);
+            return result;
+        }
+    }
+
+    protected IrExpression PropertyHelper(
+        IrExpression source,
+        string? path,
+        Type expectedType)
+    {
+        IrExpression? result = null;
+        if (_typeResolver.ShouldUseSourceObject(source.Type, path!))
+        {
+            result = source;
+        }
+        else
+        {
+            var pathMemberInfo = _typeResolver.GetProperty(source.Type, path!);
+
+            if (pathMemberInfo == null)
+            {
+                _logger.LogWarning(
+                    FormatMessage(
+                        $"Property {path} can't be known at design time, and will be late-bound, slowing performance.  Consider casting the source first so that this property can be definitely bound."));
+                return BindCqlOperator(nameof(ICqlOperators.LateBoundProperty), source, new IrConstant(path, typeof(string)),
+                                       new IrConstant(expectedType, typeof(Type)));
+            }
+
+            if (pathMemberInfo.DeclaringType != source.Type) // the property is on a derived type, so cast it
+            {
+                var isCheck = source.NewTypeIsExpression(pathMemberInfo.DeclaringType!);
+                var typeAs = source.NewTypeAsExpression(pathMemberInfo.DeclaringType!);
+                var pathAccess = new IrProperty(typeAs, pathMemberInfo);
+                IrExpression? ifIs = pathAccess;
+                IrExpression elseNull = new IrConstant(null, pathMemberInfo.PropertyType);
+                // some ops, like properties on alias refs, don't have type information on them.
+                // can't check against what we don't have.
+                if (expectedType != null)
+                {
+                    if (expectedType != ifIs.Type)
+                    {
+                        ifIs = ChangeType(ifIs, expectedType, throwOnError: true);
+                    }
+
+                    if (expectedType != elseNull.Type)
+                    {
+                        elseNull = ChangeType(elseNull, expectedType, throwOnError: true);
+                    }
+                }
+
+                var condition = new IrConditional(isCheck, ifIs, elseNull, ifIs.Type);
+                return condition;
+            }
+
+            result = PropagateNull(source, pathMemberInfo);
+        }
+
+        if (expectedType != null && expectedType != result.Type)
+        {
+            result = ChangeType(result, expectedType, throwOnError: true);
+        }
+
+        return result;
+    }
+
+    internal static PropertyInfo? GetProperty(
+        Type type,
+        string name,
+        TypeResolver typeResolver)
+    {
+        if (type.IsGenericType)
+        {
+            var gtd = type.GetGenericTypeDefinition();
+            if (gtd == typeof(Nullable<>))
+            {
+                if (string.Equals(name, "value", StringComparison.OrdinalIgnoreCase))
+                {
+                    var valueMember = type.GetProperty("Value");
+                    return valueMember;
+                }
+            }
+        }
+
+        var member = typeResolver.GetProperty(type, name);
+        return member;
+    }
+
+    /// <remarks>The old builder returned a <c>MemberAssignment</c>; the IR pipeline represents
+    /// an object-initializer binding as a <c>(MemberInfo, IrExpression)</c> pair (see
+    /// <see cref="IrMemberInit"/>).</remarks>
+    protected (MemberInfo member, IrExpression value) Binding(IrExpression value, MemberInfo memberInfo)
+    {
+        if (memberInfo is PropertyInfo property)
+        {
+            if (value.Type == property.PropertyType)
+            {
+                return (memberInfo, value);
+            }
+
+            if (property.PropertyType.IsArray)
+            {
+                if (value.Type.IsArray)
+                {
+                    if (property.PropertyType.GetElementType() == value.Type.GetElementType())
+                    {
+                        return (memberInfo, value);
+                    }
+                }
+                else if (value.Type.IsGenericType)
+                {
+                    string message = $"{value.Type} was expected to be a list type.";
+                    var valueEnumerableElement = _typeResolver.GetListElementType(value.Type) ?? throw this.NewExpressionBuildingException(message);
+                    var memberArrayElement = property.PropertyType.GetElementType()!;
+                    if (valueEnumerableElement == memberArrayElement)
+                    {
+                        var toArrayMethod = typeof(Enumerable)
+                                            .GetMethod(nameof(Enumerable.ToArray))!
+                                            .MakeGenericMethod(valueEnumerableElement);
+                        var callToArray = new IrInvoke(null, toArrayMethod, value);
+                        return (memberInfo, callToArray);
+                    }
+                    else
+                    {
+                        var selectParameter = new IrLocal(valueEnumerableElement, TypeNameToIdentifier(value.Type, this));
+                        var body = ChangeType(selectParameter, memberArrayElement, throwOnError: true);
+                        var selectLambda = new IrLambda([selectParameter], body);
+                        var callSelectMethod = BindCqlOperator(nameof(ICqlOperators.Select), [
+                            value, selectLambda
+                        ]);
+                        var toArrayMethod = typeof(Enumerable)
+                                            .GetMethod(nameof(Enumerable.ToArray))!
+                                            .MakeGenericMethod(memberArrayElement);
+                        var callToArray = new IrInvoke(null, toArrayMethod, callSelectMethod);
+                        return (memberInfo, callToArray);
+                    }
+                }
+            }
+            else if (property.PropertyType.IsImplementingGenericTypeDefinition(typeof(ICollection<>)))
+            {
+                if (_typeResolver.IsListType(value.Type))
+                {
+                    var elementType = _typeResolver.GetListElementType(property.PropertyType)!;
+                    var ctor = ConstructorInfos.ListOf(elementType);
+                    var newList = new IrNew(ctor, value);
+                    return (memberInfo, newList);
+                }
+            }
+
+            var convert = ChangeType(value, property.PropertyType, throwOnError: true);
+            return (memberInfo, convert);
+        }
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    protected IrExpression Instance(Instance ine)
+    {
+        var instanceType = _typeResolver.ResolveType(ine.classType.Name)
+                           ?? throw this.NewExpressionBuildingException($"Could not resolve type for '{ine.classType.Name}'");
+
+        if (instanceType.IsEnum())
+        {
+            // constructs like:
+            // FHIR.RemittanceOutcome {value: 'complete'}
+            // FHIR.RemittanceOutcome maps to an enum type
+            if (ine.element?.Length == 1 && string.Equals(ine.element![0].name, "value", StringComparison.OrdinalIgnoreCase))
+            {
+                var enumValueValue = TranslateArg(ine.element[0]!.value!);
+
+                if (enumValueValue.Type == instanceType)
+                    return enumValueValue;
+
+                if (enumValueValue.Type == typeof(string)) //@ TODO: Cast - Instance
+                {
+                    var methodInfo = typeof(Enum).GetMethod(nameof(Enum.Parse), new[] { typeof(Type), typeof(string), typeof(bool) })
+                                     ?? throw this.NewExpressionBuildingException($"Could not find Enum.Parse method.");
+
+                    var callEnumParse = new IrInvoke(null, methodInfo, new IrConstant(instanceType, typeof(Type)), enumValueValue, new IrConstant(true, typeof(bool)));
+                    return callEnumParse;
+                }
+            }
+        }
+
+        if (instanceType.IsGenericType
+            && instanceType.GenericTypeArguments.Length == 1
+            && instanceType.GenericTypeArguments[0].IsEnum)
+        {
+            // supports constructs like
+            //  * FHIR.ObservationStatus { value: 'final' }
+            //  * FHIR.AdministrativeGender { value: 'female' }
+            //  * ...
+            // which map to Code<ObservationStatus> or Code<AdministrativeGender
+            if (ine.element?.Length == 1
+                && string.Equals(ine.element![0].name, "value", StringComparison.OrdinalIgnoreCase))
+            {
+                var enumValueValue = TranslateArg(ine.element[0]!.value!);
+
+                if (enumValueValue.Type == instanceType)
+                    return enumValueValue;
+
+                if (enumValueValue.Type == typeof(string)) //@ TODO: Cast - Instance
+                {
+                    var enumParseMethod = typeof(Enum).GetMethod(nameof(Enum.Parse), new[] { typeof(Type), typeof(string), typeof(bool) });
+
+                    var genericType = instanceType.GenericTypeArguments[0];
+                    var constructorInfo = instanceType.GetConstructor(new[] { genericType })
+                                          ?? throw this.NewExpressionBuildingException(
+                                              $"Could not find constructor for {instanceType}<{genericType}>({genericType})");
+
+                    var parseCall = new IrInvoke(
+                        null,
+                        enumParseMethod!,
+                        new IrConstant(instanceType.GenericTypeArguments[0], typeof(Type)),
+                        enumValueValue,
+                        new IrConstant(true, typeof(bool)));
+
+                    var typedParsedValue = new IrCast(parseCall, genericType.MakeNullable(), IrCastKind.Cast);
+
+                    var genericEnumValue = new IrNew(
+                        constructorInfo,
+                        typedParsedValue);
+
+                    return genericEnumValue;
+                }
+            }
+        }
+
+        (string name, IrExpression value)[] parameterNameValuePairs = ine.element!.SelectToArray(el => (name: el.name!, value: TranslateArg(el.value)));
+
+        // Find a constructor that matches the provided parameters.
+        const int NOT_MAPPED_HAS_DEFAULT_VALUE = int.MaxValue;
+        var (ctor, ctorParameters, ctorPositionToParameterPositionMap) =
+            // Prefer constructors with more parameters, and
+            instanceType.GetConstructors()
+                        .OrderByDescending(c => c.GetParameters().Length) // Prefer constructors with more parameters
+                        .SelectWhere(ctor =>
+                        {
+                            var ctorParameters = ctor.GetParameters();
+
+                            // Exit if the constructor has fewer parameters than provided
+                            if (parameterNameValuePairs.Length > ctorParameters.Length)
+                                return default;
+
+                            // Exit if the constructor has a parameter that
+                            // is not assignable from the provided value by name or type
+                            // when the parameter has no default value.
+                            int[] ctorPositionToParameterPositionMap = new int[ctorParameters.Length];
+                            bool[] isParameterNameValuePairMapped = new bool[parameterNameValuePairs.Length];
+                            for (var i = 0; i < ctorParameters.Length; i++)
+                            {
+                                var ctorParameter = ctorParameters[i];
+                                var parameterPosition =
+                                    Array.FindIndex(
+                                        parameterNameValuePairs,
+                                        parameterNameValuePair =>
+                                            string.Equals(ctorParameter.Name, parameterNameValuePair.name, StringComparison.OrdinalIgnoreCase) &&
+                                            ctorParameter.ParameterType.IsAssignableFrom(parameterNameValuePair.value.Type));
+                                switch (parameterPosition)
+                                {
+                                    case -1 when ctorParameter.HasDefaultValue:
+                                        ctorPositionToParameterPositionMap[i] = NOT_MAPPED_HAS_DEFAULT_VALUE; break;
+                                    case -1:
+                                        return default; // Exit immediately if we cannot map this parameter
+                                    case { } p:
+                                        ctorPositionToParameterPositionMap[i] = p;
+                                        isParameterNameValuePairMapped[parameterPosition] = true;
+                                        break;
+                                }
+                            }
+
+                            // Make sure there are no provided values that are not mapped to a constructor parameter
+                            if (Array.IndexOf(isParameterNameValuePairMapped, false) >= 0)
+                                return default;
+
+                            return (true, (ctor, ctorParameters, ctorPositionToParameterPositionMap));
+                        })
+                        .FirstOrDefault();
+
+        if (ctor is not null)
+        {
+            IrExpression[] values = new IrExpression[ctorPositionToParameterPositionMap.Length];
+            for (int i = 0; i < ctorPositionToParameterPositionMap.Length; i++)
+            {
+                var parameterPosition = ctorPositionToParameterPositionMap[i];
+                var ctorParameter = ctorParameters[i];
+                values[i] = (parameterPosition, ctorParameter.DefaultValue) switch
+                {
+                    (NOT_MAPPED_HAS_DEFAULT_VALUE, null) => new IrConstant(null, ctorParameter.ParameterType),
+                    (NOT_MAPPED_HAS_DEFAULT_VALUE, {} defaultValue) => new IrConstant(defaultValue, ctorParameter.ParameterType),
+                    _                                               => parameterNameValuePairs[parameterPosition].value
+                };
+            }
+            var newInstance = new IrNew(ctor, values);
+            return newInstance;
+        }
+
+        // Fallback to member initialization if a constructor with all parameters is not available.
+        ctor = instanceType.GetConstructor(Type.EmptyTypes);
+        if (ctor != null)
+        {
+            var elementBindings = new (MemberInfo Member, IrExpression Value)[parameterNameValuePairs.Length];
+            for (int i = 0; i < parameterNameValuePairs.Length; i++)
+            {
+                var (name, value) = parameterNameValuePairs[i];
+                var memberInfo = GetProperty(instanceType, name, _typeResolver) ??
+                                 throw this.NewExpressionBuildingException($"Could not find member {name} on type {instanceType.ToCSharpString(Defaults.TypeCSharpFormat)}");
+                var binding = Binding(value, memberInfo);
+                elementBindings[i] = binding;
+            }
+
+            var @new = new IrNew(ctor);
+            var init = new IrMemberInit(@new, elementBindings);
+            return init;
+        }
+
+        throw this.NewExpressionBuildingException($"No suitable constructor found for type {instanceType}.");
+    }
+
+    protected IrExpression Tuple(Tuple tuple)
+    {
+        Type tupleType;
+        if (tuple.resultTypeSpecifier is null)
+        {
+            tupleType = TupleTypeFor(tuple);
+        }
+        else
+        {
+            var tupleTypeSpecifier = tuple.resultTypeSpecifier as TupleTypeSpecifier ??
+                                     throw this.NewExpressionBuildingException($"Tuple expression has a resultType that is not a TupleTypeSpecifier.");
+            tupleType = TupleTypeFor(tupleTypeSpecifier);
+        }
+
+        // NOTE(phase4): the reflection-emitted CQL tuple type is constructed via IrTupleInit
+        // rather than IrNew + IrMemberInit, per the phase-4 node-type mapping for CQL tuple
+        // types. Binding(...) is still used per element so that the same coercion logic
+        // (array/ICollection conversions, ChangeType fallback) applies as before.
+        if (tuple.element?.Length > 0)
+        {
+            var elementBindings =
+                tuple.element!
+                     .SelectToArray(element =>
+                     {
+                         var value = TranslateArg(element.value!);
+                         var propInfo = GetProperty(tupleType, IdentifierNormalizer.Normalize(element.name!), _typeResolver)
+                                        ?? throw this.NewExpressionBuildingException(
+                                            $"Could not find member {element} on type {tupleType.ToCSharpString(Defaults.TypeCSharpFormat)}");
+                         var binding = Binding(value, propInfo);
+                         return (binding.member.Name, binding.value);
+                     });
+            var init = new IrTupleInit(tupleType, elementBindings);
+            return init;
+        }
+
+        return new IrTupleInit(tupleType, []);
+    }
+
+    #endregion
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Refs.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Refs.cs
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Model;
+using Hl7.Cql.Operators;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using ChoiceTypeSpecifier = Hl7.Cql.Elm.ChoiceTypeSpecifier;
+using ListTypeSpecifier = Hl7.Cql.Elm.ListTypeSpecifier;
+using NamedTypeSpecifier = Hl7.Cql.Elm.NamedTypeSpecifier;
+using TypeSpecifier = Hl7.Cql.Elm.TypeSpecifier;
+
+/// <summary>
+/// IR counterpart of the reference regions of <c>ExpressionBuilderContext.cs</c>: references
+/// to other definitions (expressions, functions, parameters, codes, code systems, concepts,
+/// value sets), retrieves, and the runtime-context invocation helpers. Mechanical port of the
+/// old per-node methods; see the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    protected IrExpression FunctionRef(FunctionRef op)
+    {
+        IrExpression[] operands = TranslateArgs(op.operand);
+
+        // NOTE: Breaks
+        //var resultType = op.resultTypeSpecifier ?? op.resultTypeName?.ToNamedType() ??
+        //                 throw new InvalidOperationException($"FunctionRef {op.libraryName + "." + op.name} has no result type specifier or result type name.");
+        //var invoke = InvokeDefinedFunctionThroughRuntimeContext(op.name!, op.libraryName!, operands, resultType);
+
+        //var invoke = InvokeDefinitionThroughRuntimeContext(op.name!, op.libraryName!, op.signature, operands, op.resultTypeSpecifier);
+        var invoke = InvokeDefinedFunctionThroughRuntimeContext(op.name!, op.libraryName!, op.signature, operands, op.resultTypeSpecifier);
+        return invoke;
+    }
+
+    protected IrExpression ExpressionRef(ExpressionRef expressionRef)
+    {
+        IPopToken popToken = null!;
+        try
+        {
+            Type? expressionType = null;
+            if (expressionRef.resultTypeSpecifier != null)
+            {
+                expressionType = TypeFor(expressionRef.resultTypeSpecifier)!;
+            }
+            else if (!string.IsNullOrWhiteSpace(expressionRef.resultTypeName?.Name))
+            {
+                expressionType = _typeResolver.ResolveType(expressionRef.resultTypeName.Name);
+            }
+            else
+            {
+                var def = _libraryContext.Library.statements?.SingleOrDefault(d => d.name == expressionRef.name);
+                if (def != null)
+                {
+                    popToken = PushElement(def);
+                    expressionType = TypeFor(def);
+                }
+                else throw new NotSupportedException("Unable to resolve expression reference type.");
+            }
+
+            if (expressionType == null)
+                throw this.NewExpressionBuildingException($"Unable to determine type for {expressionRef.localId}");
+
+            var invoke = InvokeDefinitionThroughRuntimeContext(expressionRef.name!, expressionRef.libraryName, expressionType);
+
+            return invoke;
+        }
+        finally
+        {
+            popToken?.Pop();
+        }
+    }
+
+    protected IrExpression ParameterRef(ParameterRef op)
+    {
+        if (_libraryContext.LibraryDefinitions.TryGetDefinition(_libraryContext.LibraryVersionedIdentifier, op.name!, out var definition))
+        {
+            var invoke = InvokeDefinitionThroughRuntimeContext(op.name!, null, definition);
+            return invoke;
+        }
+
+        throw this.NewExpressionBuildingException($"Parameter {op.name} hasn't been defined yet.");
+    }
+
+    protected IrExpression CodeRef(CodeRef codeRef)
+    {
+        if (string.IsNullOrWhiteSpace(codeRef.name))
+            throw this.NewExpressionBuildingException("The code ref has no name.");
+
+        var type = _typeResolver.ResolveType(codeRef.resultTypeName.Name) ??
+                   throw this.NewExpressionBuildingException($"Unable to resolve type {codeRef.resultTypeName}");
+        var definitionCallExpression = InvokeDefinitionThroughRuntimeContext(codeRef.name, codeRef.libraryName, type);
+        return definitionCallExpression;
+    }
+
+    private IrExpression CodeSystemRef(CodeSystemRef codeSystemRef)
+    {
+        if (string.IsNullOrWhiteSpace(codeSystemRef.name))
+            throw this.NewExpressionBuildingException("The code system ref has no name.");
+
+        var type = _typeResolver.CodeType.MakeArrayType();
+        var definitionCallExpression = InvokeDefinitionThroughRuntimeContext(codeSystemRef.name, codeSystemRef.libraryName, type);
+        return definitionCallExpression;
+    }
+
+    protected IrExpression ConceptRef(ConceptRef conceptRef)
+    {
+        if (string.IsNullOrWhiteSpace(conceptRef.name))
+            throw this.NewExpressionBuildingException("The concept ref has no name.");
+
+        var conceptType = TypeFor(conceptRef)!;
+        return InvokeDefinitionThroughRuntimeContext(conceptRef.name, conceptRef.libraryName, conceptType);
+    }
+
+    protected IrExpression ValueSetRef(ValueSetRef valueSetRef)
+    {
+        if (string.IsNullOrWhiteSpace(valueSetRef.name))
+            throw this.NewExpressionBuildingException($"The ValueSetRef at {valueSetRef.locator} is missing a name.");
+
+        var cqlValueSet = InvokeDefinitionThroughRuntimeContext(valueSetRef.name, valueSetRef.libraryName, typeof(CqlValueSet));
+        return cqlValueSet;
+    }
+
+    private IrExpression Retrieve(Retrieve retrieve)
+    {
+        Type? sourceElementType;
+        string? cqlRetrieveResultType;
+
+        // SingletonFrom does not have this specified; in this case use DataType instead
+        if (retrieve.resultTypeSpecifier == null)
+        {
+            if (string.IsNullOrWhiteSpace(retrieve.dataType.Name))
+                throw this.NewExpressionBuildingException("If a Retrieve lacks a ResultTypeSpecifier it must have a DataType");
+            cqlRetrieveResultType = retrieve.dataType.Name;
+
+            sourceElementType = _typeResolver.ResolveType(cqlRetrieveResultType);
+        }
+        else
+        {
+            if (retrieve.resultTypeSpecifier is ListTypeSpecifier listTypeSpecifier)
+            {
+                cqlRetrieveResultType = listTypeSpecifier.elementType is NamedTypeSpecifier nts ? nts.name.Name : null;
+                sourceElementType = TypeFor(listTypeSpecifier.elementType)!;
+            }
+            else throw new NotImplementedException($"Sources with type {retrieve.resultTypeSpecifier.GetType().Name} are not implemented.").WithContext(this);
+        }
+
+        IrExpression? codeProperty;
+
+        var hasCodePropertySpecified = sourceElementType != null && retrieve.codeProperty != null;
+        var isDefaultCodeProperty = retrieve.codeProperty is null ||
+                                    (cqlRetrieveResultType is not null &&
+                                     ModelMapping.TryGetValue(cqlRetrieveResultType, out ClassInfo? classInfo) &&
+                                     classInfo.primaryCodePath == retrieve.codeProperty);
+
+        if (hasCodePropertySpecified && !isDefaultCodeProperty)
+        {
+            var codePropertyInfo = _typeResolver.GetProperty(sourceElementType!, retrieve.codeProperty!);
+            codeProperty = new IrConstant(codePropertyInfo, typeof(PropertyInfo));
+        }
+        else
+        {
+            codeProperty = new IrConstant(null, typeof(PropertyInfo));
+        }
+
+        var templateId = TranslateArg(retrieve.templateId);
+        var sourceElementTypeExpr = new IrConstant(sourceElementType, typeof(Type));
+        IrExpression values = new IrConstant(null, typeof(CqlValueSet));
+
+        if (retrieve.codes != null)
+        {
+            if (retrieve.codes is ValueSetRef valueSetRef)
+            {
+                if (string.IsNullOrWhiteSpace(valueSetRef.name))
+                    throw this.NewExpressionBuildingException($"The ValueSetRef at {valueSetRef.locator} is missing a name.");
+
+                values = InvokeDefinitionThroughRuntimeContext(valueSetRef.name!, valueSetRef.libraryName, typeof(CqlValueSet));
+            }
+            else
+            {
+                // In this construct, instead of querying a value set, we're testing resources
+                // against a list of codes, e.g., as defined by the code from or codesystem construct
+                values = TranslateArg(retrieve.codes);
+            }
+        }
+
+        return BindCqlOperator(CqlOperator.Retrieve, sourceElementTypeExpr, values, codeProperty, templateId);
+    }
+
+    private IrExpression BindValueInValueSet(
+        IrExpression valueExpr,
+        IrExpression valueSetExpr,
+        bool isList)
+    {
+        var codeType = isList ? _typeResolver.GetListElementType(valueExpr.Type, throwError: true)! : valueExpr.Type;
+
+        if (codeType == _typeResolver.CodeType)
+            return BindCqlOperator(isList ? nameof(ICqlOperators.CodesInValueSet) : nameof(ICqlOperators.CodeInValueSet), valueExpr, valueSetExpr);
+
+        if (codeType == _typeResolver.ConceptType)
+            return BindCqlOperator(isList ? nameof(ICqlOperators.ConceptsInValueSet) : nameof(ICqlOperators.ConceptInValueSet), valueExpr, valueSetExpr);
+
+        if (codeType == typeof(string))
+            return BindCqlOperator(isList ? nameof(ICqlOperators.StringsInValueSet) : nameof(ICqlOperators.StringInValueSet), valueExpr, valueSetExpr);
+
+        throw new NotImplementedException().WithContext(this);
+    }
+
+    private IrExpression TranslateValueSet(ValueSetRef valueSetRef, Elm.Expression valueSetExpression)
+    {
+        var valueSet =
+            (valueSetRef, valueSetExpression) switch
+            {
+                // If valueSetExpression is not null, use it (even if valueSetRef also exists)
+                (_, { } e) => TranslateElement(e),
+                // If only valueSetRef is not null
+                ({ } r, null) => InvokeDefinitionThroughRuntimeContext(r.name!, r.libraryName, typeof(CqlValueSet)),
+                _             => throw this.NewExpressionBuildingException("Expected either a ValueSetRef or a ValueSetExpression")
+            };
+        return valueSet;
+    }
+
+    /// <param name="name">The function name</param>
+    /// <param name="libraryAlias">If this is an external call, the local alias defined in the using statement</param>
+    /// <param name="signature">The signature as specified in the function call.</param>
+    /// <param name="arguments">The function arguments</param>
+    /// <param name="returnType">The function's return type</param>
+    /// <returns></returns>
+    protected IrExpression InvokeDefinedFunctionThroughRuntimeContext(
+        string name,
+        string? libraryAlias,
+        TypeSpecifier[]? signature,
+        IrExpression[] arguments,
+        TypeSpecifier returnType)
+    {
+        string libraryName = _libraryContext.GetLibraryVersionedIdentifierFromAlias(libraryAlias, throwError: false)
+                             ?? throw this.NewExpressionBuildingException($"Local library {libraryAlias} is not defined; are you missing a using statement?");
+
+        var rtt = TypeFor(returnType) ?? throw this.NewExpressionBuildingException($"Unable to resolve type for {returnType}");
+        var convertedArguments = arguments
+                                 .Select((a, i) => ConvertArgumentTargetType(a, signature?[i], i))
+                                 .Prepend(IrContextParameter.Instance)
+                                 .ToArray();
+
+        // NOTE(phase4): the old builder built a Func<> delegate type here (prepending CqlContext to
+        // the argument types and appending rtt) purely to construct FunctionCallExpression, which
+        // needed it to reduce to a runtime DefinitionDictionary<Delegate> lookup. IrDefinitionCall
+        // takes the return type directly and needs no delegate type.
+        var (splitLibraryName, splitLibraryVersion) = SplitLibraryVersionedIdentifier(libraryName);
+        var isLocalLibrary = libraryName == _libraryContext.LibraryVersionedIdentifier;
+        var functionCallExpression = new IrDefinitionCall(splitLibraryName, splitLibraryVersion, name, isLocalLibrary, convertedArguments, rtt);
+        return functionCallExpression;
+
+        IrExpression ConvertArgumentTargetType(
+            IrExpression argument,
+            TypeSpecifier? targetTypeSpecifier,
+            int argumentIndex)
+        {
+            /*
+                This function will handle the cases where the normal C# invocation is insufficient to represent the CQL function call:
+                the argument is of a choice type, and the parameter is of a specific type (or for now, also a choice type).
+                In this case we need to insert a conversion from the choice type to the specific type of the argument. Presumably, the
+                cql2elm compiler has already checked that the call is valid, but we do need to cast the choice type (in C# represented by
+                object/DataType) to the actual type to make this a valid C# call. CQL semantics state that the result may be null if the
+                choice is not compatible with the parameter, so we'll use an As in C#.
+            */
+            if (argument.Type == typeof(object))
+            {
+                if (targetTypeSpecifier is not null and not ChoiceTypeSpecifier)
+                {
+                    var changeType = ChangeType(argument, targetTypeSpecifier, considerSafeUpcast: true);
+                    return changeType;
+                }
+            }
+
+            /*
+               **Background**
+
+               FHIRHelpers 4.0.1 removed this line `define function ToString(value FHIR.id): value.value`
+                with the mistaken assumption that a FHIR Id inherits from FHIR String (from the diagram in 'FHIR Primitive Types'
+                referenced below)
+
+               **Solution**
+
+               So, we have to convert a FHIR Id to a FHIR String at runtime, before passing it to
+                FHIRHelpers.ToString(value FHIR.string) function.
+
+               A conversion for this is added in FhirTypeConverter.AddSubtypeConversions.
+
+               So, this convert method was added to ensure that the argument can be converted to the parameter type.
+
+               This seems like overkill for just this one case. An alternative solution could be to preprocess the Library
+                in LibraryPreprocessor.PreprocessLibrary, but since that is a non-FHIR specific class, it would require
+                more work to open it up for FHIR-specific processing.
+
+               **Note**
+
+               This new convert method makes the convertChoice (commented out) obsolete. We will keep it there for now.
+
+               **References**
+               - FHIRHelpers 4.0.1:  https://github.com/cqframework/clinical_quality_language/blame/master/Src/java/quick/src/main/resources/org/hl7/fhir/FHIRHelpers-4.0.1.cql
+               - FHIR Primitive Types:  https://hl7.org/fhir/datatypes.html#:~:text=Standards%20Status%20Colors-,Primitive%20Types,-PrimitiveType
+             */
+
+            var parameterType = TypeFor(targetTypeSpecifier, false);
+            if (parameterType is null
+                || !_cqlOperatorsBinder.TryConvert(argument, parameterType, out var result))
+            {
+                var fromArgumentType = argument.Type.ToCSharpString();
+                var toParameterType = parameterType?.ToCSharpString() ?? targetTypeSpecifier?.ToString() ?? "Unknown";
+                string message =
+                        $"Unable to bind argument to function ref parameter, however, we will ignore it and proceed to generate the expression for it."
+                        + $" From Argument Type: {fromArgumentType}"
+                        + $", To Parameter Type: {toParameterType}"
+                        + $", Library Alias: {libraryName}"
+                        + $", Function Name: {name}"
+                        + $", Parameter : #{argumentIndex}" // Signatures don't have named parameters
+                    ;
+
+                /*
+                 * Instead of failing here, just go ahead and return the argument as-is. Another quirk is
+                 *  that we have an argument of type FHIR Code to parameter FHIR String called on
+                 *  FHIRHelpers-4.0.1.ToString(value). (There is no such conversion in the CQL, but,
+                 *  in the ELM there are many methods added ToString(FHIR Code), but somehow the ELM call
+                 *  to it has a signature of ToString(FHIR String), which doesn't exist here yet.
+                 *
+                 * So, instead of failing here, just generate the C#, and this specific case will resolve there.
+                 *
+                 */
+
+                _logger.LogWarning(message);
+                return argument;
+            }
+
+            return result.conversion switch
+            {
+                TypeConversion.ExpressionCast
+                    or TypeConversion.ExpressionTypeAs => argument,
+                _                                      => result.arg
+            };
+        }
+    }
+
+    /// <remarks>The old builder resolved <c>CqlDefinition.Type</c> (the <c>Func&lt;…&gt;</c> delegate
+    /// type of the definition's <c>LambdaExpression</c>, always prefixed with <c>CqlContext</c>) for
+    /// any <see cref="IrDefinition"/>; only <see cref="IrLambdaDefinition"/> exposes a comparable
+    /// <see cref="IrLambdaDefinition.Type"/> here (the old base <c>CqlDefinition</c> did not override
+    /// <c>Expression.Type</c> either, so passing a non-lambda definition would have failed at
+    /// runtime there too). In practice only <see cref="ParameterRef"/> calls this overload, and
+    /// parameter references always resolve to an <see cref="IrParameterDefinition"/>.</remarks>
+    private IrExpression InvokeDefinitionThroughRuntimeContext(
+        string name,
+        string? libraryAlias,
+        IrDefinition definition)
+    {
+        if (definition is IrLambdaDefinition { Type: { IsGenericType: true } type })
+        {
+            var typeArgs = type.GetGenericArguments();
+            var returnType = typeArgs[^1];
+            var invoke = InvokeDefinitionThroughRuntimeContext(name, libraryAlias, returnType);
+            return invoke;
+        }
+
+        throw this.NewExpressionBuildingException("LambdaExpressions should be a variant of Func<>");
+    }
+
+    private IrDefinitionCall InvokeDefinitionThroughRuntimeContext(
+        string name,
+        string? libraryAlias,
+        Type definitionReturnType)
+    {
+        string libraryName = _libraryContext.GetLibraryVersionedIdentifierFromAlias(libraryAlias, throwError: false)
+                             ?? throw this.NewExpressionBuildingException($"Local library {libraryAlias} is not defined; are you missing a using statement?");
+        var (splitLibraryName, splitLibraryVersion) = SplitLibraryVersionedIdentifier(libraryName);
+        var isLocalLibrary = libraryName == _libraryContext.LibraryVersionedIdentifier;
+        return new IrDefinitionCall(splitLibraryName, splitLibraryVersion, name, isLocalLibrary, [IrContextParameter.Instance], definitionReturnType);
+    }
+
+    /// <summary>
+    /// Splits a <see cref="IrLibraryExpressionBuilderContext.LibraryVersionedIdentifier"/>-shaped
+    /// string (e.g. <c>"FHIRHelpers-4.0.1"</c>) back into its name and version parts, for
+    /// <see cref="IrDefinitionCall"/>, which (unlike the old <c>DefinitionCallExpression</c>/
+    /// <c>FunctionCallExpression</c>, which only ever carried the combined key for a runtime
+    /// dictionary lookup) needs the two separately to print either <c>this.…</c> or
+    /// <c>LibraryClass.Instance.…</c>.
+    /// </summary>
+    private static (string libraryName, string libraryVersion) SplitLibraryVersionedIdentifier(string libraryVersionedIdentifier)
+    {
+        var parsed = CqlVersionedLibraryIdentifier.Parse(libraryVersionedIdentifier);
+        string name = parsed.Identifier;
+        string version = parsed.Version is { } v ? v : "";
+        return (name, version);
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Scopes.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.Scopes.cs
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using IrExpressionElementPairForIdentifier = System.Collections.Generic.KeyValuePair<string, (Hl7.Cql.Compiler.Ir.IrExpression, Hl7.Cql.Elm.Element)>;
+
+/// <summary>
+/// IR counterpart of <c>ExpressionBuilderContext.Scopes.cs</c>: the query alias / let scope
+/// stack. This is a mechanical port; the scope dictionary values are
+/// <c>(IrExpression, Element)</c> instead of <c>(Expression, Element)</c>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    protected IReadOnlyDictionary<string, (IrExpression expr, Elm.Element element)> Scopes
+    {
+        get
+        {
+            _impliedAliasAndScopesStack.TryPeek(out var item);
+            return item.scopes ?? ReadOnlyDictionary<string, (IrExpression expr, Elm.Element element)>.Empty;
+        }
+    }
+
+    /// <summary>
+    /// In dodgy sort expressions where the properties are named using the undocumented IdentifierRef expression type,
+    /// this value is the implied alias name that should qualify it, e.g. from DRR-E 2022:
+    /// <code>
+    ///     "PHQ-9 Assessments" PHQ
+    ///      where ...
+    ///      sort by date from start of FHIRBase."Normalize Interval"(effective) asc
+    /// </code>
+    /// The use of "effective" here is unqualified and is implied to be PHQ.effective
+    /// No idea how this is supposed to work with queries with multiple sources (e.g., with let statements)
+    /// </summary>
+    protected string? ImpliedAlias =>
+        _impliedAliasAndScopesStack.TryPeek(out var item)
+            ? item.impliedAlias
+            : null;
+
+    protected IrExpression GetScopeExpression(string elmAlias)
+    {
+        var normalized = IdentifierNormalizer.Normalize(elmAlias!)!;
+        if (!Scopes.TryGetValue(normalized, out var kv))
+            throw this.NewExpressionBuildingException(
+                $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+
+        return kv.expr;
+    }
+
+    protected (IrExpression, Elm.Element) GetScope(string elmAlias)
+    {
+        var normalized = IdentifierNormalizer.Normalize(elmAlias!)!;
+        if (!Scopes.TryGetValue(normalized, out var kv))
+            throw this.NewExpressionBuildingException(
+                $"The scope alias {elmAlias}, normalized to {normalized}, is not present in the scopes dictionary.");
+        return kv;
+    }
+
+    protected bool HasScope(string elmAlias) => Scopes.ContainsKey(elmAlias);
+
+    protected IPopToken PushScopes(
+        string? alias = null,
+        params IrExpressionElementPairForIdentifier[] kvps)
+    {
+        _impliedAliasAndScopesStack.TryPeek(out var peek);
+
+        var scopes = new Dictionary<string, (IrExpression, Elm.Element)>(peek.scopes ?? ReadOnlyDictionary<string, (IrExpression, Elm.Element)>.Empty);
+        alias ??= peek.impliedAlias;
+
+        if (_expressionBuilderSettings.AllowScopeRedefinition)
+        {
+            foreach (var (expr, element) in kvps)
+            {
+                string? normalizedIdentifier = IdentifierNormalizer.Normalize(expr);
+                if (string.IsNullOrWhiteSpace(normalizedIdentifier))
+                    throw this.NewExpressionBuildingException("The normalized identifier is not available.");
+
+                scopes[normalizedIdentifier] = element;
+            }
+        }
+        else
+        {
+            foreach (var (expr, element) in kvps)
+            {
+                string? normalizedIdentifier = IdentifierNormalizer.Normalize(expr);
+                if (string.IsNullOrWhiteSpace(normalizedIdentifier))
+                    throw this.NewExpressionBuildingException("The normalize identifier is not available.");
+
+                if (!scopes.TryAdd(normalizedIdentifier, element))
+                    throw this.NewExpressionBuildingException(
+                        $"Scope {expr}, normalized to {IdentifierNormalizer.Normalize(expr)}, is already defined and this builder does not allow scope redefinition.  Check the CQL source, or set {nameof(_expressionBuilderSettings.AllowScopeRedefinition)} to true");
+            }
+        }
+
+        var prevId = peek.id;
+        _impliedAliasAndScopesStack = _impliedAliasAndScopesStack.Push((new object(), alias, scopes));
+        return new PopScopesToken(this, prevId);
+    }
+
+
+
+    private readonly record struct PopScopesToken : IPopToken
+    {
+        private readonly IrExpressionBuilderContext _owner;
+        private readonly object? _prevId;
+
+        public PopScopesToken(IrExpressionBuilderContext owner, object? prevId)
+        {
+            _owner = owner;
+            _prevId = prevId;
+        }
+
+        void IDisposable.Dispose() => Pop();
+
+        public void Pop()
+        {
+            var expectedPrevId = _owner._impliedAliasAndScopesStack.ElementAtOrDefault(1).id;
+
+            if (_prevId != expectedPrevId)
+                throw new InvalidOperationException("Popping should be called in the correct reverse order.");
+
+            _owner._impliedAliasAndScopesStack = _owner._impliedAliasAndScopesStack.Pop();
+        }
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.StaticHelpers.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.StaticHelpers.cs
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Compiler.Infrastructure;
+using Hl7.Cql.Model;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using F = Hl7.Fhir.Model;
+
+/// <summary>
+/// IR counterpart of <c>ExpressionBuilderContext.StaticHelpers.cs</c>: the QiCore binding
+/// workaround, nullable handling, null propagation and identifier helpers. This is a
+/// mechanical port; see the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    // Yeah, hardwired to FHIR 4.0.1 for now.
+    private static readonly IDictionary<string, ClassInfo> ModelMapping = Models.ClassesById(Models.Fhir401);
+
+
+    private static readonly Dictionary<(Type, Type), Type> KnownErrors = new()
+    {
+        [(typeof(F.ObservationStatus?), typeof(F.Code<F.VerificationResult.StatusCode>))] = typeof(F.ObservationStatus?)
+    };
+
+    // At this moment (20240308) the QICore translation by the current tooling (3.8.0.0) of the CQl-to-ELM
+    // translator is incorrect. This method is a temporary workaround to correct the incorrectly mapped binding
+    // names. This method should be removed once the QICore translation is fixed.
+    // See https://github.com/cqframework/cqf-tooling/issues/518.
+    private static bool TryCorrectQiCoreBindingError(Type source, Type to, out Type? correctedTo)
+    {
+        return KnownErrors.TryGetValue((source, to), out correctedTo);
+    }
+
+    private IrLambda NotImplemented(
+        string nav,
+        (string name, Type type)[] signature,
+        Type returnType)
+    {
+        var parameters = signature.SelectToArray(type => new IrLocal(type.type, type.name));
+        var ctor = ConstructorInfos.NotImplementedException;
+        var @new = new IrNew(ctor, new IrConstant($"External function {nav} is not implemented.", typeof(string)));
+        var @throw = new IrThrow(@new, returnType);
+        var lambda = new IrLambda(parameters, @throw);
+        return lambda;
+    }
+
+    private static IrExpression HandleNullable(IrExpression expression, Type targetType) =>
+        (
+                exprNullTypeArg: Nullable.GetUnderlyingType(expression.Type),
+                targetNullTypeArg: Nullable.GetUnderlyingType(targetType)) switch
+            {
+                // Only targetType is nullable
+                (exprNullTypeArg: null, targetNullTypeArg: not null) => expression.NewAssignToTypeExpression(targetType),
+
+                // Both are nullable or not nullable
+                ({ } exprNullTypeArg, targetNullTypeArg: null) => new IrBinary(IrBinaryOp.Coalesce, expression, new IrDefault(exprNullTypeArg)),
+
+                _ => expression,
+            };
+
+    /// <summary>
+    /// Implements the null propagation operator (x?.y) into (x == null ? null : x.y);
+    /// </summary>
+    private static IrExpression PropagateNull(IrExpression before, MemberInfo member)
+    {
+        if (before.Type.IsValueType)
+            return before;
+        return new IrProperty(before, member, nullConditional: true);
+    }
+
+    private static string TypeNameToIdentifier(Type type, IrExpressionBuilderContext? ctx = null)
+    {
+        var typeName = type.Name.ToLowerInvariant();
+        if (type.IsGenericType)
+        {
+            var typeNames = type.GetGenericArguments()
+                .Select(t => TypeNameToIdentifier(t, ctx)
+                .TrimStart('@'));
+            var genericTypeNames = string.Join("_", typeNames);
+            var tick = typeName.IndexOf('`');
+            if (tick > -1)
+                typeName = typeName[..tick];
+            var fullName = $"{typeName}_{genericTypeNames}";
+            typeName = fullName;
+        }
+
+        if (ctx != null)
+        {
+            int i = 1;
+            var uniqueTypeName = typeName;
+            while (ctx.HasScope(uniqueTypeName))
+            {
+                uniqueTypeName = $"{typeName}{i}";
+                i++;
+            }
+            typeName = uniqueTypeName;
+        }
+
+        return IdentifierNormalizer.Normalize(typeName!)!;
+    }
+
+    protected interface IPopToken : IDisposable
+    {
+        void Pop();
+    }
+
+    private readonly record struct EmptyDisposable : IPopToken
+    {
+        public static readonly EmptyDisposable Instance = new();
+
+        void IDisposable.Dispose()
+        {
+        }
+
+        void IPopToken.Pop()
+        {
+        }
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.TypeFor.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.TypeFor.cs
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Primitives;
+using Hl7.Fhir.Model;
+using Element = Hl7.Cql.Elm.Element;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <c>ExpressionBuilderContext.TypeFor.cs</c>: resolving the .NET type for
+/// an ELM element or type specifier. Mechanical port of the old partial; see the remarks on
+/// <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrExpressionBuilderContext
+{
+    private Type? TypeFor(
+        Element element,
+        bool throwIfNotFound = true)
+    {
+        if (element?.resultTypeSpecifier != null)
+            return TypeFor(element.resultTypeSpecifier);
+
+        if (!string.IsNullOrWhiteSpace(element?.resultTypeName?.Name))
+            return _typeResolver.ResolveType(element!.resultTypeName!.Name, throwIfNotFound);
+
+        switch (element)
+        {
+            case ExpressionRef expressionRef:
+            {
+                var libraryName = expressionRef.libraryName ?? _libraryContext.LibraryVersionedIdentifier;
+                if (!_libraryContext.LibraryDefinitions.TryGetDefinition(libraryName, expressionRef.name, out var definition))
+                {
+                    if (throwIfNotFound)
+                        throw new InvalidOperationException($"Unabled to get an expression by name : '{libraryName}.{expressionRef.name}'");
+                    return null;
+                }
+
+                var returnType = definition.ReturnType;
+                return returnType;
+            }
+
+            case ExpressionDef { expression: not null } def:
+            {
+                using (PushElement(def.expression))
+                {
+                    var type = TypeFor(def.expression, throwIfNotFound: false);
+                    if (type == null)
+                    {
+                        if (def.expression is SingletonFrom singleton)
+                        {
+                            type = TypeFor(singleton, throwIfNotFound: false);
+                            if (type == null)
+                            {
+                                if (singleton.operand is Retrieve retrieve && retrieve.dataType != null)
+                                {
+                                    type = _typeResolver.ResolveType(retrieve.dataType.Name, throwIfNotFound);
+                                    if (type != null)
+                                        return type;
+                                }
+                            }
+                            else return type;
+                        }
+                    }
+                }
+                break;
+            }
+
+            case Property propertyExpression when !string.IsNullOrWhiteSpace(propertyExpression.path):
+            {
+                Type? sourceType = null;
+                if (propertyExpression.source != null)
+                    sourceType = TypeFor(propertyExpression.source!, throwIfNotFound);
+                else if (propertyExpression.scope != null)
+                {
+                    var scope = GetScope(propertyExpression.scope);
+                    sourceType = scope.Item1.Type;
+                }
+                if (sourceType != null)
+                {
+                    var property = _typeResolver.GetProperty(sourceType, propertyExpression.path);
+
+                    // This is a temporary fix for the issue where the type the Firely SDK uses for a choice
+                    // property is `DataType`, whereas the type the CQL model uses is `object`.
+                    // Since GetProperty() cannot properly correct for this, we'll correct the type to `object` here.
+                    // Task https://github.com/FirelyTeam/firely-cql-sdk/issues/493 will clean this up.
+                    if (property != null)
+                        return property.PropertyType == typeof(DataType) ? typeof(object) : property.PropertyType;
+
+                    return typeof(object); // this is likely a choice
+                }
+                break;
+            }
+
+            case AliasRef aliasRef when !string.IsNullOrWhiteSpace(aliasRef.name):
+            {
+                var scope = GetScope(aliasRef.name);
+                return scope.Item1.Type;
+            }
+
+            case OperandRef operandRef when !string.IsNullOrWhiteSpace(operandRef.name):
+            {
+                IrLocal? operand = null;
+                _operands?.TryGetValue(operandRef.name, out operand);
+                if (operand != null)
+                    return operand.Type;
+                break;
+            }
+        }
+
+        if (throwIfNotFound)
+            throw this.NewExpressionBuildingException("Cannot resolve type for expression");
+
+        return null;
+    }
+
+    private Type? TypeFor(
+        TypeSpecifier? resultTypeSpecifier,
+        bool throwIfNotFound = true)
+    {
+        if (resultTypeSpecifier == null)
+            return typeof(object);
+
+        if (resultTypeSpecifier is IntervalTypeSpecifier interval)
+        {
+            var pointType = TypeFor(interval.pointType!, false);
+            if (pointType == null)
+            {
+                if (throwIfNotFound)
+                    throw new ArgumentException($"Cannot resolve type for typeSpecifier {interval.pointType}");
+
+                return null;
+            }
+
+            var intervalType = typeof(CqlInterval<>).MakeGenericType(pointType);
+            return intervalType;
+        }
+
+        if (resultTypeSpecifier is NamedTypeSpecifier named)
+        {
+            var type = _typeResolver.ResolveType(named.name.Name!, false);
+            if (type == null && throwIfNotFound)
+                throw new ArgumentException($"Cannot resolve type for typeSpecifier {named.name.Name}");
+            return type!;
+        }
+
+        if (resultTypeSpecifier is ChoiceTypeSpecifier choice)
+        {
+            // ELM produced by some translators contains choice types whose alternatives are all
+            // the same type (e.g. Choice<Condition, Condition>). In that case, use the single
+            // distinct type so the generated code stays strongly typed instead of falling back
+            // to object (and late-bound property access).
+            if (choice.choice is { Length: > 0 } choices)
+            {
+                Type? singleType = null;
+                foreach (var choiceTypeSpecifier in choices)
+                {
+                    var choiceType = TypeFor(choiceTypeSpecifier, throwIfNotFound: false);
+                    if (choiceType == null || (singleType != null && choiceType != singleType))
+                        return typeof(object);
+
+                    singleType = choiceType;
+                }
+
+                return singleType!;
+            }
+
+            return typeof(object);
+        }
+
+        if (resultTypeSpecifier is ListTypeSpecifier list)
+        {
+            if (list.elementType == null)
+            {
+                if (throwIfNotFound)
+                    throw new ArgumentException("ListTypeSpecifier must have a non-null elementType");
+
+                return null;
+            }
+
+            var elementType = TypeFor(list.elementType, throwIfNotFound);
+            if (elementType == null)
+            {
+                if (throwIfNotFound)
+                    throw new ArgumentException($"Cannot resolve type for typeSpecifier {list.elementType}");
+
+                return null;
+            }
+
+            var enumerableOfElementType = typeof(IEnumerable<>).MakeGenericType(elementType);
+            return enumerableOfElementType;
+        }
+
+        if (resultTypeSpecifier is TupleTypeSpecifier tuple)
+        {
+            // witnessed in ELM:
+            //"type" : "TupleTypeSpecifier",
+            //"resultTypeSpecifier" : {
+            //      "type" : "TupleTypeSpecifier",
+            //      "element": { ... x ... }
+            // },
+            // "element": { ... y ... }
+            //
+            // In the example above, x and y have different structures.
+            // Code handles x but not y
+            if (resultTypeSpecifier.resultTypeSpecifier != null)
+                return TypeFor(tuple.resultTypeSpecifier, throwIfNotFound);
+
+            return TupleTypeFor(tuple);
+        }
+
+        if (throwIfNotFound)
+            throw new NotImplementedException().WithContext(this);
+
+        return null;
+    }
+
+    private Type TupleTypeFor(TupleTypeSpecifier tuple, Func<Type, Type>? changeType = null)
+    {
+        var elements = tuple.element;
+
+        if (elements?.Length == 0)
+            return typeof(object);
+
+        var elementTuples = elements!.SelectToArray(e => (e.name, e.elementType));
+        return TupleTypeFor(elementTuples, changeType);
+    }
+
+    private Type TupleTypeFor(Elm.Tuple tuple, Func<Type, Type>? changeType = null)
+    {
+        var elements = tuple.element;
+
+        if (elements?.Length == 0)
+            return typeof(object);
+
+        var elementTuples = elements!
+            .SelectToArray(e => (e.name, e.value.resultTypeSpecifier
+                                         ?? throw new InvalidOperationException($"Tuple element value does not have a resultTypeSpecifier").WithContext(this)));
+        return TupleTypeFor(elementTuples, changeType);
+    }
+
+    private Type TupleTypeFor((string name, TypeSpecifier elementType)[] elements, Func<Type, Type>? changeType)
+    {
+        var tupleFields = elements!
+            .Select(el =>
+            {
+                if (el.elementType == null)
+                    throw this.NewExpressionBuildingException(
+                        $"Tuple element {el.name} has a null {nameof(el.elementType)} property.  This property is required.");
+
+                var type = TypeFor(el.elementType)!;
+                if (changeType != null)
+                    type = changeType(type);
+
+                return (type, el.name);
+            })
+            .ToList();
+
+        return _tupleBuilderCache.CreateOrGetTupleTypeFor(tupleFields);
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionBuilderContext.cs
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Compiler.Infrastructure;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Operators;
+using Hl7.Cql.Primitives;
+using TypeConverter = Hl7.Cql.Conversion.TypeConverter;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+using DateTime = Hl7.Cql.Elm.DateTime;
+using ListTypeSpecifier = Hl7.Cql.Elm.ListTypeSpecifier;
+using NamedTypeSpecifier = Hl7.Cql.Elm.NamedTypeSpecifier;
+using Tuple = Hl7.Cql.Elm.Tuple;
+
+#region Context
+
+/// <summary>
+/// The IrExpressionBuilderContext class maintains scope information for the traversal of ElmPackage statements.
+/// </summary>
+/// <remarks>
+/// IR counterpart of <see cref="ExpressionBuilderContext"/> (phase 4 of the Linq.Expressions
+/// removal, see <c>docs/linq-expression-removal-plan.md</c>): a mechanical port with the same
+/// dispatch shape, producing <see cref="IrExpression"/> trees instead of
+/// <c>System.Linq.Expressions</c> trees. The old builder remains untouched and both pipelines
+/// coexist until phase 6.
+/// </remarks>
+internal partial class IrExpressionBuilderContext
+(
+    ILogger<IrExpressionBuilder> logger,
+    ExpressionBuilderSettings expressionBuilderSettings,
+    IrCqlOperatorsBinder cqlOperatorsBinder,
+    TupleBuilderCache tupleBuilderCache,
+    TypeResolver typeResolver,
+    TypeConverter typeConverter,
+    IrCqlContextBinder cqlContextBinder,
+    IrLibraryExpressionBuilderContext libraryContext,
+    Dictionary<string, IrLocal>? operands = null // Parameters for function definitions. Used during ProcessExpressionDef.
+)
+{
+    private readonly ILogger<IrExpressionBuilder> _logger = logger;
+    private readonly ExpressionBuilderSettings _expressionBuilderSettings = expressionBuilderSettings;
+    private readonly IrCqlOperatorsBinder _cqlOperatorsBinder = cqlOperatorsBinder;
+    private readonly TupleBuilderCache _tupleBuilderCache = tupleBuilderCache;
+    private readonly TypeResolver _typeResolver = typeResolver;
+    private readonly TypeConverter _typeConverter = typeConverter;
+    private readonly IrCqlContextBinder _cqlContextBinder = cqlContextBinder;
+    private readonly IrLibraryExpressionBuilderContext _libraryContext = libraryContext;
+    private readonly Dictionary<string, IrLocal>? _operands = operands;
+
+    // NOTE(phase4): the old builder carried an IExpressionMutator list here, documented as
+    // "Not used yet, since it's always empty". That (Expression-based) hook was dropped in the
+    // IR port; see Mutate below.
+
+    private ImmutableStack<Element> _elementStack = ImmutableStack<Element>.Empty;
+
+    /// <summary>
+    /// Contains query aliases and let declarations, and any other symbol that is now "in scope"
+    /// </summary>
+    private ImmutableStack<(object? id, string? impliedAlias, IReadOnlyDictionary<string, (IrExpression expr, Element element)>? scopes)>
+        _impliedAliasAndScopesStack =
+            ImmutableStack<(object? id, string? impliedAlias, IReadOnlyDictionary<string, (IrExpression expr, Element element)>? scopes)>.Empty;
+
+    private static IrExpression[] NoArgs { get; } = [];
+
+    private static Type[] NoTypes { get; } = [];
+
+    private IrExpression BindCqlOperator<TArg>(
+        string methodName,
+        params TArg?[] args) =>
+        _cqlOperatorsBinder.BindToMethod(methodName, TranslateArgs(args), NoTypes);
+
+    private IrExpression BindCqlOperator<TArg>(
+        string methodName,
+        TArg?[] args,
+        Type[] typeArgs) =>
+        _cqlOperatorsBinder.BindToMethod(methodName, TranslateArgs(args), typeArgs);
+
+    [DebuggerStepThrough]
+    private Type[] TranslateTypes<TType>(params TType?[] args) =>
+        args switch
+        {
+            Type[] types => types,
+            { } objects  => objects.SelectToArray(obj => TranslateType(obj!)),
+            _            => [],
+        };
+
+    [DebuggerStepThrough]
+    private Type TranslateType<TType>(TType? arg) =>
+        arg switch
+        {
+            Type type                             => type,
+            XmlQualifiedName xmlQualifiedName     => _typeResolver.ResolveType(xmlQualifiedName.Name)!,
+            NamedTypeSpecifier namedTypeSpecifier => TranslateType(namedTypeSpecifier.name)!,
+            null                                  => throw this.NewExpressionBuildingException("Cannot translate null to a type"),
+            _                                     => throw this.NewExpressionBuildingException($"Cannot translate '{arg}' to a type"),
+        };
+
+    [DebuggerStepThrough]
+    private IrExpression[] TranslateArgs<TArg>(params TArg?[] args) =>
+        args switch
+        {
+            IrExpression[] expressions => expressions,
+            { } objects                => objects.SelectToArray(obj => TranslateArg(obj!)),
+            _                          => [],
+        };
+
+    [DebuggerStepThrough]
+    internal IrExpression TranslateArg<TArg>(TArg? arg) =>
+        arg switch
+        {
+            IrExpression expression => expression,
+            Element element         => TranslateElement(element),
+            null                    => new IrConstant(null, typeof(TArg)),
+            _                       => new IrConstant(arg, arg.GetType()),
+        };
+
+    private IrExpression TranslateElement(Element element) =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            using (PushElement(element))
+            {
+                /*
+                This code is useful for setting breakpoints to inspect the expression tree at a specific element.
+                The ELM json must be modified to add an annotation tags with a debug counter first.
+
+                var debugCounter = element.annotation
+                                          ?.OfType<Annotation>()
+                                          .FirstOrDefault()?.t.FirstOrDefault(t => t.name == "debug")
+                                          ?.value;
+                if (debugCounter == "42") // Identify the correct debug counter from the ELM file
+                {
+                    ; // Set a breakpoint here
+                }
+                */
+
+                IrExpression? expression = element switch
+                {
+                    //@formatter:off
+                    Ratio e            => throw new NotSupportedException($"Operator {element.GetType().Name} is not supported yet."),
+                    Flatten e          => BindCqlOperator(nameof(ICqlOperators.Flatten), e.operand),
+                    Negate e           => Negate(e),
+                    As e               => As(e),
+                    Case e             => Case(e),
+                    Interval { low: Null, high: Null } => new IrConstant(null, typeof(object)),
+                    ToTime e           => ChangeType(e.operand!, _typeResolver.TimeType),
+                    ToBoolean e        => ChangeType(e.operand!, typeof(bool?)),
+                    ToString e         => ChangeType(e.operand!, typeof(string)),
+                    ToConcept e        => ChangeType(e.operand!, _typeResolver.ConceptType),
+                    ToDate e           => ChangeType(e.operand!, _typeResolver.DateType),
+                    ToDecimal e        => ChangeType(e.operand!, typeof(decimal?)),
+                    ToInteger e        => ChangeType(e.operand!, typeof(int?)),
+                    ToDateTime e       => ChangeType(e.operand!, _typeResolver.DateTimeType),
+                    ToLong e           => ChangeType(e.operand!, typeof(long?)),
+                    ToQuantity e       => ChangeType(e.operand!, _typeResolver.QuantityType),
+                    Coalesce e         => Coalesce(e),
+                    Equivalent e       => Equivalent(e),
+                    AliasRef e         => GetScopeExpression(e.name!),
+                    QueryLetRef e      => GetScopeExpression(e.name!),
+                    IdentifierRef e    => IdentifierRef(e),
+                    If e               => If(e),
+                    IncludedIn e       => IncludedIn(e),
+                    Includes e         => Includes(e),
+                    Instance e         => Instance(e),
+                    Is e               => Is(e),
+                    IsNull e           => IsNull(e),
+                    List e             => List(e),
+                    Literal e          => Literal(e),
+                    Message e          => Message(e),
+                    Null e             => new IrConstant(null, TypeFor(e)!),
+                    OperandRef e       => OperandRef(e),
+                    ProperContains e   => ProperContains(e),
+                    ProperIn e         => ProperIn(e),
+                    ProperIncludedIn e => ProperIncludedIn(e),
+                    ProperIncludes e   => ProperIncludes(e),
+                    Property e         => Property(e),
+                    Query e            => Query(e),
+                    Tuple e            => Tuple(e),
+
+                    // InvokeDefinedFunctionThroughRuntimeContext
+                    FunctionRef e => FunctionRef(e),
+
+                    // InvokeDefinitionThroughRuntimeContext
+                    CodeRef e       => CodeRef(e),
+                    CodeSystemRef e => CodeSystemRef(e),
+                    ConceptRef e    => ConceptRef(e),
+                    ExpressionRef e => ExpressionRef(e),
+                    AnyInValueSet e => BindValueInValueSet(valueExpr: TranslateArg(e.codes), valueSetExpr: TranslateValueSet(e.valueset, e.valuesetExpression),
+                                                           isList: true),
+                    InValueSet e => BindValueInValueSet(valueExpr: TranslateArg(e.code), valueSetExpr: TranslateValueSet(e.valueset, e.valuesetExpression),
+                                                        isList: false),
+                    Retrieve e     => Retrieve(e),
+                    ValueSetRef e  => ValueSetRef(e),
+                    ParameterRef e => ParameterRef(e),
+
+                    // NOTE: Do not rename ICqlOperators.CreateValueSetFacade to ExpandValueSet
+                    ExpandValueSet e => _cqlOperatorsBinder.BindToMethod(nameof(ICqlOperators.CreateValueSetFacade), TranslateArgs(GetBindArgs(element)),
+                                                                         TranslateTypes(GetTypeArgs(element))),
+
+                    // All other Elm types matches on type name to the ICqlOperators method name
+                    _ => _cqlOperatorsBinder.BindToMethod(element.GetType().Name, TranslateArgs(GetBindArgs(element)), TranslateTypes(GetTypeArgs(element))),
+                    //@formatter:on
+                };
+
+                if (expression is not null)
+                    expression = ConvertToResultType();
+
+                expression = Mutate(element, expression);
+                return expression!;
+
+                IrExpression ConvertToResultType()
+                {
+                    var tsType = TypeFor(element.resultTypeSpecifier, false);
+                    if (tsType is not null)
+                    {
+                        return ChangeType(expression!, element.resultTypeSpecifier, throwOnError: true);
+                    }
+
+                    return expression!;
+                }
+            }
+        });
+
+    private object?[] GetTypeArgs(Element element)
+    {
+        // ReSharper disable CoVariantArrayConversion
+        object[] types = element switch
+        {
+            MinValue e => [e.valueType],
+            MaxValue e => [e.valueType],
+            Elm.Convert e => [e.resultTypeSpecifier],
+            _          => NoTypes,
+        };
+        // ReSharper restore CoVariantArrayConversion
+        return types;
+    }
+
+    private object?[] GetBindArgs(Element element)
+    {
+        // ReSharper disable CoVariantArrayConversion
+        object?[] args = element switch
+        {
+            //@formatter:off
+
+            // ORDER MATTERS.
+
+            // special cases
+            Collapse e           => Collapse(e),
+            Contains e           => Contains(e),
+            Union e              => Union(e),
+            Combine e            => [e.source, e.separator],
+            IndexOf e            => [e.source, e.element],
+            Slice e              => [e.source, e.startIndex, e.endIndex],
+            Date e               => [e.year, e.month, e.day],
+            DateTime e           => [e.year, e.month, e.day, e.hour, e.minute, e.second, e.millisecond, e.timezoneOffset],
+            Interval e           => [e.low, e.high, (object)e.lowClosedExpression ?? e.lowClosed, (object)e.highClosedExpression ?? e.highClosed],
+            LastPositionOf e     => [e.@string, e.pattern],
+            PositionOf e         => [e.pattern, e.@string],
+            Quantity e           => [e.value, e.unit], // http://unitsofmeasure.org
+            Ratio e              => [e.numerator, e.denominator],
+            Round r              => [r.operand, r.precision],
+            Split e              => [e.stringToSplit, e.separator],
+            Substring e          => [e.stringToSub, e.startIndex, e.length],
+            Time e               => [e.hour, e.minute, e.second, e.millisecond],
+            MinValue or MaxValue => [], // type is a generic type arg
+
+            // special expression types
+            UnaryWithPrecision uwp => [uwp.operand, uwp.GetPrecision()],
+            NaryWithPrecision nwp  => [.. nwp.operand, nwp.GetPrecision()],
+            IHasSource hs          => [hs.source],
+
+            // common expression types
+            Elm.UnaryExpression unary   => [unary.operand],
+            Elm.BinaryExpression binary => binary.operand,
+            TernaryExpression ternary   => ternary.operand,
+            NaryExpression nary         => nary.operand,
+            OperatorExpression          => [], // nullaries, but all others too.  handle last.
+
+            _ => throw this.NewExpressionBuildingException($"Cannot get arguments for element {element.GetType().FullName}.")
+            //@formatter:on
+        };
+        return args;
+        // ReSharper restore CoVariantArrayConversion
+
+        object?[] Collapse(Collapse e)
+        {
+            var operand = TranslateArg(e.operand![0]!);
+            if (_typeResolver.GetListElementCqlIntervalPointType(operand.Type) is { })
+            {
+                object precision = e.operand switch
+                {
+                    [_, Quantity quantity, ..] => quantity.unit,
+                    _                          => new IrConstant(null, typeof(string))
+                };
+
+                return [operand, precision];
+            }
+
+            throw this.NewExpressionBuildingException(
+                $"Collapse expects a list of intervals, but got {operand.Type.ToCSharpString(Defaults.TypeCSharpFormat)}");
+        }
+
+        object?[] Contains(Contains e)
+        {
+            if (TranslateArgs(e.operand) is [{ } left, { } right, ..])
+            {
+                if (_typeResolver.GetListElementType(left.Type, throwError: false) is { } leftType)
+                {
+                    if (leftType != right.Type)
+                    {
+                        if (leftType.IsAssignableFrom(right.Type))
+                            right = ChangeType(right, leftType, throwOnError: true);
+                    }
+
+                    return [left, right, e.GetPrecision()];
+                }
+
+                if (left.Type.IsCqlInterval(out _))
+                {
+                    return [left, right, e.GetPrecision()];
+                }
+            }
+
+            throw this.NewExpressionBuildingException($"Contains expects two arguments, but got {e.operand.Length}");
+        }
+
+        object?[] Union(Union e)
+        {
+            if (TranslateArgs(e.operand) is [{ } left, { } right, ..])
+            {
+                if (_typeResolver.GetListElementType(left.Type, throwError: false) is { } leftListElemType
+                    && _typeResolver.GetListElementType(right.Type, throwError: false) is { } rightListElemType
+                    && ElmTupleTypeUtility.AreCompatibleForUnionOperation(leftListElemType, rightListElemType, _typeConverter))
+                    return [left, right];
+
+                if (left.Type.IsCqlInterval(out var leftPointType)
+                    && right.Type.IsCqlInterval(out var rightPointType)
+                    && ElmTupleTypeUtility.AreCompatibleForUnionOperation(leftPointType, rightPointType, _typeConverter))
+                    return [left, right];
+            }
+
+            throw this.NewExpressionBuildingException($"Union expects two arguments of the same list or interval type.");
+        }
+    }
+
+    /// <summary>
+    /// No-op. The old builder aggregated an <c>IExpressionMutator</c> list here, but that list
+    /// was always empty (the hook was never used), so the IR port drops it and simply returns
+    /// the expression.
+    /// </summary>
+    protected IrExpression? Mutate(Element op, IrExpression? expression) =>
+        expression;
+}
+
+#endregion
+
+file static class LocalExtensions
+{
+    public static Type? GetListElementCqlIntervalPointType(
+        this TypeResolver typeResolver,
+        Type type) =>
+        typeResolver.GetListElementType(type, throwError: false) is { } elementType
+        && elementType.IsCqlInterval(out var pointType)
+            ? pointType
+            : null;
+}

--- a/Cql/Cql.Compiler/Ir/IrExpressionExtensions.cs
+++ b/Cql/Cql.Compiler/Ir/IrExpressionExtensions.cs
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions.Infrastructure;
+using Hl7.Cql.Fhir;
+using Hl7.Cql.Iso8601;
+using Hl7.Fhir.Utility;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="Hl7.Cql.Compiler.Expressions.ExpressionExtensions"/>: the
+/// assign-to-type / type-as / type-is / coalesce helpers the expression builder uses on
+/// subexpressions. This is a mechanical port; see the remarks on
+/// <see cref="IrExpressionBuilderContext"/>.
+///
+/// <para>NOTE(phase4): <see cref="IrCqlOperatorsBinder"/> carries a private copy of the
+/// assign-to-type logic (ported in phase 3 before this shared class existed).
+/// FIXME(phase6): consolidate the binder's private copy onto this class once the old pipeline
+/// is deleted.</para>
+/// </summary>
+internal static class IrExpressionExtensions
+{
+    public static IrExpression NewAssignToTypeExpression(
+        this IrExpression expression,
+        Type type) =>
+        TryNewAssignToTypeExpression(
+            expression,
+            type).expression!;
+
+    public static (IrExpression? expression, TypeConversion typeConversion) TryNewAssignToTypeExpression(
+        this IrExpression expression,
+        Type type,
+        bool throwError = true,
+        bool safeUpcastAllowed = false)
+    {
+        if (expression.Type == type)
+            return (expression, TypeConversion.ExactType);
+
+        if (expression is IrConstant { Value: var constantValue })
+        {
+            switch (constantValue)
+            {
+                case null when type.IsNullable(out _):
+                    return (new IrConstant(null, type), TypeConversion.ExactType);
+
+                case { } value and not string when
+                    value.GetType().IsAssignableTo(type): // <-- Don't remove this, otherwise string constant will not have double-quotes in the generated code. 🤷
+                    return (new IrConstant(value, type), TypeConversion.ExactType);
+
+                case Enum enumValue
+                    when type == typeof(string)
+                         && enumValue.GetType() is { } enumType
+                         && FhirTypeConverter.IsFhirEnum(enumType):
+
+                    var enumLiteral = enumValue.GetLiteral();
+                    return (new IrConstant(enumLiteral, typeof(string)), TypeConversion.ExactType);
+
+
+                case Hl7.Cql.Elm.DateTimePrecision dateTimePrecision
+                    when type == typeof(string):
+                    var dateTimeString = Enum.GetName(dateTimePrecision.GetType(), dateTimePrecision);
+                    if (dateTimeString is null)
+                    {
+                        // Still throw an error here, ignoring the `throwError` parameter, because this indicates a bug in the cql.
+                        throw new InvalidOperationException($"Enum value {dateTimeString} is not defined in enum type {typeof(DateTimePrecision)}");
+                    }
+
+                    return (new IrConstant(dateTimeString.ToLowerInvariant(), typeof(string)), TypeConversion.ExactType);
+            }
+        }
+
+        if (safeUpcastAllowed)
+        {
+            var isAssignableFrom =
+                expression.Type == typeof(object) // Choice?
+                || expression.Type.IsAssignableFrom(type);
+            if (isAssignableFrom || throwError)
+            {
+                IrExpression cast = new IrCast(expression, type, IrCastKind.As);
+                return (cast, TypeConversion.ExpressionTypeAs);
+            }
+        }
+
+        var isAssignableTo =
+            expression.Type == typeof(object) // Choice?
+            || expression.Type.IsAssignableTo(type);
+        if (isAssignableTo || throwError)
+        {
+            IrExpression cast = new IrCast(expression, type, IrCastKind.Cast);
+            return (cast, TypeConversion.ExpressionCast);
+        }
+
+        return (null, TypeConversion.NoMatch);
+    }
+
+    public static IrExpression NewAssignToTypeExpression<TType>(
+        this IrExpression expression) =>
+        expression.NewAssignToTypeExpression(typeof(TType));
+
+
+    public static IrExpression NewTypeAsExpression(this IrExpression expression, Type type)
+    {
+        if (expression.Type == type)
+            return expression;
+
+        var typeAs = new IrCast(expression, type, IrCastKind.As);
+        return typeAs;
+    }
+
+    public static IrExpression NewTypeAsExpression<TType>(this IrExpression expression) =>
+        expression.NewTypeAsExpression(typeof(TType));
+
+    public static IrTypeIs NewTypeIsExpression(this IrExpression expression, Type type)
+    {
+        var typeAs = new IrTypeIs(expression, type);
+        return typeAs;
+    }
+
+    public static IrExpression Coalesce(
+        this IrExpression expression)
+    {
+        if (expression.Type.IsValueType)
+        {
+            if (expression.Type.IsNullableValueType(out var underlyingType)
+                && underlyingType.IsValueType)
+            {
+                var defaultValue = Activator.CreateInstance(underlyingType)!;
+                var result = new IrBinary(IrBinaryOp.Coalesce, expression, new IrConstant(defaultValue, underlyingType));
+                return result;
+            }
+
+            return expression;
+        }
+
+        throw new InvalidOperationException(
+            $"Cannot coalesce reference '{expression.Type}'.");
+    }
+
+    public static bool IsNullConstant(this IrExpression expression) =>
+        expression is IrConstant { Value: null };
+}

--- a/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilder.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Elm;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// Encapsulates the IrExpressionBuilder and state dictionaries for building definitions.
+/// IR counterpart of <see cref="LibraryExpressionBuilder"/>; a mechanical port, see the
+/// remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+internal class IrLibraryExpressionBuilder(
+    ILogger<IrLibraryExpressionBuilder> logger,
+    IrExpressionBuilder expressionBuilder,
+    LibraryPreprocessorBuilder libraryPreprocessorBuilder)
+{
+    public IrDefinitionDictionary ProcessLibrary(
+        Library library,
+        IrDefinitionDictionary? libraryDefinitions = null,
+        IrLibrarySetExpressionBuilderContext? libsCtx = null) =>
+        NewLibraryExpressionBuilderContext(library, libraryDefinitions, libsCtx)
+            .ProcessLibrary();
+
+    public IrLibraryExpressionBuilderContext NewLibraryExpressionBuilderContext(
+        Library library,
+        IrDefinitionDictionary? libraryDefinitions = null,
+        IrLibrarySetExpressionBuilderContext? libsCtx = null) =>
+        new(logger, expressionBuilder, libraryPreprocessorBuilder, library, libraryDefinitions ?? new(), libsCtx);
+
+    public IrExpressionBuilderContext NewExpressionBuilderContext(
+        Library library,
+        IrDefinitionDictionary? libraryDefinitions = null,
+        Dictionary<string, IrLocal>? operands = null)
+    {
+        var libraryExpressionBuilderContext = NewLibraryExpressionBuilderContext(library, libraryDefinitions);
+        return expressionBuilder.NewExpressionBuilderContext(libraryExpressionBuilderContext, operands);
+    }
+}

--- a/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilderContext.LibraryDefs.cs
+++ b/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilderContext.LibraryDefs.cs
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Exceptions;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Primitives;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <c>LibraryExpressionBuilderContext.LibraryDefs.cs</c>: the definition
+/// dictionary, alias/code/code-system bookkeeping shared by the per-definition processors.
+/// Mechanical port; see the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+partial class IrLibraryExpressionBuilderContext
+{
+    #region Definitions
+
+    /// <summary>
+    /// Gets the dictionary of library definitions.
+    /// Before the library is built, this dictionary contains the definitions from all the included libraries.
+    /// After processing of the library, this dictionary also contains the definitions from the library itself.
+    /// If the library was processed within the context of a library set,
+    /// then this dictionary will be merged with the library set's dictionary.
+    /// </summary>
+    public IrDefinitionDictionary LibraryDefinitions  => _libraryDefinitions;
+
+    private void AddLibraryDefinitionsFromIncludes()
+    {
+        if (LibrarySetContext != null)
+        {
+            foreach (var libraryDependency in LibrarySetContext.LibrarySet.GetLibraryDependencies(LibraryVersionedIdentifier))
+            {
+                AddDefinitions(libraryDependency);
+            }
+        }
+
+        void AddDefinitions(Library library)
+        {
+            string libraryName = library.VersionedLibraryIdentifier;
+            if (!HasAliasForLibraryVersionedIdentifier(libraryName))
+                throw new CouldNotResolveAliasFromTheLibraryVersionedIdentifierError(library).ToException();
+
+            foreach (var (definitionSignature, expression) in LibrarySetContext!.LibrarySetDefinitions.SelectDefinitionsByLibraryName(libraryName))
+                LibraryDefinitions.AddDefinition(libraryName, definitionSignature, expression);
+        }
+    }
+
+    #endregion
+
+    #region Library Identifiers by Alias
+
+    private readonly Dictionary<string, string> _libraryIdentifiersByAlias = new();
+
+    /// <summary>
+    /// Adds an alias for the library name and version.
+    /// </summary>
+    /// <param name="alias">The alias.</param>
+    /// <param name="libraryKey">The library key.</param>
+    public void AddAliasLibraryVersionedIdentifier(string alias, string libraryKey) =>
+        _libraryIdentifiersByAlias.Add(alias, libraryKey);
+
+    /// <summary>
+    /// Gets the name and version of the library from the alias.
+    /// References to definitions from included libraries are resolved using the alias.
+    /// </summary>
+    /// <param name="alias">The alias.</param>
+    /// <param name="throwError">Indicates whether to throw an error if the alias is not found.</param>
+    /// <returns>The name and version of the library.</returns>
+    public string? GetLibraryVersionedIdentifierFromAlias(string? alias, bool throwError = true)
+    {
+        if (alias == null)
+            return LibraryVersionedIdentifier;
+        if (throwError)
+            return _libraryIdentifiersByAlias[alias];
+        _libraryIdentifiersByAlias.TryGetValue(alias, out string? libraryKey);
+        return libraryKey;
+    }
+
+    public bool HasAliasForLibraryVersionedIdentifier(string libraryKey) =>
+        _libraryIdentifiersByAlias.ContainsValue(libraryKey);
+
+    #endregion
+
+    #region Codes By CodeSystemName
+
+    private readonly Dictionary<string, List<CqlCode>> _codesByCodeSystemName = new();
+
+    /// <summary>
+    /// Tries to get the codes by code system name.
+    /// </summary>
+    /// <param name="codeSystemName">The name of the code system.</param>
+    /// <param name="codes">The list of CqlCode objects.</param>
+    /// <returns>True if the codes are found, false otherwise.</returns>
+    public bool TryGetCodesByCodeSystemName(string codeSystemName, [NotNullWhen(true)] out List<CqlCode>? codes) =>
+        _codesByCodeSystemName.TryGetValue(codeSystemName, out codes);
+
+    private List<CqlCode> GetOrCreateCodesByCodeSystemName(string codeSystemName)
+    {
+        if (_codesByCodeSystemName.TryGetValue(codeSystemName!, out var codings))
+            return codings;
+
+        codings = new List<CqlCode>();
+        _codesByCodeSystemName.Add(codeSystemName!, codings);
+        return codings;
+    }
+
+    public IrLibrarySetExpressionBuilderContext? LibrarySetContext => _libsCtx;
+
+    #endregion
+
+    #region Codes By Name (cross library???)
+
+    private readonly Dictionary<string, CqlCode> _codesByName = new();
+
+    /// <summary>
+    /// Tries to get the CqlCode object by code reference.
+    /// </summary>
+    /// <param name="codeRef">The code reference.</param>
+    /// <param name="systemCode">The CqlCode object.</param>
+    /// <returns>True if the CqlCode object is found, false otherwise.</returns>
+    public bool TryGetCode(CodeRef codeRef, [NotNullWhen(true)] out CqlCode? systemCode) =>
+        _codesByName.TryGetValue(codeRef.name, out systemCode);
+
+    /// <summary>
+    /// Adds a code definition and its corresponding CqlCode object.
+    /// </summary>
+    /// <param name="codeDef">The code definition.</param>
+    /// <param name="cqlCode">The CqlCode object.</param>
+    public void AddCode(CodeDef codeDef, CqlCode cqlCode)
+    {
+        _codesByName.Add(codeDef.name, cqlCode);
+
+        var codeSystemName = codeDef.codeSystem!.name;
+        var codings = GetOrCreateCodesByCodeSystemName(codeSystemName);
+        codings.Add(cqlCode);
+    }
+
+    #endregion
+
+    #region Url By CodeSystemRef (cross library)
+
+    private readonly CodeSystemRefDictionary<string> _codeSystemIdsByCodeSystemRefs = new();
+
+    private void AddCodeSystemRefsFromIncludes()
+    {
+        if (LibrarySetContext != null)
+        {
+            foreach (var libraryDependency in LibrarySetContext.LibrarySet.GetLibraryDependencies(LibraryVersionedIdentifier))
+            {
+                AddCodeSystemRefs(libraryDependency);
+            }
+        }
+
+        AddCodeSystemRefs(Library);
+    }
+
+    private void AddCodeSystemRefs(Library library)
+    {
+        if (library.codeSystems is { Length: > 0 } codeSystemDefs)
+        {
+            foreach (var codeSystemDef in codeSystemDefs)
+            {
+                var libraryNameAndName = (library.VersionedLibraryIdentifier, codeSystemDef.name);
+                var newValue = codeSystemDef.id;
+                if (!_codeSystemIdsByCodeSystemRefs.TryAdd(libraryNameAndName, newValue))
+                {
+                    var previousValue = _codeSystemIdsByCodeSystemRefs[libraryNameAndName];
+                    if (previousValue != newValue)
+                        throw this.NewExpressionBuildingException(
+                            $"A code system '{libraryNameAndName}' was previously added with value '{previousValue}', and it cannot accept a different value '{newValue}'.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tries to get the code system name by code system reference.
+    /// </summary>
+    /// <param name="codeSystemRef">The code system reference.</param>
+    /// <param name="url">The URL of the code system.</param>
+    /// <returns>True if the code system name is found, false otherwise.</returns>
+    public bool TryGetCodeSystemName(Elm.CodeSystemRef codeSystemRef, [NotNullWhen(true)] out string? url)
+    {
+        var libraryName = GetLibraryVersionedIdentifierFromAlias(codeSystemRef.libraryName);
+        return _codeSystemIdsByCodeSystemRefs.TryGetValue(new(libraryName, codeSystemRef.name), out url);
+    }
+
+    #endregion
+
+    private class CodeSystemRefDictionary<TValue> : Dictionary<(string? LibraryName, string Name), TValue>;
+}

--- a/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/Ir/IrLibraryExpressionBuilderContext.cs
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="LibraryExpressionBuilderContext"/>: orchestrates building all
+/// definitions of a single library into an <see cref="IrDefinitionDictionary"/>. This is a
+/// mechanical port; see the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+[DebuggerDisplay("{DebuggerView}")]
+internal partial class IrLibraryExpressionBuilderContext : IBuilderContext
+{
+    private readonly ILogger<IrLibraryExpressionBuilder> _logger;
+    private readonly IrExpressionBuilder _expressionBuilder;
+    private readonly IrDefinitionDictionary _libraryDefinitions;
+    private readonly IrLibrarySetExpressionBuilderContext? _libsCtx;
+    private readonly LibraryPreprocessor _preprocessor;
+
+    public IrLibraryExpressionBuilderContext(
+        ILogger<IrLibraryExpressionBuilder> logger,
+        IrExpressionBuilder expressionBuilder,
+        LibraryPreprocessorBuilder libraryPreprocessorBuilder,
+        Library library,
+        IrDefinitionDictionary libraryDefinitions,
+        IrLibrarySetExpressionBuilderContext? libsCtx = null)
+    {
+        _libraryDefinitions = libraryDefinitions;
+        _libsCtx = libsCtx;
+        _logger = logger;
+        _expressionBuilder = expressionBuilder;
+        Library = library;
+        LibraryVersionedIdentifier = Library.VersionedLibraryIdentifier;
+        _preprocessor =
+            LibrarySetContext?.Preprocessor
+            ?? libraryPreprocessorBuilder.Build(new LibrarySet(LibraryVersionedIdentifier, Library));
+    }
+
+    /// <summary>
+    /// Gets the library associated with the expression builder context.
+    /// </summary>
+    public Library Library { get; }
+
+    /// <summary>
+    /// Gets the versioned identifier of the library, which is the name and version of the library.
+    /// </summary>
+    /// <seealso cref="IGetVersionedIdentifierExtensions.GetVersionedLibraryIdentifierString"/>
+    public string LibraryVersionedIdentifier { get; }
+
+    public IrDefinitionDictionary ProcessLibrary() =>
+        this.CatchRethrowExpressionBuildingException(_ =>
+        {
+            _logger.LogDebug("Building expressions for '{library}'", LibraryVersionedIdentifier);
+
+            _preprocessor.PreprocessLibrary(Library);
+
+            if (Library.includes is { Length: > 0 } includeDefs)
+            {
+                foreach (var includeDef in includeDefs)
+                {
+                    _expressionBuilder.ProcessIncludes(this, includeDef);
+                }
+
+                AddLibraryDefinitionsFromIncludes();
+                AddCodeSystemRefsFromIncludes();
+            }
+
+            if (Library.valueSets is { Length: > 0 } valueSetDefs)
+            {
+                foreach (var valueSetDef in valueSetDefs)
+                {
+                    _expressionBuilder.ProcessValueSetDef(this, valueSetDef);
+                }
+            }
+
+            AddCodeSystemRefs(Library);
+
+            if (Library.codes is { Length: > 0 } codeDefs)
+            {
+                HashSet<(string codeName, string codeSystemUrl)> foundCodeNameCodeSystemUrls = new();
+
+                foreach (var codeDef in codeDefs)
+                {
+                    _expressionBuilder.ProcessCodeDef(this, codeDef, foundCodeNameCodeSystemUrls);
+                }
+            }
+
+            if (Library.codeSystems is { Length: > 0 } codeSystemDefs)
+            {
+                foreach (var codeSystemDef in codeSystemDefs)
+                {
+                    _expressionBuilder.ProcessCodeSystemDef(this, codeSystemDef);
+                }
+            }
+
+            if (Library.concepts is { Length: > 0 } conceptDefs)
+            {
+                foreach (var conceptDef in conceptDefs)
+                {
+                    _expressionBuilder.ProcessConceptDef(this, conceptDef);
+                }
+            }
+
+            if (Library.parameters is { Length: > 0 } parameterDefs)
+            {
+                foreach (var parameterDef in parameterDefs)
+                {
+                    _expressionBuilder.ProcessParameterDef(this, parameterDef);
+                }
+            }
+
+            if (Library.statements is { Length: > 0 } expressionDefs)
+            {
+                foreach (var expressionDef in expressionDefs)
+                {
+                    _expressionBuilder.ProcessExpressionDef(this, expressionDef);
+                }
+            }
+
+            return LibraryDefinitions;
+        });
+
+    #region DebuggerView
+
+    IBuilderContext? IBuilderContext.OuterBuilderContext => LibrarySetContext;
+
+    BuilderContextDebuggerInfo? IBuilderContext.DebuggerInfo => BuilderContextDebuggerInfo.FromElement(Library);
+
+    public string DebuggerView => this.GetDebuggerView();
+
+    #endregion
+}

--- a/Cql/Cql.Compiler/Ir/IrLibrarySetExpressionBuilder.cs
+++ b/Cql/Cql.Compiler/Ir/IrLibrarySetExpressionBuilder.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="LibrarySetExpressionBuilder"/>. This is a mechanical port; see
+/// the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+internal class IrLibrarySetExpressionBuilder(
+    IrLibraryExpressionBuilder libraryExpressionBuilder,
+    LibraryPreprocessorBuilder libraryPreprocessorBuilder)
+{
+    public IEnumerable<(Library library, IrDefinitionDictionary libraryDefinitions)> BuildEachLibraryDefinitions(
+        LibrarySet librarySet,
+        IrDefinitionDictionary librarySetDefinitions,
+        BatchProcessExceptionHandlingStrategyBuilder<Library>? errorStrategyBuilder = null,
+        Action<Library>? onNextLibrary = null) =>
+        NewLibrarySetExpressionBuilderContext(librarySet, librarySetDefinitions)
+            .BuildEachLibraryDefinitions(errorStrategyBuilder, onNextLibrary);
+
+    private IrLibrarySetExpressionBuilderContext NewLibrarySetExpressionBuilderContext(
+        LibrarySet librarySet,
+        IrDefinitionDictionary librarySetDefinitions) =>
+        new(libraryExpressionBuilder, libraryPreprocessorBuilder, librarySet, librarySetDefinitions);
+}

--- a/Cql/Cql.Compiler/Ir/IrLibrarySetExpressionBuilderContext.cs
+++ b/Cql/Cql.Compiler/Ir/IrLibrarySetExpressionBuilderContext.cs
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Runtime;
+using Library = Hl7.Cql.Elm.Library;
+
+namespace Hl7.Cql.Compiler.Ir;
+
+/// <summary>
+/// IR counterpart of <see cref="LibrarySetExpressionBuilderContext"/>: orchestrates building
+/// each library of a library set and merging its definitions. This is a mechanical port; see
+/// the remarks on <see cref="IrExpressionBuilderContext"/>.
+/// </summary>
+[DebuggerDisplay("{DebuggerView}")]
+internal class IrLibrarySetExpressionBuilderContext : IBuilderContext
+{
+    private readonly IrLibraryExpressionBuilder _libraryExpressionBuilder;
+
+    public IrLibrarySetExpressionBuilderContext(
+        IrLibraryExpressionBuilder libraryExpressionBuilder,
+        LibraryPreprocessorBuilder libraryPreprocessorBuilder,
+        LibrarySet librarySet,
+        IrDefinitionDictionary librarySetDefinitions)
+    {
+        _libraryExpressionBuilder = libraryExpressionBuilder;
+        LibrarySetDefinitions = librarySetDefinitions;
+        LibrarySet = librarySet;
+        Preprocessor = libraryPreprocessorBuilder.Build(librarySet);
+        DebuggerInfo = new BuilderContextDebuggerInfo("LibrarySet", Name: LibrarySet!.Name!);
+    }
+
+    /// <summary>
+    /// Gets the merged definitions of all the libraries processed in the <see cref="LibrarySet"/>.
+    /// </summary>
+    public IrDefinitionDictionary LibrarySetDefinitions { get; }
+
+    /// <summary>
+    /// Gets the library set being processed.
+    /// </summary>
+    public LibrarySet LibrarySet { get; }
+
+    public LibraryPreprocessor Preprocessor { get; }
+
+    public IEnumerable<(Library library, IrDefinitionDictionary libraryDefinitions)> BuildEachLibraryDefinitions(
+        BatchProcessExceptionHandlingStrategyBuilder<Library>? buildExceptionHandlingStrategy = null,
+        Action<Library>? prebuildLibraryHandler = null) =>
+        LibrarySet
+            .TrySelect(
+                library =>
+                {
+                    prebuildLibraryHandler?.Invoke(library);
+                    return this.CatchRethrowExpressionBuildingException(_ =>
+                    {
+                        var libraryDefinitions = _libraryExpressionBuilder.ProcessLibrary(library, null, this);
+                        LibrarySetDefinitions.Merge(libraryDefinitions);
+                        return (library, libraryDefinitions);
+                    });
+                },
+                buildExceptionHandlingStrategy);
+
+    #region DebuggerView
+
+    public IBuilderContext? OuterBuilderContext => null;
+    public BuilderContextDebuggerInfo? DebuggerInfo { get; }
+    public string DebuggerView => this.GetDebuggerView();
+
+    #endregion
+}

--- a/Cql/CqlToElmTests/(tests)/IrPipelineTests.cs
+++ b/Cql/CqlToElmTests/(tests)/IrPipelineTests.cs
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.CodeGeneration.NET;
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Elm;
+using Hl7.Cql.Fhir;
+using Microsoft.Extensions.Logging.Abstractions;
+using TypeConverter = Hl7.Cql.Conversion.TypeConverter;
+
+namespace Hl7.Cql.CqlToElm.Test;
+
+/// <summary>
+/// First end-to-end integration tests for the phase-4 typed-IR builder pipeline
+/// (<see cref="IrLibraryExpressionBuilder"/> et al.) feeding into the phase-3
+/// <see cref="CSharpIrEmitter"/>. Nothing exercised this combination before these tests; the
+/// assertions are deliberately loose (shape-level <see cref="StringAssert.Contains"/> checks,
+/// not byte-exact comparisons) since byte-parity with the old pipeline is a phase-5 concern.
+/// </summary>
+[TestClass]
+public class IrPipelineTests : Base
+{
+    /// <summary>Test stand-in for the scaffolding writer's naming conventions (mirrors
+    /// <c>CSharpIrEmitterTests.TestNamingConventions</c> in CoreTests, which lives in a
+    /// different assembly and isn't shared).</summary>
+    private sealed class TestNamingConventions : ICSharpNamingConventions
+    {
+        public string TupleMetadataFieldName(Type tupleType) => "CqlTupleMetadata_TEST";
+
+        public string DefinitionTarget(IrDefinitionCall dc) => dc.IsLocalLibrary
+            ? $"this.{dc.DefinitionName}"
+            : $"{dc.LibraryName}_{dc.LibraryVersion.Replace('.', '_')}.Instance.{dc.DefinitionName}";
+    }
+
+    /// <summary>
+    /// Builds a <see cref="Library"/> from CQL source, then runs it through the typed-IR
+    /// builder chain, mirroring the composition <c>ElmToolkitServices.AddCqlCompilerServices</c>
+    /// wires up via DI for the old (Linq.Expressions) pipeline -- see
+    /// <c>Cql\CodeGeneration.NET\Toolkit\Internal\ElmToolkitServices.cs</c> -- but constructed by
+    /// hand with <see cref="NullLogger{T}"/>/<see cref="NullLoggerFactory"/> instances, since
+    /// these new Ir* classes are not (yet) registered in that container.
+    /// </summary>
+    private static (Library library, IrDefinitionDictionary definitions) BuildIr(string cql)
+    {
+        var library = CreateCqlToolkit().MakeLibrary(cql);
+
+        var typeResolver = FhirTypeResolver.Default;
+        var typeConverter = FhirTypeConverter
+            .Create(Hl7.Fhir.Model.ModelInfo.ModelInspector)
+            .UseLogger(NullLogger<TypeConverter>.Instance);
+        typeConverter.CaptureAvailableConverters();
+
+        var tupleBuilderCache = new TupleBuilderCache(NullLogger<TupleBuilderCache>.Instance);
+        var libraryPreprocessorBuilder = new LibraryPreprocessorBuilder(NullLoggerFactory.Instance);
+        var cqlOperatorsBinder = new IrCqlOperatorsBinder(NullLogger<IrCqlOperatorsBinder>.Instance, typeResolver, typeConverter);
+        var cqlContextBinder = new IrCqlContextBinder();
+
+        var expressionBuilder = new IrExpressionBuilder(
+            NullLogger<IrExpressionBuilder>.Instance,
+            ExpressionBuilderSettings.Default,
+            cqlOperatorsBinder,
+            tupleBuilderCache,
+            typeResolver,
+            typeConverter,
+            cqlContextBinder);
+
+        var libraryExpressionBuilder = new IrLibraryExpressionBuilder(
+            NullLogger<IrLibraryExpressionBuilder>.Instance,
+            expressionBuilder,
+            libraryPreprocessorBuilder);
+
+        var definitions = libraryExpressionBuilder.ProcessLibrary(library);
+        return (library, definitions);
+    }
+
+    /// <summary>
+    /// Fetches a top-level definition of the given name from the library's own definitions
+    /// (as opposed to any included library's) and emits its body as C# via
+    /// <see cref="CSharpIrEmitter"/>. Filtering by name (rather than relying on there being a
+    /// single definition) matters because a <c>context Patient</c>/default-context library gets
+    /// a synthesized context definition alongside the CQL-authored ones (see
+    /// <c>ContextDefTest</c>).
+    /// </summary>
+    private static string EmitDefinition(Library library, IrDefinitionDictionary definitions, string name)
+    {
+        var lambdaDefinition = definitions
+            .SelectDefinitionsByLibraryName(library.VersionedLibraryIdentifier)
+            .Select(d => d.definition)
+            .OfType<IrLambdaDefinition>()
+            .First(d => d.Name == name);
+
+        var emitter = new CSharpIrEmitter(new TypeToCSharpConverter(), new TestNamingConventions());
+        return emitter.EmitBodyBlock(lambdaDefinition.Lambda).Replace("\r\n", "\n");
+    }
+
+    /// <summary>Baseline every test asserts: the builder and emitter ran without throwing, and
+    /// produced a non-empty body block that returns something.</summary>
+    private static void AssertWellFormedBody(string body)
+    {
+        Assert.IsFalse(string.IsNullOrWhiteSpace(body));
+        StringAssert.StartsWith(body, "{");
+        StringAssert.Contains(body, "return ");
+        StringAssert.EndsWith(body, "}");
+    }
+
+    [TestMethod]
+    public void IntegerArithmetic_EmitsAddCallOnOperators()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define X: 1 + 2
+            """);
+
+        var body = EmitDefinition(library, definitions, "X");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "context.Operators");
+        StringAssert.Contains(body, "Add");
+    }
+
+    [TestMethod]
+    public void IfThenElse_EmitsConditional()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define X: if 1 > 0 then 10 else 20
+            """);
+
+        var body = EmitDefinition(library, definitions, "X");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "10");
+        StringAssert.Contains(body, "20");
+        // Either a ternary or an if/else statement, depending on whether the condition
+        // is trivial enough to inline (see CSharpIrEmitterTests.Conditional_*).
+        Assert.IsTrue(body.Contains('?') || body.Contains("if ("),
+            $"Expected a ternary or if/else in the emitted body, got:\n{body}");
+    }
+
+    [TestMethod]
+    public void CaseWithMultipleBranches_EmitsIfChain()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define X:
+                case
+                    when 1 > 0 then 10
+                    when 1 = 0 then 20
+                    else 30
+                end
+            """);
+
+        var body = EmitDefinition(library, definitions, "X");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "10");
+        StringAssert.Contains(body, "20");
+        StringAssert.Contains(body, "30");
+        StringAssert.Contains(body, "if (");
+    }
+
+    [TestMethod]
+    public void QueryWithWhereClause_EmitsLocalFunctionWithAliasParameter()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define Q: ({ 1, 2, 3 }) N where N > 1 return N
+            """);
+
+        var body = EmitDefinition(library, definitions, "Q");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "Where");
+        // The alias "N" becomes the parameter name of the emitted local function.
+        StringAssert.Contains(body, "(int? N)");
+    }
+
+    [TestMethod]
+    public void PropertyAccessOverFhir_EmitsNullConditionalProperty()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+            using FHIR version '4.0.1'
+            context Patient
+
+            define GetActive: Patient.active
+            """);
+
+        var body = EmitDefinition(library, definitions, "GetActive");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "Active");
+        // The null-conditional survived the port: "Patient" (the context reference) can be
+        // null, so ".active" must print as "?.ActiveElement", not a plain ".ActiveElement".
+        StringAssert.Contains(body, "?.ActiveElement");
+    }
+
+    [TestMethod]
+    public void TupleLiteral_EmitsValueTuple()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define T: Tuple { x: 1, y: 2 }
+            """);
+
+        var body = EmitDefinition(library, definitions, "T");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "CqlTupleMetadata_TEST");
+    }
+
+    [TestMethod]
+    public void ListLiteralWithFirst_EmitsFirstCall()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define X: First({ 1, 2, 3 })
+            """);
+
+        var body = EmitDefinition(library, definitions, "X");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "First");
+    }
+
+    [TestMethod]
+    public void UserDefinedFunctionCall_EmitsThisDotCall()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define function Double(x Integer): x * 2
+            define UseDouble: Double(5)
+            """);
+
+        var body = EmitDefinition(library, definitions, "UseDouble");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "this.Double");
+    }
+
+    [TestMethod]
+    public void ParameterDefinition_EmitsResolveParameterCall()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            parameter MyParam Integer default 5
+            define UseParam: MyParam + 1
+            """);
+
+        var useParamBody = EmitDefinition(library, definitions, "UseParam");
+        AssertWellFormedBody(useParamBody);
+        // The reference to MyParam from within UseParam is a call to MyParam's own definition
+        // (not an inlined ResolveParameter call) -- the ResolveParameter call lives inside
+        // MyParam's own emitted body.
+        StringAssert.Contains(useParamBody, "this.MyParam");
+
+        var myParamBody = EmitDefinition(library, definitions, "MyParam");
+        AssertWellFormedBody(myParamBody);
+        StringAssert.Contains(myParamBody, "ResolveParameter");
+    }
+
+    [TestMethod]
+    public void IntervalLiteral_EmitsWidthCall()
+    {
+        var (library, definitions) = BuildIr("""
+            library IrPipeTest version '1.0.0'
+
+            define X: width of Interval[3, 7]
+            """);
+
+        var body = EmitDefinition(library, definitions, "X");
+        AssertWellFormedBody(body);
+        StringAssert.Contains(body, "Width");
+    }
+}

--- a/docs/linq-expression-removal-plan.md
+++ b/docs/linq-expression-removal-plan.md
@@ -1,6 +1,11 @@
 # Replacing System.Linq.Expressions with a typed IR
 
-Status: **phases 0–1 merged** ([#1311](https://github.com/FirelyTeam/firely-cql-sdk/pull/1311)); phase 2 in progress.
+Status: **phases 0–1 merged** ([#1311](https://github.com/FirelyTeam/firely-cql-sdk/pull/1311));
+phases 2–4 implemented and in review as a stacked PR chain
+([#1331](https://github.com/FirelyTeam/firely-cql-sdk/pull/1331) →
+[#1340](https://github.com/FirelyTeam/firely-cql-sdk/pull/1340) →
+[#1344](https://github.com/FirelyTeam/firely-cql-sdk/pull/1344), aggregating onto
+`feature/linq-expr-removal`); phase 5 not started.
 
 ## Context
 
@@ -121,9 +126,9 @@ standalone fixes.
 |---|---|---|
 | 0 | Delete dead visitors; golden regeneration tests over `LibrarySets\` corpora | ✅ merged (#1311) |
 | 1 | Decouple tests from `Expression.Compile()`; cache metadata references in `AssemblyCompiler` | ✅ merged (#1311) |
-| 2 | Typed IR nodes + validating factories; `CSharpEmitter` reproducing current output | in progress |
-| 3 | Port `CqlOperatorsBinder` + partials onto the IR (algorithm unchanged) | |
-| 4 | Port `ExpressionBuilderContext` + partials (FHIRHelpers workarounds, choice types, query machinery) | |
+| 2 | Typed IR nodes + validating factories; `CSharpEmitter` reproducing current output | ✅ in review (#1331) |
+| 3 | Port `CqlOperatorsBinder` + partials onto the IR (algorithm unchanged) | ✅ in review (#1340) |
+| 4 | Port `ExpressionBuilderContext` + partials (FHIRHelpers workarounds, choice types, query machinery) | ✅ in review (#1344) |
 | 5 | Dual-pipeline flag, golden diffs across all corpora + full suites, flip default | |
 | 6 | Delete the Expression-based builder/binder/visitors/custom expressions; bump generator version | |
 
@@ -132,6 +137,46 @@ constrains the emitter): multi-branch conditionals whose branches are all simple
 C# `switch` expressions instead of `if`/`else if` chains (statement form stays as the general
 fallback for branches that hoist locals), and the printing backend itself is swappable — e.g.
 emitting Roslyn syntax trees from the IR for normalized formatting.
+
+### Findings from phases 2–4
+
+- **The IR node set held.** The full builder port (all ELM constructs: queries, tuples,
+  retrieves, FHIR property null-propagation, definition/function calls) required **zero new
+  node kinds** and left no unresolved `FIXME(phase4-review)` markers — the ~18 kinds designed
+  in phase 2 from the `Expression.*` usage survey were sufficient. The first end-to-end
+  execution of the new pipeline (ten CQL constructs, `IrPipelineTests`) passed without a
+  single builder fix.
+- **Complication #3 (variable identity) was cheaper than predicted.** `IrLocal` reference
+  identity slotted in mechanically for `ParameterExpression` identity; the only subtlety
+  found was pre-existing (`WithToSelectManyBody` creates two same-alias parameters, #1343).
+- **More reuse than planned**: the exception-context machinery
+  (`IBuilderContext`/`ExpressionBuildingError`), the generic `DefinitionDictionary<T>`, and
+  `CqlOperatorsMethodsCache` are all Expression-free and shared by both pipelines instead of
+  duplicated.
+- **One deliberate shape change**: definition lambdas no longer carry an explicit
+  `CqlContext` parameter — the well-known `IrContextParameter.Instance` is referenced
+  directly, and `IrDefinitionCall` carries it as `arguments[0]`. Phase 5's
+  `DefinitionWriter` integration must account for this.
+- **Preserve-vs-fix policy, refined by practice**: anything that could change a *binding
+  outcome* is preserved bug-for-bug and tracked (#1341 generic-inference indexing, #1342
+  dead `Includes`/`IncludedIn` mismatch check, #1343); crash-path and diagnostics-only
+  defects may be fixed in the IR copy with a `NOTE` + issue (#1345 lists them for the old
+  binder, should it ever need the fixes before deletion).
+- **Phase-5 wiring landmine** (flagged during the LibraryDefs port): external-function
+  stubs register a `DefinitionSignature` with a synthetic leading context type inherited
+  from the old lambda shape — inert today, but whoever wires definition emission must not
+  key lookups off it.
+
+### Phase 6 checklist (accumulated `FIXME(phase6)` markers)
+
+- Unify the IR binder's `InvalidOperationException` + `FormatCannotBindMessage` with
+  `CannotBindToCqlOperatorError` (generalize the error type off `Expression[]`).
+- Relocate `CqlOperatorsMethodsCache` out of the deleted `CqlOperatorsBinder`.
+- Consolidate the duplicated assign-to-type helpers (`IrExpressionExtensions` vs. the
+  binder's private phase-3 copies).
+- Revisit `IrCodeDefinition.ReturnType` (parity-preserved `typeof(CqlCodeDefinition)`).
+- Fix the tracked upstream bugs in one place: #1341, #1342; review #1343; close #1345.
+- Remove the `NOTE(phase3)`/`NOTE(phase4)` markers as each is resolved.
 
 ### Findings from phases 0–1
 


### PR DESCRIPTION
## What

Phase 4 of the Linq.Expressions removal (see `docs/linq-expression-removal-plan.md`): the ELM-to-IR builder — `IrExpressionBuilderContext` + partials, the `IrDefinition` types, and the thin library-level orchestrators. ~4,700 added lines; the old Expression-based builder is untouched (both pipelines coexist until phase 6), and nothing is wired into production yet.

**Stacked PR**: based on `linq-expr-removal-phase3` (#1340), which is based on phase 2 (#1331) — will be retargeted as those merge.

## How it was built

A skeleton (core dispatch switch, `Translate*` machinery, Scopes, definition types, wrappers) plus three parallel mechanical-port batches over disjoint partial files (Operators+TypeFor, Query, Refs+LibraryDefs), each preserving the old algorithm verbatim — including its oddities, each marked `NOTE(phase4)`.

## Design points to review

1. **Variable identity**: `IrLocal` reference identity replaces `ParameterExpression` identity for query aliases — one instance per alias, shared between the scope dictionary and lambda parameter lists. The one subtle case is preserved faithfully: `WithToSelectManyBody` creates two distinct same-alias parameters exactly as the old code did (#1343 tracks revisiting this post-migration).
2. **Context parameter**: definition lambdas no longer carry an explicit `CqlContext` parameter — the well-known `IrContextParameter.Instance` is referenced directly, and `IrDefinitionCall` carries it as `arguments[0]`. This is the phase''s only deliberate shape change (established by the phase-2 IR design).
3. **Reuse over duplication**: the exception-context machinery (`IBuilderContext`, `ExpressionBuildingError`) and the generic `DefinitionDictionary<T>` turned out to be Expression-free and are reused directly — two fewer parallel types than planned.
4. The always-empty `IExpressionMutator` hook is dropped.
5. Ratified substitutions (flagged in-code): eager `Expression.Or` over pure type-tests → short-circuiting `OrElse`; the two cast-to-object unwrap shapes collapse into the single `IrCast` node by design.

## Preserved upstream oddities → issues

- #1342 — `Includes`/`IncludedIn` compute `rightElementType` from the left operand (dead mismatch check), found during this port, preserved as-is.
- #1343 — the `WithToSelectManyBody` double-parameter question above.
- (#1341 from phase 3 remains the policy template: bug-for-bug fidelity until golden parity, fix once after phase 6.)

## Verification

- **`IrPipelineTests`** (new, in CqlToElmTests): ten end-to-end tests running CQL source → ELM → `IrLibraryExpressionBuilder` → `CSharpIrEmitter`, with the real FHIR service composition — the first execution of the new pipeline. All ten passed against the ported builder **without a single fix**: arithmetic, if/then/else, case, queries with where/return (local-function alias parameters), FHIR property access with null propagation (`a_?.ActiveElement` verified in the emitted text), tuples, list + First, user-defined function calls (`this.Double(context, 5)`), parameters, interval width.
- Binder, emitter, and golden-file test suites all green; git shows only added files against the old pipeline.
- The remaining correctness backstop is phase 5 itself: dual-pipeline golden diffs over the `LibrarySets\` corpora, which is the point where old-vs-new output is compared byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)