### PR TITLE
Golden parity: the typed-IR pipeline, selectable via UseIrPipeline (phase 5)

### DIFF
--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
@@ -100,8 +100,73 @@ internal partial class CSharpIrEmitter
             ? $"{call.Method.Name}<{string.Join(", ", call.Method.GetGenericArguments().Select(_typeToCSharpConverter.ToCSharp))}>"
             : call.Method.Name;
 
-        var arguments = string.Join(", ", call.Arguments.Select(a => child(a).Code));
+        var parameters = call.Method.GetParameters();
+        var arguments = string.Join(", ", call.Arguments.Select((a, i) =>
+        {
+            var code = child(a).Code;
+            // Null/default arguments carry a cast to the parameter type so overload intent
+            // stays visible — the old writer's BuildArguments rule.
+            if (a is IrConstant { Value: null } or IrDefault && code is "null" or "default")
+                return $"({_typeToCSharpConverter.ToCSharp(parameters[i].ParameterType)}){code}";
+            return code;
+        }));
         return $"{target}{(call.NullConditional ? "?." : ".")}{methodName}({arguments})";
+    }
+
+    /// <summary>
+    /// Prints an entire subtree as one inline expression — no hoisting at all, calls
+    /// included. Used for "simple" conditionals, which the old pipeline returned unvisited
+    /// so their whole subtree (the test included, however complex) printed inline.
+    /// </summary>
+    internal string PrintFullyInline(IrExpression node) =>
+        node switch
+        {
+            IrConstant or IrDefault or IrContextParameter => PrintSimple(node),
+            IrLocal local => _assignedNames.TryGetValue(local, out var name)
+                ? name
+                : throw new InvalidOperationException($"Local '{local}' is used before it is introduced."),
+            IrConditional conditional => PrintInlineConditional(conditional, PrintFullyInline),
+            IrLambda lambda => PrintInlineLambda(lambda),
+            IrIfChain => throw new NotSupportedException(
+                "An if-chain cannot print as an inline expression; this subtree should not have been classified inline-only."),
+            _ => PrintShallow(node, child => new Atom(PrintFullyInline(child), child)),
+        };
+
+    /// <summary>
+    /// The old writer's ternary format (BuildConditionalExpression): open paren, test on its
+    /// own line, indented <c>? ifTrue</c> / <c>: ifFalse)</c> lines.
+    /// </summary>
+    internal string PrintInlineConditional(IrConditional conditional, Func<IrExpression, string> print)
+    {
+        var isb = new IndentedStringBuilder();
+        isb.Append("(");
+        isb.AppendLine(print(conditional.Test));
+        using (isb.Indent())
+        {
+            isb.AppendLine($"? {print(conditional.IfTrue)}");
+            isb.Append($": {print(conditional.IfFalse)})");
+        }
+        return isb;
+    }
+
+    private string PrintInlineLambda(IrLambda lambda)
+    {
+        // Parameters of an inline lambda still need names; allocate them in the current
+        // emission like any other scope's parameters would be.
+        foreach (var p in lambda.Parameters)
+        {
+            if (!_assignedNames.ContainsKey(p))
+            {
+                var candidate = p.NameHint is { } hint && _usedNames.Add(hint) ? hint : null;
+                if (candidate is null)
+                    throw new NotSupportedException(
+                        "An inline lambda parameter without a usable name hint is not supported; this subtree should not have been classified inline-only.");
+                _assignedNames[p] = candidate;
+            }
+        }
+        var parameters = string.Join(", ", lambda.Parameters.Select(p => _assignedNames[p]));
+        var parameterList = lambda.Parameters.Count == 1 ? parameters : $"({parameters})";
+        return $"{parameterList} => {PrintFullyInline(lambda.Body)}";
     }
 
     private string PrintDefinitionCall(IrDefinitionCall call, Func<IrExpression, Atom> child)
@@ -121,6 +186,11 @@ internal partial class CSharpIrEmitter
 
     private string PrintCast(IrCast cast, Func<IrExpression, Atom> child)
     {
+        // Boxing casts are dropped from the output (the C# compiler re-inserts the boxing),
+        // exactly like the old writer's StripBoxing.
+        if (cast is { Kind: IrCastKind.Cast, Type: var t } && t == typeof(object) && cast.Operand.Type.IsValueType)
+            return child(cast.Operand).Code;
+
         var atom = child(cast.Operand);
         var operand = atom.Code.ParenthesizeIfNeeded();
         var typeName = _typeToCSharpConverter.ToCSharp(cast.Type);

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
@@ -181,15 +181,42 @@ internal partial class CSharpIrEmitter
             return $"{_typeToCSharpConverter.ToCSharp(property.Member.DeclaringType!)}.{property.Member.Name}";
 
         var target = child(receiver).Code.ParenthesizeIfNeeded();
-        return $"{target}{(property.NullConditional ? "?." : ".")}{property.Member.Name}";
+
+        // The old writer's GetMemberAccessNullabilityOperator: a plain (non-null-conditional)
+        // property access still prints "?." when the receiver's static type is a nullable
+        // value type, OR a CQL tuple type — CQL tuples are represented as ordinary reference
+        // classes but are treated as always-nullable "to be consistent with the original
+        // tuple types" (the old converter's own comment), so member access on one always
+        // null-propagates regardless of the node's own NullConditional flag.
+        var nullConditional = property.NullConditional
+            || receiver.Type.IsNullableValueType(out _)
+            || _typeToCSharpConverter.ShouldUseTupleType(receiver.Type);
+        return $"{target}{(nullConditional ? "?." : ".")}{property.Member.Name}";
     }
 
     private string PrintCast(IrCast cast, Func<IrExpression, Atom> child)
     {
-        // Casts to object are dropped from the output (the C# compiler re-inserts the
-        // boxing/upcast): the old writer's StripBoxing removed the value-typed ones and the
-        // old RedundantCastsTransformer the reference-typed ones — net effect, none survive.
-        if (cast.Type == typeof(object) && cast.Operand.Type != typeof(object))
+        // Boxing casts are dropped from the output (the C# compiler re-inserts the boxing),
+        // exactly like the old writer's StripBoxing — value-typed operands unconditionally.
+        //
+        // A reference-typed cast to object is redundant C# too (an implicit reference
+        // conversion always exists), and the old RedundantCastsTransformer struck those as
+        // well — EXCEPT it could only ever see a cast that already existed as a raw
+        // Convert/TypeAs node when its single pass ran. A cast built from the ELM "as"
+        // operator was instead represented by ElmAsExpression, a lazy wrapper that only
+        // reduces to a real Convert/TypeAs (specifically TypeAs for a non-strict "as", which
+        // this always is here) at print time, i.e. AFTER RedundantCastsTransformer had already
+        // run — such a cast was invisible to it and always survived. That happens precisely
+        // when a non-strict "as"-to-object cast is nested directly around ANOTHER cast (a
+        // Choice-typed union coercion wrapping a CQL "as" cast, e.g. CMS56's case/when/then
+        // branches: "(ad_ as CqlDateTime) as object" — the inner cast node stands for the
+        // ElmAsExpression operand the outer one wrapped). Every other shape — a strict
+        // Cast/Convert to object (e.g. RR23's Operators.Convert argument,
+        // "(object)(e_ as FhirDateTime)"), or an As/Cast wrapping a plain non-cast node (e.g. a
+        // ResolveParameter argument, "c_ as object") — was always a raw Convert/TypeAs from the
+        // start and got stripped like any other redundant reference cast.
+        if (cast.Type == typeof(object)
+            && (cast.Operand.Type.IsValueType || cast.Kind != IrCastKind.As || cast.Operand is not IrCast))
             return child(cast.Operand).Code;
 
         var atom = child(cast.Operand);
@@ -242,10 +269,11 @@ internal partial class CSharpIrEmitter
 
     private static string PrintBinary(IrBinary binary, Func<IrExpression, Atom> child)
     {
-        // ((T?)a) ?? b, where a is a non-nullable T, reduces to just a — the old
-        // RedundantCastsTransformer's coalesce rule (the cast-then-coalesce contributes
-        // nothing once the value is known non-null).
-        if (binary is { Op: IrBinaryOp.Coalesce, Left: IrCast { Kind: IrCastKind.Cast } leftCast }
+        // ((T?)a) ?? b or (a as T?) ?? b, where a is a non-nullable T, reduces to just a — the
+        // old RedundantCastsTransformer's coalesce rule, which matched both Convert AND TypeAs
+        // on the left (the cast-then-coalesce contributes nothing once the value is known
+        // non-null, regardless of which cast kind produced the nullable wrapper).
+        if (binary is { Op: IrBinaryOp.Coalesce, Left: IrCast leftCast }
             && Nullable.GetUnderlyingType(leftCast.Type) == leftCast.Operand.Type)
             return child(leftCast.Operand).Code;
 

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
@@ -151,17 +151,16 @@ internal partial class CSharpIrEmitter
 
     private string PrintInlineLambda(IrLambda lambda)
     {
-        // Parameters of an inline lambda still need names; allocate them in the current
-        // emission like any other scope's parameters would be.
+        // Parameters of an inline lambda print their name hints verbatim — exactly like the
+        // old writer, which printed a LambdaExpression's parameter names as-is with no
+        // legality or collision checks (a colliding or keyword alias would produce the same
+        // non-compiling output from both pipelines).
         foreach (var p in lambda.Parameters)
         {
             if (!_assignedNames.ContainsKey(p))
             {
-                var candidate = p.NameHint is { } hint && _usedNames.Add(hint) ? hint : null;
-                if (candidate is null)
-                    throw new NotSupportedException(
-                        "An inline lambda parameter without a usable name hint is not supported; this subtree should not have been classified inline-only.");
-                _assignedNames[p] = candidate;
+                _assignedNames[p] = p.NameHint ?? throw new NotSupportedException(
+                    "An inline lambda parameter without a name hint is not supported; this subtree should not have been classified inline-only.");
             }
         }
         var parameters = string.Join(", ", lambda.Parameters.Select(p => _assignedNames[p]));

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Print.cs
@@ -186,9 +186,10 @@ internal partial class CSharpIrEmitter
 
     private string PrintCast(IrCast cast, Func<IrExpression, Atom> child)
     {
-        // Boxing casts are dropped from the output (the C# compiler re-inserts the boxing),
-        // exactly like the old writer's StripBoxing.
-        if (cast is { Kind: IrCastKind.Cast, Type: var t } && t == typeof(object) && cast.Operand.Type.IsValueType)
+        // Casts to object are dropped from the output (the C# compiler re-inserts the
+        // boxing/upcast): the old writer's StripBoxing removed the value-typed ones and the
+        // old RedundantCastsTransformer the reference-typed ones — net effect, none survive.
+        if (cast.Type == typeof(object) && cast.Operand.Type != typeof(object))
             return child(cast.Operand).Code;
 
         var atom = child(cast.Operand);
@@ -241,13 +242,22 @@ internal partial class CSharpIrEmitter
 
     private static string PrintBinary(IrBinary binary, Func<IrExpression, Atom> child)
     {
+        // ((T?)a) ?? b, where a is a non-nullable T, reduces to just a — the old
+        // RedundantCastsTransformer's coalesce rule (the cast-then-coalesce contributes
+        // nothing once the value is known non-null).
+        if (binary is { Op: IrBinaryOp.Coalesce, Left: IrCast { Kind: IrCastKind.Cast } leftCast }
+            && Nullable.GetUnderlyingType(leftCast.Type) == leftCast.Operand.Type)
+            return child(leftCast.Operand).Code;
+
         var left = child(binary.Left).Code.ParenthesizeIfNeeded();
         var right = child(binary.Right).Code;
 
         return binary.Op switch
         {
-            IrBinaryOp.Equal when right == "null" => $"{left} is null",
-            IrBinaryOp.NotEqual when right == "null" => $"{left} is not null",
+            // "default" rewrites to "null" in patterns: a default literal is not a legal
+            // pattern (CS8505) — the old writer's rule.
+            IrBinaryOp.Equal when right is "null" or "default" => $"{left} is null",
+            IrBinaryOp.NotEqual when right is "null" or "default" => $"{left} is not null",
             IrBinaryOp.Equal => $"{left} == {right.ParenthesizeIfNeeded()}",
             IrBinaryOp.NotEqual => $"{left} != {right.ParenthesizeIfNeeded()}",
             IrBinaryOp.Coalesce => $"{left} ?? {right.ParenthesizeIfNeeded()}",
@@ -279,8 +289,20 @@ internal partial class CSharpIrEmitter
 
     private string PrintNewArray(IrNewArray newArray, Func<IrExpression, Atom> child)
     {
-        var items = string.Join(", ", newArray.Items.Select(i => child(i).Code));
-        return $"new {_typeToCSharpConverter.ToCSharp(newArray.ElementType)}[] {{ {items} }}";
+        // The old writer's collection-expression format: one element per line, each with a
+        // trailing comma.
+        if (newArray.Items.Count == 0)
+            return "[]";
+
+        var isb = new IndentedStringBuilder();
+        isb.AppendLine("[");
+        using (isb.Indent())
+        {
+            foreach (var item in newArray.Items)
+                isb.AppendLine($"{child(item).Code},");
+        }
+        isb.Append("]");
+        return isb;
     }
 
     /// <summary>

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
@@ -21,7 +21,14 @@ internal partial class CSharpIrEmitter
     {
         private readonly CSharpIrEmitter _emitter;
         private readonly VariableNameGenerator _names;
-        private readonly List<string> _statements = [];
+
+        // Statements are deferred renderers: plain declarations resolve immediately, but a
+        // hoisted local function's INTERIOR renders only when the enclosing scope writes out.
+        // This reproduces the old RenameVariablesVisitor naming order, which named all of a
+        // block's own variables before descending into nested function bodies (so an inner
+        // local is named h_ even though textually it precedes the d_..g_ that follow its
+        // enclosing function definition).
+        private readonly List<Func<string>> _statements = [];
         private readonly Dictionary<string, Atom> _dedup = [];
 
         private Scope(CSharpIrEmitter emitter, VariableNameGenerator names)
@@ -84,7 +91,7 @@ internal partial class CSharpIrEmitter
         public void WriteStatements(IndentedStringBuilder isb)
         {
             foreach (var statement in _statements)
-                isb.AppendLine(statement);
+                isb.AppendLine(statement());
         }
 
         /// <summary>
@@ -127,59 +134,91 @@ internal partial class CSharpIrEmitter
                     or IrNew
                     or IrThrow
                     or IrBinary { Op: IrBinaryOp.Equal or IrBinaryOp.NotEqual or IrBinaryOp.Coalesce }:
-                    return new Atom(_emitter.PrintShallow(node, child => Linearize(child)!), node);
+                {
+                    var (printed, keyPrinted) = PrintBoth(node);
+                    return new Atom(printed, keyPrinted, node);
+                }
 
                 default:
                 {
                     // Spine node (calls, constructions, null-conditional access, type tests,
                     // logical operators): linearize the children, print this node shallowly
                     // over the child atoms, and hoist it into a named local (deduplicated).
-                    var printed = _emitter.PrintShallow(node, child => Linearize(child)!);
-                    return Hoist(printed, node);
+                    var (printed, keyPrinted) = PrintBoth(node);
+                    return Hoist(printed, keyPrinted, node);
                 }
             }
         }
 
-        private Atom Hoist(string code, IrExpression node)
+        /// <summary>Prints <paramref name="node"/> shallowly twice over the same linearized
+        /// children: once with replacement codes (the real output) and once with
+        /// pre-replacement key codes (for dedup decisions). Children are linearized exactly
+        /// once via the memo.</summary>
+        private (string printed, string keyPrinted) PrintBoth(IrExpression node)
+        {
+            Dictionary<IrExpression, Atom> memo = new(ReferenceEqualityComparer.Instance);
+            Atom Child(IrExpression child) =>
+                memo.TryGetValue(child, out var atom) ? atom : memo[child] = Linearize(child)!;
+
+            var printed = _emitter.PrintShallow(node, child => Child(child));
+            var keyPrinted = _emitter.PrintShallow(node, child => Child(child) with { Code = Child(child).KeyCode });
+            return (printed, keyPrinted);
+        }
+
+        private Atom Hoist(string code, string keyCode, IrExpression node)
         {
             var typeSyntax = _emitter._typeToCSharpConverter.ToCSharp(node.Type);
-            var dedupKey = $"{code}::{typeSyntax}";
+            var dedupKey = $"{keyCode}::{typeSyntax}";
             if (_dedup.TryGetValue(dedupKey, out var existing))
-                return existing;
+            {
+                // The old pipeline still named the duplicate before the deduper removed its
+                // statement, leaving a gap in the letter sequence; the burned name is the
+                // duplicate's key identity for any parent's dedup decision.
+                var burnedName = AllocateName(null);
+                return existing with { KeyCode = burnedName };
+            }
 
             var local = new IrLocal(node.Type);
             var name = AllocateName(null);
             _emitter._assignedNames[local] = name;
-            _statements.Add($"{typeSyntax} {name} = {code};");
+            var statement = $"{typeSyntax} {name} = {code};";
+            _statements.Add(() => statement);
 
-            var atom = new Atom(name, local);
+            var atom = new Atom(name, name, local);
             _dedup[dedupKey] = atom;
             return atom;
         }
 
         private Atom HoistLocalFunction(IrLambda lambda)
         {
-            var nested = CreateNested(lambda.Parameters);
-            var result = nested.Linearize(lambda.Body, tailPosition: true);
-
+            // The function's own name is allocated now (it participates in this scope's
+            // naming sequence), but its interior renders deferred — see _statements.
             var functionLocal = new IrLocal(lambda.Type);
             var functionName = AllocateName(null);
             _emitter._assignedNames[functionLocal] = functionName;
 
-            var parameterList = string.Join(", ",
-                lambda.Parameters.Select(p => $"{_emitter._typeToCSharpConverter.ToCSharp(p.Type)} {_emitter._assignedNames[p]}"));
-
-            var isb = new IndentedStringBuilder();
-            isb.AppendLine($"{_emitter._typeToCSharpConverter.ToCSharp(lambda.Body.Type)} {functionName}({parameterList})");
-            isb.AppendLine("{");
-            using (isb.Indent())
+            _statements.Add(() =>
             {
-                nested.WriteStatements(isb);
-                if (result is not null)
-                    isb.AppendLine(TailStatement(result));
-            }
-            isb.AppendLine("}");
-            _statements.Add(isb);
+                var nested = CreateNested(lambda.Parameters);
+                var result = nested.Linearize(lambda.Body, tailPosition: true);
+
+                var parameterList = string.Join(", ",
+                    lambda.Parameters.Select(p => $"{_emitter._typeToCSharpConverter.ToCSharp(p.Type)} {_emitter._assignedNames[p]}"));
+
+                // Old format: blank line before the definition, opening brace on the
+                // signature line, blank line after (via the trailing newline).
+                var isb = new IndentedStringBuilder();
+                isb.AppendLine("");
+                isb.AppendLine($"{_emitter._typeToCSharpConverter.ToCSharp(lambda.Body.Type)} {functionName}({parameterList}) {{");
+                using (isb.Indent())
+                {
+                    nested.WriteStatements(isb);
+                    if (result is not null)
+                        isb.AppendLine(TailStatement(result));
+                }
+                isb.AppendLine("}");
+                return isb;
+            });
 
             return new Atom(functionName, functionLocal);
         }
@@ -198,17 +237,18 @@ internal partial class CSharpIrEmitter
                 return new Atom(_emitter.PrintInlineConditional(conditional, _emitter.PrintFullyInline), conditional);
             }
 
-            // Flatten the else-if chain (old: ToCwt) and emit as statement form. The old
-            // pipeline wrapped this in an invoked lambda; the native if/else chain is the
-            // documented intentional divergence (docs/linq-expression-removal-plan.md).
-            var cases = new List<(Atom Test, IrExpression Then)>();
+            // Flatten the else-if chain (old: ToCwt) and emit in the old pipeline's form: a
+            // zero-parameter local function containing the if/else chain, invoked where the
+            // value is needed. (A native if/else chain would be cleaner — post-parity
+            // cleanup, see docs/linq-expression-removal-plan.md.)
+            var cases = new List<(IrExpression When, IrExpression Then)>();
             IrExpression current = conditional;
             while (current is IrConditional c)
             {
-                cases.Add((Linearize(c.Test)!, c.IfTrue));
+                cases.Add((c.Test, c.IfTrue));
                 current = c.IfFalse;
             }
-            return EmitBranches(conditional.Type, cases, current);
+            return HoistConditionalFunction(conditional.Type, cases, current);
         }
 
         /// <summary>
@@ -237,81 +277,110 @@ internal partial class CSharpIrEmitter
                 _ => false,
             };
 
-        private Atom? LinearizeIfChain(IrIfChain chain, bool tailPosition)
-        {
-            var linearizedCases = chain.Cases
-                .Select(c => (Test: Linearize(c.When)!, c.Then))
-                .ToList();
-
-            if (tailPosition)
-            {
-                // In tail position each branch returns directly — the style the previous
-                // pipeline printed for case/when in a definition body.
-                var isb = new IndentedStringBuilder();
-                bool first = true;
-                foreach (var (test, then) in linearizedCases)
-                {
-                    isb.AppendLine(first ? $"if ({test.Code})" : $"else if ({test.Code})");
-                    EmitBranchBlock(isb, then, assignTo: null);
-                    first = false;
-                }
-                isb.AppendLine("else");
-                EmitBranchBlock(isb, chain.Else, assignTo: null);
-                _statements.Add(((string)isb).TrimEnd());
-                return null;
-            }
-
-            return EmitBranches(chain.Type, linearizedCases, chain.Else);
-        }
+        private Atom? LinearizeIfChain(IrIfChain chain, bool tailPosition) =>
+            HoistConditionalFunction(chain.Type, chain.Cases, chain.Else);
 
         /// <summary>
-        /// Emits a value-position multi-branch as a declared local assigned in an
-        /// <c>if</c>/<c>else if</c>/<c>else</c> chain, and returns that local.
+        /// Emits a multi-branch conditional in the old pipeline's exact form: a hoisted
+        /// zero-parameter local function (opening brace on the signature line, a trailing
+        /// <c>;</c> after the final else block — quirks of the old CaseWhenThen printing,
+        /// preserved for golden parity) whose branches <c>return</c>, invoked as
+        /// <c>name()</c> wherever the value is needed.
         /// </summary>
-        private Atom EmitBranches(
+        private Atom HoistConditionalFunction(
             Type resultType,
-            IReadOnlyList<(Atom Test, IrExpression Then)> cases,
+            IReadOnlyList<(IrExpression When, IrExpression Then)> cases,
             IrExpression @else)
         {
-            var resultLocal = new IrLocal(resultType);
-            var resultName = AllocateName(null);
-            _emitter._assignedNames[resultLocal] = resultName;
-            var typeSyntax = _emitter._typeToCSharpConverter.ToCSharp(resultType);
+            // The function's own name participates in this scope's naming sequence now; the
+            // interior renders deferred, like every hoisted function — see _statements.
+            var functionLocal = new IrLocal(resultType);
+            var functionName = AllocateName(null);
+            _emitter._assignedNames[functionLocal] = functionName;
 
-            var isb = new IndentedStringBuilder();
-            isb.AppendLine($"{typeSyntax} {resultName};");
-            bool first = true;
-            foreach (var (test, then) in cases)
+            _statements.Add(() =>
             {
-                isb.AppendLine(first
-                    ? $"if ({test.Code})"
-                    : $"else if ({test.Code})");
-                EmitBranchBlock(isb, then, assignTo: resultName);
-                first = false;
-            }
-            isb.AppendLine("else");
-            EmitBranchBlock(isb, @else, assignTo: resultName);
-            _statements.Add(((string)isb).TrimEnd());
+                // The whole if/else chain lives inside the function's own scope: hoisted
+                // when-functions and branch statements belong to it, and evaluation stays
+                // deferred until the function is invoked — the old lambda-wrap semantics.
+                var functionScope = CreateNested([]);
 
-            return new Atom(resultName, resultLocal);
+                var isb = new IndentedStringBuilder();
+                isb.AppendLine(""); // the old writer's blank line before the function definition
+                isb.AppendLine($"{_emitter._typeToCSharpConverter.ToCSharp(resultType)} {functionName}() {{");
+                using (isb.Indent())
+                {
+                    bool first = true;
+                    foreach (var (when, then) in cases)
+                    {
+                        var test = functionScope.PrintWhen(when);
+                        functionScope.WriteStatements(isb); // when-functions hoisted by PrintWhen
+                        functionScope._statements.Clear();
+                        isb.AppendLine(first ? $"if ({test})" : $"else if ({test})");
+                        EmitBranchBlock(isb, then, terminator: null);
+                        first = false;
+                    }
+                    isb.AppendLine("else");
+                    EmitBranchBlock(isb, @else, terminator: ";");
+                }
+                isb.AppendLine("}");
+                return isb;
+            });
+
+            return new Atom($"{functionName}()", functionLocal);
         }
 
         /// <summary>
-        /// Emits <c>{ …hoisted…; assignTo = value; }</c> for a branch, or a
-        /// <c>return value;</c> tail when <paramref name="assignTo"/> is null.
+        /// Prints a when-condition following the old isSimpleWhen rule: conditions that would
+        /// hoist at most one statement print fully inline; more complex ones are wrapped in a
+        /// hoisted zero-parameter function and invoked, keeping their evaluation as late as
+        /// possible (a later case's condition must not evaluate before the earlier cases have
+        /// been tested).
         /// </summary>
-        private void EmitBranchBlock(IndentedStringBuilder isb, IrExpression value, string? assignTo)
+        private string PrintWhen(IrExpression when)
+        {
+            if (CountSpineNodes(when) <= 1)
+                return _emitter.PrintFullyInline(when);
+
+            var atom = HoistLocalFunction(new IrLambda([], when));
+            return $"{atom.Code}()";
+        }
+
+        /// <summary>The number of statements linearizing <paramref name="node"/> would hoist —
+        /// the IR equivalent of the old trial visit's assignment count.</summary>
+        private static int CountSpineNodes(IrExpression node) =>
+            node switch
+            {
+                IrConstant or IrDefault or IrContextParameter or IrLocal => 0,
+                IrProperty { NullConditional: false } p => p.Receiver is null ? 0 : CountSpineNodes(p.Receiver),
+                IrCast c => CountSpineNodes(c.Operand),
+                IrNew n => n.Arguments.Sum(CountSpineNodes),
+                IrThrow t => CountSpineNodes(t.Exception),
+                IrBinary { Op: IrBinaryOp.Equal or IrBinaryOp.NotEqual or IrBinaryOp.Coalesce } b =>
+                    CountSpineNodes(b.Left) + CountSpineNodes(b.Right),
+                IrConditional c when
+                    c.IfFalse is not IrConditional && IsInlineOnly(c.IfTrue) && IsInlineOnly(c.IfFalse) => 0,
+                IrInvoke i => 1 + (i.Receiver is null ? 0 : CountSpineNodes(i.Receiver)) + i.Arguments.Sum(CountSpineNodes),
+                _ => 2, // any other spine node: treat as "complex enough" to defer
+            };
+
+        /// <summary>
+        /// Emits <c>{ …hoisted…; return value; }</c> for a branch of the conditional
+        /// function, with an optional statement terminator after the closing brace (the old
+        /// writer leaves a stray <c>;</c> after the final else block).
+        /// </summary>
+        private void EmitBranchBlock(IndentedStringBuilder isb, IrExpression value, string? terminator)
         {
             isb.AppendLine("{");
             using (isb.Indent())
             {
                 var branchScope = CreateNested([]);
-                var atom = branchScope.Linearize(value, tailPosition: assignTo is null);
+                var atom = branchScope.Linearize(value, tailPosition: true);
                 branchScope.WriteStatements(isb);
                 if (atom is not null)
-                    isb.AppendLine(assignTo is null ? TailStatement(atom) : $"{assignTo} = {atom.Code};");
+                    isb.AppendLine(TailStatement(atom));
             }
-            isb.AppendLine("}");
+            isb.AppendLine($"}}{terminator}");
         }
     }
 }

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
@@ -116,10 +116,24 @@ internal partial class CSharpIrEmitter
                 case IrIfChain chain:
                     return LinearizeIfChain(chain, tailPosition);
 
+                // Pass-through composites: printed inline over their (spine-linearized)
+                // children instead of being hoisted into a local. This mirrors the old
+                // SimplifyExpressionsVisitor's dispatch exactly — Constant/Parameter/New/
+                // Member/ElmAs/Default passed straight through, Convert/TypeAs/Throw unaries
+                // and Equal/NotEqual/Coalesce binaries were not simplified — balancing
+                // unnecessary hoisting against per-line readability.
+                case IrProperty { NullConditional: false }
+                    or IrCast
+                    or IrNew
+                    or IrThrow
+                    or IrBinary { Op: IrBinaryOp.Equal or IrBinaryOp.NotEqual or IrBinaryOp.Coalesce }:
+                    return new Atom(_emitter.PrintShallow(node, child => Linearize(child)!), node);
+
                 default:
                 {
-                    // Compound node: linearize the children, print this node shallowly over
-                    // the child atoms, and hoist it into a named local (deduplicated).
+                    // Spine node (calls, constructions, null-conditional access, type tests,
+                    // logical operators): linearize the children, print this node shallowly
+                    // over the child atoms, and hoist it into a named local (deduplicated).
                     var printed = _emitter.PrintShallow(node, child => Linearize(child)!);
                     return Hoist(printed, node);
                 }
@@ -162,7 +176,7 @@ internal partial class CSharpIrEmitter
             {
                 nested.WriteStatements(isb);
                 if (result is not null)
-                    isb.AppendLine($"return {result.Code};");
+                    isb.AppendLine(TailStatement(result));
             }
             isb.AppendLine("}");
             _statements.Add(isb);
@@ -172,27 +186,56 @@ internal partial class CSharpIrEmitter
 
         private Atom LinearizeConditional(IrConditional conditional)
         {
-            var test = Linearize(conditional.Test)!;
-
-            // When neither branch needs hoisted statements the conditional prints as an
-            // inline ternary (the readable common case); otherwise it becomes an if/else
-            // statement so each branch's work stays inside its branch, preserving
-            // conditional evaluation exactly like the previous pipeline's CaseWhenThen
-            // rewrite. A branch needs hoisting if and only if it is a compound node, so
-            // this is a static test — no trial linearization (which would burn names).
-            if (IsSimple(conditional.IfTrue) && IsSimple(conditional.IfFalse))
+            // Mirrors the old SimplifyExpressionsVisitor.VisitConditional: a "simple"
+            // conditional (IfFalse is not itself a conditional, and neither branch would
+            // hoist anything) is returned UNVISITED — its entire subtree, the test included
+            // (however complex), prints as one inline ternary. Everything else flattens the
+            // else-chain into statement form.
+            if (conditional.IfFalse is not IrConditional
+                && IsInlineOnly(conditional.IfTrue)
+                && IsInlineOnly(conditional.IfFalse))
             {
-                var trueAtom = Linearize(conditional.IfTrue)!;
-                var falseAtom = Linearize(conditional.IfFalse)!;
-                return Hoist($"{test.Code} ? {trueAtom.Code} : {falseAtom.Code}", conditional);
+                return new Atom(_emitter.PrintInlineConditional(conditional, _emitter.PrintFullyInline), conditional);
             }
 
-            return EmitBranches(conditional.Type, [(test, conditional.IfTrue)], conditional.IfFalse);
+            // Flatten the else-if chain (old: ToCwt) and emit as statement form. The old
+            // pipeline wrapped this in an invoked lambda; the native if/else chain is the
+            // documented intentional divergence (docs/linq-expression-removal-plan.md).
+            var cases = new List<(Atom Test, IrExpression Then)>();
+            IrExpression current = conditional;
+            while (current is IrConditional c)
+            {
+                cases.Add((Linearize(c.Test)!, c.IfTrue));
+                current = c.IfFalse;
+            }
+            return EmitBranches(conditional.Type, cases, current);
         }
 
-        /// <summary>True for nodes that print in place without hoisting any statements.</summary>
-        private static bool IsSimple(IrExpression node) =>
-            node is IrConstant or IrDefault or IrContextParameter or IrLocal;
+        /// <summary>
+        /// True when linearizing <paramref name="node"/> would hoist no statements — the IR
+        /// equivalent of the old visitor's trial visit yielding zero assignments. Spine nodes
+        /// (calls, constructions, null-conditional access, type tests, logical operators,
+        /// lambdas, if-chains) always hoist; pass-through nodes are inline-only when all
+        /// their children are. A nested conditional counts as inline-only when it is itself
+        /// "simple" — its test is not examined, exactly like the old trial visit (which
+        /// returned simple conditionals unvisited).
+        /// </summary>
+        private static bool IsInlineOnly(IrExpression node) =>
+            node switch
+            {
+                IrConstant or IrDefault or IrContextParameter or IrLocal => true,
+                IrProperty { NullConditional: false } p => p.Receiver is null || IsInlineOnly(p.Receiver),
+                IrCast c => IsInlineOnly(c.Operand),
+                IrNew n => n.Arguments.All(IsInlineOnly),
+                IrThrow t => IsInlineOnly(t.Exception),
+                IrBinary { Op: IrBinaryOp.Equal or IrBinaryOp.NotEqual or IrBinaryOp.Coalesce } b =>
+                    IsInlineOnly(b.Left) && IsInlineOnly(b.Right),
+                IrConditional nested =>
+                    nested.IfFalse is not IrConditional
+                    && IsInlineOnly(nested.IfTrue)
+                    && IsInlineOnly(nested.IfFalse),
+                _ => false,
+            };
 
         private Atom? LinearizeIfChain(IrIfChain chain, bool tailPosition)
         {
@@ -266,7 +309,7 @@ internal partial class CSharpIrEmitter
                 var atom = branchScope.Linearize(value, tailPosition: assignTo is null);
                 branchScope.WriteStatements(isb);
                 if (atom is not null)
-                    isb.AppendLine(assignTo is null ? $"return {atom.Code};" : $"{assignTo} = {atom.Code};");
+                    isb.AppendLine(assignTo is null ? TailStatement(atom) : $"{assignTo} = {atom.Code};");
             }
             isb.AppendLine("}");
         }

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
@@ -77,6 +77,10 @@ internal partial class CSharpIrEmitter
             return name;
         }
 
+        /// <summary>True when linearization hoisted at least one statement onto this scope —
+        /// i.e. the linearized body cannot print as a single expression.</summary>
+        public bool HasStatements => _statements.Count > 0;
+
         public void WriteStatements(IndentedStringBuilder isb)
         {
             foreach (var statement in _statements)

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
@@ -22,6 +22,16 @@ internal partial class CSharpIrEmitter
         private readonly CSharpIrEmitter _emitter;
         private readonly VariableNameGenerator _names;
 
+        // Hint names (original CQL alias names, e.g. a lambda parameter's NameHint) reserved
+        // in THIS LINEAGE only: copied — not shared — into each nested scope, exactly like the
+        // old VariableNameGenerator.Reserved list (ForNewScope conses onto a copy of the
+        // parent's list). A hint used by an earlier SIBLING scope (e.g. one "where" lambda's
+        // alias) is therefore free to be reused by a later, unrelated lambda with the same CQL
+        // alias — reproducing CMS56's "LowerBodyFracture" reused verbatim as the parameter of
+        // two separate (sibling) local functions in the same method. Only an ANCESTOR scope's
+        // hint (still live/capturable from a nested closure) blocks reuse.
+        private readonly HashSet<string> _reservedHints;
+
         // Statements are deferred renderers: plain declarations resolve immediately, but a
         // hoisted local function's INTERIOR renders only when the enclosing scope writes out.
         // This reproduces the old RenameVariablesVisitor naming order, which named all of a
@@ -31,10 +41,11 @@ internal partial class CSharpIrEmitter
         private readonly List<Func<string>> _statements = [];
         private readonly Dictionary<string, Atom> _dedup = [];
 
-        private Scope(CSharpIrEmitter emitter, VariableNameGenerator names)
+        private Scope(CSharpIrEmitter emitter, VariableNameGenerator names, HashSet<string> reservedHints)
         {
             _emitter = emitter;
             _names = names;
+            _reservedHints = reservedHints;
         }
 
         public static Scope CreateRoot(CSharpIrEmitter emitter, IReadOnlyList<IrLocal> parameters)
@@ -42,14 +53,17 @@ internal partial class CSharpIrEmitter
             var names = new VariableNameGenerator(
                 reserved: parameters.Select(p => p.NameHint).OfType<string>(),
                 postfix: "_");
-            var scope = new Scope(emitter, names);
+            var scope = new Scope(emitter, names, []);
             scope.NameParameters(parameters);
             return scope;
         }
 
         private Scope CreateNested(IReadOnlyList<IrLocal> parameters)
         {
-            var nested = new Scope(_emitter, _names.ForNewScope(parameters.Select(p => p.NameHint).OfType<string>()));
+            var nested = new Scope(
+                _emitter,
+                _names.ForNewScope(parameters.Select(p => p.NameHint).OfType<string>()),
+                [.. _reservedHints]); // copy, not share: see _reservedHints
             nested.NameParameters(parameters);
             return nested;
         }
@@ -65,23 +79,23 @@ internal partial class CSharpIrEmitter
 
         /// <summary>
         /// Allocates a variable name, honoring <paramref name="hint"/> only when it is legal:
-        /// not a C# keyword and not already used in this emission — duplicate hints, or a
-        /// hint colliding with a generated name, would print duplicate or shadowing
-        /// declarations (CS0100/CS0136).
+        /// not a C# keyword and not already reserved in this lineage (see
+        /// <see cref="_reservedHints"/>) — a duplicate hint still live in an ancestor scope, or
+        /// one colliding with a generated name from this lineage, would print duplicate or
+        /// shadowing declarations (CS0100/CS0136).
         /// </summary>
         private string AllocateName(string? hint)
         {
             if (hint is not null
                 && SyntaxFacts.GetKeywordKind(hint) == SyntaxKind.None
-                && _emitter._usedNames.Add(hint))
+                && _reservedHints.Add(hint))
                 return hint;
 
-            string name;
-            do
-            {
-                name = _names.Next();
-            } while (!_emitter._usedNames.Add(name));
-            return name;
+            // The generated-letter sequence (_names) is shared and monotonically increasing
+            // across the whole emission, so it never repeats a value; VariableNameGenerator's
+            // own Reserved list (threaded per-lineage via ForNewScope) already skips any name
+            // reserved by this lineage's hints, so no further legality check is needed here.
+            return _names.Next();
         }
 
         /// <summary>True when linearization hoisted at least one statement onto this scope —
@@ -204,12 +218,23 @@ internal partial class CSharpIrEmitter
 
                 var parameterList = string.Join(", ",
                     lambda.Parameters.Select(p => $"{_emitter._typeToCSharpConverter.ToCSharp(p.Type)} {_emitter._assignedNames[p]}"));
+                var returnType = _emitter._typeToCSharpConverter.ToCSharp(lambda.Body.Type);
+
+                // A body that linearizes without hoisting any statement prints expression-
+                // bodied ("=> expr;"), matching the old writer's BuildLambdaOperator, which
+                // used the block ("{ }") form only `lambda.Body is BlockExpression` — i.e. only
+                // when simplification actually produced a multi-statement block. The old
+                // BuildBlockExpression's "give local function definitions some space" rule also
+                // keyed on the body being a BlockExpression, so the expression-bodied form gets
+                // none of the surrounding blank lines either.
+                if (!nested.HasStatements && result is not null)
+                    return $"{returnType} {functionName}({parameterList}) => {result.Code};";
 
                 // Old format: blank line before the definition, opening brace on the
                 // signature line, blank line after (via the trailing newline).
                 var isb = new IndentedStringBuilder();
                 isb.AppendLine("");
-                isb.AppendLine($"{_emitter._typeToCSharpConverter.ToCSharp(lambda.Body.Type)} {functionName}({parameterList}) {{");
+                isb.AppendLine($"{returnType} {functionName}({parameterList}) {{");
                 using (isb.Indent())
                 {
                     nested.WriteStatements(isb);
@@ -305,19 +330,26 @@ internal partial class CSharpIrEmitter
                 // deferred until the function is invoked — the old lambda-wrap semantics.
                 var functionScope = CreateNested([]);
 
+                // Every case's when-condition is visited — and, for complex ones, hoisted into
+                // its own zero-parameter local function — BEFORE any if/else-if statement
+                // prints. This mirrors the old VisitCaseWhenThenExpression, which ran
+                // visitCase (and so every when-lambda) for ALL cases via one shared block
+                // visitor, collecting their hoisted statements up front, before the
+                // CaseWhenThenExpression was rendered into its block.
+                var tests = cases.Select(c => functionScope.PrintWhen(c.When)).ToList();
+
                 var isb = new IndentedStringBuilder();
                 isb.AppendLine(""); // the old writer's blank line before the function definition
                 isb.AppendLine($"{_emitter._typeToCSharpConverter.ToCSharp(resultType)} {functionName}() {{");
                 using (isb.Indent())
                 {
+                    functionScope.WriteStatements(isb); // all when-functions hoisted by PrintWhen, up front
+
                     bool first = true;
-                    foreach (var (when, then) in cases)
+                    for (int i = 0; i < cases.Count; i++)
                     {
-                        var test = functionScope.PrintWhen(when);
-                        functionScope.WriteStatements(isb); // when-functions hoisted by PrintWhen
-                        functionScope._statements.Clear();
-                        isb.AppendLine(first ? $"if ({test})" : $"else if ({test})");
-                        EmitBranchBlock(isb, then, terminator: null);
+                        isb.AppendLine(first ? $"if ({tests[i]})" : $"else if ({tests[i]})");
+                        EmitBranchBlock(isb, cases[i].Then, terminator: null);
                         first = false;
                     }
                     isb.AppendLine("else");

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.Scope.cs
@@ -78,11 +78,15 @@ internal partial class CSharpIrEmitter
         }
 
         /// <summary>
-        /// Allocates a variable name, honoring <paramref name="hint"/> only when it is legal:
-        /// not a C# keyword and not already reserved in this lineage (see
-        /// <see cref="_reservedHints"/>) — a duplicate hint still live in an ancestor scope, or
-        /// one colliding with a generated name from this lineage, would print duplicate or
-        /// shadowing declarations (CS0100/CS0136).
+        /// Allocates a variable name, honoring <paramref name="hint"/> only when it is not a
+        /// C# keyword and not already reserved in this lineage (see
+        /// <see cref="_reservedHints"/>) — a duplicate hint still live in an ancestor scope
+        /// would print shadowing declarations (CS0136).
+        /// <para>Deliberately NOT guarded (matching the old pipeline exactly): a hint that
+        /// happens to collide with a GENERATED name (an alias literally shaped like
+        /// <c>a_</c>) is used verbatim, just as the old builder used alias names verbatim on
+        /// its ParameterExpressions — such an alias would produce the same non-compiling
+        /// output from both pipelines.</para>
         /// </summary>
         private string AllocateName(string? hint)
         {

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
@@ -41,7 +41,6 @@ internal partial class CSharpIrEmitter
     private readonly ICSharpNamingConventions _namingConventions;
 
     private readonly Dictionary<IrLocal, string> _assignedNames = new(ReferenceEqualityComparer.Instance);
-    private readonly HashSet<string> _usedNames = [];
 
     /// <param name="typeToCSharpConverter">Renders .NET types as C# type syntax.</param>
     /// <param name="namingConventions">The generated-class naming conventions the printed
@@ -65,7 +64,6 @@ internal partial class CSharpIrEmitter
         // Naming is scoped to one definition body: each emission starts fresh, so earlier
         // emissions can neither cause collisions nor grow the maps without bound.
         _assignedNames.Clear();
-        _usedNames.Clear();
 
         var scope = Scope.CreateRoot(this, lambda.Parameters);
         var result = scope.Linearize(lambda.Body, tailPosition: true);
@@ -99,7 +97,6 @@ internal partial class CSharpIrEmitter
     public string? TryEmitExpressionBody(IrLambda lambda)
     {
         _assignedNames.Clear();
-        _usedNames.Clear();
 
         var scope = Scope.CreateRoot(this, lambda.Parameters);
         var result = scope.Linearize(lambda.Body, tailPosition: true);

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
@@ -76,11 +76,17 @@ internal partial class CSharpIrEmitter
         {
             scope.WriteStatements(isb);
             if (result is not null) // null when the tail was emitted as a return-ing if-chain
-                isb.AppendLine($"return {result.Code};");
+                isb.AppendLine(TailStatement(result));
         }
         isb.Append("}");
         return isb;
     }
+
+    /// <summary>The final statement for a block whose tail value is <paramref name="result"/>:
+    /// a <c>return</c>, except before a throw-expression (the old writer's
+    /// BuildBlockExpression rule — <c>return throw …</c> is not legal C#).</summary>
+    private static string TailStatement(Atom result) =>
+        result.Node is IrThrow ? $"{result.Code};" : $"return {result.Code};";
 
     /// <summary>
     /// Emits the body of a definition as a single C# expression when it linearizes without

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
@@ -33,7 +33,7 @@ namespace Hl7.Cql.CodeGeneration.NET;
 /// emitting Roslyn syntax trees from the IR) without touching the IR itself.</para>
 ///
 /// <para>Instances are not thread-safe: naming state is per emission, reset at the start of
-/// each <see cref="EmitBodyBlock"/> call.</para>
+/// each <see cref="EmitBodyBlock"/>/<see cref="TryEmitExpressionBody"/> call.</para>
 /// </summary>
 internal partial class CSharpIrEmitter
 {
@@ -83,9 +83,27 @@ internal partial class CSharpIrEmitter
     }
 
     /// <summary>
+    /// Emits the body of a definition as a single C# expression when it linearizes without
+    /// hoisting any statements (e.g. a constant body), for the scaffolding writer's
+    /// expression-bodied (<c>=> expr;</c>) member form. Returns <see langword="null"/> when
+    /// the body needs hoisted statements — use <see cref="EmitBodyBlock"/> then instead.
+    /// Semantically this is exactly the case where <see cref="EmitBodyBlock"/> would produce
+    /// a block whose only statement is <c>return expr;</c>.
+    /// </summary>
+    public string? TryEmitExpressionBody(IrLambda lambda)
+    {
+        _assignedNames.Clear();
+        _usedNames.Clear();
+
+        var scope = Scope.CreateRoot(this, lambda.Parameters);
+        var result = scope.Linearize(lambda.Body, tailPosition: true);
+        return scope.HasStatements || result is null ? null : result.Code;
+    }
+
+    /// <summary>
     /// The name the emitter assigned to each parameter of <paramref name="lambda"/> in the
-    /// last <see cref="EmitBodyBlock"/> call, for the scaffolding writer to print the
-    /// parameter list.
+    /// last <see cref="EmitBodyBlock"/>/<see cref="TryEmitExpressionBody"/> call, for the
+    /// scaffolding writer to print the parameter list.
     /// </summary>
     public IReadOnlyList<string> GetParameterNames(IrLambda lambda) =>
         [.. lambda.Parameters.Select(p => _assignedNames.TryGetValue(p, out var n) ? n : p.NameHint ?? "?")];

--- a/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
+++ b/Cql/CodeGeneration.NET/CSharpIrEmitter.cs
@@ -115,9 +115,17 @@ internal partial class CSharpIrEmitter
         [.. lambda.Parameters.Select(p => _assignedNames.TryGetValue(p, out var n) ? n : p.NameHint ?? "?")];
 
     /// <summary>A linearized subexpression: the C# code of a simple (non-compound)
-    /// expression, plus the IR node it denotes (for type-driven peepholes).</summary>
-    private sealed record Atom(string Code, IrExpression Node)
+    /// expression, plus the IR node it denotes (for type-driven peepholes).
+    /// <para><see cref="KeyCode"/> is the code as it would print WITHOUT duplicate
+    /// elimination — a deduplicated local contributes its own (burned) name here, not its
+    /// replacement. Dedup decisions key on it, reproducing the old LocalVariableDeduper's
+    /// single-pass behavior: duplicates whose operands only become identical AFTER
+    /// replacement are NOT collapsed (no fixpoint), and every duplicate still consumed a
+    /// name from the sequence before being removed (the letter gaps in the old output).</para></summary>
+    private sealed record Atom(string Code, string KeyCode, IrExpression Node)
     {
+        public Atom(string code, IrExpression node) : this(code, code, node) { }
+
         public Type Type => Node.Type;
     }
 }

--- a/Cql/CodeGeneration.NET/CSharpNamingConventions.cs
+++ b/Cql/CodeGeneration.NET/CSharpNamingConventions.cs
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+/// <summary>
+/// The production <see cref="ICSharpNamingConventions"/> implementation, backed by the same
+/// building blocks the library scaffolding writer uses — <see cref="IdentifierNormalizer"/>
+/// for member/class names and <see cref="TupleMetadataBuilder"/> for the tuple-metadata field
+/// names — so the expression bodies printed by <see cref="CSharpIrEmitter"/> reference exactly
+/// the members the scaffolding declares.
+///
+/// <para>One instance exists per library being written: <paramref name="libraryVersionedIdentifier"/>
+/// is the "Name-Version" identifier of that library (e.g. <c>"FHIRHelpers-4.0.1"</c>), which
+/// keys the tuple-metadata registrations and matches how the old
+/// <c>LambdaDefinitionWriter.GetTargetedMemberName</c>/<c>BuildMemberInitTupleExpression</c>
+/// resolved these names.</para>
+/// </summary>
+internal sealed class CSharpNamingConventions(
+    TypeToCSharpConverter typeToCSharpConverter,
+    TupleMetadataBuilder tupleMetadataBuilder,
+    string libraryVersionedIdentifier) : ICSharpNamingConventions
+{
+    /// <inheritdoc/>
+    /// <remarks>Registers the tuple type's signature with the shared
+    /// <see cref="TupleMetadataBuilder"/> as a side effect, exactly like the old pipeline's
+    /// <c>BuildMemberInitTupleExpression</c> did — the scaffolding writer later emits one
+    /// static field per registered signature (see <c>AppendCqlTupleMetadataProperties</c>).</remarks>
+    public string TupleMetadataFieldName(Type tupleType)
+    {
+        var tupleProperties = typeToCSharpConverter
+                              .GetTupleProperties(tupleType)
+                              .ToList();
+        return tupleMetadataBuilder.GetTupleMetadataPropertyName(tupleProperties, libraryVersionedIdentifier);
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>Mirrors the old <c>LambdaDefinitionWriter.GetTargetedMemberName</c>:
+    /// <c>this.{member}</c> for the library being generated, and
+    /// <c>{normalizedLibraryClassName}.Instance.{member}</c> for an included library, where
+    /// the class name is the normalized "Name-Version" identifier — the same mangling
+    /// <c>LibraryWriter.AppendLibraryFile</c> applies when naming the generated classes.</remarks>
+    public string DefinitionTarget(IrDefinitionCall definitionCall)
+    {
+        var member = IdentifierNormalizer.Normalize(definitionCall.DefinitionName);
+
+        if (definitionCall.IsLocalLibrary)
+            return $"this.{member}";
+
+        var versionedIdentifier = definitionCall.LibraryVersion is { Length: > 0 } version
+            ? $"{definitionCall.LibraryName}-{version}"
+            : definitionCall.LibraryName;
+        return $"{IdentifierNormalizer.Normalize(versionedIdentifier)}.Instance.{member}";
+    }
+}

--- a/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.DefinitionWriter.cs
+++ b/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.DefinitionWriter.cs
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+partial class IrLibrarySetCSharpCodeGenerator
+{
+    // Verbatim port of LibrarySetCSharpCodeGenerator.DefinitionWriter onto the typed IR:
+    // the value set / concept / code system / code writers are Expression-free and copied
+    // as-is; only the lambda definitions dispatch to the IR-based LambdaDefinitionWriter.
+    private class DefinitionWriter
+    {
+        private readonly LambdaDefinitionWriter _lambdaDefinitionWriter;
+
+        public DefinitionWriter(
+            LibraryWriter LibraryWriter,
+            IrDefinition IrDefinition)
+        {
+            this.LibraryWriter = LibraryWriter;
+            this.IrDefinition = IrDefinition;
+            _lambdaDefinitionWriter = new LambdaDefinitionWriter(this.LibraryWriter);
+        }
+
+        private IndentedStringBuilder ISB => LibraryWriter.ISB;
+        public LibraryWriter LibraryWriter { get; }
+        public IrDefinition IrDefinition { get; }
+
+        public void AppendDefinition()
+        {
+            switch (IrDefinition)
+            {
+                case IrValueSetDefinition vsd:
+                    AppendValueSetDefinition(vsd);
+                    return;
+
+                case IrConceptDefinition ccd:
+                    AppendConceptDefinition(ccd);
+                    return;
+
+                case IrCodeSystemDefinition csd:
+                    AppendCodeSystemDefinition(csd);
+                    return;
+
+                case IrCodeDefinition cd:
+                    AppendCodeDefinition(cd);
+                    return;
+
+                case IrLambdaDefinition ld:
+                    _lambdaDefinitionWriter.AppendLambdaDefinition(ld);
+                    break;
+
+                default:
+                    throw new NotSupportedException($"No support for {IrDefinition.GetType()}");
+            }
+        }
+
+        private void AppendCodeDefinition(
+            IrCodeDefinition cd)
+        {
+            var (quotedName, methodName, fieldName) = GetMemberNames(IrDefinition);
+            var quotedCodeId = cd.Code.code!.QuoteString();
+            var quotedCodeSystem = cd.Code.system.QuoteOrNullString();
+            ISB.AppendLine(
+                $$"""
+                  [CqlCodeDefinition({{quotedName}}, codeId: {{quotedCodeId}}, codeSystem: {{quotedCodeSystem}})]
+                  public CqlCode {{methodName}}(CqlContext _) => {{fieldName}};
+                  private static readonly CqlCode {{fieldName}} = new CqlCode({{quotedCodeId}}, {{quotedCodeSystem}});
+                  """);
+        }
+
+        private void AppendCodeSystemDefinition(
+            IrCodeSystemDefinition csd)
+        {
+            var (quotedName, methodName, fieldName) = GetMemberNames(IrDefinition);
+            string quotedCodeSystemId = csd.CodeSystem.id!.QuoteString();
+            string quotedCodeSystemVersion = csd.CodeSystem.version.QuoteOrNullString();
+            string arrayOfCodes = string.Join(
+                ",",
+                csd.CodeSystem.codes.Select(code =>
+                {
+                    var cqlCodeDefinition = LibraryWriter.CodeDefinitions.FirstOrDefault(codeDefinition => codeDefinition.Code == code);
+                    var codeField = cqlCodeDefinition is not null
+                                        ? IdentifierNormalizer.Normalize($"_{cqlCodeDefinition.Name}")
+                                        : $"new CqlCode({code.code!.QuoteString()}, {code.system.QuoteOrNullString()})";
+                    return $"""
+
+                                  {codeField}
+                            """;
+                }));
+            ISB.AppendLine(
+                $$"""
+                  [CqlCodeSystemDefinition({{quotedName}}, codeSystemId: {{quotedCodeSystemId}}, codeSystemVersion: {{quotedCodeSystemVersion}})]
+                  public CqlCodeSystem {{methodName}}(CqlContext _) => {{fieldName}};
+                  private static readonly CqlCodeSystem {{fieldName}} =
+                    new CqlCodeSystem({{quotedCodeSystemId}}, {{quotedCodeSystemVersion}}, [{{arrayOfCodes}}]);
+                  """);
+        }
+
+        private void AppendConceptDefinition(
+            IrConceptDefinition ccd)
+        {
+            var (quotedName, methodName, fieldName) = GetMemberNames(IrDefinition);
+            string quotedConceptDisplay = ccd.Display.QuoteOrNullString();
+            string arrayOfCodes = string.Join(
+                ",",
+                ccd.Codes.Select(code =>
+                {
+                    var cqlCodeDefinition = LibraryWriter.CodeDefinitions.FirstOrDefault(codeDefinition => codeDefinition.Code == code);
+                    var codeField = cqlCodeDefinition is not null
+                                        ? IdentifierNormalizer.Normalize($"_{cqlCodeDefinition.Name}")
+                                        : $"new CqlCode({code.code!.QuoteString()}, {code.system.QuoteOrNullString()})";
+                    return $"""
+
+                                  {codeField}
+                            """;
+                }));
+            ISB.AppendLine(
+                $$"""
+                  [CqlConceptDefinition({{quotedName}})]
+                  public CqlConcept {{methodName}}(CqlContext _) => {{fieldName}};
+                  private static readonly CqlConcept {{fieldName}} =
+                    new CqlConcept([{{arrayOfCodes}}],
+                        {{quotedConceptDisplay}});
+                  """);
+        }
+
+        private void AppendValueSetDefinition(
+            IrValueSetDefinition vsd)
+        {
+            var (quotedName, methodName, fieldName) = GetMemberNames(IrDefinition);
+            string quotedValueSetId = vsd.ValueSetId.QuoteString();
+            string quotedValueSetVersion = vsd.ValueSetVersion.QuoteOrNullString();
+            ISB.AppendLine(
+                $$"""
+                  [CqlValueSetDefinition({{quotedName}}, valueSetId: {{quotedValueSetId}}, valueSetVersion: {{quotedValueSetVersion}})]
+                  public CqlValueSet {{methodName}}(CqlContext _) => {{fieldName}};
+                  private static readonly CqlValueSet {{fieldName}} = new CqlValueSet({{quotedValueSetId}}, {{quotedValueSetVersion}});
+                  """);
+        }
+    }
+}

--- a/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LambdaDefinitionWriter.cs
+++ b/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LambdaDefinitionWriter.cs
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler.Ir;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+partial class IrLibrarySetCSharpCodeGenerator
+{
+    /// <summary>
+    /// Port of <c>LibrarySetCSharpCodeGenerator.LambdaDefinitionWriter</c>'s non-body logic
+    /// (attributes incl. tags, cache-key generation + <c>GetOrCompute</c> wrapper for
+    /// parameterless definitions, method naming, parameter list, return type) onto
+    /// <see cref="IrLambdaDefinition"/>. The method bodies themselves are produced by
+    /// <see cref="CSharpIrEmitter"/> — which replaces the old writer's four visitor passes
+    /// plus recursive <c>BuildExpression</c> printing.
+    /// </summary>
+    private record LambdaDefinitionWriter(LibraryWriter LibraryWriter)
+    {
+        private TypeToCSharpConverter TypeToCSharpConverter => LibraryWriter.LibrarySetWriter.TypeToCSharpConverter;
+
+        private IndentedStringBuilder ISB => LibraryWriter.ISB;
+
+        public void AppendLambdaDefinition(
+            IrLambdaDefinition ld)
+        {
+            var (quotedName, methodName, _) = GetMemberNames(ld);
+
+            // NOTE: unlike the old CqlLambdaDefinition, the IR lambda does not carry the
+            // implicit CqlContext parameter (see IrLambdaDefinition remarks) — these are only
+            // the CQL operands; the printed signature prepends "CqlContext context" explicitly.
+            var parameters = ld.Lambda.Parameters;
+            var returnType = TypeToCSharpConverter.ToCSharp(ld.Lambda.Body.Type);
+
+            var useCache = parameters is not { Count: > 0 };
+
+            // Emit the body before printing the signature: emitting is what assigns the
+            // parameter names (honoring hints unless they collide), and it decides between
+            // block form and the expression-bodied (=> expr;) form — the same decision the
+            // old writer made on "did the visitors leave a BlockExpression".
+            var emitter = LibraryWriter.Emitter;
+            string lambdaBody;
+            bool bodyIsBlock;
+            if (emitter.TryEmitExpressionBody(ld.Lambda) is { } expressionBody)
+            {
+                lambdaBody = expressionBody;
+                bodyIsBlock = false;
+            }
+            else
+            {
+                lambdaBody = emitter.EmitBodyBlock(ld.Lambda);
+                bodyIsBlock = true;
+            }
+
+            // Map the IR definition type onto the old attribute names:
+            // IrExpressionDefinition => [CqlExpressionDefinition("...")], etc.
+            var definitionAttributeTypeName = $"Cql{ld.GetType().Name["Ir".Length..]}";
+
+            // [CqlExpressionDefinition("Patient")] or [CqlFunctionDefinition("Patient")]
+            ISB.AppendLine($"[{definitionAttributeTypeName}({quotedName})]");
+
+            // [CqlTag("tagName1", "tagValue")]
+            // [CqlTag("tagName1", "tagValue")]
+            // [CqlTag("tagName2", "tagValue")]
+            if (ld is IrExpressionDefinition ed)
+                foreach (var tag in ed.Tags)
+                    foreach (var tagValue in tag.Values)
+                        ISB.AppendLine($"[CqlTag({tag.Name.QuoteString()}, {tagValue.QuoteString()})]");
+
+            // Signature
+            ISB.Append($"public {returnType} {methodName}");
+
+            // Extract original parameter names if this is an IrFunctionDefinition
+            IReadOnlyDictionary<string, string>? originalParameterNames =
+                ld is IrFunctionDefinition { OriginalParameterNames.Count: > 0 } functionDef
+                    ? functionDef.OriginalParameterNames
+                    : null;
+            var lambdaParameters = BuildLambdaParameters(ld.Lambda, emitter.GetParameterNames(ld.Lambda), originalParameterNames);
+
+            if (useCache)
+            {
+                // Generate cache key from library identifier and definition name
+                var libraryVersionedIdentifier = LibraryWriter.LibraryName.ToString();
+                var definitionName = ld.Name;
+                var cacheKey = LibraryWriter.LibrarySetWriter.CacheKeyGenerator.GenerateCacheKey(libraryVersionedIdentifier, definitionName);
+                var cacheIndexFieldName = $"_cacheIndex_{methodName}";
+                var computeMethodName = $"{methodName}_Compute";
+
+                // Public method delegates to context.GetOrCompute with a private compute method (no closure)
+                ISB.AppendLine($"{lambdaParameters} =>");
+                using (ISB.Indent())
+                {
+                    ISB.AppendLine($"context.GetOrCompute({cacheIndexFieldName}, {computeMethodName});");
+                }
+                ISB.AppendLine();
+
+                // Const cache index field (value is a compile-time literal)
+                ISB.AppendLine($"private const long {cacheIndexFieldName} = {cacheKey}L;");
+                ISB.AppendLine();
+
+                // Private compute method containing the actual logic
+                var semicolon = bodyIsBlock ? "" : ";";
+                var lambdaOperator = bodyIsBlock ? "" : " =>";
+                ISB.AppendLine(
+                    $"""
+                     private {returnType} {computeMethodName}{lambdaParameters}{lambdaOperator}
+                     {lambdaBody}{semicolon}
+
+                     """);
+            }
+            else
+            {
+                var lambdaOperator = bodyIsBlock ? "" : " =>";
+                var semicolon = bodyIsBlock ? "" : ";";
+                ISB.AppendLine(
+                    $"""
+                     {lambdaParameters}{lambdaOperator}
+                     {lambdaBody}{semicolon}
+
+                     """);
+            }
+        }
+
+        private string BuildLambdaParameters(
+            IrLambda lambda,
+            IReadOnlyList<string> parameterNames,
+            IReadOnlyDictionary<string, string>? originalParameterNames)
+        {
+            var parameters = lambda.Parameters.Select((p, i) =>
+            {
+                var typeDeclaration = TypeToCSharpConverter.ToCSharp(p.Type);
+                var parameterName = parameterNames[i].EscapeKeywords();
+
+                // Add attribute if original name differs from normalized name. The dictionary
+                // is keyed by the normalized CQL operand name, which is the parameter's name
+                // hint (the emitter only deviates from the hint on collisions).
+                var attributePrefix = "";
+                if (originalParameterNames?.TryGetValue(p.NameHint ?? parameterNames[i], out var originalName) == true)
+                {
+                    attributePrefix = $"[CqlFunctionParameter({originalName.QuoteString()})] ";
+                }
+
+                return $"{attributePrefix}{typeDeclaration} {parameterName}";
+            }).ToList();
+
+            // inserts the context parameter in the start of the parameter list; the IR lambda
+            // does not carry it (see IrLambdaDefinition remarks) but the generated method does.
+            parameters.Insert(0, "CqlContext context");
+
+            return $"({string.Join(", ", parameters)})";
+        }
+    }
+}

--- a/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LibrarySetWriter.cs
+++ b/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LibrarySetWriter.cs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+partial class IrLibrarySetCSharpCodeGenerator
+{
+    // Verbatim port of LibrarySetCSharpCodeGenerator.LibrarySetWriter onto the typed IR
+    // (only the definitions dictionary type differs).
+    private class LibrarySetWriter(
+        IrLibrarySetCSharpCodeGenerator librarySetCSharpCodeGenerator,
+        LibrarySet librarySet,
+        IrDefinitionDictionary definitions,
+        ICacheKeyGenerator cacheKeyGenerator,
+        string? @namespace = null)
+    {
+        public TupleMetadataBuilder TupleMetadataBuilder { get; } = new();
+        public TypeToCSharpConverter TypeToCSharpConverter => librarySetCSharpCodeGenerator._typeToCSharpConverter;
+        public IReadOnlyList<(string alias, string type)> AliasedUsings => librarySetCSharpCodeGenerator._aliasedUsings;
+        public HashSet<string> Usings => librarySetCSharpCodeGenerator._usings;
+        public string? Namespace { get; } = @namespace;
+        public LibrarySet LibrarySet { get; } = librarySet;
+        public IrDefinitionDictionary Definitions { get; } = definitions;
+        public ICacheKeyGenerator CacheKeyGenerator { get; } = cacheKeyGenerator;
+
+        public IEnumerable<(ElmLibrary library, string cSharp)> GenerateEachLibraryToCSharp(
+            BatchProcessExceptionHandlingStrategyBuilder<ElmLibrary>? buildExceptionHandlingStrategy = null,
+            Action<ElmLibrary>? onBeforeProcessLibrary = null) =>
+            LibrarySet
+                .Where(library => Definitions.Libraries.Contains(library.VersionedLibraryIdentifier))
+                .TrySelect(
+                    library =>
+                    {
+                        onBeforeProcessLibrary?.Invoke(library);
+
+                        var isb = new IndentedStringBuilder();
+                        var libraryWriter = new LibraryWriter(this);
+                        libraryWriter.AppendLibraryFile(library, isb);
+                        var cSharp = isb.ToString();
+                        return (library, cSharp);
+                    },
+                    buildExceptionHandlingStrategy);
+    }
+}

--- a/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LibraryWriter.cs
+++ b/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.LibraryWriter.cs
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using System.Diagnostics;
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+using Hl7.Cql.Runtime;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+partial class IrLibrarySetCSharpCodeGenerator
+{
+    // Verbatim port of LibrarySetCSharpCodeGenerator.LibraryWriter onto the typed IR: the
+    // scaffolding it writes is Expression-free, so only the definition types and the body
+    // emitter (created per library in AppendLibraryFile) differ from the old pipeline.
+    private class LibraryWriter
+    {
+        public LibraryWriter(
+            LibrarySetWriter librarySetWriter)
+        {
+            LibrarySetWriter = librarySetWriter;
+        }
+
+        internal CqlVersionedLibraryIdentifier LibraryName => _library?.VersionedLibraryIdentifier ?? throw new InvalidOperationException("Library not initialized.");
+        private string _className = string.Empty;
+        private readonly Dictionary<string, int> _cacheFieldNameCount = new();
+
+        public string GetUniqueCacheFieldName(string baseName)
+        {
+            if (string.IsNullOrEmpty(baseName))
+                throw new ArgumentException("Base name cannot be null or empty.", nameof(baseName));
+
+            var count = _cacheFieldNameCount.GetValueOrDefault(baseName, 0);
+            string fieldName;
+            do
+            {
+                fieldName = count == 0 ? baseName : $"{baseName}_{count}";
+                count++;
+            } while (_cacheFieldNameCount.ContainsKey(fieldName));
+
+            _cacheFieldNameCount[baseName] = count;
+            _cacheFieldNameCount[fieldName] = 0; // Mark this specific name as used
+            return fieldName;
+        }
+
+        public void AppendLibraryFile(ElmLibrary library, IndentedStringBuilder isb)
+        {
+            _library = library;
+            ISB = isb;
+            _className = IdentifierNormalizer.Normalize(library.VersionedLibraryIdentifier);
+            _definitions = LibrarySetWriter
+                           .Definitions
+                           .SelectDefinitionsByLibraryName(LibraryName)
+                           .Select(t => t.definition)
+                           .ToArray();
+            CodeDefinitions = _definitions
+                               .OfType<IrCodeDefinition>()
+                               .ToArray();
+
+            // The emitter prints the lambda bodies; its naming conventions must agree with the
+            // class scaffolding this writer produces (see ICSharpNamingConventions).
+            _emitter = new CSharpIrEmitter(
+                LibrarySetWriter.TypeToCSharpConverter,
+                new CSharpNamingConventions(
+                    LibrarySetWriter.TypeToCSharpConverter,
+                    LibrarySetWriter.TupleMetadataBuilder,
+                    LibraryName));
+
+            AppendUsings();
+            AppendNamespaceFileScope();
+            AppendClass();
+        }
+
+        private void AppendCqlTupleMetadataProperties()
+        {
+            var tupleMetadataBuilder = LibrarySetWriter.TupleMetadataBuilder;
+            var signatures = tupleMetadataBuilder.GetLibraryTupleMetadataPropertySignatures(LibraryName).ToList();
+            for (var i = 0; i < signatures.Count; i++)
+            {
+                var (propertyName, signature) = signatures[i];
+                if (i == 0)
+                    ISB.AppendLine(
+                        """
+                        #region CqlTupleMetadata Properties
+
+                        """);
+
+                var types = string.Join(", ", signature.Select(t => $"typeof({LibrarySetWriter.TypeToCSharpConverter.ToCSharp(t.Type)})"));
+                var names = string.Join(", ", signature.Select(t => t.PropName.QuoteString()));
+                ISB.AppendLine(
+                    $"""
+                     private static CqlTupleMetadata {propertyName} = new(
+                        [{types}],
+                        [{names}]);
+
+                     """);
+            }
+
+            if (signatures.Count > 0)
+                ISB.AppendLine(
+                    """
+                    #endregion CqlTupleMetadata Properties
+
+                    """);
+        }
+
+        private void AppendLibraryInterfaceImplementation()
+        {
+            ISB.AppendLine(
+                $"""
+                 #region ILibrary Implementation
+
+                 public string Name => {LibraryName!.Identifier.ToString().QuoteString()};
+                 public string Version => {LibraryName!.Version?.ToString().QuoteOrNullString()};
+                 """);
+            var dependencies =
+                LibrarySetWriter.LibrarySet
+                                .GetLibraryDependencies(LibraryName, throwError: true)
+                                .Select(dep => IdentifierNormalizer.Normalize(dep.VersionedLibraryIdentifier))
+                                .Select(typeName => $"{typeName}.Instance");
+            ISB.AppendLine(
+                $"""
+                 public ILibrary[] Dependencies => [{string.Join(", ", dependencies)}];
+
+                 #endregion ILibrary Implementation
+
+                 """);
+        }
+
+        private void AppendUsings()
+        {
+            foreach (var @using in LibrarySetWriter.Usings)
+                ISB.AppendLine($"using {@using};");
+
+            foreach (var @using in LibrarySetWriter.AliasedUsings)
+                ISB.AppendLine($"using {@using.Item1} = {@using.Item2};");
+
+            ISB.AppendLine();
+        }
+
+        private void AppendNamespaceFileScope()
+        {
+            if (LibrarySetWriter.Namespace is { Length: > 0 } @namespace)
+            {
+                ISB.AppendLine(
+                    $"""
+                     namespace {@namespace};
+
+                     """);
+            }
+        }
+
+        private IrDefinition[] _definitions = Array.Empty<IrDefinition>();
+
+        public IrCodeDefinition[] CodeDefinitions { get; private set; } = Array.Empty<IrCodeDefinition>();
+
+        public LibrarySetWriter LibrarySetWriter { get; }
+        private ElmLibrary? _library;
+        private CSharpIrEmitter? _emitter;
+        public IndentedStringBuilder ISB { get; private set; } = new();
+
+        /// <summary>The body emitter for the library being written, created per library in
+        /// <see cref="AppendLibraryFile"/> (its naming conventions carry the library name).</summary>
+        public CSharpIrEmitter Emitter => _emitter ?? throw new InvalidOperationException("Library not initialized.");
+
+        private static string GetDefinitionRegion(IrDefinition definition) =>
+            definition switch
+            {
+                // IrFunctionDefinition is an IrExpressionDefinition
+                // We combine them into one region otherwise we would have too many segments switching between Function and Expression
+                IrExpressionDefinition => "Functions and Expressions",
+
+                // Extract the region name from the definition type name e.g. Ir[Parameter]Definition => Parameters
+                _ => $"{definition.GetType().Name["Ir".Length..^"Definition".Length]}s"
+            };
+
+        private void AppendMethods()
+        {
+            string lastDefinitionRegion = "";
+
+            // Pre-compute region counts for the region header
+            var regionCounts = _definitions
+                .GroupBy(GetDefinitionRegion)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            // Assumption: definitions are already sorted by definition type
+            foreach (var definition in _definitions)
+            {
+                // Assumption: type name will be Ir....Definition
+                Debug.Assert(definition.GetType().Name is { } name && name.StartsWith("Ir") && name.EndsWith("Definition"));
+                string definitionRegion = GetDefinitionRegion(definition);
+
+                if (lastDefinitionRegion != definitionRegion)
+                {
+                    if (lastDefinitionRegion != "")
+                    {
+                        ISB.AppendLine(
+                            $"""
+                             #endregion {lastDefinitionRegion}
+
+                             """);
+                    }
+
+                    var count = regionCounts[definitionRegion];
+                    ISB.AppendLine(
+                        $"""
+                         #region {definitionRegion} ({count})
+
+                         """);
+                }
+
+                lastDefinitionRegion = definitionRegion;
+
+                var methodWriter = new DefinitionWriter(this, definition);
+                methodWriter.AppendDefinition();
+                ISB.AppendLine();
+            }
+
+            if (lastDefinitionRegion != "")
+            {
+                ISB.AppendLine($"""
+                                #endregion {lastDefinitionRegion}
+
+                                """);
+            }
+        }
+
+        private void AppendClass()
+        {
+            ISB.AppendLine(
+                $"[System.CodeDom.Compiler.GeneratedCode({GeneratorToolName.QuoteString()}, {GeneratorToolVersion.QuoteString()})]");
+
+            ISB.AppendLine(
+                LibraryName!.Version is { } version && Version.TryParse(version, out _)
+                    ? $"[CqlLibrary({LibraryName!.Identifier.ToString().QuoteString()}, {version.ToString().QuoteString()})]"
+                    : $"[CqlLibrary({LibraryName!.Identifier.ToString().QuoteString()})]");
+
+            ISB.AppendLine(
+                $$"""
+                  public partial class {{_className}} : ILibrary, ISingleton<{{_className}}>
+                  {
+                  """);
+
+            using (ISB.Indent())
+            {
+                // Put logic first
+                AppendMethods();
+
+                // These are all boilerplate
+                AppendSingletonLifetimeMembers();
+                AppendLibraryInterfaceImplementation();
+                AppendCqlTupleMetadataProperties();
+            }
+
+            ISB.AppendLine("}");
+        }
+
+        private void AppendSingletonLifetimeMembers()
+        {
+            ISB.AppendLine(
+                $$"""
+                  #region Singleton Lifetime Members
+
+                  private {{_className}}() {}
+
+                  public static {{_className}} Instance { get; } = new();
+
+                  #endregion
+
+                  """);
+        }
+    }
+}

--- a/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.cs
+++ b/Cql/CodeGeneration.NET/IrLibrarySetCSharpCodeGenerator.cs
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026, Firely, NCQA and contributors
+ * See the file CONTRIBUTORS for details.
+ *
+ * This file is licensed under the BSD 3-Clause license
+ * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
+ */
+
+using Hl7.Cql.Abstractions;
+using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+using Hl7.Cql.Operators;
+using Hl7.Cql.Primitives;
+using Hl7.Cql.Runtime;
+using Hl7.Cql.ValueSets;
+
+namespace Hl7.Cql.CodeGeneration.NET;
+
+/// <summary>
+/// Processes a definition dictionary of <see cref="IrDefinition"/> into a .NET class per library.
+///
+/// <para>IR counterpart of <see cref="LibrarySetCSharpCodeGenerator"/> (phase 5 of the
+/// Linq.Expressions removal, see <c>docs/linq-expression-removal-plan.md</c>): the class
+/// scaffolding (usings, regions, attributes, tuple-metadata fields, singleton/ILibrary
+/// boilerplate) is Expression-free and copied verbatim from the old generator so the two
+/// pipelines can be golden-diffed; only the lambda bodies are produced differently, by
+/// <see cref="CSharpIrEmitter"/> instead of the expression-tree visitor pipeline.</para>
+/// </summary>
+internal partial class IrLibrarySetCSharpCodeGenerator
+{
+    /// <summary>
+    /// Processes a definition dictionary of <see cref="IrDefinition"/> into a .NET class per library.
+    /// </summary>
+    public IrLibrarySetCSharpCodeGenerator(
+        TypeResolver typeResolver,
+        TypeToCSharpConverter typeToCSharpConverter)
+    {
+        _typeToCSharpConverter = typeToCSharpConverter;
+        _usings = BuildUsings(typeResolver);
+        _aliasedUsings = typeResolver.Aliases.ToList();
+    }
+
+    /// <summary>
+    /// Gets the product of this <see cref="IrLibrarySetCSharpCodeGenerator"/> as will appear
+    /// in the <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Tool"/>.
+    /// </summary>
+    private static string GeneratorToolName { get; } = GetGeneratorToolNameFromAssemblyProductName();
+
+    /// <summary>
+    /// Gets the version of this generator as will appear in the
+    /// <see cref="System.CodeDom.Compiler.GeneratedCodeAttribute.Version"/>. Shared with the
+    /// old pipeline (<see cref="LibrarySetCSharpCodeGenerator.GeneratorToolVersion"/>) so both
+    /// generate byte-identical headers until the flip-over bumps it.
+    /// </summary>
+    private const string GeneratorToolVersion = LibrarySetCSharpCodeGenerator.GeneratorToolVersion;
+
+    private readonly TypeToCSharpConverter _typeToCSharpConverter;
+
+    /// <summary>
+    /// Gets the <see langword="using"/> statements to be included in the generated code.
+    /// </summary>
+    private readonly HashSet<string> _usings;
+
+    /// <summary>
+    /// Gets the aliased <see langword="using"/> statements to be included in the generated code.
+    /// For example,
+    /// <code>
+    /// using Item1 = Item2;
+    /// </code>
+    /// </summary>
+    private readonly IReadOnlyList<(string alias, string type)> _aliasedUsings;
+
+    private static string GetGeneratorToolNameFromAssemblyProductName() =>
+        typeof(IrLibrarySetCSharpCodeGenerator)
+            .Assembly
+            .GetCustomAttributes(false)
+            .OfType<AssemblyProductAttribute>()
+            .SingleOrDefault()?
+            .Product ?? "ELM-to-CSharp";
+
+    private static HashSet<string> BuildUsings(TypeResolver typeResolver)
+    {
+        var hashSet = new HashSet<string>
+        {
+            nameof(System),
+            typeof(Enumerable).Namespace!,    // System.Linq
+            typeof(ICollection<>).Namespace!, // System.Collections.Generic
+            typeof(CqlContext).Namespace!,
+            typeof(CqlPrimitiveType).Namespace!,
+            typeof(CqlDefinitionAttribute).Namespace!,
+            typeof(IValueSetFacade).Namespace!,
+            typeof(Iso8601.DateIso8601).Namespace!,
+            typeof(PropertyInfo).Namespace!,
+            typeof(RetrieveParameters).Namespace!,
+        };
+
+        foreach (var @using in typeResolver.ModelNamespaces)
+            hashSet.Add(@using);
+
+        return hashSet;
+    }
+
+    public IEnumerable<(ElmLibrary library, string cSharp)> GenerateEachLibraryToCSharp(
+        LibrarySet librarySet,
+        IrDefinitionDictionary definitions,
+        string? @namespace = null,
+        BatchProcessExceptionHandlingStrategyBuilder<ElmLibrary>? buildExceptionHandlingStrategy = null,
+        Action<ElmLibrary>? onBeforeProcessLibrary = null)
+    {
+        var cacheKeyGenerator = new DeterministicIdGenerator(librarySet.Name);
+        var librarySetWriter = new LibrarySetWriter(this, librarySet, definitions, cacheKeyGenerator, @namespace);
+        return librarySetWriter.GenerateEachLibraryToCSharp(buildExceptionHandlingStrategy, onBeforeProcessLibrary);
+    }
+
+    private static (string quotedName, string methodName, string fieldName) GetMemberNames(IrDefinition definition)
+    {
+        var name = definition.Name;
+        string quotedName = name.QuoteString();
+        string methodName = IdentifierNormalizer.Normalize(name);
+        string fieldName = IdentifierNormalizer.Normalize($"_{name}");
+        return (quotedName, methodName, fieldName);
+    }
+}

--- a/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
+++ b/Cql/CodeGeneration.NET/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig.UseIrPipeline.get -> bool
+Hl7.Cql.CodeGeneration.NET.Toolkit.ElmToolkitConfig.UseIrPipeline.init -> void

--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkit.cs
@@ -10,6 +10,7 @@ using Hl7.Cql.Abstractions;
 using Hl7.Cql.Abstractions.Infrastructure;
 using Hl7.Cql.CodeGeneration.NET.Toolkit.Internal;
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
 using Hl7.Cql.Runtime;
 using Hl7.Cql.Toolkit;
 using Microsoft.Extensions.DependencyInjection;
@@ -137,8 +138,6 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
         var cSharpNamespace = Config.CSharpNamespace;
         var debugInformationFormat = Config.DebugSymbolsFormat;
         AssemblyCompiler assemblyCompiler = _services.AssemblyCompiler;
-        LibrarySetCSharpCodeGenerator cSharpCodeProcessor = _services.LibrarySetCSharpCodeGenerator;
-        LibrarySetExpressionBuilder librarySetExpressionBuilderScoped = servicesScope.LibrarySetExpressionBuilder;
         ElmLibrary[] libraries = _artifactsById.Values.Select(selector: v => v.InputElmLibrary).ToArray();
         LibrarySet librarySet = new LibrarySet(name: "", libraries: libraries);
 
@@ -146,8 +145,20 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
         foreach (var (id, _) in removedLibraries)
             logger.LogWarning(message: "Removed library with missing dependencies: {id}", args: id);
 
-        var librarySetDefinitions = BuildLibrarySetDefinitions(librarySetExpressionBuilderScoped, librarySet);
-        var cSharps = GenerateCSharp(cSharpCodeProcessor, librarySet, librarySetDefinitions, cSharpNamespace);
+        // Both branches produce IEnumerable<(ElmLibrary library, string cSharp)>; the rest of the
+        // pipeline (assembly compilation) is agnostic to which builder/generator produced it. See
+        // docs/linq-expression-removal-plan.md for the typed-IR pipeline behind UseIrPipeline.
+        var cSharps = Config.UseIrPipeline
+            ? GenerateCSharp(
+                _services.IrLibrarySetCSharpCodeGenerator,
+                librarySet,
+                BuildLibrarySetDefinitions(servicesScope.IrLibrarySetExpressionBuilder, librarySet),
+                cSharpNamespace)
+            : GenerateCSharp(
+                _services.LibrarySetCSharpCodeGenerator,
+                librarySet,
+                BuildLibrarySetDefinitions(servicesScope.LibrarySetExpressionBuilder, librarySet),
+                cSharpNamespace);
         var assemblyBinaries = CompileAssemblies(assemblyCompiler, librarySet, cSharps, debugInformationFormat);
 
         var entriesBuilder = _artifactsById.ToBuilder();
@@ -241,6 +252,32 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
                 library => _services.Logger.LogInformation("Generating definitions into C#: {lib} ", library.VersionedLibraryIdentifier));
 
     /// <summary>
+    /// Generates the C# code for the libraries, using the typed-IR code generator
+    /// (see <see cref="ElmToolkitConfig.UseIrPipeline"/>).
+    /// </summary>
+    /// <param name="cSharpCodeProcessor">The typed-IR C# code processor to use.</param>
+    /// <param name="librarySet">The set of libraries to generate code for.</param>
+    /// <param name="librarySetDefinitions">The typed-IR definitions for the library set.</param>
+    /// <param name="namespace">The C# namespace to use for generated code.</param>
+    /// <returns>The generated C# code.</returns>
+    private IEnumerable<(ElmLibrary library, string cSharp)> GenerateCSharp(
+        IrLibrarySetCSharpCodeGenerator cSharpCodeProcessor,
+        LibrarySet librarySet,
+        IrDefinitionDictionary librarySetDefinitions,
+        string? @namespace) =>
+        cSharpCodeProcessor
+            .GenerateEachLibraryToCSharp(
+                librarySet,
+                librarySetDefinitions,
+                @namespace,
+                errorStrategy => errorStrategy
+                                 .SetContinuation(BatchProcessExceptionContinuation)
+                                 .AddLoggerExceptionHandler(
+                                     _services.Logger,
+                                     (library, log) => log("Could not generate definitions into C#: {lib}", library.VersionedLibraryIdentifier)),
+                library => _services.Logger.LogInformation("Generating definitions into C#: {lib} ", library.VersionedLibraryIdentifier));
+
+    /// <summary>
     /// Builds the library set definitions.
     /// </summary>
     /// <param name="librarySetExpressionBuilderScoped">The library set expression builder to use.</param>
@@ -251,6 +288,33 @@ public sealed class ElmToolkit : IToolkit<ElmToolkit>
         LibrarySet librarySet)
     {
         DefinitionDictionary<CqlDefinition> librarySetDefinitions = new();
+        librarySetExpressionBuilderScoped
+            .BuildEachLibraryDefinitions(
+                librarySet,
+                librarySetDefinitions,
+                errorStrategy => errorStrategy
+                                 .SetContinuation(BatchProcessExceptionContinuation)
+                                 .AddLoggerExceptionHandler(
+                                     _services.Logger,
+                                     (library, logMessage) =>
+                                         logMessage("Could not convert ELM into definitions for {id}", library.VersionedLibraryIdentifier)),
+                library => _services.Logger.LogInformation("Converting ELM Library into definitions for {id}", library.VersionedLibraryIdentifier))
+            .ForEach(); // Important to enumerate
+        return librarySetDefinitions;
+    }
+
+    /// <summary>
+    /// Builds the library set definitions, using the typed-IR expression builder
+    /// (see <see cref="ElmToolkitConfig.UseIrPipeline"/>).
+    /// </summary>
+    /// <param name="librarySetExpressionBuilderScoped">The typed-IR library set expression builder to use.</param>
+    /// <param name="librarySet">The set of libraries to build definitions for.</param>
+    /// <returns>The dictionary of typed-IR library set definitions.</returns>
+    private IrDefinitionDictionary BuildLibrarySetDefinitions(
+        IrLibrarySetExpressionBuilder librarySetExpressionBuilderScoped,
+        LibrarySet librarySet)
+    {
+        IrDefinitionDictionary librarySetDefinitions = new();
         librarySetExpressionBuilderScoped
             .BuildEachLibraryDefinitions(
                 librarySet,

--- a/Cql/CodeGeneration.NET/Toolkit/ElmToolkitConfig.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/ElmToolkitConfig.cs
@@ -80,6 +80,15 @@ public record ElmToolkitConfig(
     public bool AllowUnresolvedExternals { get; init; } = AllowUnresolvedExternals;
 
     /// <summary>
+    /// When <see langword="true"/>, selects the typed-IR expression builder and C# code generator
+    /// (<see cref="Hl7.Cql.Compiler.Ir"/>) instead of the default Expression-tree-based pipeline.
+    /// The typed-IR pipeline produces C# output that is byte-identical to the default pipeline's
+    /// output; see <c>docs/linq-expression-removal-plan.md</c> for background on this migration.
+    /// The default value is <see langword="false"/>.
+    /// </summary>
+    public bool UseIrPipeline { get; init; } = false;
+
+    /// <summary>
     /// Converts the current configuration settings to <see cref="ExpressionBuilderSettings"/>.
     /// </summary>
     /// <returns>An instance of <see cref="ExpressionBuilderSettings"/> with the current configuration settings.</returns>

--- a/Cql/CodeGeneration.NET/Toolkit/Internal/ElmToolkitScopedState.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/Internal/ElmToolkitScopedState.cs
@@ -7,6 +7,7 @@
  */
 
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Hl7.Cql.CodeGeneration.NET.Toolkit.Internal;
@@ -14,6 +15,8 @@ namespace Hl7.Cql.CodeGeneration.NET.Toolkit.Internal;
 internal sealed class ElmToolkitScopedState(IServiceScope scope) : IDisposable
 {
     public LibrarySetExpressionBuilder LibrarySetExpressionBuilder { get; } = scope.ServiceProvider.GetRequiredService<LibrarySetExpressionBuilder>();
+
+    public IrLibrarySetExpressionBuilder IrLibrarySetExpressionBuilder { get; } = scope.ServiceProvider.GetRequiredService<IrLibrarySetExpressionBuilder>();
 
     public void Dispose() => scope.Dispose();
 }

--- a/Cql/CodeGeneration.NET/Toolkit/Internal/ElmToolkitServices.cs
+++ b/Cql/CodeGeneration.NET/Toolkit/Internal/ElmToolkitServices.cs
@@ -8,6 +8,7 @@
 
 using Hl7.Cql.Abstractions;
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
 using Hl7.Cql.Compiler.Preprocessing;
 using Hl7.Cql.Fhir;
 using Hl7.Cql.Runtime.Hosting;
@@ -23,7 +24,8 @@ internal readonly record struct ElmToolkitServices(
     ServiceProvider ServiceProvider,
     ILogger<ElmToolkit> Logger,
     AssemblyCompiler AssemblyCompiler,
-    LibrarySetCSharpCodeGenerator LibrarySetCSharpCodeGenerator)
+    LibrarySetCSharpCodeGenerator LibrarySetCSharpCodeGenerator,
+    IrLibrarySetCSharpCodeGenerator IrLibrarySetCSharpCodeGenerator)
 {
     public static ElmToolkitServices Create(
         ILoggerFactory loggerFactory,
@@ -45,6 +47,7 @@ internal readonly record struct ElmToolkitServices(
         AddCqlCompilerServices(services, config.LRUCacheSize, expressionBuilderSettings);
         services.TryAddSingleton<TypeToCSharpConverter>();
         services.TryAddSingleton<LibrarySetCSharpCodeGenerator>();
+        services.TryAddSingleton<IrLibrarySetCSharpCodeGenerator>();
         services.TryAddSingleton<AssemblyCompiler>();
     }
 
@@ -80,11 +83,21 @@ internal readonly record struct ElmToolkitServices(
         services.TryAddScoped<LibraryExpressionBuilder>();
         services.TryAddScoped<ExpressionBuilder>();
 
+        // Typed-IR pipeline (docs/linq-expression-removal-plan.md), selected via
+        // ElmToolkitConfig.UseIrPipeline. Shares TypeResolver/TypeConverter/TupleBuilderCache/
+        // LibraryPreprocessorBuilder with the Expression-based pipeline above.
+        services.TryAddSingleton<IrCqlOperatorsBinder>();
+        services.TryAddSingleton<IrCqlContextBinder>();
+        services.TryAddScoped<IrExpressionBuilder>();
+        services.TryAddScoped<IrLibraryExpressionBuilder>();
+        services.TryAddScoped<IrLibrarySetExpressionBuilder>();
+
         return services;
     }
 
     public ServiceProvider ServiceProvider { get; } = ServiceProvider;
     public AssemblyCompiler AssemblyCompiler { get; } = AssemblyCompiler;
     public LibrarySetCSharpCodeGenerator LibrarySetCSharpCodeGenerator { get; } = LibrarySetCSharpCodeGenerator;
+    public IrLibrarySetCSharpCodeGenerator IrLibrarySetCSharpCodeGenerator { get; } = IrLibrarySetCSharpCodeGenerator;
     public ElmToolkitScopedState CreateScopedState() => new(ServiceProvider.CreateScope());
 }

--- a/Cql/CoreTests/CSharpGenerationGoldenTests.cs
+++ b/Cql/CoreTests/CSharpGenerationGoldenTests.cs
@@ -176,11 +176,13 @@ public class CSharpGenerationGoldenTests
             var generatedLine = i < generatedLines.Length ? generatedLines[i] : "<end of file>";
             if (goldenLine != generatedLine)
             {
-                var contextStart = Math.Max(0, i - 3);
-                var context = string.Join("\n", generatedLines.Skip(contextStart).Take(i - contextStart));
+                var contextStart = Math.Max(0, i - 8);
+                string Window(string[] lines) => string.Join("\n",
+                    lines.Skip(contextStart).Take(Math.Min(i + 4, lines.Length) - contextStart));
                 Assert.Fail(
                     $"Generated C# for {libraryIdentifier} differs from {goldenPath} at line {i + 1}:\n" +
-                    $"--- context (generated) ---\n{context}\n" +
+                    $"--- golden window ---\n{Window(goldenLines)}\n" +
+                    $"--- generated window ---\n{Window(generatedLines)}\n" +
                     $"--- golden    : {goldenLine}\n" +
                     $"--- generated : {generatedLine}");
             }

--- a/Cql/CoreTests/CSharpGenerationGoldenTests.cs
+++ b/Cql/CoreTests/CSharpGenerationGoldenTests.cs
@@ -6,9 +6,15 @@
  * available at https://raw.githubusercontent.com/FirelyTeam/firely-cql-sdk/main/LICENSE
  */
 
+using Hl7.Cql.CodeGeneration.NET;
 using Hl7.Cql.CodeGeneration.NET.Toolkit;
 using Hl7.Cql.CodeGeneration.NET.Toolkit.Extensions;
 using Hl7.Cql.Compiler;
+using Hl7.Cql.Compiler.Ir;
+using Hl7.Cql.Compiler.Preprocessing;
+using Hl7.Cql.Fhir;
+using Microsoft.Extensions.Logging.Abstractions;
+using TypeConverter = Hl7.Cql.Conversion.TypeConverter;
 
 namespace CoreTests;
 
@@ -18,7 +24,9 @@ namespace CoreTests;
 /// differences and a trailing newline (git may rewrite line endings on checkout, so the
 /// comparison normalizes those before asserting equality).
 /// These tests guard the C# code generator against unintended output changes
-/// (e.g. while refactoring the expression-building or code-writing pipeline).
+/// (e.g. while refactoring the expression-building or code-writing pipeline), and — during the
+/// Linq.Expressions removal (docs/linq-expression-removal-plan.md) — prove that the typed-IR
+/// pipeline produces the same output as the Expression-based one.
 /// When an output change is intentional, regenerate the corpus with PackagerCLI
 /// (see its launchSettings.json profiles) and commit the updated <c>.g.cs</c> files.
 /// </summary>
@@ -27,42 +35,105 @@ public class CSharpGenerationGoldenTests
 {
     [TestMethod]
     public void Regenerated_RR23_CSharp_Matches_CheckedInFiles() =>
-        AssertRegeneratedCSharpMatchesGoldenFiles(
+        AssertGeneratedCSharpMatchesGoldenFiles(
             LibrarySetsDirs.RR23.ElmDir,
             "RR23",
             LibrarySetsDirs.RR23.CSharpDir,
+            GenerateWithOldPipeline,
             version: "1.0.0",
             goldenCorpusIsComplete: true);
 
     [TestMethod]
     public void Regenerated_DqmQiCore2025_CMS56_CSharp_Matches_CheckedInFiles() =>
-        AssertRegeneratedCSharpMatchesGoldenFiles(
+        AssertGeneratedCSharpMatchesGoldenFiles(
             LibrarySetsDirs.DqmQiCore2025.ElmDir,
             "CMS56FHIRFuncStatHipReplacement",
             LibrarySetsDirs.DqmQiCore2025.ExtractedCSharpDir,
+            GenerateWithOldPipeline,
             // Only the top library's C# is checked in (extracted from the packaged FHIR Library
             // resource); its dependencies are generated but have no golden counterpart.
             goldenCorpusIsComplete: false);
 
-    private static void AssertRegeneratedCSharpMatchesGoldenFiles(
+    [TestMethod]
+    public void IrPipeline_RR23_CSharp_Matches_CheckedInFiles() =>
+        AssertGeneratedCSharpMatchesGoldenFiles(
+            LibrarySetsDirs.RR23.ElmDir,
+            "RR23",
+            LibrarySetsDirs.RR23.CSharpDir,
+            GenerateWithIrPipeline,
+            version: "1.0.0",
+            goldenCorpusIsComplete: true);
+
+    [TestMethod]
+    public void IrPipeline_DqmQiCore2025_CMS56_CSharp_Matches_CheckedInFiles() =>
+        AssertGeneratedCSharpMatchesGoldenFiles(
+            LibrarySetsDirs.DqmQiCore2025.ElmDir,
+            "CMS56FHIRFuncStatHipReplacement",
+            LibrarySetsDirs.DqmQiCore2025.ExtractedCSharpDir,
+            GenerateWithIrPipeline,
+            goldenCorpusIsComplete: false);
+
+    private static Dictionary<string, string> GenerateWithOldPipeline(LibrarySet librarySet)
+    {
+        var elmToolkit =
+            new ElmToolkit()
+                .AddElmLibraries(librarySet)
+                .CompileToAssemblies();
+
+        return elmToolkit
+            .GetElmToCSharpResults()
+            .ToDictionary(t => t.libraryIdentifier.ToString()!, t => t.cSharp);
+    }
+
+    private static Dictionary<string, string> GenerateWithIrPipeline(LibrarySet librarySet)
+    {
+        // Mirrors the service composition of ElmToolkitServices.AddCqlCompilerServices with
+        // the typed-IR classes (same wiring as IrPipelineTests in CqlToElmTests).
+        var typeResolver = FhirTypeResolver.Default;
+        var typeConverter = FhirTypeConverter
+            .Create(Hl7.Fhir.Model.ModelInfo.ModelInspector)
+            .UseLogger(NullLogger<TypeConverter>.Instance);
+        typeConverter.CaptureAvailableConverters();
+
+        var tupleBuilderCache = new TupleBuilderCache(NullLogger<TupleBuilderCache>.Instance);
+        var libraryPreprocessorBuilder = new LibraryPreprocessorBuilder(NullLoggerFactory.Instance);
+
+        var expressionBuilder = new IrExpressionBuilder(
+            NullLogger<IrExpressionBuilder>.Instance,
+            ExpressionBuilderSettings.Default,
+            new IrCqlOperatorsBinder(NullLogger<IrCqlOperatorsBinder>.Instance, typeResolver, typeConverter),
+            tupleBuilderCache,
+            typeResolver,
+            typeConverter,
+            new IrCqlContextBinder());
+
+        var libraryExpressionBuilder = new IrLibraryExpressionBuilder(
+            NullLogger<IrLibraryExpressionBuilder>.Instance,
+            expressionBuilder,
+            libraryPreprocessorBuilder);
+
+        var librarySetBuilder = new IrLibrarySetExpressionBuilder(libraryExpressionBuilder, libraryPreprocessorBuilder);
+
+        IrDefinitionDictionary definitions = new();
+        _ = librarySetBuilder.BuildEachLibraryDefinitions(librarySet, definitions).ToList(); // drain the batch
+
+        return new IrLibrarySetCSharpCodeGenerator(typeResolver, new TypeToCSharpConverter())
+            .GenerateEachLibraryToCSharp(librarySet, definitions)
+            .ToDictionary(t => t.library.VersionedLibraryIdentifier.ToString()!, t => t.cSharp);
+    }
+
+    private static void AssertGeneratedCSharpMatchesGoldenFiles(
         DirectoryInfo elmDir,
         string topLibraryName,
         DirectoryInfo goldenCSharpDir,
+        Func<LibrarySet, Dictionary<string, string>> generate,
         string version = "",
         bool goldenCorpusIsComplete = true)
     {
         LibrarySet librarySet = new();
         librarySet.LoadLibraryAndDependencies(elmDir, topLibraryName, version);
 
-        var elmToolkit =
-            new ElmToolkit()
-                .AddElmLibraries(librarySet)
-                .CompileToAssemblies();
-
-        var generatedByIdentifier =
-            elmToolkit
-                .GetElmToCSharpResults()
-                .ToDictionary(t => t.libraryIdentifier.ToString()!, t => t.cSharp);
+        var generatedByIdentifier = generate(librarySet);
 
         var goldenFiles = goldenCSharpDir.GetFiles("*.g.cs");
         Assert.AreNotEqual(0, goldenFiles.Length, $"No golden .g.cs files found in {goldenCSharpDir.FullName}.");
@@ -75,10 +146,7 @@ public class CSharpGenerationGoldenTests
                 $"No C# was generated for golden file {goldenFile.Name}. Generated libraries: {string.Join(", ", generatedByIdentifier.Keys)}.");
 
             var golden = File.ReadAllText(goldenFile.FullName);
-            Assert.AreEqual(
-                NormalizeLineEndings(golden),
-                NormalizeLineEndings(generated!),
-                $"Regenerated C# for {libraryIdentifier} differs from the checked-in {goldenFile.FullName}.");
+            AssertEqualCSharp(golden, generated!, libraryIdentifier, goldenFile.FullName);
         }
 
         if (goldenCorpusIsComplete)
@@ -91,6 +159,31 @@ public class CSharpGenerationGoldenTests
                 0,
                 extraGenerated.Count,
                 $"C# was generated for libraries without a checked-in golden file: {string.Join(", ", extraGenerated)}.");
+        }
+    }
+
+    /// <summary>Asserts equality (line endings normalized), failing with the first differing
+    /// line plus surrounding context — far easier to iterate on than two multi-hundred-line
+    /// strings in a failure message.</summary>
+    private static void AssertEqualCSharp(string golden, string generated, string libraryIdentifier, string goldenPath)
+    {
+        var goldenLines = NormalizeLineEndings(golden).Split('\n');
+        var generatedLines = NormalizeLineEndings(generated).Split('\n');
+
+        for (int i = 0; i < Math.Max(goldenLines.Length, generatedLines.Length); i++)
+        {
+            var goldenLine = i < goldenLines.Length ? goldenLines[i] : "<end of file>";
+            var generatedLine = i < generatedLines.Length ? generatedLines[i] : "<end of file>";
+            if (goldenLine != generatedLine)
+            {
+                var contextStart = Math.Max(0, i - 3);
+                var context = string.Join("\n", generatedLines.Skip(contextStart).Take(i - contextStart));
+                Assert.Fail(
+                    $"Generated C# for {libraryIdentifier} differs from {goldenPath} at line {i + 1}:\n" +
+                    $"--- context (generated) ---\n{context}\n" +
+                    $"--- golden    : {goldenLine}\n" +
+                    $"--- generated : {generatedLine}");
+            }
         }
     }
 

--- a/Cql/CoreTests/CSharpGenerationGoldenTests.cs
+++ b/Cql/CoreTests/CSharpGenerationGoldenTests.cs
@@ -73,6 +73,43 @@ public class CSharpGenerationGoldenTests
             GenerateWithIrPipeline,
             goldenCorpusIsComplete: false);
 
+    /// <summary>
+    /// Same corpus as <see cref="IrPipeline_RR23_CSharp_Matches_CheckedInFiles"/>, but going through
+    /// the PUBLIC <see cref="ElmToolkit"/> API (<see cref="ElmToolkitConfig.UseIrPipeline"/> set to
+    /// <see langword="true"/>) rather than manually wiring the typed-IR classes. This proves the
+    /// toolkit flag selects the typed-IR pipeline end-to-end, including assembly compilation.
+    /// </summary>
+    [TestMethod]
+    public void IrPipelineViaToolkit_RR23_CSharp_Matches_CheckedInFiles()
+    {
+        ElmToolkit? elmToolkitCapture = null;
+
+        AssertGeneratedCSharpMatchesGoldenFiles(
+            LibrarySetsDirs.RR23.ElmDir,
+            "RR23",
+            LibrarySetsDirs.RR23.CSharpDir,
+            librarySet =>
+            {
+                var elmToolkit =
+                    new ElmToolkit(config: ElmToolkitConfig.Default with { UseIrPipeline = true })
+                        .AddElmLibraries(librarySet)
+                        .CompileToAssemblies();
+                elmToolkitCapture = elmToolkit;
+
+                return elmToolkit
+                    .GetElmToCSharpResults()
+                    .ToDictionary(t => t.libraryIdentifier.ToString()!, t => t.cSharp);
+            },
+            version: "1.0.0",
+            goldenCorpusIsComplete: true);
+
+        Assert.IsNotNull(elmToolkitCapture);
+        var assemblyResults = elmToolkitCapture!.GetElmToAssemblyResults().ToList();
+        Assert.AreNotEqual(0, assemblyResults.Count, "No compiled assembly results were produced via the toolkit.");
+        foreach (var (libraryIdentifier, _, _, assemblyBinary, _) in assemblyResults)
+            Assert.IsNotNull(assemblyBinary, $"AssemblyBinary was null for library {libraryIdentifier}.");
+    }
+
     private static Dictionary<string, string> GenerateWithOldPipeline(LibrarySet librarySet)
     {
         var elmToolkit =

--- a/Cql/CoreTests/CSharpIrEmitterTests.cs
+++ b/Cql/CoreTests/CSharpIrEmitterTests.cs
@@ -137,23 +137,21 @@ public class CSharpIrEmitterTests
     {
         var applyFunc = typeof(CSharpIrEmitterTestHelpers).GetMethod(nameof(CSharpIrEmitterTestHelpers.ApplyFunc))!;
         var p = new IrLocal(typeof(int), "n");
-        // A cast is a compound node, so the local function's own body hoists it into a local
-        // before returning it -- this is what pins down where the local-function-name
-        // allocation happens relative to hoisting inside its body (after, per the source).
+        // Casts are pass-through, so the function body returns the cast inline; the
+        // function's own generated name comes first in the a_, b_, ... sequence.
         var innerLambda = new IrLambda([p], new IrCast(p, typeof(int?), IrCastKind.Cast));
         var call = new IrInvoke(null, applyFunc, innerLambda, new IrConstant(5, typeof(int)));
         var lambda = new IrLambda([], call);
 
         var expected =
             "{\n" +
-            "    int? b_(int n)\n" +
+            "    int? a_(int n)\n" +
             "    {\n" +
-            "        int? a_ = (int?)n;\n" +
-            "        return a_;\n" +
+            "        return (int?)n;\n" +
             "    }\n" +
             "\n" +
-            "    int? c_ = CSharpIrEmitterTestHelpers.ApplyFunc(b_, 5);\n" +
-            "    return c_;\n" +
+            "    int? b_ = CSharpIrEmitterTestHelpers.ApplyFunc(a_, 5);\n" +
+            "    return b_;\n" +
             "}";
         Assert.AreEqual(expected, EmitBody(lambda));
     }
@@ -166,7 +164,7 @@ public class CSharpIrEmitterTests
         var lambda = new IrLambda([test], conditional);
 
         Assert.AreEqual(
-            "{\n    int a_ = c ? 1 : 2;\n    return a_;\n}",
+            "{\n    return (c\n        ? 1\n        : 2);\n}",
             EmitBody(lambda));
     }
 
@@ -235,7 +233,7 @@ public class CSharpIrEmitterTests
 
         var instance = new IrProperty(x, stringLength, nullConditional: false);
         Assert.AreEqual(
-            "{\n    int a_ = x.Length;\n    return a_;\n}",
+            "{\n    return x.Length;\n}",
             EmitBody(new IrLambda([x], instance)));
         Assert.AreEqual(typeof(int), instance.Type);
 
@@ -248,7 +246,7 @@ public class CSharpIrEmitterTests
         var newLine = typeof(Environment).GetProperty(nameof(Environment.NewLine))!;
         var staticProperty = new IrProperty(null, newLine);
         Assert.AreEqual(
-            "{\n    string a_ = Environment.NewLine;\n    return a_;\n}",
+            "{\n    return Environment.NewLine;\n}",
             EmitBody(new IrLambda([], staticProperty)));
     }
 
@@ -257,13 +255,13 @@ public class CSharpIrEmitterTests
     {
         var explicitCast = new IrCast(new IrConstant(3, typeof(int)), typeof(long), IrCastKind.Cast);
         Assert.AreEqual(
-            "{\n    long a_ = (long)3;\n    return a_;\n}",
+            "{\n    return (long)3;\n}",
             EmitBody(new IrLambda([], explicitCast)));
 
         var o = new IrLocal(typeof(object), "o");
         var safeCast = new IrCast(o, typeof(string), IrCastKind.As);
         Assert.AreEqual(
-            "{\n    string a_ = o as string;\n    return a_;\n}",
+            "{\n    return o as string;\n}",
             EmitBody(new IrLambda([o], safeCast)));
     }
 
@@ -277,7 +275,7 @@ public class CSharpIrEmitterTests
         var lambda = new IrLambda([], cast);
 
         Assert.AreEqual(
-            "{\n    decimal? a_ = (decimal?)((object)true);\n    return a_;\n}",
+            "{\n    return (decimal?)((object)true);\n}",
             EmitBody(lambda));
     }
 
@@ -318,7 +316,7 @@ public class CSharpIrEmitterTests
         var coalesce = new IrBinary(IrBinaryOp.Coalesce, x, new IrConstant(5, typeof(int)));
         Assert.AreEqual(typeof(int), coalesce.Type);
         Assert.AreEqual(
-            "{\n    int a_ = x ?? 5;\n    return a_;\n}",
+            "{\n    return x ?? 5;\n}",
             EmitBody(new IrLambda([x], coalesce)));
 
         var s = new IrLocal(typeof(string), "s");
@@ -327,12 +325,12 @@ public class CSharpIrEmitterTests
         // "default" instead -- see Constants_PrintExpectedLiterals).
         var equalNull = new IrBinary(IrBinaryOp.Equal, s, new IrConstant(null, typeof(object)));
         Assert.AreEqual(
-            "{\n    bool a_ = s is null;\n    return a_;\n}",
+            "{\n    return s is null;\n}",
             EmitBody(new IrLambda([s], equalNull)));
 
         var notEqualNull = new IrBinary(IrBinaryOp.NotEqual, s, new IrConstant(null, typeof(object)));
         Assert.AreEqual(
-            "{\n    bool a_ = s is not null;\n    return a_;\n}",
+            "{\n    return s is not null;\n}",
             EmitBody(new IrLambda([s], notEqualNull)));
     }
 
@@ -342,7 +340,7 @@ public class CSharpIrEmitterTests
         var listCtor = typeof(List<int>).GetConstructor([typeof(int)])!;
         var @new = new IrNew(listCtor, new IrConstant(4, typeof(int)));
         Assert.AreEqual(
-            "{\n    List<int> a_ = new List<int>(4);\n    return a_;\n}",
+            "{\n    return new List<int>(4);\n}",
             EmitBody(new IrLambda([], @new)));
 
         var widgetCtor = typeof(CSharpIrEmitterTestWidget).GetConstructor(Type.EmptyTypes)!;

--- a/Cql/CoreTests/CSharpIrEmitterTests.cs
+++ b/Cql/CoreTests/CSharpIrEmitterTests.cs
@@ -121,14 +121,18 @@ public class CSharpIrEmitterTests
     {
         // Two separately-constructed, but structurally identical, IrInvoke nodes: the emitter
         // dedups on printed code + type, so only one "Math.Abs(-5)" local is introduced even
-        // though it is referenced twice.
+        // though it is referenced twice. The deduped duplicate still burns a name from the
+        // sequence (the old LocalVariableDeduper's letter-gap behavior — see Hoist's
+        // "burnedName" in CSharpIrEmitter.Scope.cs), so the array itself is named "c_", not
+        // "b_"; arrays also print as multi-line collection expressions (see
+        // ObjectCreation_NewArrayAndNewArrayBounds).
         var call1 = new IrInvoke(null, MathAbsInt, new IrConstant(-5, typeof(int)));
         var call2 = new IrInvoke(null, MathAbsInt, new IrConstant(-5, typeof(int)));
         var array = new IrNewArray(typeof(int), call1, call2);
         var lambda = new IrLambda([], array);
 
         Assert.AreEqual(
-            "{\n    int a_ = Math.Abs(-5);\n    int[] b_ = new int[] { a_, a_ };\n    return b_;\n}",
+            "{\n    int a_ = Math.Abs(-5);\n    int[] c_ = [\n        a_,\n        a_,\n    ];\n    return c_;\n}",
             EmitBody(lambda));
     }
 
@@ -138,18 +142,18 @@ public class CSharpIrEmitterTests
         var applyFunc = typeof(CSharpIrEmitterTestHelpers).GetMethod(nameof(CSharpIrEmitterTestHelpers.ApplyFunc))!;
         var p = new IrLocal(typeof(int), "n");
         // Casts are pass-through, so the function body returns the cast inline; the
-        // function's own generated name comes first in the a_, b_, ... sequence.
+        // function's own generated name comes first in the a_, b_, ... sequence. The body
+        // linearizes without hoisting any statement, so the local function prints expression-
+        // bodied ("=> expr;", no surrounding blank lines) — the old writer's
+        // BuildLambdaOperator/BuildBlockExpression rule, keyed on the body actually being a
+        // multi-statement block (see HoistLocalFunction in CSharpIrEmitter.Scope.cs).
         var innerLambda = new IrLambda([p], new IrCast(p, typeof(int?), IrCastKind.Cast));
         var call = new IrInvoke(null, applyFunc, innerLambda, new IrConstant(5, typeof(int)));
         var lambda = new IrLambda([], call);
 
         var expected =
             "{\n" +
-            "    int? a_(int n)\n" +
-            "    {\n" +
-            "        return (int?)n;\n" +
-            "    }\n" +
-            "\n" +
+            "    int? a_(int n) => (int?)n;\n" +
             "    int? b_ = CSharpIrEmitterTestHelpers.ApplyFunc(a_, 5);\n" +
             "    return b_;\n" +
             "}";
@@ -173,8 +177,11 @@ public class CSharpIrEmitterTests
     {
         var test = new IrLocal(typeof(bool), "c");
         // The true branch needs its own hoisted statement, so the conditional can no longer
-        // print as a single-expression ternary and must become an if/else assigning a
-        // declared result local instead.
+        // print as a single-expression ternary and must flatten into the old pipeline's
+        // CaseWhenThen form instead: a hoisted zero-parameter local function containing the
+        // if/else chain (branches `return`, a stray `;` after the final else block), invoked
+        // where the value is needed (see HoistConditionalFunction in
+        // CSharpIrEmitter.Scope.cs).
         var ifTrue = new IrInvoke(null, MathAbsInt, new IrConstant(-5, typeof(int)));
         var ifFalse = new IrConstant(2, typeof(int));
         var conditional = new IrConditional(test, ifTrue, ifFalse, typeof(int));
@@ -182,21 +189,22 @@ public class CSharpIrEmitterTests
 
         var actual = EmitBody(lambda);
 
-        // A declared result local assigned in an if/else statement; names stay contiguous
-        // because the inline-vs-statement decision is a static test, not a trial hoist.
         var expected =
             "{\n" +
-            "    int a_;\n" +
-            "    if (c)\n" +
-            "    {\n" +
-            "        int b_ = Math.Abs(-5);\n" +
-            "        a_ = b_;\n" +
+            "\n" +
+            "    int a_() {\n" +
+            "        if (c)\n" +
+            "        {\n" +
+            "            int b_ = Math.Abs(-5);\n" +
+            "            return b_;\n" +
+            "        }\n" +
+            "        else\n" +
+            "        {\n" +
+            "            return 2;\n" +
+            "        };\n" +
             "    }\n" +
-            "    else\n" +
-            "    {\n" +
-            "        a_ = 2;\n" +
-            "    }\n" +
-            "    return a_;\n" +
+            "\n" +
+            "    return a_();\n" +
             "}";
         Assert.AreEqual(expected, actual);
     }
@@ -204,6 +212,10 @@ public class CSharpIrEmitterTests
     [TestMethod]
     public void IfChain_TailPosition_PrintsReturningIfElseChain()
     {
+        // If-chains flatten into the same hoisted-local-function CaseWhenThen form as a
+        // compound conditional (see HoistConditionalFunction in CSharpIrEmitter.Scope.cs);
+        // here neither the "when" (a bare local) nor either branch (bare constants) hoists
+        // anything, so the function body is just the if/else chain itself.
         var when = new IrLocal(typeof(bool), "w");
         var chain = new IrIfChain(
             [(when, new IrConstant(1, typeof(int)))],
@@ -213,14 +225,19 @@ public class CSharpIrEmitterTests
 
         var expected =
             "{\n" +
-            "    if (w)\n" +
-            "    {\n" +
-            "        return 1;\n" +
+            "\n" +
+            "    int a_() {\n" +
+            "        if (w)\n" +
+            "        {\n" +
+            "            return 1;\n" +
+            "        }\n" +
+            "        else\n" +
+            "        {\n" +
+            "            return 2;\n" +
+            "        };\n" +
             "    }\n" +
-            "    else\n" +
-            "    {\n" +
-            "        return 2;\n" +
-            "    }\n" +
+            "\n" +
+            "    return a_();\n" +
             "}";
         Assert.AreEqual(expected, EmitBody(lambda));
     }
@@ -355,9 +372,11 @@ public class CSharpIrEmitterTests
     [TestMethod]
     public void ObjectCreation_NewArrayAndNewArrayBounds()
     {
+        // Arrays print as multi-line collection expressions with trailing commas, matching
+        // the old writer's array format (see CSharpIrEmitter.Print.cs PrintNewArray).
         var newArray = new IrNewArray(typeof(int), new IrConstant(1, typeof(int)), new IrConstant(2, typeof(int)));
         Assert.AreEqual(
-            "{\n    int[] a_ = new int[] { 1, 2 };\n    return a_;\n}",
+            "{\n    int[] a_ = [\n        1,\n        2,\n    ];\n    return a_;\n}",
             EmitBody(new IrLambda([], newArray)));
 
         var newArrayBounds = new IrNewArrayBounds(typeof(string), new IrConstant(3, typeof(int)));

--- a/Cql/CqlToElmTests/(tests)/IrPipelineTests.cs
+++ b/Cql/CqlToElmTests/(tests)/IrPipelineTests.cs
@@ -50,7 +50,12 @@ public class IrPipelineTests : Base
     private static (Library library, IrDefinitionDictionary definitions) BuildIr(string cql)
     {
         var library = CreateCqlToolkit().MakeLibrary(cql);
+        return (library, BuildIrDefinitions(library));
+    }
 
+    /// <inheritdoc cref="BuildIr"/>
+    private static IrDefinitionDictionary BuildIrDefinitions(Library library)
+    {
         var typeResolver = FhirTypeResolver.Default;
         var typeConverter = FhirTypeConverter
             .Create(Hl7.Fhir.Model.ModelInfo.ModelInspector)
@@ -76,8 +81,7 @@ public class IrPipelineTests : Base
             expressionBuilder,
             libraryPreprocessorBuilder);
 
-        var definitions = libraryExpressionBuilder.ProcessLibrary(library);
-        return (library, definitions);
+        return libraryExpressionBuilder.ProcessLibrary(library);
     }
 
     /// <summary>
@@ -278,5 +282,72 @@ public class IrPipelineTests : Base
         var body = EmitDefinition(library, definitions, "X");
         AssertWellFormedBody(body);
         StringAssert.Contains(body, "Width");
+    }
+
+    /// <summary>
+    /// Phase-5 smoke test: run one CQL library end to end through BOTH C#-generation
+    /// pipelines — the existing Expression-based <c>LibrarySetCSharpCodeGenerator</c> (via the
+    /// toolkit services, see <see cref="Base.Run"/>) and the typed-IR
+    /// <c>IrLibrarySetCSharpCodeGenerator</c> — and assert the generated library files are
+    /// byte-identical (modulo line endings, like <c>CSharpGenerationGoldenTests</c>).
+    /// </summary>
+    [TestMethod]
+    public void SmokeTest_OldAndIrPipelines_GenerateIdenticalCSharp()
+    {
+        const string cql = """
+            library IrSmokeTest version '1.0.0'
+
+            codesystem "ACME": 'http://acme.org/cs'
+            valueset "Fall Injuries": 'http://acme.org/vs/falls'
+            code "Tiny": 'T1' from "ACME" display 'Tiny code'
+            concept "Tiny Concept": { "Tiny" } display 'Tiny concept'
+
+            define Constant: 1
+            define function Identity(x Integer): x
+            define UseIdentity: Identity(3)
+            define TupleValue: Tuple { x: 1, y: 2 }
+            """;
+
+        var library = CreateCqlToolkit().MakeLibrary(cql);
+        LibrarySet librarySet = new("IrSmokeTest", library);
+
+        // Old pipeline: build definitions and generate C# through the toolkit services.
+        var elmToolkit = CreateElmToolkit();
+        var oldDefinitions = elmToolkit.ProcessLibrary(library);
+        var oldCSharp = elmToolkit
+            .GetLibrarySetCSharpCodeGenerator()
+            .GenerateEachLibraryToCSharp(librarySet, oldDefinitions)
+            .Single().cSharp;
+
+        // New pipeline: same Library instance through the typed-IR builder + generator.
+        var irDefinitions = BuildIrDefinitions(library);
+        var newCSharp = new IrLibrarySetCSharpCodeGenerator(FhirTypeResolver.Default, new TypeToCSharpConverter())
+            .GenerateEachLibraryToCSharp(librarySet, irDefinitions)
+            .Single().cSharp;
+
+        AssertEqualCSharp(oldCSharp, newCSharp);
+    }
+
+    /// <summary>Asserts the two generated sources are equal (line endings normalized) and, on
+    /// mismatch, fails with the first differing line plus context — much easier to iterate on
+    /// than two multi-hundred-line strings in the failure message.</summary>
+    private static void AssertEqualCSharp(string oldCSharp, string newCSharp)
+    {
+        var oldLines = oldCSharp.Replace("\r\n", "\n").Split('\n');
+        var newLines = newCSharp.Replace("\r\n", "\n").Split('\n');
+
+        for (int i = 0; i < Math.Max(oldLines.Length, newLines.Length); i++)
+        {
+            var oldLine = i < oldLines.Length ? oldLines[i] : "<end of file>";
+            var newLine = i < newLines.Length ? newLines[i] : "<end of file>";
+            if (oldLine != newLine)
+            {
+                string Context(string[] lines) => string.Join("\n", lines.Skip(Math.Max(0, i - 2)).Take(8));
+                Assert.Fail(
+                    $"Generated C# differs at line {i + 1}.\n" +
+                    $"--- old pipeline ---\n{Context(oldLines)}\n" +
+                    $"--- new pipeline ---\n{Context(newLines)}");
+            }
+        }
     }
 }

--- a/docs/generated-csharp-optimization-opportunities.md
+++ b/docs/generated-csharp-optimization-opportunities.md
@@ -1,0 +1,111 @@
+# Generated C#: optimization opportunities (post-phase-6)
+
+Companion to `linq-expression-removal-plan.md`. Once phase 6 deletes the Expression-based
+pipeline, byte-parity no longer constrains the output and the typed IR — which carries the
+static .NET type of every node — makes a class of optimizations straightforward that the old
+pipeline could not attempt. This catalogue is evidence-based: each item points at real
+generated code from the golden corpus.
+
+Ground rule: **measure first**. The BenchmarkDotNet integration runner (#97) should get a
+baseline per corpus before and after each class lands, and every class needs semantic tests
+(CQL three-valued logic and overflow/precision rules are where "obvious" native lowerings go
+wrong).
+
+## The evidence, from one small define
+
+CQL (`RR23`): `AgeInYearsAt(start of "Measurement Period") >= 16 and exists(...)`
+
+Generated:
+
+```csharp
+Patient a_ = this.Patient(context);
+Date b_ = a_?.BirthDateElement;
+CqlDateTime c_ = context.Operators.Convert<CqlDateTime>(b_);
+CqlInterval<CqlDateTime> d_ = this.Measurement_Period(context);
+CqlDateTime e_ = context.Operators.Start(d_);
+int? f_ = context.Operators.CalculateAgeAt(c_, e_, "year");
+bool? g_ = context.Operators.GreaterOrEqual(f_, 16);
+IEnumerable<Condition> h_ = this.Injury_due_to_falling_rock_within_measurement_period(context);
+bool? i_ = context.Operators.Exists<Condition>(h_);
+bool? j_ = context.Operators.And(g_, i_);
+return j_;
+```
+
+Every operation is an interface-dispatched call on `ICqlOperators`, even where C# has an
+exact native equivalent.
+
+## Opportunity classes, by expected impact
+
+### 1. Native-operator lowering (highest impact, widest reach)
+
+The binder/emitter know every operand type statically. Where a native C# construct has
+*exactly* CQL semantics, emit it instead of the operator call:
+
+- `Operators.And/Or/Not/Xor` on `bool?` → `&`, `|`, `!`, `^`: C#'s lifted `&`/`|` on
+  `bool?` **are** Kleene three-valued logic — a zero-risk, zero-cost replacement.
+- `Operators.Equal` on primitives → `==` (lifted equality matches CQL for non-null; CQL's
+  null-propagating equality needs the `HasValue` guard below).
+- Comparisons (`Greater[OrEqual]`, `Less[OrEqual]`) on `int?/long?/decimal?`: NOT a direct
+  lifted-operator replacement (C# lifted comparison returns `bool`, false for null; CQL
+  returns null) — but a tiny aggressively-inlinable static helper, or inline
+  `f_.HasValue ? f_ >= 16 : (bool?)null`, still beats interface dispatch.
+- Arithmetic on primitives: candidate, but **semantics first** — CQL overflow behavior vs.
+  C# wrap/checked, and decimal precision rules, must be pinned by tests per operator before
+  lowering.
+
+### 2. Devirtualization of what remains
+
+`context.Operators` is an interface receiver — virtual dispatch on every call, largely
+opaque to JIT inlining. Options: generate calls against the concrete (sealed)
+`CqlOperators` type; or make hot operators static. Cheap to try, benchmark decides.
+
+### 3. Conversion specialization
+
+`context.Operators.Convert<CqlDateTime>(b_)` goes generic → boxing → runtime
+`TypeConverter` dictionary lookup, **per evaluation**. The binder already knows the specific
+conversion at compile time (its `ConversionFunctionName` path); the generic path is the
+fallback. Emit the specific conversion call; reserve `Convert<T>` for genuinely dynamic
+cases (Choice types).
+
+### 4. Honest deduplication (fixes a replicated runtime cost)
+
+The old deduper is single-pass without fixpoint, so "second-order" duplicates survive — in
+`RR23`, `FHIRHelpers...ToDateTime(context, q_ as FhirDateTime)` is **computed twice** at
+runtime (`r_` and `v_`), a cost we currently replicate for parity (see the emitter's
+dual-text Atom comments). Post-parity, fixpoint dedup is both cleaner output and a real
+win wherever conversions/calls repeat. (Also removes the burned-letter naming gaps.)
+
+### 5. Constant folding and static hoisting
+
+- `context.Operators.Quantity(7m, "days")` allocates a `CqlQuantity` on every evaluation of
+  its containing lambda — a `private static readonly` field candidate, like codes already
+  are. Same for constant intervals (the `Measurement Period` default) and
+  `RetrieveParameters` with constant arguments.
+- Literal arithmetic (`1 + 2`) can fold at generation time.
+- Precision strings (`"year"`, `"days"`, `(string)default`) are parsed at runtime per call;
+  an enum overload on the operator surface removes repeated parsing.
+
+### 6. Delegate and closure pressure in queries
+
+Query translation allocates `Func<>` delegates (and display classes, since lambdas capture
+`context` and outer aliases) per evaluation, plus enumerator layers per `Where`/`Select`.
+Two tiers:
+- cheap: cache non-capturing delegates; make the conditional-shape local functions `static`
+  where possible.
+- ambitious: inline simple query pipelines into generated `foreach` loops, eliminating the
+  delegate + enumerator machinery entirely. High effort; benchmark a hot measure first.
+
+### 7. Cosmetic artifacts (readability, negligible perf)
+
+Already in the post-parity ledger: the stray `};`, letter-gap naming, surviving
+`as object` casts (visitor-ordering accident), `null as CqlInterval<...>` instead of plain
+returns, `(bool?)x ?? false` in conditions, and the invoked-local-function conditional shape
+(a native `if/else` or `switch` expression reads better).
+
+## Sequencing suggestion
+
+Phase 6 deletes the old pipeline and bumps the generator version (goldens regenerate once).
+Then: (7) cosmetics + (4) honest dedup land together in that same regeneration; (1)–(3) as
+measured, per-operator-class PRs with semantic tests; (5) alongside; (6) last, driven by
+benchmarks. Each class changes generated output, so each is one golden regeneration —
+batching related classes keeps corpus churn reviewable.

--- a/docs/linq-expression-removal-plan.md
+++ b/docs/linq-expression-removal-plan.md
@@ -136,7 +136,13 @@ Post-parity cleanups (once the old pipeline is gone and byte-identical output no
 constrains the emitter): multi-branch conditionals whose branches are all simple can print as
 C# `switch` expressions instead of `if`/`else if` chains (statement form stays as the general
 fallback for branches that hoist locals), and the printing backend itself is swappable — e.g.
-emitting Roslyn syntax trees from the IR for normalized formatting.
+emitting Roslyn syntax trees from the IR for normalized formatting. The phase-5 grind added
+several faithfully-replicated old quirks worth revisiting (all documented at their emitter
+sites): duplicate eliminations burn a letter from the naming sequence (visible gaps);
+the multi-branch conditional form carries a stray `;` after its final else block; and
+redundant `as object` casts survive only when they wrap another cast — an accident of the
+old visitor ordering (`ElmAsExpression` reduced after `RedundantCastsTransformer` ran),
+not a design choice.
 
 ### Findings from phases 2–4
 

--- a/docs/type-system-unification-assessment.md
+++ b/docs/type-system-unification-assessment.md
@@ -6,6 +6,24 @@ specialization). Assessment of whether this repo should migrate its CQL primitiv
 (`Hl7.Fhir.ElementModel.Types`, "P.*"), reachable from POCOs via `IToSystemPrimitive`
 (SDK ≥ 5.13.1/6.0.0; this repo references 6.2.0).
 
+## Why this is a semantics question, not just deduplication
+
+FhirPath and CQL do not merely happen to have similar primitive types: **FhirPath's type
+system was deliberately aligned with CQL's when it was added** (the then-separate FhirPath
+and CQL specification efforts unified on it), and **FhirPath is specified as a subset of
+CQL** — FhirPath expressions are translatable to ELM. The two engines in this product
+family therefore implement the *same specified type system* twice. That changes the stakes
+of every difference catalogued below:
+
+- a divergence between P.* and Cql.Primitives is not a "local variation" — one side (or
+  both) is wrong against the shared spec, and FhirPath evaluation (validator invariants,
+  search, server) can disagree with CQL logic over the same data;
+- the SDK-side gap list at the end of this document is not a favor to the cql-sdk — each
+  item is arguably a FhirPath spec-compliance improvement in its own right;
+- the bridge proposed below doubles as a **conformance instrument**: differential tests
+  across the two implementations expose exactly where they disagree on shared semantics,
+  and every disagreement found is a bug report for one side.
+
 ## The two systems, honestly compared
 
 **Where they overlap** — the scalar/temporal core — both are serious implementations:
@@ -66,9 +84,17 @@ roadmap item gated on a concrete gap list (below).**
 4. **The realistic unification path runs through the SDK**, over its own release cadence:
    add a generic `Interval<T>`, UCUM canonicalization (Fhir.Metrics), CQL-grade
    Code/Concept/Ratio semantics, and the spec-shaped sub-second/decimal rules to
-   ElementModel.Types — each valuable to FhirPath users independently. Re-evaluate the
-   cql-sdk migration when that gap list closes; the golden corpus built for the
-   Linq.Expressions removal is then exactly the safety net a type swap would need.
+   ElementModel.Types. Because FhirPath is specified as a subset of CQL, each of these is
+   a FhirPath spec-compliance improvement independently of this repo — the gap list is an
+   SDK backlog on its own merits. Re-evaluate the cql-sdk migration when that list closes;
+   the golden corpus built for the Linq.Expressions removal is then exactly the safety net
+   a type swap would need.
+5. **Start the bridge with differential tests.** Before (and while) writing adapters, run
+   both implementations over a shared table of comparison/arithmetic cases (partial
+   precisions, offsets, sub-second values, decimal scales, calendar vs UCUM durations).
+   Where they disagree, the shared spec decides which side has the bug — file it there.
+   This turns the alignment intent behind the specifications into something enforced by CI
+   rather than remembered by people.
 
 ## The gap list (what ElementModel.Types would need to be CQL-grade)
 

--- a/docs/type-system-unification-assessment.md
+++ b/docs/type-system-unification-assessment.md
@@ -1,0 +1,86 @@
+# Unifying the CQL type systems: Cql.Primitives vs. Hl7.Fhir.ElementModel.Types
+
+Companion to `generated-csharp-optimization-opportunities.md` (§3, conversion
+specialization). Assessment of whether this repo should migrate its CQL primitives
+(`Hl7.Cql.Primitives` + `Hl7.Cql.Iso8601`) onto the Firely .NET SDK's System types
+(`Hl7.Fhir.ElementModel.Types`, "P.*"), reachable from POCOs via `IToSystemPrimitive`
+(SDK ≥ 5.13.1/6.0.0; this repo references 6.2.0).
+
+## The two systems, honestly compared
+
+**Where they overlap** — the scalar/temporal core — both are serious implementations:
+both have partial-precision dates/times with genuinely ternary comparison (`int?`/null =
+incomparable), offset handling, and calendar-duration arithmetic. This is real duplication:
+two partial-precision datetime engines, two ternary comparers, two quantity models, in one
+product family.
+
+**Where they differ** decides the question:
+
+| Capability | Cql.Primitives (here) | ElementModel.Types (SDK 6.2) |
+|---|---|---|
+| `Interval<T>` with open/closed bounds | first-class; **186 signature references in ICqlOperators** | **absent entirely** |
+| UCUM canonicalization/conversion | yes (Fhir.Metrics 1.3), incl. the CQL calendar-unit shim | none — Quantity comparison requires exact unit equality (doc-comment overstates) |
+| Code/Concept CQL semantics | records with defined equality | explicitly none; `Parse` throws `NotImplementedException` |
+| Ratio ordering/equivalence | present | absent (structural `==` only) |
+| Sub-second comparison | spec-shaped | deliberately simplified (second+ms collapsed; documented) |
+| Decimal equality | comparer-based | scale-based, self-described "sloppy" vs. spec precision |
+| Calendar-vs-UCUM year/month arithmetic rules | explicit (`CqlUcumYearArithmeticError` etc.) | throws `ArgumentException` on unknown units, no such distinction |
+| Tuple metadata (structural typing) | `CqlTupleMetadata` | no analogue |
+| POCO conversions | runtime converter dictionary (~30 in, ~14 out) + generated FHIRHelpers | **compile-time-known `IToSystemPrimitive` on the POCOs** + `Any.TryConvertTo` table |
+| Battle-tested by | this repo's corpus + spec tests | the FhirPath engine (equality/ordering/conversion are load-bearing there) |
+
+Today the repo's only contact with P.* is incidental: `FhirTypeConverter` borrows the SDK's
+`TryToSystemDate/Time/DateTime` to parse FHIR primitives, then immediately re-wraps into
+`CqlDate/CqlDateTime/CqlTime`, discarding the P.* value. There is no other wiring.
+
+## Verdict
+
+**Do not migrate now; build a first-class bridge now; treat unification as an SDK-side
+roadmap item gated on a concrete gap list (below).**
+
+1. **Migration is not viable against SDK 6.2 as-is.** The absent pieces (Interval — the
+   single largest coupling in `ICqlOperators` — UCUM math, Code/Concept semantics, tuple
+   metadata) mean this repo would keep roughly half its types anyway, while paying the full
+   blast radius for the other half: `ICqlOperators` + every operator/comparer
+   implementation, `FhirTypeConverter`, both code generators, the shipped public API, full
+   golden-corpus regeneration, and — the expensive part — re-verifying three-valued
+   comparison semantics everywhere, against a P.* layer that has documented spec
+   simplifications (sub-second, decimal scale) this repo does not share.
+2. **The reverse (SDK adopts Cql.Primitives) is a non-starter**: the SDK cannot depend on
+   this repo, and P.* semantics are load-bearing for FhirPath evaluation across the whole
+   product line — changing them ripples into the validator and server.
+3. **The bridge is cheap, immediately valuable, and is the prerequisite work for any later
+   merge.** Concretely, in `Cql.Firely`:
+   - use `IToSystemPrimitive` as the POCO→System entry point and add System↔Cql adapters
+     (`P.DateTime ↔ CqlDateTime`, `P.Date ↔ CqlDate`, `P.Time ↔ CqlTime`,
+     `P.Quantity ↔ CqlQuantity`, `P.Code ↔ CqlCode`, `P.Concept ↔ CqlConcept`) — roughly a
+     dozen small, allocation-conscious functions;
+   - let the post-phase-6 conversion specialization (optimization doc §3) target these
+     compile-time-known paths instead of the runtime converter dictionary — the two ideas
+     compose: the binder already knows the types statically, and `IToSystemPrimitive` gives
+     it a hard-coded method to call;
+   - expose the adapters publicly for consumers mixing FhirPath and CQL evaluation.
+   Writing the bridge also *forces* precise enumeration of the semantic diffs (sub-second,
+   decimal scale, tz-normalization-by-precision, calendar-unit shim) — with tests — which is
+   exactly the artifact a future unification needs.
+4. **The realistic unification path runs through the SDK**, over its own release cadence:
+   add a generic `Interval<T>`, UCUM canonicalization (Fhir.Metrics), CQL-grade
+   Code/Concept/Ratio semantics, and the spec-shaped sub-second/decimal rules to
+   ElementModel.Types — each valuable to FhirPath users independently. Re-evaluate the
+   cql-sdk migration when that gap list closes; the golden corpus built for the
+   Linq.Expressions removal is then exactly the safety net a type swap would need.
+
+## The gap list (what ElementModel.Types would need to be CQL-grade)
+
+1. Generic `Interval<T>` with `bool?` open/closed bounds and the interval operator algebra.
+2. UCUM canonicalization/conversion (Fhir.Metrics) + the CQL calendar-unit 1:1 shim
+   (year↔a, month↔mo, …) that deliberately bypasses metric conversion.
+3. `Code`/`Concept`: CQL equality/equivalence; working `Parse`.
+4. `Ratio`: `ICqlEquatable`/`ICqlOrderable`.
+5. Sub-second (second+millisecond as decimal) comparison semantics; decimal
+   precision-vs-scale reconciliation.
+6. The tz-normalization-by-precision comparison rule (normalize at hour+ precision; skip
+   when exactly one operand has an offset).
+7. Calendar-vs-UCUM arithmetic distinction with the year/month UCUM prohibition.
+8. Consistency fixes: `P.DateTime.Equals` throws where `Date`/`Time` return false; FhirPath
+   ordering throws for non-orderable types (open TODO in EqualityOperators).


### PR DESCRIPTION
## The headline

**The typed-IR pipeline produces byte-identical C# to the Expression-based pipeline over the entire golden corpus** — FHIRHelpers-4.0.1, RR23-1.0.0, and CMS56FHIRFuncStatHipReplacement over its 10-library closure — verified three ways: golden-file comparison for both pipelines, a dual-pipeline whole-library equality smoke test, and a public-toolkit-path test that also compiles the output to assemblies. Full suites: CoreTests 755/0, CqlToElmTests 2437/0.

**Stacked PR**: based on `linq-expr-removal-phase4` (#1344 → #1340 → #1331), retargeted as the chain merges.

## What''s in it

1. **The IR-side file generator** (`IrLibrarySetCSharpCodeGenerator` + partials): scaffolding ported verbatim from the old generator; bodies produced by `CSharpIrEmitter`; `CSharpNamingConventions` closes the naming seam designed in phase 2 (tuple-metadata fields, definition-call targets, cache keys — all byte-compatible).
2. **Emitter parity**: the phase-2 emitter''s linearization was reworked to reproduce the old pipeline''s deliberate hoisting design and its accumulated printing behaviors, each fix citing the old mechanism in a code comment. The interesting ones:
   - pass-through vs. spine node classification (the old `SimplifyExpressionsVisitor` dispatch, balancing hoisting against per-line readability);
   - "simple" conditionals print fully inline — the whole subtree, test included (old returned them unvisited);
   - non-simple conditionals emit the old CaseWhenThen shape: a hoisted zero-parameter local function (same-line brace, stray `;` after the final else) invoked where needed, when-conditions deferring via nested functions;
   - local functions render **deferred** so naming follows the old `RenameVariablesVisitor` block-variables-first order;
   - dedup reproduces `LocalVariableDeduper` exactly via dual-text atoms: single-pass, keyed on **pre-replacement** names, with every duplicate burning a letter (the gaps in old output);
   - assorted peepholes: casts-to-object stripping (with the exact `ElmAsExpression`-ordering exception, see below), `((T?)a) ?? b → a`, `default`→`null` in patterns, multi-line collection expressions, per-lineage alias reservation, forced `?.` on nullable/tuple receivers.
3. **`ElmToolkitConfig.UseIrPipeline`** (default **false**): a single branch point in `CompileToAssemblies` selects the pipeline; IR services live in the same composition root sharing all singletons; assembly compilation and artifacts unchanged. Only public-API addition is the config property.

## For the post-parity ledger (per the "some of this may be bugs" policy)

The grind surfaced three faithfully-replicated quirks now documented at their emitter sites and in the plan doc:
- deduplicated statements burn a letter from the naming sequence (visible gaps in generated names);
- the multi-branch conditional form carries a stray `;` after its final else block;
- redundant `as object` casts survive **only** when they wrap another cast — an accident of old visitor ordering (`ElmAsExpression` reduced *after* `RedundantCastsTransformer` ran), not a design choice. Verified against the old pipeline on concrete corpus cases.

## The flip-over questions (for this review)

1. **When does `UseIrPipeline` default to true?** Proposal: after this chain merges to `feature/linq-expr-removal` and soaks, flip the default in a follow-up commit on the feature branch — trivially revertable.
2. **Golden regeneration**: none needed — parity is byte-exact, goldens stay as-is. The `GeneratedCode` version bump waits for phase 6 (deletion) per the plan.
3. Phase 6 (delete the old pipeline, unify the FIXME(phase6) sites — checklist in `docs/linq-expression-removal-plan.md`) becomes mechanical once the default has soaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)